### PR TITLE
fix: improve project and dropdown UI

### DIFF
--- a/server/app.mjs
+++ b/server/app.mjs
@@ -484,6 +484,34 @@ function parseProjectCreate(body) {
   return { id, name, workspacePath };
 }
 
+function isDirectoryPickerCancellation(error) {
+  const details = `${error?.message ?? ""} ${error?.stderr ?? ""}`.toLowerCase();
+  return error?.code === 1 && (details.includes("cancel") || details.includes("-128"));
+}
+
+async function chooseLocalDirectory() {
+  if (process.platform !== "darwin") {
+    throw new ApiError(
+      501,
+      "DIRECTORY_PICKER_UNSUPPORTED",
+      "当前系统暂不支持选择文件夹，请手动输入项目目录。",
+    );
+  }
+
+  try {
+    const { stdout } = await execFileAsync(
+      "/usr/bin/osascript",
+      ["-e", 'POSIX path of (choose folder with prompt "选择项目文件夹")'],
+      { maxBuffer: 16 * 1024, timeout: 120_000 },
+    );
+    const selectedPath = stdout.trim();
+    return selectedPath ? path.normalize(selectedPath) : null;
+  } catch (error) {
+    if (isDirectoryPickerCancellation(error)) return null;
+    throw new ApiError(500, "DIRECTORY_PICKER_FAILED", "无法打开文件夹选择器，请手动输入项目目录。");
+  }
+}
+
 function parseThreadId(value) {
   if (value === undefined) return undefined;
   return stringField(value, "threadId", { required: true, maxLength: 256 });
@@ -1401,6 +1429,12 @@ export function createTaskboardServer(options = {}) {
           return sendJson(response, 200, { mode: "local", authenticated: false });
         }
         return methodNotAllowed(response, ["GET", "PUT", "DELETE"]);
+      }
+
+      if (pathname === "/api/local/select-directory") {
+        if (request.method !== "POST") return methodNotAllowed(response, ["POST"]);
+        await assertEmptyRequestBody(request, "POST /api/local/select-directory");
+        return sendJson(response, 200, { workspacePath: await chooseLocalDirectory() });
       }
 
       const projectMappingRoute = pathname.match(/^\/api\/local\/project-mappings\/([^/]+)$/);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -34,6 +34,7 @@ import {
   moveTask as moveTaskRequest,
   removeTaskRelation,
   restoreTask as restoreTaskRequest,
+  selectLocalDirectory,
   setCurrentUserActor,
   uploadAttachment,
   updateTask as updateTaskRequest,
@@ -52,6 +53,7 @@ import {
 } from "./components/InlineMediaComposer";
 import { LinearIcon } from "./components/LinearIcon";
 import { ProjectAutomationMenu } from "./components/ProjectAutomationMenu";
+import { ProjectCreator } from "./components/ProjectCreator";
 import { TaskContextMenu } from "./components/TaskContextMenu";
 import { TaskDetail } from "./components/TaskDetail";
 import { TaskEditor } from "./components/TaskEditor";
@@ -365,6 +367,18 @@ function workspaceName(path?: string): string | null {
   return parts.at(-1) ?? path;
 }
 
+function projectIdFromName(name: string): string {
+  const slug = name
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+  if (slug) return slug;
+  return `project-${Date.now()}`;
+}
+
 function errorMessage(error: unknown): string {
   if (error instanceof ApiError) return error.message;
   if (error instanceof Error) return error.message;
@@ -554,6 +568,7 @@ export function App() {
   const [columnVisibilityByProject, setColumnVisibilityByProject] = useState(readColumnVisibilityByProject);
   const [boardView, setBoardView] = useState<BoardView>("issues");
   const [editor, setEditor] = useState<EditorState | null>(null);
+  const [projectCreatorOpen, setProjectCreatorOpen] = useState(false);
   const [detailTaskIdentifier, setDetailTaskIdentifier] = useState<string | null>(
     () => readIssueIdentifier(window.location.search),
   );
@@ -1746,6 +1761,18 @@ export function App() {
     window.history.replaceState(null, "", url);
   }
 
+  async function createProjectFromDialog(name: string, workspacePath: string) {
+    setActionError(null);
+    const project = await createProjectRequest({
+      id: projectIdFromName(name),
+      name,
+      workspacePath,
+    });
+    setProjects((current) => [...current, project]);
+    setProjectCreatorOpen(false);
+    changeProject(project.id);
+  }
+
   function returnToProjectHome() {
     closeContextMenu();
     setProjectMenuOpen(false);
@@ -2096,8 +2123,20 @@ export function App() {
         {!selectedProjectId ? (
           <section className="project-home">
             <div className="project-home-heading">
-              <span>任务面板</span>
-              <h1>选择项目</h1>
+              <div className="project-home-heading-row">
+                <div className="project-home-heading-copy">
+                  <span>任务面板</span>
+                  <h1>选择项目</h1>
+                </div>
+                <button
+                  className="button primary project-create-button"
+                  type="button"
+                  onClick={() => setProjectCreatorOpen(true)}
+                >
+                  <LinearIcon name="plus" />
+                  新建项目
+                </button>
+              </div>
               <p>从 Codex 项目开始，或继续使用之前保存的项目。</p>
             </div>
             {projectsLoading ? (
@@ -2298,6 +2337,14 @@ export function App() {
           developmentScanLoading={developmentScanLoading}
           onCancel={() => setEditor(null)}
           onSave={saveEditor}
+        />
+      )}
+
+      {projectCreatorOpen && (
+        <ProjectCreator
+          onCancel={() => setProjectCreatorOpen(false)}
+          onCreate={createProjectFromDialog}
+          onSelectDirectory={selectLocalDirectory}
         />
       )}
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -216,6 +216,13 @@ export async function listDeviceWorkspaces(signal?: AbortSignal): Promise<Record
   }
 }
 
+export async function selectLocalDirectory(): Promise<string | null> {
+  const data = await request<{ workspacePath: string | null }>("/api/local/select-directory", {
+    method: "POST",
+  });
+  return data.workspacePath;
+}
+
 export async function listWorkflowCapabilities(
   workspacePath?: string,
   signal?: AbortSignal,

--- a/web/src/components/ProjectCreator.tsx
+++ b/web/src/components/ProjectCreator.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useRef, useState, type FormEvent } from "react";
+import { LinearIcon } from "./LinearIcon";
+
+interface ProjectCreatorProps {
+  onCancel: () => void;
+  onCreate: (name: string, workspacePath: string) => Promise<void>;
+  onSelectDirectory: () => Promise<string | null>;
+}
+
+export function ProjectCreator({ onCancel, onCreate, onSelectDirectory }: ProjectCreatorProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
+  const [name, setName] = useState("");
+  const [workspacePath, setWorkspacePath] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [selectingDirectory, setSelectingDirectory] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    dialogRef.current?.showModal();
+    nameRef.current?.focus();
+    return () => {
+      if (dialogRef.current?.open) dialogRef.current.close();
+    };
+  }, []);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const cleanName = name.trim();
+    const cleanWorkspacePath = workspacePath.trim();
+    if (!cleanName) {
+      setError("请填写项目名称。");
+      nameRef.current?.focus();
+      return;
+    }
+    if (!cleanWorkspacePath) {
+      setError("请填写项目目录。");
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      await onCreate(cleanName, cleanWorkspacePath);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "无法创建项目。");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleSelectDirectory() {
+    setSelectingDirectory(true);
+    setError(null);
+    try {
+      const selectedPath = await onSelectDirectory();
+      if (selectedPath) setWorkspacePath(selectedPath);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "无法选择项目目录。");
+    } finally {
+      setSelectingDirectory(false);
+    }
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="project-create-dialog"
+      aria-labelledby="project-create-title"
+      onCancel={(event) => {
+        event.preventDefault();
+        if (!saving) onCancel();
+      }}
+      onClick={(event) => {
+        if (event.target === event.currentTarget && !saving) onCancel();
+      }}
+    >
+      <form className="project-create-form" onSubmit={handleSubmit}>
+        <header className="dialog-header">
+          <div className="dialog-context">
+            <strong id="project-create-title">新建项目</strong>
+          </div>
+          <div className="dialog-header-actions">
+            <button
+              type="button"
+              className="icon-button dialog-close"
+              onClick={onCancel}
+              disabled={saving}
+              aria-label="关闭新建项目"
+            >
+              <LinearIcon name="close" />
+            </button>
+          </div>
+        </header>
+
+        <div className="project-create-body">
+          <label className="project-create-field">
+            <span>项目名称</span>
+            <div className="project-create-input">
+              <LinearIcon name="project" />
+              <input
+                ref={nameRef}
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="输入项目名称"
+                maxLength={120}
+                autoComplete="off"
+              />
+            </div>
+          </label>
+
+          <label className="project-create-field">
+            <span>项目目录</span>
+            <div className="project-create-input">
+              <button
+                className="project-create-folder-button"
+                type="button"
+                onClick={() => void handleSelectDirectory()}
+                disabled={saving || selectingDirectory}
+                aria-label="选择项目文件夹"
+                title="选择项目文件夹"
+              >
+                <LinearIcon name="folder" />
+              </button>
+              <input
+                value={workspacePath}
+                onChange={(event) => setWorkspacePath(event.target.value)}
+                placeholder="输入项目文件夹路径"
+                maxLength={4096}
+                spellCheck={false}
+                autoComplete="off"
+              />
+            </div>
+            <small>选择或输入本机项目文件夹。</small>
+          </label>
+
+          {error && <div className="form-error" role="alert">{error}</div>}
+        </div>
+
+        <footer className="dialog-footer project-create-footer">
+          <div className="dialog-actions">
+            <button className="button secondary" type="button" onClick={onCancel} disabled={saving}>
+              取消
+            </button>
+            <button className="button primary" type="submit" disabled={saving}>
+              {saving ? "正在创建…" : "创建项目"}
+            </button>
+          </div>
+        </footer>
+      </form>
+    </dialog>
+  );
+}

--- a/web/src/components/PropertyPicker.tsx
+++ b/web/src/components/PropertyPicker.tsx
@@ -1,0 +1,152 @@
+import { Fragment, useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
+import { LinearIcon } from "./LinearIcon";
+
+export interface PropertyPickerOption {
+  value: string;
+  label: string;
+  group?: string;
+  icon?: ReactNode;
+}
+
+interface PropertyPickerProps {
+  value: string;
+  options: PropertyPickerOption[];
+  icon?: ReactNode;
+  open: boolean;
+  disabled?: boolean;
+  className?: string;
+  triggerClassName: string;
+  placeholder: string;
+  ariaLabel: string;
+  searchable?: boolean;
+  searchPlaceholder?: string;
+  hideSelectedOption?: boolean;
+  onOpenChange: (open: boolean) => void;
+  onChange: (value: string) => void;
+}
+
+export function PropertyPicker({
+  value,
+  options,
+  icon,
+  open,
+  disabled = false,
+  className = "",
+  triggerClassName,
+  placeholder,
+  ariaLabel,
+  searchable = false,
+  searchPlaceholder = "搜索…",
+  hideSelectedOption = false,
+  onOpenChange,
+  onChange,
+}: PropertyPickerProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [search, setSearch] = useState("");
+  const selectedOption = options.find((option) => option.value === value);
+  const normalizedSearch = search.trim().toLocaleLowerCase();
+  const filteredOptions = searchable
+    ? options.filter((option) => (
+      !normalizedSearch || option.label.toLocaleLowerCase().includes(normalizedSearch)
+    ))
+    : options;
+  const visibleOptions = hideSelectedOption
+    ? filteredOptions.filter((option) => option.value !== value)
+    : filteredOptions;
+
+  useEffect(() => {
+    if (!open) {
+      setSearch("");
+      return;
+    }
+
+    function closeFromOutside(event: PointerEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) onOpenChange(false);
+    }
+
+    function closeFromEscape(event: globalThis.KeyboardEvent) {
+      if (event.key === "Escape") {
+        onOpenChange(false);
+        triggerRef.current?.focus();
+      }
+    }
+
+    document.addEventListener("pointerdown", closeFromOutside);
+    window.addEventListener("keydown", closeFromEscape);
+    return () => {
+      document.removeEventListener("pointerdown", closeFromOutside);
+      window.removeEventListener("keydown", closeFromEscape);
+    };
+  }, [onOpenChange, open]);
+
+  function selectOption(optionValue: string) {
+    if (disabled) return;
+    onChange(optionValue);
+    onOpenChange(false);
+    triggerRef.current?.focus();
+  }
+
+  let previousGroup: string | undefined;
+
+  return (
+    <div ref={rootRef} className={`composer-menu-anchor property-picker${className ? ` ${className}` : ""}`}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`property-picker-trigger ${triggerClassName}`}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => onOpenChange(!open)}
+      >
+        {icon && <span className="property-picker-trigger-icon">{icon}</span>}
+        <span className="property-picker-trigger-value">{selectedOption?.label ?? placeholder}</span>
+        <LinearIcon name="chevronDown" className="property-picker-chevron" />
+      </button>
+      {open && (
+    <div
+      className={`composer-popover label-popover property-picker-popover${searchable ? " is-searchable" : ""}`}
+      role="dialog"
+      aria-label={ariaLabel}
+    >
+          {searchable && (
+            <input
+              autoFocus
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder={searchPlaceholder}
+              aria-label={`搜索${ariaLabel}`}
+            />
+          )}
+          <div className="label-options property-picker-options" role="listbox" aria-label={ariaLabel}>
+            {visibleOptions.length > 0 ? visibleOptions.map((option) => {
+              const showGroup = Boolean(option.group && option.group !== previousGroup);
+              previousGroup = option.group;
+              return (
+                <Fragment key={option.value}>
+                  {showGroup && <div className="property-picker-group" role="presentation">{option.group}</div>}
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={option.value === value}
+                    disabled={disabled}
+                    onClick={() => selectOption(option.value)}
+                  >
+                    <span className="property-picker-option-icon">{option.icon}</span>
+                    <span className="property-picker-option-label">{option.label}</span>
+                    {option.value === value && <b className="property-picker-option-check"><LinearIcon name="check" /></b>}
+                  </button>
+                </Fragment>
+              );
+            }) : (
+              <div className="property-picker-empty">没有匹配的选项</div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/TaskEditor.tsx
+++ b/web/src/components/TaskEditor.tsx
@@ -23,6 +23,7 @@ import { ActorAvatar } from "./ActorAvatar";
 import { STATUS_DETAILS } from "./BoardColumn";
 import { LabelPicker } from "./LabelPicker";
 import { LinearIcon, LinearPriorityIcon, LinearStatusIcon } from "./LinearIcon";
+import { PropertyPicker } from "./PropertyPicker";
 import {
   fileKey,
   MAX_ATTACHMENT_SIZE,
@@ -128,7 +129,7 @@ export function TaskEditor({
   const [developmentContext, setDevelopmentContext] = useState<DevelopmentContext | null>(task?.developmentContext ?? null);
   const [dueDate, setDueDate] = useState(task?.dueDate ?? "");
   const [recurrence, setRecurrence] = useState<Recurrence | null>(task?.recurrence ?? null);
-  const [menu, setMenu] = useState<"labels" | "more" | "due" | "recurrence" | null>(null);
+  const [menu, setMenu] = useState<"labels" | "status" | "priority" | "assignee" | "workflow" | "development" | "more" | "due" | "recurrence" | null>(null);
   const [expanded, setExpanded] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -285,37 +286,54 @@ export function TaskEditor({
 
         <div className="task-form-dock">
           <div className="property-row">
-            <label className="property-control property-status">
-              <LinearStatusIcon status={status} className={`status-icon-${STATUS_DETAILS[status].tone}`} />
-              <span className="sr-only">状态</span>
-              <select value={status} onChange={(event) => setStatus(event.target.value as TaskStatus)}>
-                {TASK_STATUSES.map((value) => <option value={value} key={value}>{STATUS_DETAILS[value].label}</option>)}
-              </select>
-            </label>
-            <label className={`property-control property-priority priority-${priority}`}>
-              <LinearPriorityIcon priority={priority} />
-              <span className="sr-only">优先级</span>
-              <select value={priority} onChange={(event) => setPriority(event.target.value as TaskPriority)}>
-                {TASK_PRIORITIES.map((value) => <option value={value} key={value}>{PRIORITY_LABELS[value]}</option>)}
-              </select>
-            </label>
-            <label className="property-control property-assignee">
-              <ActorAvatar actor={assignee} className="property-assignee-avatar" />
-              <select
-                aria-label="负责人"
-                value={actorKey(assignee)}
-                onChange={(event) => {
-                  const selected = assigneeOptions.find((actor) => actorKey(actor) === event.target.value);
-                  if (selected) setAssignee(selected);
-                }}
-              >
-                {assigneeOptions.map((actor) => (
-                  <option value={actorKey(actor)} key={actorKey(actor)}>
-                    {actor.id === currentUser.id ? `${actor.name}（我）` : actor.name}
-                  </option>
-                ))}
-              </select>
-            </label>
+            <PropertyPicker
+              value={status}
+              options={TASK_STATUSES.map((value) => ({
+                value,
+                label: STATUS_DETAILS[value].label,
+                icon: <LinearStatusIcon status={value} className={`status-icon-${STATUS_DETAILS[value].tone}`} />,
+              }))}
+              icon={<LinearStatusIcon status={status} className={`status-icon-${STATUS_DETAILS[status].tone}`} />}
+              open={menu === "status"}
+              triggerClassName="property-control property-status"
+              placeholder="状态"
+              ariaLabel="状态"
+              onOpenChange={(open) => setMenu(open ? "status" : null)}
+              onChange={(value) => setStatus(value as TaskStatus)}
+            />
+            <PropertyPicker
+              value={priority}
+              options={TASK_PRIORITIES.map((value) => ({
+                value,
+                label: PRIORITY_LABELS[value],
+                icon: <LinearPriorityIcon priority={value} />,
+              }))}
+              icon={<LinearPriorityIcon priority={priority} />}
+              open={menu === "priority"}
+              triggerClassName={`property-control property-priority priority-${priority}`}
+              placeholder="优先级"
+              ariaLabel="优先级"
+              onOpenChange={(open) => setMenu(open ? "priority" : null)}
+              onChange={(value) => setPriority(value as TaskPriority)}
+            />
+            <PropertyPicker
+              value={actorKey(assignee)}
+              options={assigneeOptions.map((actor) => ({
+                value: actorKey(actor),
+                label: actor.id === currentUser.id ? `${actor.name}（我）` : actor.name,
+                icon: <ActorAvatar actor={actor} className="property-assignee-avatar" />,
+              }))}
+              icon={<ActorAvatar actor={assignee} className="property-assignee-avatar" />}
+              open={menu === "assignee"}
+              triggerClassName="property-control property-assignee"
+              placeholder="负责人"
+              ariaLabel="负责人"
+              onOpenChange={(open) => setMenu(open ? "assignee" : null)}
+              onChange={(value) => {
+                const selected = assigneeOptions.find((actor) => actorKey(actor) === value);
+                if (selected) setAssignee(selected);
+              }}
+            />
             <LabelPicker
               availableLabels={availableLabels}
               selectedLabels={selectedLabels}
@@ -326,35 +344,50 @@ export function TaskEditor({
               onChange={setSelectedLabels}
             />
 
-            <label className="property-control property-workflow">
-              <LinearIcon name="dashboard" />
-              <span className="sr-only">工作流</span>
-              <select value={workflowId} onChange={(event) => setWorkflowId(event.target.value)}>
-                <option value="">工作流</option>
-                {!workflowAvailable && <option value={workflowId}>当前设备未找到此流程</option>}
-                {workflows.map((workflow) => (
-                  <option value={workflow.id} key={workflow.id}>{workflow.name}</option>
-                ))}
-              </select>
-            </label>
+            <PropertyPicker
+              value={workflowId}
+              options={[
+                { value: "", label: "工作流", icon: <LinearIcon name="dashboard" /> },
+                ...(!workflowAvailable ? [{ value: workflowId, label: "当前设备未找到此流程", icon: <LinearIcon name="dashboard" /> }] : []),
+                ...workflows.map((workflow) => ({ value: workflow.id, label: workflow.name, icon: <LinearIcon name="dashboard" /> })),
+              ]}
+              icon={<LinearIcon name="dashboard" />}
+              open={menu === "workflow"}
+              triggerClassName="property-control property-workflow"
+              placeholder="工作流"
+              ariaLabel="工作流"
+              onOpenChange={(open) => setMenu(open ? "workflow" : null)}
+              onChange={setWorkflowId}
+            />
 
-            <label className="property-control property-development" title={developmentScan.workspacePath ?? undefined}>
-              <LinearIcon name="branch" />
-              <span className="sr-only">代码分支或 Worktree</span>
-              <select
-                value={contextValue(developmentContext)}
-                disabled={developmentScanLoading}
-                onChange={(event) => setDevelopmentContext(event.target.value ? JSON.parse(event.target.value) as DevelopmentContext : null)}
-              >
-                <option value="">{developmentScanLoading ? "正在扫描 Git…" : "分支 / Worktree"}</option>
-                <optgroup label="代码分支">
-                  {developmentOptions.filter((context) => context.type === "branch").map((context) => <option value={contextValue(context)} key={contextValue(context)}>{contextLabel(context)}</option>)}
-                </optgroup>
-                <optgroup label="Worktree">
-                  {developmentOptions.filter((context) => context.type === "worktree").map((context) => <option value={contextValue(context)} key={contextValue(context)}>{contextLabel(context)}</option>)}
-                </optgroup>
-              </select>
-            </label>
+            <PropertyPicker
+              value={contextValue(developmentContext)}
+              options={[
+                { value: "", label: developmentScanLoading ? "正在扫描 Git…" : "分支 / Worktree", icon: <LinearIcon name="branch" /> },
+                ...developmentOptions.filter((context) => context.type === "branch").map((context) => ({
+                  value: contextValue(context),
+                  label: contextLabel(context),
+                  group: "代码分支",
+                  icon: <LinearIcon name="branch" />,
+                })),
+                ...developmentOptions.filter((context) => context.type === "worktree").map((context) => ({
+                  value: contextValue(context),
+                  label: contextLabel(context),
+                  group: "Worktree",
+                  icon: <LinearIcon name="folder" />,
+                })),
+              ]}
+              icon={<LinearIcon name="branch" />}
+              open={menu === "development"}
+              disabled={developmentScanLoading}
+              triggerClassName="property-control property-development"
+              placeholder="分支 / Worktree"
+              ariaLabel="代码分支或 Worktree"
+              searchable
+              searchPlaceholder="搜索分支或 Worktree…"
+              onOpenChange={(open) => setMenu(open ? "development" : null)}
+              onChange={(value) => setDevelopmentContext(value ? JSON.parse(value) as DevelopmentContext : null)}
+            />
 
             {dueDate && <button className="property-control" type="button" onClick={() => setMenu("due")}><span>截止 {displayDate(dueDate)}</span></button>}
             {recurrence && <button className="property-control" type="button" onClick={() => setMenu("recurrence")}><span>每 {recurrence.interval} {RECURRENCE_UNITS[recurrence.unit]}</span></button>}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -485,6 +485,35 @@ kbd {
   letter-spacing: 0.06em;
 }
 
+.project-home-heading-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.project-home-heading-copy {
+  min-width: 0;
+}
+
+.project-home-heading-copy > span {
+  color: var(--text-tertiary);
+  font-size: 10px;
+  font-weight: 550;
+  letter-spacing: 0.06em;
+}
+
+.project-create-button {
+  flex: 0 0 auto;
+  margin-top: 10px;
+}
+
+.project-create-button svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+}
+
 .project-home-heading h1 {
   margin: 7px 0 5px;
   color: var(--text-primary);
@@ -5782,6 +5811,152 @@ kbd {
   background: var(--surface);
   color: var(--text-primary);
   box-shadow: 0 9px 48px rgba(0, 0, 0, 0.08), 0 6px 24px rgba(0, 0, 0, 0.1), 0 1px 1px rgba(0, 0, 0, 0.04);
+}
+
+.project-create-dialog {
+  width: min(520px, calc(100vw - 32px));
+  padding: 0;
+  overflow: hidden;
+  border: 0.5px solid var(--border);
+  border-radius: 18px;
+  background: var(--surface);
+  color: var(--text-primary);
+  box-shadow: var(--dialog-shadow);
+}
+
+.project-create-dialog::backdrop {
+  background: rgba(13, 14, 16, 0.38);
+  backdrop-filter: blur(2px);
+}
+
+.project-create-form {
+  min-width: 0;
+}
+
+.project-create-body {
+  display: grid;
+  gap: 17px;
+  padding: 20px 22px 8px;
+}
+
+.project-create-field {
+  display: grid;
+  gap: 7px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 550;
+}
+
+.project-create-input {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  height: 36px;
+  gap: 8px;
+  padding: 0 10px;
+  border: var(--border-hairline) solid var(--border-strong);
+  border-radius: 7px;
+  background: var(--surface-muted);
+  color: var(--text-tertiary);
+  transition: border-color 100ms ease, background-color 100ms ease;
+}
+
+.project-create-input:focus-within {
+  border-color: var(--accent);
+  background: var(--surface);
+}
+
+.project-create-input svg {
+  flex: 0 0 auto;
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.25;
+}
+
+.project-create-input input {
+  width: 100%;
+  min-width: 0;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 450;
+}
+
+.project-create-input input::placeholder,
+.project-create-field small {
+  color: var(--text-tertiary);
+}
+
+.project-create-folder-button {
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 22px;
+  height: 24px;
+  margin: 0 -2px;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.project-create-folder-button:hover:not(:disabled) {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.project-create-folder-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.project-create-folder-button:disabled {
+  cursor: wait;
+  opacity: 0.5;
+}
+
+.project-create-folder-button svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.25;
+}
+
+.project-create-field small {
+  font-size: 10px;
+  font-weight: 450;
+}
+
+.dialog-footer.project-create-footer {
+  justify-content: flex-end;
+  padding: 14px 22px 18px;
+}
+
+@media (max-width: 520px) {
+  .project-home-heading-row {
+    display: grid;
+    gap: 10px;
+  }
+
+  .project-create-button {
+    justify-self: start;
+    margin-top: 0;
+  }
+
 }
 
 .task-dialog::backdrop {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6138,6 +6138,34 @@ kbd {
   color: var(--text-primary);
 }
 
+.property-picker-trigger {
+  max-width: 100%;
+}
+
+.property-picker-trigger-icon,
+.property-picker-trigger-value {
+  min-width: 0;
+}
+
+.property-picker-trigger-icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+}
+
+.property-picker-trigger-value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.property-picker-chevron {
+  flex: 0 0 auto;
+  width: 12px !important;
+  height: 12px !important;
+  color: var(--text-tertiary);
+}
+
 .property-assignee-avatar {
   width: 14px;
   height: 14px;
@@ -6188,8 +6216,8 @@ kbd {
 .property-priority.priority-medium { color: var(--warning); }
 
 .property-thread input { width: 178px; }
-.property-workflow select { max-width: 190px; }
-.property-development select { max-width: 190px; }
+.property-workflow .property-picker-trigger { max-width: 190px; }
+.property-development .property-picker-trigger { max-width: 190px; }
 .property-more { width: 28px; padding: 0; justify-content: center; letter-spacing: 1px; }
 
 .composer-attachment-button {
@@ -6533,6 +6561,103 @@ kbd {
 .more-popover button b {
   color: var(--text-tertiary);
   font-weight: 500;
+}
+
+.property-picker-popover {
+  width: max-content;
+  min-width: 132px;
+  max-width: min(280px, calc(100vw - 24px));
+}
+
+.property-picker-popover.is-searchable {
+  width: max-content;
+  min-width: 248px;
+  max-width: min(420px, calc(100vw - 24px));
+}
+
+.property-picker-popover.is-searchable .property-picker-options {
+  width: max-content;
+  min-width: 100%;
+  max-width: 100%;
+}
+
+.property-picker-popover.is-searchable .property-picker-options button {
+  width: max-content;
+  min-width: 100%;
+  max-width: 100%;
+}
+
+.property-picker-popover:not(.is-searchable) {
+  min-width: 0;
+}
+
+.property-picker-group {
+  padding: 6px 12px 4px;
+  color: var(--text-tertiary);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.property-picker-options button {
+  gap: 10px;
+}
+
+.property-picker-popover:not(.is-searchable) .property-picker-options {
+  width: max-content;
+}
+
+.property-picker-popover:not(.is-searchable) .property-picker-options button {
+  width: max-content;
+  min-width: 0;
+}
+
+.property-picker-popover:not(.is-searchable) .property-picker-option-label {
+  flex: 0 0 auto;
+  overflow: visible;
+  text-overflow: clip;
+}
+
+.property-picker-options .property-picker-option-icon {
+  display: grid;
+  flex: 0 0 16px;
+  place-items: center;
+  color: var(--text-secondary);
+}
+
+.property-picker-option-icon:empty {
+  visibility: hidden;
+}
+
+.property-picker-option-icon svg {
+  width: 14px;
+  height: 14px;
+}
+
+.property-picker-option-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.property-picker-option-check {
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  color: var(--accent);
+}
+
+.property-picker-option-check svg {
+  width: 14px;
+  height: 14px;
+}
+
+.property-picker-empty {
+  padding: 12px;
+  color: var(--text-tertiary);
+  font-size: 12px;
+  text-align: center;
 }
 
 .more-popover {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -28,9 +28,10 @@
   --border: #e1e1e1;
   --border-strong: #d5d5d5;
   --border-hairline: 0.5px;
-  --accent: #5e6ad2;
-  --accent-hover: #6872d5;
-  --accent-soft: rgba(94, 106, 210, 0.11);
+  --accent: #2c2c2f;
+  --accent-hover: #1f1f22;
+  --accent-soft: rgba(44, 44, 47, 0.09);
+  --accent-foreground: #ffffff;
   --danger: #f34e52;
   --danger-soft: #fff0f0;
   --warning: #f0bf00;
@@ -40,7 +41,7 @@
   --status-progress: #f0bf00;
   --status-review: #43bc58;
   --status-blocked: #f34e52;
-  --status-done: #5e6ad2;
+  --status-done: #43bc58;
   --status-canceled: #9e9ea1;
   --scrollbar-thumb: rgba(27, 27, 27, 0.15);
   --scrollbar-thumb-hover: rgba(27, 27, 27, 0.46);
@@ -65,9 +66,10 @@
   --text-quaternary: #65656b;
   --border: rgba(255, 255, 255, 0.075);
   --border-strong: rgba(255, 255, 255, 0.13);
-  --accent: #6e78df;
-  --accent-hover: #7c86e5;
-  --accent-soft: rgba(110, 120, 223, 0.16);
+  --accent: #e8e8ea;
+  --accent-hover: #ffffff;
+  --accent-soft: rgba(232, 232, 234, 0.14);
+  --accent-foreground: #1b1b1d;
   --danger: #ef686d;
   --danger-soft: rgba(229, 72, 77, 0.12);
   --warning: #e5b729;
@@ -77,7 +79,7 @@
   --status-progress: #e4b50f;
   --status-review: #53b98a;
   --status-blocked: #ef686d;
-  --status-done: #6e78df;
+  --status-done: #53b98a;
   --status-canceled: #85858b;
   --scrollbar-thumb: rgba(238, 238, 239, 0.15);
   --scrollbar-thumb-hover: rgba(238, 238, 239, 0.5);
@@ -157,6 +159,12 @@ textarea,
 select {
   color: inherit;
   font: inherit;
+}
+
+select option,
+select optgroup {
+  background: var(--surface);
+  color: var(--text-primary);
 }
 
 button,
@@ -5745,7 +5753,7 @@ kbd {
 
 .button.primary {
   background: var(--accent);
-  color: white;
+  color: var(--accent-foreground);
   box-shadow: inset 0 0 0 0.5px rgba(255, 255, 255, 0.18), 0 1px 2px rgba(0, 0, 0, 0.16);
 }
 


### PR DESCRIPTION
## Summary

- Align the taskboard accent, native select colors, and dark theme presentation.
- Add local project creation with a native folder picker on macOS.
- Replace issue editor property selects with reusable picker menus.
- Make picker widths content-aware and keep searchable branch menus within the viewport.

## Validation

- `npm run typecheck` passed.
- `npm run build` passed.
- `git diff --check` passed.
- `npm test` currently reports 329 passing and 20 failing tests. The failures include stale assertions for the removed native select markup and unrelated AI, Cloud, and workflow contracts; they are recorded here for follow-up.
