### PR TITLE
fix: restore Codex taskboard injection

### DIFF
--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -299,7 +299,10 @@
   }
 
   function findPageHost() {
-    const direct = document.querySelector(".app-shell-main-content-frame");
+    const direct = document.querySelector(".app-shell-main-content-frame")
+      || document.querySelector(
+        "[data-app-shell-main-content-layout] > [data-app-shell-thread-edge-divider]",
+      );
     if (direct?.closest?.("[data-app-shell-main-content-layout]")) return direct;
 
     const viewport = document.querySelector("[data-app-shell-main-content-layout]");

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -306,8 +306,19 @@ async function codexTargets(port) {
       target.type === "page" &&
       target.webSocketDebuggerUrl &&
       !target.url?.includes("initialRoute=%2Fglobal-dictation") &&
+      !target.url?.includes("initialRoute=%2Favatar-overlay") &&
       (target.url?.startsWith("app://") || target.title === "Codex"),
   );
+}
+
+async function waitForCodexTargets(port, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const targets = await codexTargets(port);
+    if (targets.length > 0) return targets;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error("Timed out waiting for the Codex renderer target");
 }
 
 function codexDebuggingPorts(preferredPort) {
@@ -1262,6 +1273,7 @@ async function main() {
       await waitUntilReachable(cdpVersionUrl, 30_000);
     }
 
+    await waitForCodexTargets(options.port, 30_000);
     const { source, sourceHash } = await currentInjectionSource();
     const injectedTargets = new Map();
     const firstResults = await injectAll(


### PR DESCRIPTION
## Summary

- `ce17bba` fixes Codex taskboard injection against the current desktop renderer.
- Wait for the main Codex renderer before injecting and exclude the avatar overlay target.
- Mount the taskboard against the current stable main-content data attributes while retaining the legacy class fallback.

## Root cause

The launcher treated the CDP endpoint as sufficient readiness, so injection could run before the main renderer existed. Once targets appeared, the auxiliary avatar overlay was also eligible and could be selected before the main window. In addition, the current Codex renderer no longer exposes the legacy `.app-shell-main-content-frame` class used as the direct mount selector.

## Impact

`npm run codex` now injects into the main Codex window and loads the embedded taskboard instead of failing with `No Codex renderer target found` or `Taskboard iframe did not finish loading in the Codex renderer`.

## Validation

- `node --check scripts/codex-injector.mjs`
- `node --check inject/codex-taskboard.user.js`
- `node --test test/injector.test.mjs` — 8/8 passed
- Live Codex App verification — `entryMounted: true`, `pageVisible: true`, `frameLoaded: true`
- DOM readback — sidebar entry visible at 201.6 × 27 px; taskboard iframe visible at 1704 × 1050 px

The combined existing injection suites report 30 passing tests and one unrelated stale Automation payload fixture failure in `test/inject.test.mjs`.
