### PR TITLE
docs: open source project with funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: "https://support.xiangruiai.com/dashi-taskboard"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Dashi Taskboard contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A local-first issue board that runs in a browser and can be embedded in Codex through the standalone CDP launcher or its injection script. The same HTTP API powers the React UI and the `taskctl` CLI used by the bundled Codex Skill.
 
+Codex Taskboard is open source under the [MIT License](LICENSE).
+
 ## Requirements
 
 - Node.js 22.5 or newer
@@ -9,6 +11,8 @@ A local-first issue board that runs in a browser and can be embedded in Codex th
 ## Run locally
 
 ```bash
+git clone https://github.com/chuspeeism/dashi-taskboard.git
+cd dashi-taskboard
 npm install
 npm run build
 npm start
@@ -130,3 +134,7 @@ npm run check
 ```
 
 This runs TypeScript checking, a production frontend build, and the server/CLI/injection test suite.
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary

- declare the project open source under the MIT License
- add complete clone and local run instructions to the README
- add a GitHub Sponsors custom funding link to the live WeChat Pay support page

## Why

The repository was public but did not include an explicit open-source license or a real funding destination.

## Impact

After merge, GitHub can display the repository Sponsor button and send supporters to `https://support.xiangruiai.com/dashi-taskboard`.

## Validation

- `git diff --check`
- funding URL returns HTTP 200 with a valid TLS certificate
- GitHub `FUNDING.yml` custom URL syntax follows the documented schema

## Existing baseline

The repository's full `npm test` suite currently fails on unmodified `main`, including missing `insertSkillMention` exports and existing UI assertion failures. This documentation-only PR does not change application or test code.
