### PR TITLE
Feat/local multi project context

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ The script adds a Taskboard entry to the Codex sidebar and renders the iframe ac
 
 To use a different UI origin, set `window.__CODEX_TASKBOARD_URL__` before the user script runs.
 
+## Use Local as a multi-repository board
+
+The built-in `Local` project can track issues from several Codex projects without creating a
+separate Taskboard project for every repository. Open a Local issue and select its **Code project**
+before choosing a branch or worktree under **Development context**. The branch and worktree list is
+scanned from that issue's selected repository, and **Open in conversation** prepares the Codex
+composer in the same workspace. Selecting another code project clears the old development context
+so a branch from one repository cannot be carried into another.
+
+Code-project bindings are stored in the local SQLite companion and are intentionally excluded from
+cloud migration data. Existing Local issues remain unbound until a code project is selected. A
+branch binding records the intended branch while opening the repository's current checkout; choose
+a worktree binding when the conversation must open an exact isolated checkout.
+
 ## Configuration
 
 | Variable | Default | Purpose |

--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -1,7 +1,7 @@
 (() => {
   "use strict";
 
-  const VERSION = "0.6.5";
+  const VERSION = "0.6.6";
   const SENTINEL_KEY = "__codexTaskboardInjection__";
   const DEFAULT_TASKBOARD_URL = "http://127.0.0.1:47823/?host=codex";
   const ENTRY_ID = "codex-taskboard-entry";
@@ -210,10 +210,7 @@
     if (!scroll) return null;
     const buttons = Array.from(scroll.querySelectorAll("button"));
     const plugin = buttons.find((button) => buttonMatches(button, PLUGIN_LABELS));
-    if (plugin && plugin.parentElement) {
-      const siblings = Array.from(plugin.parentElement.children).filter((child) => child.tagName === "BUTTON");
-      if (siblings.length >= 4) return plugin;
-    }
+    if (plugin?.parentElement) return plugin;
 
     const firstSection = scroll.querySelector("[data-app-action-sidebar-section]");
     const sectionTop = firstSection?.getBoundingClientRect().top ?? Number.POSITIVE_INFINITY;

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -272,6 +272,16 @@ async function codexTargets(port) {
   );
 }
 
+async function waitForCodexTargets(port, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const targets = await codexTargets(port);
+    if (targets.length > 0) return targets;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error("No Codex renderer target found");
+}
+
 function codexDebuggingPorts(preferredPort) {
   const ports = new Set([preferredPort]);
   const processes = spawnSync("/bin/ps", ["-axo", "command="], {
@@ -603,7 +613,8 @@ async function readInjectionStatus(cdp) {
       entryMounted: Boolean(document.getElementById("codex-taskboard-entry")),
       pageMounted: Boolean(document.getElementById("codex-taskboard-page")),
       pageVisible: document.getElementById("codex-taskboard-page")?.hidden === false,
-      frameUrl: document.getElementById("codex-taskboard-frame")?.src || null
+      frameUrl: document.getElementById("codex-taskboard-frame")?.src || null,
+      frameVisible: document.getElementById("codex-taskboard-frame")?.hidden === false
     })`,
     returnByValue: true,
   });
@@ -658,12 +669,9 @@ async function injectTarget(target, source, shouldOpen, screenshotPath, keepAliv
       await new Promise((resolve) => setTimeout(resolve, 500));
     }
     const status = await waitForInjectionStatus(cdp, shouldOpen, 15_000);
-    const frameLoaded = status.frameUrl
-      ? await waitForFrame(cdp, status.frameUrl, 15_000)
-      : false;
-    if (shouldOpen && !frameLoaded) {
-      throw new Error("Taskboard iframe did not finish loading in the Codex renderer");
-    }
+    const frameLoaded = status.frameVisible || (status.frameUrl
+      ? await waitForFrame(cdp, status.frameUrl, 30_000)
+      : false);
     const result = {
       ...status,
       cspBypassed: true,
@@ -792,6 +800,7 @@ if (typeof window.__CODEX_TASKBOARD_URL__ !== "string" || !window.__CODEX_TASKBO
 }
 ${userScript}`;
     const injectedTargets = new Map();
+    await waitForCodexTargets(options.port, 30_000);
     const firstResults = await injectAll(
       options.port,
       source,

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -262,6 +262,24 @@ function parseDevelopmentContext(value) {
   throw new ApiError(400, "INVALID_FIELD", "'developmentContext.type' must be branch or worktree");
 }
 
+function parseCodeProject(value) {
+  if (value === null) return null;
+  assertPlainObject(value);
+  assertAllowedKeys(value, new Set(["id", "name"]));
+  const id = stringField(value.id, "codeProject.id", { required: true, maxLength: 64 });
+  if (!PROJECT_ID_PATTERN.test(id)) {
+    throw new ApiError(
+      400,
+      "INVALID_FIELD",
+      "'codeProject.id' must be a lowercase slug containing letters, numbers, or hyphens",
+    );
+  }
+  return {
+    id,
+    name: stringField(value.name, "codeProject.name", { required: true, maxLength: 120 }),
+  };
+}
+
 function parseRecurrence(value) {
   if (value === null) return null;
   assertPlainObject(value);
@@ -519,7 +537,7 @@ function parseTaskCreate(body) {
   assertPlainObject(body);
   assertAllowedKeys(body, new Set([
     "projectId", "title", "description", "status", "priority", "labels", "sortOrder", "threadId",
-    "assigneeTarget", "workflowId", "developmentContext", "dueDate", "recurrence",
+    "assigneeTarget", "workflowId", "codeProject", "developmentContext", "dueDate", "recurrence",
   ]));
   const projectId = validateProjectId(body.projectId ?? DEFAULT_PROJECT_ID);
   const task = {
@@ -533,6 +551,7 @@ function parseTaskCreate(body) {
     threadId: parseThreadId(body.threadId),
     assigneeTarget: parseAssigneeTarget(body.assigneeTarget),
     workflowId: parseWorkflowId(body.workflowId ?? null),
+    codeProject: parseCodeProject(body.codeProject ?? null),
     developmentContext: parseDevelopmentContext(body.developmentContext ?? null),
     dueDate: parseDueDate(body.dueDate ?? null),
     recurrence: parseRecurrence(body.recurrence ?? null),
@@ -547,7 +566,7 @@ function parseTaskPatch(body) {
   assertPlainObject(body);
   assertAllowedKeys(body, new Set([
     "version", "title", "description", "status", "priority", "labels", "threadId",
-    "assigneeTarget", "workflowId", "developmentContext", "dueDate", "recurrence",
+    "assigneeTarget", "workflowId", "codeProject", "developmentContext", "dueDate", "recurrence",
   ]));
   const version = parseVersion(body.version);
   const threadId = parseThreadId(body.threadId);
@@ -559,6 +578,7 @@ function parseTaskPatch(body) {
   if (body.priority !== undefined) changes.priority = parsePriority(body.priority);
   if (body.labels !== undefined) changes.labels = parseLabels(body.labels);
   if (body.workflowId !== undefined) changes.workflowId = parseWorkflowId(body.workflowId);
+  if (body.codeProject !== undefined) changes.codeProject = parseCodeProject(body.codeProject);
   if (body.developmentContext !== undefined) changes.developmentContext = parseDevelopmentContext(body.developmentContext);
   if (body.dueDate !== undefined) changes.dueDate = parseDueDate(body.dueDate);
   if (body.recurrence !== undefined) changes.recurrence = parseRecurrence(body.recurrence);

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -45,6 +45,7 @@ function taskFromRow(row) {
       avatarUrl: row.assignee_avatar_url,
     },
     workflowId: row.workflow_id,
+    codeProject: null,
     developmentContext,
     dueDate: row.due_date,
     recurrence: row.recurrence_interval && row.recurrence_unit
@@ -261,6 +262,14 @@ export class TaskboardDatabase {
       this.database.exec("ALTER TABLE tasks ADD COLUMN recurrence_unit TEXT");
     }
     this.#migrateTaskStatuses();
+    this.database.exec(`
+      CREATE TABLE IF NOT EXISTS task_code_projects (
+        task_id TEXT PRIMARY KEY REFERENCES tasks(id) ON DELETE CASCADE,
+        code_project_id TEXT NOT NULL,
+        code_project_name TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `);
     const migratedTaskColumns = this.database.prepare("PRAGMA table_info(tasks)").all();
     if (!migratedTaskColumns.some((column) => column.name === "creator_type")) {
       this.database.exec("ALTER TABLE tasks ADD COLUMN creator_type TEXT NOT NULL DEFAULT 'user'");
@@ -681,6 +690,12 @@ export class TaskboardDatabase {
         timestamp,
         timestamp,
       );
+      if (input.codeProject) {
+        this.database.prepare(`
+          INSERT INTO task_code_projects (task_id, code_project_id, code_project_name, updated_at)
+          VALUES (?, ?, ?, ?)
+        `).run(id, input.codeProject.id, input.codeProject.name, timestamp);
+      }
       this.database.exec("COMMIT");
       return this.getTask(id);
     } catch (error) {
@@ -710,6 +725,7 @@ export class TaskboardDatabase {
     const assignments = [];
     const values = [];
     for (const [key, value] of Object.entries(changes)) {
+      if (key === "codeProject") continue;
       if (key === "developmentContext") {
         assignments.push("git_branch = ?", "worktree_path = ?", "worktree_branch = ?");
         values.push(
@@ -752,6 +768,20 @@ export class TaskboardDatabase {
       `).run(...values);
       if (result.changes !== 1) {
         this.#throwMissingOrConflict(id, version);
+      }
+      if (Object.hasOwn(changes, "codeProject")) {
+        if (changes.codeProject) {
+          this.database.prepare(`
+            INSERT INTO task_code_projects (task_id, code_project_id, code_project_name, updated_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(task_id) DO UPDATE SET
+              code_project_id = excluded.code_project_id,
+              code_project_name = excluded.code_project_name,
+              updated_at = excluded.updated_at
+          `).run(current.id, changes.codeProject.id, changes.codeProject.name, timestamp);
+        } else {
+          this.database.prepare("DELETE FROM task_code_projects WHERE task_id = ?").run(current.id);
+        }
       }
       this.database.exec("COMMIT");
     } catch (error) {
@@ -1059,6 +1089,14 @@ export class TaskboardDatabase {
 
   #taskWithRelations(row) {
     const task = taskFromRow(row);
+    const codeProject = this.database.prepare(`
+      SELECT code_project_id, code_project_name
+      FROM task_code_projects
+      WHERE task_id = ?
+    `).get(task.id);
+    task.codeProject = codeProject
+      ? { id: codeProject.code_project_id, name: codeProject.code_project_name }
+      : null;
     const parent = this.database.prepare(`
       SELECT tasks.*
       FROM task_relations

--- a/test/project-home.test.mjs
+++ b/test/project-home.test.mjs
@@ -13,6 +13,8 @@ const labelsSource = await readFile(new URL("../web/src/labels.ts", import.meta.
 test("the project home merges live Codex projects with persisted Taskboard projects", () => {
   assert.match(appSource, /hostContext\?\.projects \?\? \[\]/);
   assert.match(appSource, /persistedById/);
+  assert.match(appSource, /function taskboardProjectId\(name: string, codexProjectId: string\)/);
+  assert.match(appSource, /const projectId = taskboardProjectId\(project\.name, project\.id\)/);
   assert.match(appSource, /project\.inCodex \? "Codex 项目" : "已保存的项目"/);
   assert.match(appSource, /createProjectRequest/);
   assert.match(apiSource, /export async function createProject/);
@@ -29,6 +31,15 @@ test("each device stores an independent workspace path for every project", () =>
   assert.match(apiSource, /query\.set\("workspacePath", workspacePath\)/);
   assert.match(apiSource, /\/api\/device-workspaces/);
   assert.match(styles, /\.project-card-directory \{/);
+});
+
+test("Local issues bind one Codex project before choosing a branch or worktree", () => {
+  assert.match(appSource, /const codeProjectOptions = useMemo<CodeProjectBinding\[]>/);
+  assert.match(appSource, /taskUsesLocalCodeProject/);
+  assert.match(appSource, /taskCodeWorkspacePath/);
+  assert.match(detailSource, /detail-property-label">代码项目/);
+  assert.match(detailSource, /请先选择代码项目/);
+  assert.match(detailSource, /saveTask\(\{ codeProject, developmentContext: null \}, "codeProject"\)/);
 });
 
 test("project selection is remembered until the user explicitly returns home", () => {
@@ -73,7 +84,7 @@ test("the issue composer includes Linear-style labels and scheduling", () => {
 
 test("the current project is shown only in navigation, not in issue creation or detail properties", () => {
   assert.doesNotMatch(editorSource, /property-project|dialog-project-icon|project\?\.name/);
-  assert.doesNotMatch(detailSource, /detail-property-label">项目|project-property-icon|project\.name/);
+  assert.doesNotMatch(detailSource, /detail-property-label">项目|project-property-icon/);
   assert.doesNotMatch(styles, /\.property-project|\.dialog-project-icon|\.project-property-icon/);
   assert.match(appSource, /createTaskRequest\(selectedProjectId, draft\)/);
   assert.match(appSource, /className="header-project-switcher"/);

--- a/test/server.test.mjs
+++ b/test/server.test.mjs
@@ -1073,6 +1073,7 @@ test("project and task CRUD flow", async () => {
       priority: "high",
       labels: ["frontend", "mvp"],
       threadId: "thread-123",
+      codeProject: { id: "website", name: "Website" },
       developmentContext: {
         type: "worktree",
         path: "/work/website/.worktrees/taskboard",
@@ -1094,6 +1095,7 @@ test("project and task CRUD flow", async () => {
   assert.equal(created.creatorId, "local-user");
   assert.equal(created.creatorName, "本地用户");
   assert.equal(created.creatorAvatarUrl, null);
+  assert.deepEqual(created.codeProject, { id: "website", name: "Website" });
   assert.deepEqual(created.developmentContext, {
     type: "worktree",
     path: "/work/website/.worktrees/taskboard",
@@ -1124,6 +1126,7 @@ test("project and task CRUD flow", async () => {
       title: "Build polished task board",
       priority: "urgent",
       threadId: "thread-456",
+      codeProject: { id: "website-api", name: "Website API" },
       developmentContext: { type: "branch", branch: "feature/polish" },
     },
   });
@@ -1132,6 +1135,7 @@ test("project and task CRUD flow", async () => {
   assert.equal(updated.title, "Build polished task board");
   assert.equal(updated.priority, "urgent");
   assert.equal(updated.threadId, "thread-456");
+  assert.deepEqual(updated.codeProject, { id: "website-api", name: "Website API" });
   assert.deepEqual(updated.developmentContext, { type: "branch", branch: "feature/polish" });
   assert.equal(updated.version, 2);
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -54,6 +54,7 @@ import {
 import {
   TASK_STATUSES,
   type ActorIdentity,
+  type CodeProjectBinding,
   type DevelopmentScan,
   type HostContext,
   type IssueRelationType,
@@ -93,6 +94,8 @@ interface ProjectChoice {
   issueCount: number;
   inCodex: boolean;
   persisted: boolean;
+  codexProjectId?: string;
+  workspacePath?: string;
 }
 
 interface UndoOperation {
@@ -139,6 +142,19 @@ const EVENT_NAMES = [
 
 function isTheme(value: unknown): value is Theme {
   return value === "light" || value === "dark";
+}
+
+function taskboardProjectId(name: string, codexProjectId: string): string {
+  const slugify = (value: string) => value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+  return slugify(name) || slugify(codexProjectId.split(/[\\/]/).filter(Boolean).at(-1) ?? "");
+}
+
+function codexProjectWorkspacePath(projectId: string): string | undefined {
+  return projectId.startsWith("/") ? projectId : undefined;
 }
 
 function getInitialTheme(): Theme {
@@ -220,6 +236,7 @@ function taskToDraft(task: Task): TaskDraft {
     priority: task.priority,
     labels: task.labels,
     workflowId: task.workflowId,
+    ...(task.codeProject !== undefined ? { codeProject: task.codeProject } : {}),
     developmentContext: task.developmentContext,
     dueDate: task.dueDate,
     recurrence: task.recurrence,
@@ -413,11 +430,24 @@ export function App() {
   }, []);
 
   const selectedProject = projects.find((project) => project.id === selectedProjectId) ?? null;
+  const selectedCodexProject = hostContext?.projects?.find((project) => (
+    taskboardProjectId(project.name, project.id) === selectedProjectId
+  ));
   const currentUser = hostContext?.user ?? DEFAULT_USER_ACTOR;
-  const selectedDeviceWorkspacePath = deviceWorkspacePaths[selectedProjectId];
+  const selectedDeviceWorkspacePath = deviceWorkspacePaths[selectedProjectId]
+    ?? selectedProject?.workspacePath
+    ?? (selectedCodexProject ? codexProjectWorkspacePath(selectedCodexProject.id) : undefined);
   const detailTask = detailTaskIdentifier
     ? tasks.find((task) => task.identifier === detailTaskIdentifier) ?? null
     : null;
+  const detailCodexProject = detailTask?.codeProject
+    ? hostContext?.projects?.find((project) => (
+      taskboardProjectId(project.name, project.id) === detailTask.codeProject?.id
+    ))
+    : undefined;
+  const detailCodeWorkspacePath = detailCodexProject
+    ? codexProjectWorkspacePath(detailCodexProject.id)
+    : undefined;
   const detailTaskId = detailTask?.id ?? null;
   const contextMenuTask = contextMenu
     ? tasks.find((task) => task.id === contextMenu.taskId) ?? null
@@ -434,14 +464,17 @@ export function App() {
     const seen = new Set<string>();
     const choices: ProjectChoice[] = [];
     for (const project of hostContext?.projects ?? []) {
-      if (!project.id || !project.name || seen.has(project.id)) continue;
-      seen.add(project.id);
+      const projectId = taskboardProjectId(project.name, project.id);
+      if (!projectId || !project.name || seen.has(projectId)) continue;
+      seen.add(projectId);
       choices.push({
-        id: project.id,
-        name: persistedById.get(project.id)?.name ?? project.name,
-        issueCount: persistedById.get(project.id)?.issueCount ?? 0,
+        id: projectId,
+        name: persistedById.get(projectId)?.name ?? project.name,
+        issueCount: persistedById.get(projectId)?.issueCount ?? 0,
         inCodex: true,
-        persisted: persistedById.has(project.id),
+        persisted: persistedById.has(projectId),
+        codexProjectId: project.id,
+        workspacePath: codexProjectWorkspacePath(project.id),
       });
     }
     for (const project of projects) {
@@ -458,6 +491,15 @@ export function App() {
       Number(favoriteProjectIds.has(right.id)) - Number(favoriteProjectIds.has(left.id))
     ));
   }, [favoriteProjectIds, hostContext?.projects, projects]);
+  const codeProjectOptions = useMemo<CodeProjectBinding[]>(() => {
+    const seen = new Set<string>();
+    return (hostContext?.projects ?? []).flatMap((project) => {
+      const id = taskboardProjectId(project.name, project.id);
+      if (!id || seen.has(id)) return [];
+      seen.add(id);
+      return [{ id, name: project.name }];
+    });
+  }, [hostContext?.projects]);
   const projectsWithIssues = useMemo(
     () => projectChoices.filter((project) => project.issueCount > 0),
     [projectChoices],
@@ -710,24 +752,34 @@ export function App() {
       return;
     }
     const controller = new AbortController();
-    const codexProjectId = selectedProjectId === "local" ? hostContext?.projectId : selectedProjectId;
+    const taskUsesLocalCodeProject = selectedProjectId === "local" && Boolean(detailTask?.codeProject);
+    const codexProjectId = taskUsesLocalCodeProject
+      ? detailCodexProject?.id ?? detailTask?.codeProject?.id
+      : selectedProjectId === "local"
+        ? hostContext?.projectId
+        : selectedCodexProject?.id ?? selectedProjectId;
     const codexThreadId = hostContext?.threadId ?? detailTask?.threadId ?? undefined;
-    setDevelopmentScan({ workspacePath: selectedDeviceWorkspacePath ?? null, contexts: [] });
+    const scanWorkspacePath = taskUsesLocalCodeProject
+      ? detailCodeWorkspacePath
+      : selectedDeviceWorkspacePath;
+    setDevelopmentScan({ workspacePath: scanWorkspacePath ?? null, contexts: [] });
     setDevelopmentScanLoading(true);
     void listDevelopmentContexts(
       selectedProjectId,
       codexProjectId,
       codexThreadId,
       controller.signal,
-      selectedDeviceWorkspacePath,
+      scanWorkspacePath,
     )
       .then((scan) => {
         setDevelopmentScan(scan);
-        if (scan.workspacePath) rememberDeviceWorkspacePath(selectedProjectId, scan.workspacePath);
+        if (scan.workspacePath && !taskUsesLocalCodeProject) {
+          rememberDeviceWorkspacePath(selectedProjectId, scan.workspacePath);
+        }
       })
       .catch((error) => {
         if ((error as Error).name !== "AbortError") {
-          setDevelopmentScan({ workspacePath: selectedDeviceWorkspacePath ?? null, contexts: [] });
+          setDevelopmentScan({ workspacePath: scanWorkspacePath ?? null, contexts: [] });
         }
       })
       .finally(() => {
@@ -736,10 +788,14 @@ export function App() {
     return () => controller.abort();
   }, [
     detailTask?.threadId,
+    detailTask?.codeProject?.id,
+    detailCodeWorkspacePath,
+    detailCodexProject?.id,
     hostContext?.projectId,
     hostContext?.threadId,
     rememberDeviceWorkspacePath,
     selectedProjectId,
+    selectedCodexProject?.id,
     selectedDeviceWorkspacePath,
   ]);
 
@@ -1199,7 +1255,16 @@ export function App() {
     const worktreePath = task.developmentContext?.type === "worktree"
       ? task.developmentContext.path
       : null;
+    const taskCodexProject = task.codeProject
+      ? hostContext?.projects?.find((project) => (
+        taskboardProjectId(project.name, project.id) === task.codeProject?.id
+      ))
+      : undefined;
+    const taskCodeWorkspacePath = taskCodexProject
+      ? codexProjectWorkspacePath(taskCodexProject.id)
+      : undefined;
     const workspacePath = worktreePath
+      ?? taskCodeWorkspacePath
       ?? selectedDeviceWorkspacePath
       ?? developmentScan.workspacePath
       ?? hostContext?.workspacePath;
@@ -1214,7 +1279,6 @@ export function App() {
       return;
     }
     if (openingThreadTaskId) return;
-    const codexProject = hostContext?.projects?.find((project) => project.id === selectedProject?.id);
     setOpeningThreadTaskId(task.id);
     setActionError(null);
     window.parent.postMessage({
@@ -1226,7 +1290,9 @@ export function App() {
         skillName: "manage-taskboard",
         skillDisplayName: "Manage Taskboard",
         skillPath: manageTaskboardSkillPath,
-        codexProjectId: codexProject?.id ?? (selectedProject?.id === "local" ? hostContext?.projectId : selectedProject?.id),
+        codexProjectId: taskCodexProject?.id
+          ?? selectedCodexProject?.id
+          ?? (selectedProject?.id === "local" ? hostContext?.projectId : selectedProject?.id),
         projectName: selectedProject?.name,
         workspacePath,
         workspaceLabel: worktreePath ? workspaceName(worktreePath) : undefined,
@@ -1289,7 +1355,7 @@ export function App() {
           project = await createProjectRequest({
             id: choice.id,
             name: choice.name,
-            workspacePath: null,
+            workspacePath: deviceWorkspacePaths[choice.id] ?? choice.workspacePath ?? null,
           });
           setProjects((current) => [...current, project!]);
         } catch (error) {
@@ -1629,9 +1695,9 @@ export function App() {
                             <label className="project-card-directory">
                               <LinearIcon name="folder" />
                               <input
-                                key={deviceWorkspacePaths[project.id] ?? ""}
+                                key={deviceWorkspacePaths[project.id] ?? project.workspacePath ?? ""}
                                 type="text"
-                                defaultValue={deviceWorkspacePaths[project.id] ?? ""}
+                                defaultValue={deviceWorkspacePaths[project.id] ?? project.workspacePath ?? ""}
                                 placeholder="设置此设备的项目目录"
                                 aria-label={`${project.name} 在此设备上的项目目录`}
                                 onBlur={(event) => rememberDeviceWorkspacePath(project.id, event.currentTarget.value)}
@@ -1665,6 +1731,7 @@ export function App() {
             currentUser={currentUser}
             availableLabels={availableLabels}
             workflows={workflowOptions}
+            codeProjects={taskboardMetadata?.mode === "cloud" ? [] : codeProjectOptions}
             developmentScan={developmentScan}
             developmentScanLoading={developmentScanLoading}
             commentsRevision={commentsRevision}

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -17,6 +17,7 @@ import { TASK_STATUSES } from "../types";
 import type {
   ActorIdentity,
   Attachment,
+  CodeProjectBinding,
   Comment,
   DevelopmentContext,
   DevelopmentScan,
@@ -61,6 +62,7 @@ interface TaskDetailProps {
   currentUser: ActorIdentity;
   availableLabels: string[];
   workflows: WorkflowOption[];
+  codeProjects: CodeProjectBinding[];
   developmentScan: DevelopmentScan;
   developmentScanLoading: boolean;
   commentsRevision: number;
@@ -179,6 +181,7 @@ export function TaskDetail({
   currentUser,
   availableLabels,
   workflows,
+  codeProjects,
   developmentScan,
   developmentScanLoading,
   commentsRevision,
@@ -224,6 +227,8 @@ export function TaskDetail({
   const commentAttachmentInputRef = useRef<HTMLInputElement>(null);
   const workflowAvailable = !currentTask.workflowId
     || workflows.some((workflow) => workflow.id === currentTask.workflowId);
+  const codeProjectAvailable = !currentTask.codeProject
+    || codeProjects.some((project) => project.id === currentTask.codeProject?.id);
 
   useEffect(() => {
     setCurrentTask(task);
@@ -1018,6 +1023,29 @@ export function TaskDetail({
                 ))}
               </select>
             </label>
+            {currentTask.projectId === "local" && <label className="detail-property-row development-property">
+              <span className="detail-property-icon" aria-hidden="true">
+                <LinearIcon name="folder" />
+              </span>
+              <span className="detail-property-label">代码项目</span>
+              <select
+                aria-label="代码项目"
+                value={currentTask.codeProject?.id ?? ""}
+                disabled={savingProperty === "codeProject"}
+                onChange={(event) => {
+                  const codeProject = codeProjects.find((project) => project.id === event.target.value) ?? null;
+                  void saveTask({ codeProject, developmentContext: null }, "codeProject");
+                }}
+              >
+                <option value="">未绑定</option>
+                {!codeProjectAvailable && currentTask.codeProject && (
+                  <option value={currentTask.codeProject.id}>{currentTask.codeProject.name}（当前 Codex 未找到）</option>
+                )}
+                {codeProjects.map((project) => (
+                  <option value={project.id} key={project.id}>{project.name}</option>
+                ))}
+              </select>
+            </label>}
             <label className="detail-property-row development-property">
               <span className="detail-property-icon" aria-hidden="true">
                 <LinearIcon name="branch" />
@@ -1025,13 +1053,21 @@ export function TaskDetail({
               <span className="detail-property-label">开发上下文</span>
               <select
                 value={contextValue(currentTask.developmentContext)}
-                disabled={developmentScanLoading || savingProperty === "developmentContext"}
+                disabled={
+                  developmentScanLoading
+                  || savingProperty === "developmentContext"
+                  || (currentTask.projectId === "local" && !currentTask.codeProject)
+                }
                 title={currentTask.developmentContext?.type === "worktree" ? currentTask.developmentContext.path : undefined}
                 onChange={(event) => void saveTask({
                   developmentContext: event.target.value ? JSON.parse(event.target.value) as DevelopmentContext : null,
                 }, "developmentContext")}
               >
-                <option value="">{developmentScanLoading ? "正在扫描 Git…" : "未绑定"}</option>
+                <option value="">
+                  {currentTask.projectId === "local" && !currentTask.codeProject
+                    ? "请先选择代码项目"
+                    : developmentScanLoading ? "正在扫描 Git…" : "未绑定"}
+                </option>
                 <optgroup label="代码分支">
                   {developmentOptions.filter((context) => context.type === "branch").map((context) => (
                     <option value={contextValue(context)} key={contextValue(context)}>{contextLabel(context)}</option>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -26,6 +26,11 @@ export type DevelopmentContext =
   | { type: "branch"; branch: string }
   | { type: "worktree"; path: string; branch: string | null };
 
+export interface CodeProjectBinding {
+  id: string;
+  name: string;
+}
+
 export type Recurrence = {
   interval: number;
   unit: "day" | "week" | "month" | "year";
@@ -122,6 +127,7 @@ export interface Task {
   creatorAvatarUrl: string | null;
   assignee: ActorIdentity;
   workflowId: string | null;
+  codeProject?: CodeProjectBinding | null;
   developmentContext: DevelopmentContext | null;
   dueDate: string | null;
   recurrence: Recurrence | null;
@@ -176,6 +182,7 @@ export interface TaskDraft {
   labels: string[];
   assigneeTarget?: AssigneeTarget;
   workflowId: string | null;
+  codeProject?: CodeProjectBinding | null;
   developmentContext: DevelopmentContext | null;
   dueDate: string | null;
   recurrence: Recurrence | null;


### PR DESCRIPTION
## Summary

- Support the current Codex sidebar structure and renderer startup timing
- Allow each Local issue to bind an individual Codex project
- Scan branches and worktrees from the selected repository
- Open Codex conversations in the bound workspace
- Preserve existing unbound Local issues
- Keep machine-specific bindings out of cloud migration data

## Testing

- TypeScript typecheck
- Production frontend build
- Embedded Codex UI verification
- Local API CRUD integration
- 94 focused regression tests