### PR TITLE
fix: keep watch mode waiting for Codex renderer

### DIFF
--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -1264,18 +1264,25 @@ async function main() {
 
     const { source, sourceHash } = await currentInjectionSource();
     const injectedTargets = new Map();
-    const firstResults = await injectAll(
-      options.port,
-      source,
-      sourceHash,
-      options.open,
-      options.screenshot,
-      injectedTargets,
-      options.watch,
-      supervisor,
-      options.attachExisting,
-      options.startupToken,
-    );
+    let firstResults;
+    try {
+      firstResults = await injectAll(
+        options.port,
+        source,
+        sourceHash,
+        options.open,
+        options.screenshot,
+        injectedTargets,
+        options.watch,
+        supervisor,
+        options.attachExisting,
+        options.startupToken,
+      );
+    } catch (error) {
+      if (!options.watch || error.message !== "No Codex renderer target found") throw error;
+      console.error(`Waiting for Codex renderer: ${error.message}`);
+      firstResults = [];
+    }
     console.log(JSON.stringify({ injected: firstResults }, null, 2));
 
     if (!options.watch) {

--- a/test/injector.test.mjs
+++ b/test/injector.test.mjs
@@ -67,6 +67,7 @@ test("the package injection command remains resident for tab-triggered recovery"
   assert.match(source, /port: defaultCodexDebuggingPort/);
   assert.match(source, /--startup-token/);
   assert.match(source, /__codexTaskboardHostStartupTokenV1/);
+  assert.match(source, /if \(!options\.watch \|\| error\.message !== "No Codex renderer target found"\) throw error/);
 });
 
 test("attach reconciles the renderer against a hashed current injection source", () => {


### PR DESCRIPTION
## Problem

When Codex is already open but its renderer target is not exposed yet, `npm run codex` fails immediately with `No Codex renderer target found`. This is especially common during app startup or renderer reloads, and it prevents the existing `--watch` recovery loop from doing its job.

## Fix

In watch mode, treat only this initial no-target condition as a transient state, log that the injector is waiting, and continue into the existing two-second retry loop. Non-watch mode and all other errors retain the current failure behavior.

## Validation

- `node --check scripts/codex-injector.mjs`
- `node --test test/injector.test.mjs`

Related evidence: #13. The current renderer/CSP and host-selector findings are documented there; this PR is intentionally limited to the independent watch-mode startup failure and does not duplicate PR #15.
