### PR TITLE
fix: improve dark mode select contrast

### DIFF
--- a/test/board-interactions.test.mjs
+++ b/test/board-interactions.test.mjs
@@ -64,6 +64,12 @@ test("scrollbars stay proportional while the workflow node library hides its bar
   assert.match(styles, /\.workflow-node-groups::\-webkit-scrollbar \{[\s\S]*?display: none;[\s\S]*?width: 0;[\s\S]*?height: 0/);
 });
 
+test("native select options remain readable in dark theme", () => {
+  assert.match(styles, /:root\[data-theme="dark"\] select \{[\s\S]*?color-scheme: dark/);
+  assert.match(styles, /:root\[data-theme="dark"\] select option \{[\s\S]*?background-color: var\(--surface-raised\);[\s\S]*?color: var\(--text-primary\)/);
+  assert.match(styles, /:root\[data-theme="dark"\] select option:checked \{[\s\S]*?background-color: var\(--surface-active\)/);
+});
+
 test("each status column remains a drop target for the full board height", () => {
   assert.match(styles, /\.board \{[\s\S]*?align-items: stretch;[\s\S]*?height: 100%/);
   assert.match(styles, /\.board-column \{[\s\S]*?display: flex;[\s\S]*?flex-direction: column;[\s\S]*?height: 100%/);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -164,6 +164,19 @@ select {
   cursor: pointer;
 }
 
+:root[data-theme="dark"] select {
+  color-scheme: dark;
+}
+
+:root[data-theme="dark"] select option {
+  background-color: var(--surface-raised);
+  color: var(--text-primary);
+}
+
+:root[data-theme="dark"] select option:checked {
+  background-color: var(--surface-active);
+}
+
 button:disabled,
 select:disabled {
   cursor: not-allowed;


### PR DESCRIPTION
## Summary

- fix unreadable native `select` options in dark mode
- apply the dark theme color scheme to select controls and option popovers
- use the raised surface/text tokens for option and checked-option contrast
- add a regression test for the dark select styles

Related issue: xianjianlf2/dashi-taskboard#1

## Verification

- `npm run typecheck` ✅
- `npm run build:web` ✅
- targeted dark select test ✅
- `npm test` ⚠️ baseline currently has 18 unrelated failures in existing AI/chat, cloud, workflow, and comment assertions