### PR TITLE
Support Windows Codex injection

### DIFF
--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -147,7 +147,7 @@
         min-width: 0;
         min-height: 0;
         overflow: hidden;
-        background: Canvas;
+        background: var(--color-background-surface, var(--wb-surface-primary, Canvas));
         color: CanvasText;
         pointer-events: auto;
       }
@@ -159,7 +159,7 @@
         width: 100%;
         height: 100%;
         border: 0;
-        background: Canvas;
+        background: var(--color-background-surface, var(--wb-surface-primary, Canvas));
       }
       #${FRAME_ID}[hidden] {
         display: none !important;
@@ -370,6 +370,73 @@
     }
   }
 
+  function readHostPalette() {
+    const rootStyle = window.getComputedStyle(document.documentElement);
+    const readToken = (...names) => {
+      for (const name of names) {
+        const value = rootStyle.getPropertyValue(name).trim();
+        if (value && !value.includes("var(")) return value;
+      }
+      return "";
+    };
+    const bodyStyle = document.body ? window.getComputedStyle(document.body) : rootStyle;
+    const background = readToken(
+      "--color-background-surface",
+      "--wb-surface-primary",
+      "--color-surface",
+    ) || bodyStyle.backgroundColor;
+    const backgroundUnder = readToken(
+      "--color-background-surface-under",
+      "--wb-surface-secondary",
+      "--color-surface-secondary",
+      "--vscode-sideBar-background",
+    ) || background;
+    const surface = readToken(
+      "--color-background-secondary-soft",
+      "--color-surface-tertiary",
+    ) || background;
+    return {
+      background,
+      backgroundUnder,
+      surface,
+      surfaceRaised: readToken(
+        "--color-background-primary-soft",
+        "--color-surface-elevated-secondary",
+        "--color-background-control",
+      ) || surface,
+      surfaceMuted: readToken(
+        "--color-background-secondary-soft-alpha",
+        "--color-background-secondary-soft",
+      ) || surface,
+      surfaceHover: readToken(
+        "--color-background-primary-ghost-hover",
+        "--vscode-settings-rowHoverBackground",
+      ) || surface,
+      surfaceActive: readToken(
+        "--color-background-primary-soft-active",
+        "--color-background-control",
+      ) || surface,
+      columnHeader: readToken(
+        "--color-background-primary-soft-alpha",
+        "--color-background-secondary-soft-alpha",
+      ) || surface,
+      textPrimary: readToken("--color-text-foreground", "--color-text"),
+      textSecondary: readToken(
+        "--color-text-foreground-secondary",
+        "--color-text-secondary-solid",
+        "--color-text-secondary",
+      ),
+      textTertiary: readToken(
+        "--color-text-foreground-tertiary",
+        "--color-text-tertiary",
+        "--color-text-disabled",
+      ),
+      textQuaternary: readToken("--color-text-disabled", "--color-text-tertiary"),
+      border: readToken("--color-border", "--vscode-sideBar-border"),
+      borderStrong: readToken("--color-border-strong", "--color-border-heavy"),
+    };
+  }
+
   function threadIdFromLocation() {
     const source = `${window.location.pathname || ""}${window.location.search || ""}${window.location.hash || ""}`;
     const match = source.match(/(?:session|conversation|thread)(?:\/|=|:|-)([A-Za-z0-9_.-]+)/i)
@@ -538,6 +605,7 @@
     const workspacePath = workspaceFromLocation();
     const payload = {
       theme: currentTheme(),
+      palette: readHostPalette(),
       projects,
       user: readCodexUser() ?? undefined,
       titlebarLeftInset: titlebarLeftInset(),
@@ -571,7 +639,7 @@
         }
       : liveContext;
     postToFrame({ type: "taskboard:host-context", payload });
-    postToFrame({ type: "taskboard:theme", theme: payload.theme });
+    postToFrame({ type: "taskboard:theme", theme: payload.theme, palette: payload.palette });
   }
 
   function findThreadRow(threadId) {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "codex": "node scripts/codex-injector.mjs --launch --watch --open",
+    "codex:windows": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/codex-windows.ps1",
     "codex:inject": "node scripts/codex-injector.mjs --watch",
     "codex:daemon": "node scripts/codex-injector.mjs --daemon --open",
     "codex:refresh": "node scripts/codex-injector.mjs --refresh",

--- a/scripts/codex-windows.ps1
+++ b/scripts/codex-windows.ps1
@@ -1,0 +1,102 @@
+[CmdletBinding()]
+param(
+  [ValidateRange(1, 65535)]
+  [int]$Port = 9229,
+
+  [switch]$NoOpen
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($env:OS -ne "Windows_NT") {
+  throw "codex-windows.ps1 requires Windows."
+}
+
+$runningMainProcess = Get-CimInstance Win32_Process -Filter "Name = 'ChatGPT.exe'" |
+  Where-Object { $_.CommandLine -notmatch "--type=" } |
+  Select-Object -First 1
+
+if ($runningMainProcess) {
+  throw "Codex is already running without the requested CDP cold start. Quit Codex completely, then run npm run codex:windows again."
+}
+
+$codexApp = Get-StartApps |
+  Where-Object { $_.AppID -like "OpenAI.Codex_*!App" } |
+  Select-Object -First 1
+
+if (-not $codexApp) {
+  throw "The Microsoft Store Codex application is not installed for this Windows user."
+}
+
+$activationSource = @'
+using System;
+using System.Runtime.InteropServices;
+
+[ComImport]
+[Guid("2e941141-7f97-4756-ba1d-9decde894a3d")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+public interface IApplicationActivationManager {
+  [PreserveSig]
+  int ActivateApplication(
+    [MarshalAs(UnmanagedType.LPWStr)] string appUserModelId,
+    [MarshalAs(UnmanagedType.LPWStr)] string arguments,
+    uint options,
+    out uint processId);
+}
+
+[ComImport]
+[Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C")]
+public class ApplicationActivationManager {}
+
+public static class CodexStoreApplication {
+  public static uint Activate(string appUserModelId, string arguments) {
+    var manager = (IApplicationActivationManager)new ApplicationActivationManager();
+    uint processId;
+    int result = manager.ActivateApplication(appUserModelId, arguments, 0, out processId);
+    Marshal.ThrowExceptionForHR(result);
+    return processId;
+  }
+}
+'@
+
+Add-Type -TypeDefinition $activationSource
+
+$launchArguments = "--remote-debugging-port=$Port --remote-allow-origins=http://127.0.0.1:$Port"
+$launchedProcessId = [CodexStoreApplication]::Activate($codexApp.AppID, $launchArguments)
+Write-Host "Started Codex process $launchedProcessId with CDP port $Port."
+
+$targetsUrl = "http://127.0.0.1:$Port/json/list"
+$deadline = [DateTime]::UtcNow.AddSeconds(30)
+$readyChecks = 0
+while ([DateTime]::UtcNow -lt $deadline) {
+  try {
+    $targets = @(Invoke-RestMethod -Uri $targetsUrl -TimeoutSec 1)
+    $mainTarget = $targets | Where-Object {
+      $_.type -eq "page" -and ($_.url -like "app://*" -or $_.title -eq "Codex")
+    } | Select-Object -First 1
+    if ($mainTarget) {
+      $readyChecks += 1
+      if ($readyChecks -ge 3) {
+        break
+      }
+    } else {
+      $readyChecks = 0
+    }
+  } catch {
+    $readyChecks = 0
+  }
+  Start-Sleep -Milliseconds 250
+}
+
+if ($readyChecks -lt 3) {
+  throw "Codex started, but its CDP renderer did not become ready at $targetsUrl within 30 seconds."
+}
+
+$injectorPath = Join-Path $PSScriptRoot "codex-injector.mjs"
+$injectorArguments = @($injectorPath, "--watch", "--port", "$Port")
+if (-not $NoOpen) {
+  $injectorArguments += "--open"
+}
+
+& node @injectorArguments
+exit $LASTEXITCODE

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -71,6 +71,7 @@ import {
   type ActorIdentity,
   type DevelopmentScan,
   type HostContext,
+  type HostThemePalette,
   type IssueRelationType,
   type Project,
   type Task,
@@ -223,6 +224,32 @@ const EVENT_NAMES = [
 
 function isTheme(value: unknown): value is Theme {
   return value === "light" || value === "dark";
+}
+
+const HOST_PALETTE_VARIABLES: Array<[keyof HostThemePalette, string]> = [
+  ["background", "--bg"],
+  ["background", "--header-bg"],
+  ["backgroundUnder", "--sidebar-bg"],
+  ["surface", "--surface"],
+  ["surfaceRaised", "--surface-raised"],
+  ["surfaceMuted", "--surface-muted"],
+  ["surfaceHover", "--surface-hover"],
+  ["surfaceActive", "--surface-active"],
+  ["columnHeader", "--column-header"],
+  ["textPrimary", "--text-primary"],
+  ["textSecondary", "--text-secondary"],
+  ["textTertiary", "--text-tertiary"],
+  ["textQuaternary", "--text-quaternary"],
+  ["border", "--border"],
+  ["borderStrong", "--border-strong"],
+];
+
+function isHostThemePalette(value: unknown): value is HostThemePalette {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.values(value).every((color) => (
+    color === undefined
+    || (typeof color === "string" && color.length <= 200 && !/[;{}]/.test(color))
+  ));
 }
 
 function getInitialTheme(): Theme {
@@ -533,6 +560,7 @@ export function App() {
   const embedded = query.get("host") === "codex";
   const undoShortcut = navigator.userAgent.includes("Macintosh") ? "⌘Z" : "Ctrl+Z";
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
+  const [hostPalette, setHostPalette] = useState<HostThemePalette | null>(null);
   const [hostContext, setHostContext] = useState<HostContext | null>(null);
   const [developmentScan, setDevelopmentScan] = useState<DevelopmentScan>({ workspacePath: null, contexts: [] });
   const [developmentScanLoading, setDevelopmentScanLoading] = useState(false);
@@ -959,6 +987,19 @@ export function App() {
   }, [embedded, theme]);
 
   useEffect(() => {
+    const root = document.documentElement;
+    if (!embedded || !hostPalette) return;
+    const applied: string[] = [];
+    for (const [paletteKey, variable] of HOST_PALETTE_VARIABLES) {
+      const value = hostPalette[paletteKey];
+      if (!value) continue;
+      root.style.setProperty(variable, value);
+      applied.push(variable);
+    }
+    return () => applied.forEach((variable) => root.style.removeProperty(variable));
+  }, [embedded, hostPalette]);
+
+  useEffect(() => {
     writeTaskFilters(filters);
   }, [filters]);
 
@@ -993,7 +1034,12 @@ export function App() {
 
     function receiveHostMessage(event: MessageEvent) {
       if (event.source !== window.parent || !event.data || typeof event.data !== "object") return;
-      const message = event.data as { type?: string; payload?: unknown; theme?: unknown };
+      const message = event.data as {
+        type?: string;
+        payload?: unknown;
+        theme?: unknown;
+        palette?: unknown;
+      };
 
       if (message.type === "taskboard:automation-response" && message.payload) {
         const payload = message.payload as Partial<AutomationHostResponse>;
@@ -1011,6 +1057,7 @@ export function App() {
 
       if (message.type === "taskboard:theme" && isTheme(message.theme)) {
         setTheme(message.theme);
+        if (isHostThemePalette(message.palette)) setHostPalette(message.palette);
         return;
       }
 
@@ -1031,6 +1078,7 @@ export function App() {
       setHostContext(payload);
       setCurrentUserActor(payload.user);
       if (isTheme(payload.theme)) setTheme(payload.theme);
+      if (isHostThemePalette(payload.palette)) setHostPalette(payload.palette);
     }
 
     window.addEventListener("message", receiveHostMessage);

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -244,11 +244,29 @@ export interface Attachment {
   createdAt: string;
 }
 
+export interface HostThemePalette {
+  background?: string;
+  backgroundUnder?: string;
+  surface?: string;
+  surfaceRaised?: string;
+  surfaceMuted?: string;
+  surfaceHover?: string;
+  surfaceActive?: string;
+  columnHeader?: string;
+  textPrimary?: string;
+  textSecondary?: string;
+  textTertiary?: string;
+  textQuaternary?: string;
+  border?: string;
+  borderStrong?: string;
+}
+
 export interface HostContext {
   user?: ActorIdentity;
   workspacePath?: string;
   threadId?: string;
   theme?: "light" | "dark";
+  palette?: HostThemePalette;
   projectId?: string;
   projects?: Array<{ id: string; name: string }>;
   titlebarLeftInset?: number;


### PR DESCRIPTION
## What

- Add a Windows launcher for the Microsoft Store Codex app that enables CDP before startup and starts the existing injector.
- Read Codex's native theme palette from the host DOM and forward it into the embedded taskboard.
- Map host background, surface, text, and border tokens onto taskboard CSS variables while leaving standalone mode unchanged.

## Why

The Store-packaged Windows app cannot be launched through the existing executable path, and the taskboard's static dark colors visibly differ from Codex's layered native surfaces.

## Impact

Windows users can quit Codex and run `npm run codex:windows` to cold-start Codex with injection enabled. The embedded taskboard now follows Codex's native regional colors.

## Validation

- `npm run typecheck`
- `npm run build`
- `node --check inject/codex-taskboard.user.js`
- PowerShell parser validation for `scripts/codex-windows.ps1`
- Windows runtime: Store Codex cold launch, CDP connection on port 9229, DOM injection, taskboard load, and native palette propagation verified
- `node --test test/inject.test.mjs`: 22 passed, 1 existing Windows-only CRLF-sensitive source-slicing assertion failed