### PR TITLE
feat: add a global Codex session board

### DIFF
--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -1,7 +1,7 @@
 (() => {
   "use strict";
 
-  const VERSION = "0.6.8";
+  const VERSION = "0.7.1";
   const SOURCE_HASH = window.__CODEX_TASKBOARD_SOURCE_HASH__;
   const SENTINEL_KEY = "__codexTaskboardInjection__";
   const DEFAULT_TASKBOARD_URL = "http://127.0.0.1:47823/?host=codex";
@@ -25,6 +25,7 @@
   const HOST_HEARTBEAT_MAX_AGE_MS = 8_000;
   const MACOS_TITLEBAR_SAFE_LEFT = 80;
   const FRAME_REFRESH_PARAM = "__codex_taskboard_refresh";
+  const PROJECT_CATALOG_CACHE_KEY = "codex.taskboard-project-catalog";
   const PLUGIN_LABELS = ["插件", "plugins"];
   const NATIVE_PAGE_LABELS = [
     "新建任务",
@@ -73,6 +74,7 @@
   let lastNativeThreadId = "";
   let active = false;
   let destroyed = false;
+  let projectCatalogSnapshot = readStoredProjectCatalog();
 
   function normalizedLabel(value) {
     return String(value || "").replace(/\s+/g, " ").trim().toLowerCase();
@@ -385,7 +387,54 @@
       || null;
   }
 
+  function readStoredProjectCatalog() {
+    try {
+      const projects = JSON.parse(window.localStorage.getItem(PROJECT_CATALOG_CACHE_KEY) || "[]");
+      return Array.isArray(projects) ? projects : [];
+    } catch (_) {
+      return [];
+    }
+  }
+
+  function readProjectIndexRow(row) {
+    const fiberKey = Object.keys(row).find((key) => key.startsWith("__reactFiber"));
+    let fiber = fiberKey ? row[fiberKey] : null;
+    for (let depth = 0; fiber && depth < 10; depth += 1, fiber = fiber.return) {
+      const project = fiber.memoizedProps?.row;
+      if (!project?.projectId || !project?.name) continue;
+      const group = project.group && typeof project.group === "object" ? project.group : {};
+      return {
+        id: String(project.projectId),
+        name: String(project.name),
+        workspacePath: typeof group.path === "string"
+          ? group.path
+          : Array.isArray(group.rootPaths) && typeof group.rootPaths[0] === "string"
+            ? group.rootPaths[0]
+            : "",
+        threadIds: [...new Set([
+          ...(Array.isArray(group.threadKeys) ? group.threadKeys : []),
+          ...(Array.isArray(project.recentThreadKeys) ? project.recentThreadKeys : []),
+        ].map(normalizeThreadId).filter(Boolean))],
+      };
+    }
+    return null;
+  }
+
+  function readProjectCatalog() {
+    const container = document.querySelector("[data-projects-rows]");
+    if (!container) return projectCatalogSnapshot;
+    projectCatalogSnapshot = Array.from(container.querySelectorAll("[data-project-row]"))
+      .map(readProjectIndexRow)
+      .filter(Boolean);
+    try {
+      window.localStorage.setItem(PROJECT_CATALOG_CACHE_KEY, JSON.stringify(projectCatalogSnapshot));
+    } catch (_) {}
+    return projectCatalogSnapshot;
+  }
+
   function readCodexProjects() {
+    const catalog = readProjectCatalog();
+    if (catalog.length > 0) return catalog;
     const seen = new Set();
     return Array.from(document.querySelectorAll("[data-app-action-sidebar-project-row]"))
       .flatMap((row) => {
@@ -399,6 +448,97 @@
         seen.add(id);
         return [{ id, name }];
       });
+  }
+
+  function readThreadRowState(row) {
+    const fiberKey = Object.keys(row).find((key) => key.startsWith("__reactFiber"));
+    let fiber = fiberKey ? row[fiberKey] : null;
+    let statusState = null;
+    let pendingApproval = false;
+    let projectId = "";
+    let projectName = "";
+    let conversationId = "";
+    let workspacePath = "";
+    for (let depth = 0; fiber && depth < 10; depth += 1, fiber = fiber.return) {
+      const props = fiber.memoizedProps;
+      if (!props || typeof props !== "object") continue;
+      if (!statusState && props.statusState && typeof props.statusState === "object") {
+        statusState = props.statusState;
+      }
+      pendingApproval ||= props.hasPendingChildApproval === true;
+      if (!projectId && typeof props.hoverCardProjectId === "string") {
+        projectId = props.hoverCardProjectId.trim();
+      }
+      if (!projectName && typeof props.hoverCardProjectLabel === "string") {
+        projectName = props.hoverCardProjectLabel.trim();
+      }
+      if (!conversationId && typeof props.conversationId === "string") {
+        conversationId = normalizeThreadId(props.conversationId);
+      }
+      if (!workspacePath && typeof props.displayCwd === "string") {
+        workspacePath = props.displayCwd.trim();
+      }
+    }
+    return { statusState, pendingApproval, projectId, projectName, conversationId, workspacePath };
+  }
+
+  function taskStatusForThreadRow(row, state) {
+    const type = normalizedLabel(state.statusState?.type);
+    if (state.pendingApproval || type.includes("approval")) return "in_review";
+    if (type.includes("response") || type.includes("input") || type.includes("waiting")) return "todo";
+    if (type.includes("error") || type.includes("failed")) return "blocked";
+    if (type.includes("cancel") || type.includes("interrupt")) return "canceled";
+    if (type === "loading" || type === "running" || row.querySelector(".animate-spin")) {
+      return "in_progress";
+    }
+    if (state.statusState?.unread === true || Number(state.statusState?.unreadCount) > 0) {
+      return "in_review";
+    }
+    return "done";
+  }
+
+  function readCodexSessions() {
+    const sessions = new Map();
+    const statusPriority = {
+      done: 0,
+      canceled: 1,
+      blocked: 2,
+      in_review: 3,
+      todo: 4,
+      in_progress: 5,
+    };
+    for (const row of document.querySelectorAll("[data-app-action-sidebar-thread-id]")) {
+      const state = readThreadRowState(row);
+      const id = state.conversationId
+        || normalizeThreadId(row.getAttribute("data-app-action-sidebar-thread-id"));
+      const title = row.getAttribute("data-app-action-sidebar-thread-title")?.trim()
+        || row.getAttribute("aria-label")?.trim()
+        || row.textContent?.replace(/\s+/g, " ").trim()
+        || "未命名会话";
+      if (!id || id.startsWith("client-new-thread:")) continue;
+      const projectList = row.closest("[data-app-action-sidebar-project-list-id]");
+      const status = taskStatusForThreadRow(row, state);
+      const session = {
+        id,
+        title,
+        status,
+        nativeStatus: typeof state.statusState?.type === "string" ? state.statusState.type : "unknown",
+        unread: state.statusState?.unread === true || Number(state.statusState?.unreadCount) > 0,
+        pinned: row.getAttribute("data-app-action-sidebar-thread-pinned") === "true",
+        projectId: state.projectId
+          || projectList?.getAttribute("data-app-action-sidebar-project-list-id")
+          || "",
+        projectName: state.projectName,
+        cwd: state.workspacePath,
+      };
+      const existing = sessions.get(id);
+      if (!existing || statusPriority[status] > statusPriority[existing.status]) {
+        sessions.set(id, { ...existing, ...session });
+      } else if (!existing.projectId && session.projectId) {
+        sessions.set(id, { ...existing, projectId: session.projectId, projectName: session.projectName });
+      }
+    }
+    return [...sessions.values()];
   }
 
   function findProjectsSection() {
@@ -539,6 +679,7 @@
     const payload = {
       theme: currentTheme(),
       projects,
+      sessions: readCodexSessions(),
       user: readCodexUser() ?? undefined,
       titlebarLeftInset: titlebarLeftInset(),
       sidebarCollapsed: nativeSidebarCollapsed(),
@@ -1185,6 +1326,7 @@
     if (destroyed || reattachTimer !== null) return;
     reattachTimer = window.setTimeout(() => {
       reattachTimer = null;
+      readProjectCatalog();
       ensureEntry();
       mountActivePage();
       postHostContext();
@@ -1192,6 +1334,7 @@
   }
 
   function refresh() {
+    readProjectCatalog();
     ensureEntry();
     mountActivePage();
     postHostContext();

--- a/scripts/codex-rate-limits.mjs
+++ b/scripts/codex-rate-limits.mjs
@@ -6,7 +6,7 @@ const REQUEST_TIMEOUT_MS = 8_000;
 export async function readCodexQuotaStatus(model) {
   const checkedAt = Date.now();
   try {
-    const session = startAppServer();
+    const session = startCodexAppServer();
     try {
       await session.request("initialize", {
         clientInfo: { name: "codex-taskboard", version: "0.1.0" },
@@ -29,8 +29,8 @@ export async function readCodexQuotaStatus(model) {
   }
 }
 
-function startAppServer() {
-  const child = spawn("codex", ["app-server", "--stdio"], {
+export function startCodexAppServer(codexExecutable = "codex") {
+  const child = spawn(codexExecutable, ["app-server", "--stdio"], {
     stdio: ["pipe", "pipe", "ignore"],
   });
   const pending = new Map();

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -18,6 +18,7 @@ import {
 import { normalizeWorkflowSnapshot } from "../shared/workflow-control-flow.mjs";
 import { AiChatService } from "./ai-chat.mjs";
 import { createCloudConfigStore } from "./cloud-config.mjs";
+import { CodexSessionCatalog } from "./codex-sessions.mjs";
 import {
   CloudProxyError,
   createCloudProxy,
@@ -1332,6 +1333,7 @@ export function createTaskboardServer(options = {}) {
     codexStatePath: resolved.codexStatePath,
     manageTaskboardSkillPath: resolved.skillPath,
   });
+  const codexSessions = new CodexSessionCatalog(resolved.codexExecutable);
   const aiEventResponses = new Set();
 
   const server = createServer(async (request, response) => {
@@ -1401,6 +1403,12 @@ export function createTaskboardServer(options = {}) {
           return sendJson(response, 200, { mode: "local", authenticated: false });
         }
         return methodNotAllowed(response, ["GET", "PUT", "DELETE"]);
+      }
+
+      if (pathname === "/api/local/codex/sessions") {
+        if (request.method !== "GET") return methodNotAllowed(response, ["GET"]);
+        assertNoQuery(url.searchParams, "GET /api/local/codex/sessions");
+        return sendJson(response, 200, { sessions: await codexSessions.list() });
       }
 
       const projectMappingRoute = pathname.match(/^\/api\/local\/project-mappings\/([^/]+)$/);
@@ -2079,6 +2087,7 @@ export function createTaskboardServer(options = {}) {
       for (const response of aiEventResponses) response.end();
       aiEventResponses.clear();
       await aiChat.close();
+      codexSessions.close();
       await serverClosed;
       listening = false;
       database.close();

--- a/server/codex-sessions.mjs
+++ b/server/codex-sessions.mjs
@@ -1,0 +1,104 @@
+import { startCodexAppServer } from "../scripts/codex-rate-limits.mjs";
+
+const PAGE_SIZE = 100;
+
+export function taskStatusForCodexThread(status) {
+  if (status?.type === "active") {
+    if (status.activeFlags?.includes("waitingOnApproval")) return "in_review";
+    if (status.activeFlags?.includes("waitingOnUserInput")) return "todo";
+    return "in_progress";
+  }
+  if (status?.type === "systemError") return "blocked";
+  return "done";
+}
+
+function normalizeThread(thread) {
+  const title = typeof thread?.name === "string" && thread.name.trim()
+    ? thread.name.trim()
+    : String(thread?.preview ?? "").split("\n", 1)[0].trim() || "未命名会话";
+  return {
+    id: String(thread.id),
+    title,
+    cwd: typeof thread.cwd === "string" ? thread.cwd : "",
+    status: taskStatusForCodexThread(thread.status),
+    nativeStatus: thread.status?.type ?? "notLoaded",
+    activeFlags: Array.isArray(thread.status?.activeFlags) ? thread.status.activeFlags : [],
+    pinned: thread.isPinned === true,
+    createdAt: Number(thread.createdAt) || 0,
+    updatedAt: Number(thread.recencyAt ?? thread.updatedAt) || 0,
+  };
+}
+
+export class CodexSessionCatalog {
+  constructor(codexExecutable = "codex") {
+    this.codexExecutable = codexExecutable;
+    this.client = null;
+    this.connecting = null;
+    this.pendingList = null;
+  }
+
+  async list() {
+    if (this.pendingList) return this.pendingList;
+    this.pendingList = this.#list().finally(() => {
+      this.pendingList = null;
+    });
+    return this.pendingList;
+  }
+
+  async #list() {
+    const client = await this.#client();
+    const threads = [];
+    let cursor = null;
+    do {
+      let result;
+      try {
+        result = await client.request("thread/list", {
+          cursor,
+          limit: PAGE_SIZE,
+          sortKey: "updated_at",
+          sortDirection: "desc",
+          archived: false,
+          useStateDbOnly: true,
+        });
+      } catch (error) {
+        this.#reset();
+        throw error;
+      }
+      threads.push(...(Array.isArray(result?.data) ? result.data : []));
+      cursor = typeof result?.nextCursor === "string" ? result.nextCursor : null;
+    } while (cursor);
+    return threads.filter((thread) => thread?.id).map(normalizeThread);
+  }
+
+  async #client() {
+    if (this.client) return this.client;
+    if (!this.connecting) {
+      this.connecting = (async () => {
+        const client = startCodexAppServer(this.codexExecutable);
+        try {
+          await client.request("initialize", {
+            clientInfo: { name: "codex-taskboard", version: "0.1.0" },
+          });
+          client.notify("initialized", {});
+          this.client = client;
+          return client;
+        } catch (error) {
+          client.close();
+          throw error;
+        } finally {
+          this.connecting = null;
+        }
+      })();
+    }
+    return this.connecting;
+  }
+
+  #reset() {
+    this.client?.close();
+    this.client = null;
+  }
+
+  close() {
+    this.#reset();
+  }
+}

--- a/test/codex-sessions.test.mjs
+++ b/test/codex-sessions.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { taskStatusForCodexThread } from "../server/codex-sessions.mjs";
+
+test("Codex thread states map to taskboard columns", () => {
+  assert.equal(taskStatusForCodexThread({ type: "active", activeFlags: [] }), "in_progress");
+  assert.equal(taskStatusForCodexThread({ type: "active", activeFlags: ["waitingOnUserInput"] }), "todo");
+  assert.equal(taskStatusForCodexThread({ type: "active", activeFlags: ["waitingOnApproval"] }), "in_review");
+  assert.equal(taskStatusForCodexThread({ type: "systemError" }), "blocked");
+  assert.equal(taskStatusForCodexThread({ type: "idle" }), "done");
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -44,6 +44,7 @@ import {
 } from "./actors";
 import { BoardColumn, STATUS_DETAILS } from "./components/BoardColumn";
 import { AiChat } from "./components/AiChat";
+import { CodexSessionBoard } from "./components/CodexSessionBoard";
 import { BoardSettingsMenu } from "./components/BoardSettingsMenu";
 import { HiddenColumns } from "./components/HiddenColumns";
 import {
@@ -542,7 +543,6 @@ export function App() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [selectedProjectId, setSelectedProjectId] = useState("");
   const [tasks, setTasks] = useState<Task[]>([]);
-  const [projectsLoading, setProjectsLoading] = useState(true);
   const [tasksLoading, setTasksLoading] = useState(false);
   const [hasLoadedTasks, setHasLoadedTasks] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -696,14 +696,6 @@ export function App() {
       Number(favoriteProjectIds.has(right.id)) - Number(favoriteProjectIds.has(left.id))
     ));
   }, [favoriteProjectIds, hostContext?.projects, projects]);
-  const projectsWithIssues = useMemo(
-    () => projectChoices.filter((project) => project.issueCount > 0),
-    [projectChoices],
-  );
-  const projectsWithoutIssues = useMemo(
-    () => projectChoices.filter((project) => project.issueCount === 0),
-    [projectChoices],
-  );
   const closeContextMenu = useCallback(() => setContextMenu(null), []);
 
   const writeProjectAutomation = useCallback((
@@ -1066,7 +1058,6 @@ export function App() {
   }, [detailTaskId, embedded, selectedProjectId]);
 
   const loadProjectList = useCallback(async (signal?: AbortSignal) => {
-    setProjectsLoading(true);
     setLoadError(null);
     try {
       const [nextProjects, metadata, workspaces] = await Promise.all([
@@ -1095,16 +1086,12 @@ export function App() {
       setProjects(nextProjects);
       setSelectedProjectId((current) => {
         const fromQuery = new URLSearchParams(window.location.search).get("project");
-        const remembered = window.localStorage.getItem(LAST_PROJECT_KEY);
         if (fromQuery && nextProjects.some((project) => project.id === fromQuery)) return fromQuery;
         if (current && nextProjects.some((project) => project.id === current)) return current;
-        if (remembered && nextProjects.some((project) => project.id === remembered)) return remembered;
         return "";
       });
     } catch (error) {
       if ((error as Error).name !== "AbortError") setLoadError(errorMessage(error));
-    } finally {
-      setProjectsLoading(false);
     }
   }, []);
 
@@ -2014,7 +2001,27 @@ export function App() {
           </div>
           </header>
         ) : (
-          <div ref={dragRegionRef} className="home-window-drag-region" aria-hidden="true" />
+          <header className="workspace-header">
+            <div className="workspace-title">
+              <div className="workspace-kicker">
+                {embedded && hostContext?.sidebarCollapsed && (
+                  <button
+                    className="detail-back-button codex-sidebar-expand-button"
+                    type="button"
+                    aria-label="展开 Codex 侧边栏"
+                    title="展开侧边栏"
+                    onClick={expandCodexSidebar}
+                  >
+                    <LinearIcon name="codexSidebarExpand" />
+                  </button>
+                )}
+                <span className="project-avatar" aria-hidden="true"><LinearIcon name="myIssues" /></span>
+                <span className="project-name">全部 Codex 会话</span>
+              </div>
+            </div>
+            <div ref={dragRegionRef} className="workspace-drag-region" aria-hidden="true" />
+            <div className="header-actions" />
+          </header>
         )}
 
         {selectedProjectId && !detailTask && <div className="board-toolbar">
@@ -2094,83 +2101,17 @@ export function App() {
         )}
 
         {!selectedProjectId ? (
-          <section className="project-home">
-            <div className="project-home-heading">
-              <span>任务面板</span>
-              <h1>选择项目</h1>
-              <p>从 Codex 项目开始，或继续使用之前保存的项目。</p>
-            </div>
-            {projectsLoading ? (
-              <div className="project-grid project-grid-loading" aria-label="正在加载项目" aria-busy="true">
-                <span /><span /><span />
-              </div>
-            ) : projectChoices.length > 0 ? (
-              <div className="project-home-groups">
-                {[
-                  { id: "with-issues", title: "已有议题", projects: projectsWithIssues },
-                  { id: "without-issues", title: "尚未添加议题", projects: projectsWithoutIssues },
-                ].map((group) => (
-                  <section className="project-home-group" key={group.id} aria-labelledby={`project-group-${group.id}`}>
-                    <div className="project-group-heading">
-                      <h2 id={`project-group-${group.id}`}>{group.title}</h2>
-                      <span>{group.projects.length}</span>
-                    </div>
-                    {group.projects.length > 0 ? (
-                      <div className="project-grid">
-                        {group.projects.map((project) => (
-                          <div className="project-card" key={project.id}>
-                            <button
-                              className="project-card-open"
-                              type="button"
-                              disabled={openingProjectId !== null}
-                              onClick={() => void selectProject(project)}
-                            >
-                              <span className="project-card-avatar" aria-hidden="true">
-                                {project.name.slice(0, 1).toUpperCase()}
-                              </span>
-                              <span className="project-card-copy">
-                                <strong>{project.name}</strong>
-                                <span>
-                                  {project.inCodex ? "Codex 项目" : "已保存的项目"}
-                                  {project.issueCount > 0 ? ` · ${project.issueCount} 个议题` : ""}
-                                </span>
-                              </span>
-                              {favoriteProjectIds.has(project.id) && <span className="project-card-favorite" aria-label="已收藏"><LinearIcon name="favorite" /></span>}
-                              <span className="project-card-action" aria-hidden="true">
-                                {openingProjectId === project.id ? "正在打开…" : <LinearIcon name="chevronRight" />}
-                              </span>
-                            </button>
-                            <label className="project-card-directory">
-                              <LinearIcon name="folder" />
-                              <input
-                                key={deviceWorkspacePaths[project.id] ?? ""}
-                                type="text"
-                                defaultValue={deviceWorkspacePaths[project.id] ?? ""}
-                                placeholder="设置此设备的项目目录"
-                                aria-label={`${project.name} 在此设备上的项目目录`}
-                                onBlur={(event) => rememberDeviceWorkspacePath(project.id, event.currentTarget.value)}
-                                onKeyDown={(event) => {
-                                  if (event.key === "Enter") event.currentTarget.blur();
-                                }}
-                              />
-                            </label>
-                          </div>
-                        ))}
-                      </div>
-                    ) : (
-                      <p className="project-group-empty">暂无项目</p>
-                    )}
-                  </section>
-                ))}
-              </div>
-            ) : (
-              <div className="project-home-empty">
-                <span className="empty-orbit" aria-hidden="true"><i /><i /></span>
-                <h2>还没有项目</h2>
-                <p>在 Codex 中创建项目后，再打开任务面板。</p>
-              </div>
-            )}
-          </section>
+          <CodexSessionBoard
+            liveSessions={hostContext?.sessions ?? []}
+            projects={projects}
+            codexProjects={hostContext?.projects ?? []}
+            deviceWorkspacePaths={deviceWorkspacePaths}
+            onOpenThread={openThread}
+            onOpenProject={(projectId) => {
+              const project = projectChoices.find((candidate) => candidate.id === projectId);
+              if (project) void selectProject(project);
+            }}
+          />
         ) : detailTask && selectedProject ? (
           <TaskDetail
             key={detailTask.id}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -8,6 +8,7 @@ import type {
   AiChatThreadSnapshot,
   Attachment,
   Comment,
+  CodexSession,
   DevelopmentScan,
   IssueRelationType,
   Project,
@@ -87,6 +88,11 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 export async function listProjects(signal?: AbortSignal): Promise<Project[]> {
   const data = await request<{ projects: Project[] }>("/api/projects", { signal });
   return data.projects;
+}
+
+export async function listCodexSessions(signal?: AbortSignal): Promise<CodexSession[]> {
+  const data = await request<{ sessions: CodexSession[] }>("/api/local/codex/sessions", { signal });
+  return data.sessions;
 }
 
 export async function getTaskboardMetadata(signal?: AbortSignal): Promise<TaskboardMetadata> {

--- a/web/src/components/CodexSessionBoard.tsx
+++ b/web/src/components/CodexSessionBoard.tsx
@@ -189,13 +189,17 @@ export function CodexSessionBoard({
                   <div className="column-list">
                     {sessionsByStatus[status].map((session) => (
                       <article className="task-card session-card" key={session.id}>
-                        <button className="session-card-open" type="button" onClick={() => onOpenThread(session.id)}>
-                          <span className="session-card-id">{session.id.slice(0, 8)}</span>
-                          <strong>{session.title}</strong>
-                        </button>
+                        <button
+                          className="task-card-open"
+                          type="button"
+                          aria-label={`打开会话：${session.title}`}
+                          onClick={() => onOpenThread(session.id)}
+                        />
+                        <span className="session-card-id">{session.id.slice(0, 8)}</span>
+                        <strong className="session-card-title">{session.title}</strong>
                         <span className="session-card-meta">
                           {session.projectId ? (
-                            <button className="session-project-link" type="button" onClick={() => onOpenProject(session.projectId)}>{session.projectName}</button>
+                            <button className="session-project-link thread-link" type="button" onClick={() => onOpenProject(session.projectId)}>{session.projectName}</button>
                           ) : <span>{session.projectName}</span>}
                           <span>{formatUpdatedAt(session.updatedAt)}</span>
                         </span>

--- a/web/src/components/CodexSessionBoard.tsx
+++ b/web/src/components/CodexSessionBoard.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useMemo, useState } from "react";
+import { listCodexSessions } from "../api";
+import {
+  TASK_STATUSES,
+  type CodexLiveSession,
+  type CodexProject,
+  type CodexSession,
+  type Project,
+  type TaskStatus,
+} from "../types";
+import { STATUS_DETAILS, StatusIcon } from "./BoardColumn";
+import { LinearIcon } from "./LinearIcon";
+
+interface SessionProject {
+  id: string;
+  name: string;
+  workspacePath: string;
+  threadIds: string[];
+}
+
+interface DisplaySession extends CodexSession {
+  projectId: string;
+  projectName: string;
+  unread: boolean;
+}
+
+interface CodexSessionBoardProps {
+  liveSessions: CodexLiveSession[];
+  projects: Project[];
+  codexProjects: CodexProject[];
+  deviceWorkspacePaths: Record<string, string>;
+  onOpenThread: (threadId: string) => void;
+  onOpenProject: (projectId: string) => void;
+}
+
+function isInsideWorkspace(cwd: string, workspacePath: string) {
+  const path = workspacePath.replace(/\/+$/, "");
+  return cwd === path || cwd.startsWith(`${path}/`);
+}
+
+function projectForSession(session: CodexSession, projects: SessionProject[]) {
+  const explicit = projects.find((project) => project.threadIds.includes(session.id));
+  if (explicit) return explicit;
+  const mapped = projects
+    .filter((project) => project.workspacePath && isInsideWorkspace(session.cwd, project.workspacePath))
+    .sort((left, right) => right.workspacePath.length - left.workspacePath.length)[0];
+  if (mapped) return mapped;
+  const folder = session.cwd.replace(/\/+$/, "").split("/").filter(Boolean).pop()?.toLowerCase();
+  return folder ? projects.find((project) => project.name.toLowerCase() === folder) : undefined;
+}
+
+function formatUpdatedAt(timestamp: number) {
+  if (!timestamp) return "";
+  return new Intl.DateTimeFormat("zh-CN", {
+    month: "numeric",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(timestamp * 1000));
+}
+
+export function CodexSessionBoard({
+  liveSessions,
+  projects,
+  codexProjects,
+  deviceWorkspacePaths,
+  onOpenThread,
+  onOpenProject,
+}: CodexSessionBoardProps) {
+  const [sessions, setSessions] = useState<CodexSession[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [search, setSearch] = useState("");
+  const [projectFilter, setProjectFilter] = useState("");
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function refresh() {
+      try {
+        setSessions(await listCodexSessions(controller.signal));
+        setError("");
+      } catch (cause) {
+        if ((cause as Error).name !== "AbortError") setError((cause as Error).message);
+      } finally {
+        setLoading(false);
+      }
+    }
+    void refresh();
+    const interval = window.setInterval(() => void refresh(), 10_000);
+    return () => {
+      controller.abort();
+      window.clearInterval(interval);
+    };
+  }, []);
+
+  const sessionProjects = useMemo<SessionProject[]>(() => {
+    const persisted = new Map(projects.map((project) => [project.id, project]));
+    return codexProjects.map((project) => ({
+      ...project,
+      name: persisted.get(project.id)?.name ?? project.name,
+      workspacePath: project.workspacePath
+        ?? deviceWorkspacePaths[project.id]
+        ?? persisted.get(project.id)?.workspacePath
+        ?? "",
+      threadIds: project.threadIds ?? [],
+    }));
+  }, [codexProjects, deviceWorkspacePaths, projects]);
+
+  const displaySessions = useMemo<DisplaySession[]>(() => {
+    const byId = new Map(sessions.map((session) => [session.id, session]));
+    for (const live of liveSessions) {
+      const stored = byId.get(live.id);
+      byId.set(live.id, {
+        id: live.id,
+        title: live.title || stored?.title || "未命名会话",
+        cwd: stored?.cwd || live.cwd || "",
+        status: live.status,
+        nativeStatus: live.nativeStatus,
+        activeFlags: stored?.activeFlags ?? [],
+        pinned: live.pinned || stored?.pinned === true,
+        createdAt: stored?.createdAt ?? 0,
+        updatedAt: stored?.updatedAt ?? 0,
+      });
+    }
+    return [...byId.values()].map((session) => {
+      const live = liveSessions.find((candidate) => candidate.id === session.id);
+      const project = sessionProjects.find((candidate) => candidate.id === live?.projectId)
+        ?? projectForSession(session, sessionProjects);
+      return {
+        ...session,
+        projectId: project?.id ?? "",
+        projectName: project?.name ?? "未归类",
+        unread: live?.unread === true,
+      };
+    }).sort((left, right) => right.updatedAt - left.updatedAt);
+  }, [liveSessions, sessionProjects, sessions]);
+
+  const projectOptions = sessionProjects.map((project) => ({ id: project.id, name: project.name }));
+  const normalizedSearch = search.trim().toLowerCase();
+  const filteredSessions = displaySessions.filter((session) => (
+    (!projectFilter || session.projectId === projectFilter)
+    && (!normalizedSearch || `${session.title} ${session.projectName}`.toLowerCase().includes(normalizedSearch))
+  ));
+  const sessionsByStatus = Object.fromEntries(TASK_STATUSES.map((status) => [
+    status,
+    filteredSessions.filter((session) => session.status === status),
+  ])) as Record<TaskStatus, DisplaySession[]>;
+  const visibleStatuses = TASK_STATUSES.filter((status) => sessionsByStatus[status].length > 0);
+
+  return (
+    <>
+      <div className="board-toolbar session-board-toolbar">
+        <div className="session-board-summary">
+          <strong>会话看板</strong>
+          <span>{displaySessions.length} 个 Codex 会话 · 按实时状态自动归类</span>
+        </div>
+        <div className="toolbar-tools">
+          <label className="session-project-filter">
+            <span className="sr-only">按项目筛选</span>
+            <select value={projectFilter} onChange={(event) => setProjectFilter(event.target.value)}>
+              <option value="">全部项目</option>
+              {projectOptions.map((project) => <option key={project.id} value={project.id}>{project.name}</option>)}
+            </select>
+          </label>
+          <label className={`search-field${search ? " has-value" : ""}`}>
+            <LinearIcon className="search-icon" name="search" />
+            <span className="sr-only">搜索会话</span>
+            <input type="search" value={search} onChange={(event) => setSearch(event.target.value)} placeholder="搜索会话…" />
+          </label>
+        </div>
+      </div>
+      {error && <div className="session-board-notice" role="alert">{error}</div>}
+      {loading && displaySessions.length === 0 ? (
+        <div className="workflow-board-loading">正在读取 Codex 会话…</div>
+      ) : (
+        <div className="board-scroll session-board-scroll" aria-label="Codex 会话看板">
+          <div className="board session-board">
+            {visibleStatuses.map((status) => {
+              const details = STATUS_DETAILS[status];
+              return (
+                <section className={`board-column status-${status}`} key={status}>
+                  <header className="column-header">
+                    <div className="column-heading">
+                      <span className={`status-icon status-icon-${details.tone}`}><StatusIcon status={status} /></span>
+                      <h2>{details.label}</h2>
+                      <span className="task-count">{sessionsByStatus[status].length}</span>
+                    </div>
+                  </header>
+                  <div className="column-list">
+                    {sessionsByStatus[status].map((session) => (
+                      <article className="task-card session-card" key={session.id}>
+                        <button className="session-card-open" type="button" onClick={() => onOpenThread(session.id)}>
+                          <span className="session-card-id">{session.id.slice(0, 8)}</span>
+                          <strong>{session.title}</strong>
+                        </button>
+                        <span className="session-card-meta">
+                          {session.projectId ? (
+                            <button className="session-project-link" type="button" onClick={() => onOpenProject(session.projectId)}>{session.projectName}</button>
+                          ) : <span>{session.projectName}</span>}
+                          <span>{formatUpdatedAt(session.updatedAt)}</span>
+                        </span>
+                      </article>
+                    ))}
+                  </div>
+                </section>
+              );
+            })}
+            {visibleStatuses.length === 0 && (
+              <section className="page-empty filter-empty board-filter-empty">
+                <h2>没有匹配的会话</h2>
+                <p>调整项目或搜索条件。</p>
+              </section>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1780,6 +1780,141 @@ kbd {
   gap: 8px;
 }
 
+.session-board-toolbar {
+  justify-content: space-between;
+}
+
+.session-board-summary {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.session-board-summary strong {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.session-board-summary span {
+  overflow: hidden;
+  color: var(--text-tertiary);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-project-filter select {
+  height: 30px;
+  padding: 0 28px 0 10px;
+  border: var(--border-hairline) solid var(--border);
+  border-radius: 6px;
+  outline: none;
+  background: var(--surface);
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 12px;
+}
+
+.session-project-filter select:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+.session-board-notice {
+  padding: 8px 16px;
+  border-bottom: var(--border-hairline) solid var(--border);
+  background: color-mix(in srgb, var(--status-blocked) 8%, var(--bg));
+  color: var(--status-blocked);
+  font-size: 12px;
+}
+
+.session-board .board-column {
+  flex-basis: 320px;
+  width: 320px;
+}
+
+.session-card {
+  min-height: 88px;
+  cursor: default;
+}
+
+.session-card-open {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 5px;
+  padding: 0;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+
+.session-card-open::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+}
+
+.session-card-open:focus-visible::after {
+  border-radius: 6px;
+  box-shadow: inset 0 0 0 2px var(--accent);
+}
+
+.session-card-id {
+  color: var(--text-tertiary);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+
+.session-card-open strong {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 550;
+  line-height: 18px;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.session-card-meta {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--text-tertiary);
+  font-size: 10px;
+}
+
+.session-project-link {
+  max-width: 70%;
+  padding: 2px 6px;
+  overflow: hidden;
+  border: 0;
+  border-radius: 4px;
+  background: var(--surface-active);
+  color: var(--text-secondary);
+  font: inherit;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-project-link:hover,
+.session-project-link:focus-visible {
+  color: var(--text-primary);
+  outline: 1px solid var(--border-strong);
+}
+
 .hidden-columns {
   flex: 0 0 280px;
   width: 280px;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1837,33 +1837,6 @@ kbd {
 
 .session-card {
   min-height: 88px;
-  cursor: default;
-}
-
-.session-card-open {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 5px;
-  padding: 0;
-  border: 0;
-  outline: none;
-  background: transparent;
-  color: inherit;
-  font: inherit;
-  text-align: left;
-}
-
-.session-card-open::after {
-  position: absolute;
-  inset: 0;
-  content: "";
-}
-
-.session-card-open:focus-visible::after {
-  border-radius: 6px;
-  box-shadow: inset 0 0 0 2px var(--accent);
 }
 
 .session-card-id {
@@ -1873,7 +1846,7 @@ kbd {
   letter-spacing: 0.02em;
 }
 
-.session-card-open strong {
+.session-card-title {
   display: -webkit-box;
   overflow: hidden;
   color: var(--text-primary);

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -250,9 +250,41 @@ export interface HostContext {
   threadId?: string;
   theme?: "light" | "dark";
   projectId?: string;
-  projects?: Array<{ id: string; name: string }>;
+  projects?: CodexProject[];
+  sessions?: CodexLiveSession[];
   titlebarLeftInset?: number;
   sidebarCollapsed?: boolean;
+}
+
+export interface CodexProject {
+  id: string;
+  name: string;
+  workspacePath?: string;
+  threadIds?: string[];
+}
+
+export interface CodexSession {
+  id: string;
+  title: string;
+  cwd: string;
+  status: TaskStatus;
+  nativeStatus: string;
+  activeFlags: string[];
+  pinned: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface CodexLiveSession {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  nativeStatus: string;
+  unread: boolean;
+  pinned: boolean;
+  projectId: string;
+  projectName: string;
+  cwd: string;
 }
 
 export interface TaskDraft {


### PR DESCRIPTION
## Product suggestion

Taskboard currently starts with a project picker and only becomes useful after the user enters a project. That model does not match how Codex users work across many concurrent chats: the useful top-level view is the set of Codex sessions and their live states, while projects are a classification and filtering dimension.

This PR proposes making the default Taskboard landing page a global Codex session board.

## What changed

- Show every local Codex session on the default board without requiring project selection.
- Combine the full historical session catalog from `codex app-server` with live renderer state from CDP.
- Automatically map active, waiting-for-input, waiting-for-approval, failed, unread, and completed sessions to board columns.
- Read the canonical Codex Projects index for project filtering instead of treating arbitrary working-directory names as projects.
- Keep project issue boards available as a secondary view from project badges.
- Resolve temporary `client-new-thread` rows to their real `conversationId`, so newly running chats are not omitted.

## User impact

Opening Taskboard immediately answers two questions: what is Codex working on now, and what needs attention? Project membership remains available, but it no longer blocks the global workflow view.

## Implementation notes

- A small local API exposes the paginated app-server thread catalog.
- The existing CDP injector publishes visible session state and the canonical Projects catalog to the embedded board.
- The existing MutationObserver drives live refreshes; no log-based status inference is used.
- The Projects snapshot is cached locally so the filter remains complete outside the Projects route.

The CDP layer currently reads renderer DOM and React props because Codex does not expose equivalent stable host APIs. If stable project/session-status APIs become available, this adapter can be replaced without changing the board component.

## Validation

- `npm run typecheck`
- `npm run build`
- `node --test test/codex-sessions.test.mjs`
- Manual validation in the Codex desktop app with multiple concurrent running sessions
- Manual validation that the project dropdown matches the Codex Projects index and filters sessions correctly
