### PR TITLE
fix: prevent unintended issue dialog dismissal

### DIFF
--- a/web/src/components/TaskEditor.tsx
+++ b/web/src/components/TaskEditor.tsx
@@ -113,6 +113,7 @@ export function TaskEditor({
   onSave,
 }: TaskEditorProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const openedAtRef = useRef(0);
   const titleRef = useRef<HTMLInputElement>(null);
   const attachmentInputRef = useRef<HTMLInputElement>(null);
   const [title, setTitle] = useState(task?.title ?? "");
@@ -151,6 +152,7 @@ export function TaskEditor({
     ));
 
   useEffect(() => {
+    openedAtRef.current = performance.now();
     dialogRef.current?.showModal();
     titleRef.current?.focus();
     return () => {
@@ -231,8 +233,12 @@ export function TaskEditor({
         event.preventDefault();
         if (!saving) onCancel();
       }}
-      onClick={(event) => {
-        if (event.target === event.currentTarget && !saving) onCancel();
+      onMouseDown={(event) => {
+        if (
+          performance.now() - openedAtRef.current >= 250
+          && event.target === event.currentTarget
+          && !saving
+        ) onCancel();
       }}
     >
       <form className="task-form" onSubmit={handleSubmit}>


### PR DESCRIPTION
## Summary

- record when the native issue editor dialog opens and ignore backdrop presses during the first 250ms
- handle backdrop dismissal on `mousedown` so text-selection drags that end outside the dialog do not close the editor
- preserve deliberate backdrop dismissal, the close button, and the existing cancel path

## Verification

- `npm run typecheck` ✅
- `npm run build:web` ✅
- `git diff --check` ✅
- local browser verification ✅
  - rapid double-clicking **New issue** keeps the dialog open
  - dragging title text outside the dialog keeps the dialog and entered text intact
  - dragging description text outside the dialog keeps the dialog and entered text intact
  - a deliberate backdrop press after 250ms still closes the dialog
  - the close button still closes the dialog

## Test suite note

- `npm test` still reports existing failures in unrelated AI, Cloud, Workflow, Comment, and automation assertions
- `node --test test/board-interactions.test.mjs` reports 13 passing checks and one existing unrelated comment-attachment assertion failure
- this PR changes only `web/src/components/TaskEditor.tsx`

Closes #6
