### PR TITLE
ASH-49: add project Context view

### DIFF
--- a/cloud/migrations/0002_project_context.sql
+++ b/cloud/migrations/0002_project_context.sql
@@ -1,0 +1,78 @@
+CREATE TABLE project_context_entries (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  kind TEXT NOT NULL CHECK (kind IN (
+    'requirement', 'decision', 'constraint', 'fact', 'risk', 'handoff', 'summary'
+  )),
+  title TEXT NOT NULL,
+  body TEXT NOT NULL CHECK (length(CAST(body AS BLOB)) <= 65536),
+  tags TEXT NOT NULL DEFAULT '[]'
+    CHECK (json_valid(tags) = 1 AND json_type(tags) = 'array'),
+  source_type TEXT NOT NULL CHECK (source_type IN (
+    'manual', 'issue', 'comment', 'thread_summary', 'agent'
+  )),
+  source_id TEXT,
+  source_thread_id TEXT,
+  author_type TEXT NOT NULL CHECK (author_type IN ('user', 'agent')),
+  author_id TEXT NOT NULL,
+  author_name TEXT NOT NULL,
+  pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0, 1)),
+  archived_at TEXT,
+  version INTEGER NOT NULL DEFAULT 1 CHECK (version > 0),
+  idempotency_key TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX project_context_entries_project_idempotency
+  ON project_context_entries(project_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+CREATE INDEX project_context_entries_project_page
+  ON project_context_entries(project_id, archived_at, created_at DESC, id DESC);
+
+CREATE INDEX project_context_entries_project_kind
+  ON project_context_entries(project_id, archived_at, kind, created_at DESC, id DESC);
+
+CREATE INDEX project_context_entries_project_pinned
+  ON project_context_entries(project_id, archived_at, pinned DESC, updated_at DESC, id);
+
+CREATE TABLE project_context_revisions (
+  id TEXT PRIMARY KEY,
+  entry_id TEXT NOT NULL REFERENCES project_context_entries(id) ON DELETE CASCADE,
+  version INTEGER NOT NULL CHECK (version > 0),
+  title TEXT NOT NULL,
+  body TEXT NOT NULL CHECK (length(CAST(body AS BLOB)) <= 65536),
+  kind TEXT NOT NULL CHECK (kind IN (
+    'requirement', 'decision', 'constraint', 'fact', 'risk', 'handoff', 'summary'
+  )),
+  tags TEXT NOT NULL DEFAULT '[]'
+    CHECK (json_valid(tags) = 1 AND json_type(tags) = 'array'),
+  author_id TEXT NOT NULL,
+  author_name TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX project_context_revisions_entry_version_unique
+  ON project_context_revisions(entry_id, version);
+
+CREATE INDEX project_context_revisions_entry_versions
+  ON project_context_revisions(entry_id, version DESC);
+
+CREATE TRIGGER project_context_entries_global_revision_insert
+AFTER INSERT ON project_context_entries
+BEGIN
+  UPDATE global_revision SET revision = revision + 1 WHERE singleton = 1;
+END;
+
+CREATE TRIGGER project_context_entries_global_revision_update
+AFTER UPDATE ON project_context_entries
+BEGIN
+  UPDATE global_revision SET revision = revision + 1 WHERE singleton = 1;
+END;
+
+CREATE TRIGGER project_context_entries_global_revision_delete
+AFTER DELETE ON project_context_entries
+BEGIN
+  UPDATE global_revision SET revision = revision + 1 WHERE singleton = 1;
+END;

--- a/cloud/migrations/0002_project_context.sql
+++ b/cloud/migrations/0002_project_context.sql
@@ -1,78 +1,11 @@
-CREATE TABLE project_context_entries (
-  id TEXT PRIMARY KEY,
-  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
-  kind TEXT NOT NULL CHECK (kind IN (
-    'requirement', 'decision', 'constraint', 'fact', 'risk', 'handoff', 'summary'
-  )),
-  title TEXT NOT NULL,
-  body TEXT NOT NULL CHECK (length(CAST(body AS BLOB)) <= 65536),
-  tags TEXT NOT NULL DEFAULT '[]'
-    CHECK (json_valid(tags) = 1 AND json_type(tags) = 'array'),
-  source_type TEXT NOT NULL CHECK (source_type IN (
-    'manual', 'issue', 'comment', 'thread_summary', 'agent'
-  )),
-  source_id TEXT,
-  source_thread_id TEXT,
-  author_type TEXT NOT NULL CHECK (author_type IN ('user', 'agent')),
-  author_id TEXT NOT NULL,
-  author_name TEXT NOT NULL,
-  pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0, 1)),
-  archived_at TEXT,
-  version INTEGER NOT NULL DEFAULT 1 CHECK (version > 0),
-  idempotency_key TEXT,
-  created_at TEXT NOT NULL,
-  updated_at TEXT NOT NULL
-);
-
-CREATE UNIQUE INDEX project_context_entries_project_idempotency
-  ON project_context_entries(project_id, idempotency_key)
-  WHERE idempotency_key IS NOT NULL;
-
-CREATE INDEX project_context_entries_project_page
-  ON project_context_entries(project_id, archived_at, created_at DESC, id DESC);
-
-CREATE INDEX project_context_entries_project_kind
-  ON project_context_entries(project_id, archived_at, kind, created_at DESC, id DESC);
-
-CREATE INDEX project_context_entries_project_pinned
-  ON project_context_entries(project_id, archived_at, pinned DESC, updated_at DESC, id);
-
-CREATE TABLE project_context_revisions (
-  id TEXT PRIMARY KEY,
-  entry_id TEXT NOT NULL REFERENCES project_context_entries(id) ON DELETE CASCADE,
-  version INTEGER NOT NULL CHECK (version > 0),
-  title TEXT NOT NULL,
-  body TEXT NOT NULL CHECK (length(CAST(body AS BLOB)) <= 65536),
-  kind TEXT NOT NULL CHECK (kind IN (
-    'requirement', 'decision', 'constraint', 'fact', 'risk', 'handoff', 'summary'
-  )),
-  tags TEXT NOT NULL DEFAULT '[]'
-    CHECK (json_valid(tags) = 1 AND json_type(tags) = 'array'),
-  author_id TEXT NOT NULL,
-  author_name TEXT NOT NULL,
-  created_at TEXT NOT NULL
-);
-
-CREATE UNIQUE INDEX project_context_revisions_entry_version_unique
-  ON project_context_revisions(entry_id, version);
-
-CREATE INDEX project_context_revisions_entry_versions
-  ON project_context_revisions(entry_id, version DESC);
-
-CREATE TRIGGER project_context_entries_global_revision_insert
-AFTER INSERT ON project_context_entries
-BEGIN
-  UPDATE global_revision SET revision = revision + 1 WHERE singleton = 1;
-END;
-
-CREATE TRIGGER project_context_entries_global_revision_update
-AFTER UPDATE ON project_context_entries
-BEGIN
-  UPDATE global_revision SET revision = revision + 1 WHERE singleton = 1;
-END;
-
-CREATE TRIGGER project_context_entries_global_revision_delete
-AFTER DELETE ON project_context_entries
-BEGIN
-  UPDATE global_revision SET revision = revision + 1 WHERE singleton = 1;
-END;
+CREATE TABLE project_context_entries (id TEXT PRIMARY KEY, project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE, kind TEXT NOT NULL CHECK (kind IN ('requirement', 'decision', 'constraint', 'fact', 'risk', 'handoff', 'summary')), title TEXT NOT NULL, body TEXT NOT NULL CHECK (length(CAST(body AS BLOB)) <= 65536), tags TEXT NOT NULL DEFAULT '[]' CHECK (json_valid(tags) = 1 AND json_type(tags) = 'array'), source_type TEXT NOT NULL CHECK (source_type IN ('manual', 'issue', 'comment', 'thread_summary', 'agent')), source_id TEXT, source_thread_id TEXT, author_type TEXT NOT NULL CHECK (author_type IN ('user', 'agent')), author_id TEXT NOT NULL, author_name TEXT NOT NULL, pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0, 1)), archived_at TEXT, version INTEGER NOT NULL DEFAULT 1 CHECK (version > 0), idempotency_key TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL);
+CREATE UNIQUE INDEX project_context_entries_project_idempotency ON project_context_entries(project_id, idempotency_key) WHERE idempotency_key IS NOT NULL;
+CREATE INDEX project_context_entries_project_page ON project_context_entries(project_id, archived_at, created_at DESC, id DESC);
+CREATE INDEX project_context_entries_project_kind ON project_context_entries(project_id, archived_at, kind, created_at DESC, id DESC);
+CREATE INDEX project_context_entries_project_pinned ON project_context_entries(project_id, archived_at, pinned DESC, updated_at DESC, id);
+CREATE TABLE project_context_revisions (id TEXT PRIMARY KEY, entry_id TEXT NOT NULL REFERENCES project_context_entries(id) ON DELETE CASCADE, version INTEGER NOT NULL CHECK (version > 0), title TEXT NOT NULL, body TEXT NOT NULL CHECK (length(CAST(body AS BLOB)) <= 65536), kind TEXT NOT NULL CHECK (kind IN ('requirement', 'decision', 'constraint', 'fact', 'risk', 'handoff', 'summary')), tags TEXT NOT NULL DEFAULT '[]' CHECK (json_valid(tags) = 1 AND json_type(tags) = 'array'), author_id TEXT NOT NULL, author_name TEXT NOT NULL, created_at TEXT NOT NULL);
+CREATE UNIQUE INDEX project_context_revisions_entry_version_unique ON project_context_revisions(entry_id, version);
+CREATE INDEX project_context_revisions_entry_versions ON project_context_revisions(entry_id, version DESC);
+CREATE TRIGGER project_context_entries_global_revision_insert AFTER INSERT ON project_context_entries BEGIN UPDATE global_revision SET revision = revision + 1 WHERE singleton = 1; END;
+CREATE TRIGGER project_context_entries_global_revision_update AFTER UPDATE ON project_context_entries BEGIN UPDATE global_revision SET revision = revision + 1 WHERE singleton = 1; END;
+CREATE TRIGGER project_context_entries_global_revision_delete AFTER DELETE ON project_context_entries BEGIN UPDATE global_revision SET revision = revision + 1 WHERE singleton = 1; END;

--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -1,4 +1,17 @@
 import { normalizeWorkflowSnapshot } from "../../shared/workflow-control-flow.mjs";
+import {
+  buildProjectContextBrief,
+  contextEntryFromRow,
+  contextRevisionFromRow,
+  decodeContextCursor,
+  encodeContextCursor,
+  sameContextCreatePayload,
+  CONTEXT_BODY_MAX_BYTES,
+  CONTEXT_KINDS,
+  CONTEXT_LIST_DEFAULT_LIMIT,
+  CONTEXT_LIST_MAX_LIMIT,
+  CONTEXT_SOURCE_TYPES,
+} from "../../shared/project-context.mjs";
 
 const JSON_BODY_LIMIT = 1024 * 1024;
 const ATTACHMENT_BODY_LIMIT = 25 * 1024 * 1024;
@@ -384,8 +397,11 @@ function resolveAssignee(target, actor) {
 }
 
 async function readJson(request) {
-  const contentType = request.headers.get("content-type") ?? "";
-  if (!contentType.toLowerCase().startsWith("application/json")) {
+  const contentType = (request.headers.get("content-type") ?? "")
+    .split(";", 1)[0]
+    .trim()
+    .toLowerCase();
+  if (contentType !== "application/json") {
     throw new ApiError(
       415,
       "UNSUPPORTED_MEDIA_TYPE",
@@ -688,6 +704,336 @@ async function getTask(env, id) {
   return row ? hydrateTask(env, row) : null;
 }
 
+async function contextEntryRow(env, id) {
+  return env.DB.prepare("SELECT * FROM project_context_entries WHERE id = ?").bind(id).first();
+}
+
+async function requireContextEntryRow(env, id) {
+  const row = await contextEntryRow(env, id);
+  if (!row) throw new ApiError(404, "CONTEXT_NOT_FOUND", `Context entry '${id}' does not exist`);
+  return row;
+}
+
+function assertContextVersion(row, expectedVersion) {
+  if (row.version !== expectedVersion) {
+    throw new ApiError(409, "VERSION_CONFLICT", "Context entry was changed by another client", {
+      expectedVersion,
+      actualVersion: row.version,
+    });
+  }
+}
+
+async function listProjectContext(env, projectId, filters) {
+  await requireProject(env, projectId);
+  const where = ["project_context_entries.project_id = ?"];
+  const values = [projectId];
+  if (filters.archived === "false") where.push("project_context_entries.archived_at IS NULL");
+  else if (filters.archived === "true") where.push("project_context_entries.archived_at IS NOT NULL");
+  if (filters.kind !== undefined) {
+    where.push("project_context_entries.kind = ?");
+    values.push(filters.kind);
+  }
+  if (filters.tag !== undefined) {
+    where.push(`EXISTS (
+      SELECT 1 FROM json_each(project_context_entries.tags)
+      WHERE json_each.value = ?
+    )`);
+    values.push(filters.tag);
+  }
+  if (filters.pinned !== undefined) {
+    where.push("project_context_entries.pinned = ?");
+    values.push(filters.pinned ? 1 : 0);
+  }
+  if (filters.query !== undefined) {
+    const escaped = filters.query
+      .replaceAll("\\", "\\\\")
+      .replaceAll("%", "\\%")
+      .replaceAll("_", "\\_");
+    const pattern = `%${escaped}%`;
+    where.push(`(
+      project_context_entries.title LIKE ? ESCAPE '\\'
+      OR project_context_entries.body LIKE ? ESCAPE '\\'
+      OR EXISTS (
+        SELECT 1 FROM json_each(project_context_entries.tags)
+        WHERE json_each.value LIKE ? ESCAPE '\\'
+      )
+    )`);
+    values.push(pattern, pattern, pattern);
+  }
+  if (filters.cursor) {
+    where.push(`(
+      project_context_entries.created_at < ?
+      OR (project_context_entries.created_at = ? AND project_context_entries.id < ?)
+    )`);
+    values.push(filters.cursor[0], filters.cursor[0], filters.cursor[1]);
+  }
+  const rows = await all(env.DB.prepare(`
+    SELECT * FROM project_context_entries
+    WHERE ${where.join(" AND ")}
+    ORDER BY project_context_entries.created_at DESC, project_context_entries.id DESC
+    LIMIT ?
+  `).bind(...values, filters.limit + 1));
+  const hasMore = rows.length > filters.limit;
+  const entries = rows.slice(0, filters.limit).map(contextEntryFromRow);
+  return {
+    entries,
+    nextCursor: hasMore
+      ? encodeContextCursor([rows[filters.limit - 1].created_at, rows[filters.limit - 1].id])
+      : null,
+  };
+}
+
+async function getProjectContextBrief(env, projectId) {
+  await requireProject(env, projectId);
+  const rows = await all(env.DB.prepare(`
+    SELECT * FROM project_context_entries
+    WHERE project_id = ?
+      AND archived_at IS NULL
+      AND (pinned = 1 OR kind IN ('requirement', 'constraint', 'decision', 'risk', 'handoff', 'summary'))
+    ORDER BY
+      CASE
+        WHEN pinned = 1 THEN 0
+        WHEN kind IN ('requirement', 'constraint', 'decision') THEN 1
+        WHEN kind IN ('risk', 'handoff') THEN 2
+        ELSE 3
+      END,
+      updated_at DESC,
+      id ASC
+    LIMIT 1000
+  `).bind(projectId));
+  return buildProjectContextBrief(rows.map(contextEntryFromRow));
+}
+
+async function listContextRevisions(env, id) {
+  const entry = await requireContextEntryRow(env, id);
+  const rows = await all(env.DB.prepare(`
+    SELECT * FROM project_context_revisions
+    WHERE entry_id = ?
+    ORDER BY version ASC, id ASC
+  `).bind(entry.id));
+  return rows.map(contextRevisionFromRow);
+}
+
+function contextRevisionValues(entry, version, actor, timestamp, id = crypto.randomUUID()) {
+  return [
+    id,
+    entry.id,
+    version,
+    entry.title,
+    entry.body,
+    entry.kind,
+    JSON.stringify(entry.tags),
+    actor.id,
+    actor.name,
+    timestamp,
+  ];
+}
+
+async function sameContextCreatePayloadForExistingEntry(env, entry, input) {
+  if (entry.version <= 1) return sameContextCreatePayload(entry, input);
+  const originalRow = await env.DB.prepare(`
+    SELECT *
+    FROM project_context_revisions
+    WHERE entry_id = ? AND version = 1
+  `).bind(entry.id).first();
+  if (!originalRow) return sameContextCreatePayload(entry, input);
+  const original = contextRevisionFromRow(originalRow);
+  // Revision snapshots intentionally follow the public schema and do not carry
+  // the mutable pinned flag. Compare the original create fields, not later edits.
+  return sameContextCreatePayload(
+    {
+      ...entry,
+      kind: original.kind,
+      title: original.title,
+      body: original.body,
+      tags: original.tags,
+    },
+    input,
+    { ignorePinned: true },
+  );
+}
+
+async function createContextEntry(env, projectId, input, authContext) {
+  await requireProject(env, projectId);
+  if (input.idempotencyKey !== null) {
+    const existingRow = await env.DB.prepare(`
+      SELECT * FROM project_context_entries
+      WHERE project_id = ? AND idempotency_key = ?
+    `).bind(projectId, input.idempotencyKey).first();
+    if (existingRow) {
+      const existing = contextEntryFromRow(existingRow);
+      if (!(await sameContextCreatePayloadForExistingEntry(env, existing, input))) {
+        throw new ApiError(409, "IDEMPOTENCY_CONFLICT", "Idempotency key was already used with different context content");
+      }
+      return { entry: existing, created: false };
+    }
+  }
+  const id = crypto.randomUUID();
+  const timestamp = now();
+  const actor = authContext.actor;
+  try {
+    const results = await env.DB.batch([
+      env.DB.prepare(`
+        INSERT INTO project_context_entries (
+          id, project_id, kind, title, body, tags,
+          source_type, source_id, source_thread_id,
+          author_type, author_id, author_name, pinned, archived_at,
+          version, idempotency_key, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, 1, ?, ?, ?)
+      `).bind(
+        id,
+        projectId,
+        input.kind,
+        input.title,
+        input.body,
+        JSON.stringify(input.tags),
+        input.sourceType,
+        input.sourceId,
+        input.sourceThreadId,
+        actor.type,
+        actor.id,
+        actor.name,
+        input.pinned ? 1 : 0,
+        input.idempotencyKey,
+        timestamp,
+        timestamp,
+      ),
+      env.DB.prepare(`
+        INSERT INTO project_context_revisions (
+          id, entry_id, version, title, body, kind, tags,
+          author_id, author_name, created_at
+        )
+        SELECT ?, id, 1, title, body, kind, tags, ?, ?, ?
+        FROM project_context_entries
+        WHERE id = ? AND version = 1
+      `).bind(
+        crypto.randomUUID(),
+        actor.id,
+        actor.name,
+        timestamp,
+        id,
+      ),
+    ]);
+    if (!changed(results[0])) {
+      throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${projectId}' does not exist`);
+    }
+    return { entry: contextEntryFromRow(await requireContextEntryRow(env, id)), created: true };
+  } catch (error) {
+    if (!String(error?.message).includes("UNIQUE constraint failed")) throw error;
+    const existingRow = await env.DB.prepare(`
+      SELECT * FROM project_context_entries
+      WHERE project_id = ? AND idempotency_key = ?
+    `).bind(projectId, input.idempotencyKey).first();
+    if (!existingRow) throw error;
+    const existing = contextEntryFromRow(existingRow);
+    if (!(await sameContextCreatePayloadForExistingEntry(env, existing, input))) {
+      throw new ApiError(409, "IDEMPOTENCY_CONFLICT", "Idempotency key was already used with different context content");
+    }
+    return { entry: existing, created: false };
+  }
+}
+
+async function updateContextEntry(env, id, expectedVersion, changes, authContext) {
+  const currentRow = await requireContextEntryRow(env, id);
+  assertContextVersion(currentRow, expectedVersion);
+  const current = contextEntryFromRow(currentRow);
+  const next = { ...current, ...changes, version: expectedVersion + 1 };
+  const timestamp = now();
+  const actor = authContext.actor;
+  const assignments = [];
+  const values = [];
+  const columns = { kind: "kind", title: "title", body: "body", tags: "tags", pinned: "pinned" };
+  for (const [key, column] of Object.entries(columns)) {
+    if (!Object.hasOwn(changes, key)) continue;
+    assignments.push(`${column} = ?`);
+    values.push(key === "tags" ? JSON.stringify(changes[key]) : key === "pinned" ? (changes[key] ? 1 : 0) : changes[key]);
+  }
+  values.push(timestamp, id, expectedVersion);
+  const results = await env.DB.batch([
+    env.DB.prepare(`
+      INSERT INTO project_context_revisions (
+        id, entry_id, version, title, body, kind, tags,
+        author_id, author_name, created_at
+      )
+      SELECT ?, id, ?, ?, ?, ?, ?, ?, ?, ?
+      FROM project_context_entries
+      WHERE id = ? AND version = ?
+    `).bind(
+      crypto.randomUUID(),
+      next.version,
+      next.title,
+      next.body,
+      next.kind,
+      JSON.stringify(next.tags),
+      actor.id,
+      actor.name,
+      timestamp,
+      id,
+      expectedVersion,
+    ),
+    env.DB.prepare(`
+      UPDATE project_context_entries
+      SET ${assignments.concat(["version = version + 1", "updated_at = ?"]).join(", ")}
+      WHERE id = ? AND version = ?
+    `).bind(...values),
+  ]);
+  if (!changed(results[1])) {
+    const latest = await requireContextEntryRow(env, id);
+    throw new ApiError(409, "VERSION_CONFLICT", "Context entry was changed by another client", {
+      expectedVersion,
+      actualVersion: latest.version,
+    });
+  }
+  return contextEntryFromRow(await requireContextEntryRow(env, id));
+}
+
+async function setContextArchived(env, id, expectedVersion, authContext, archived) {
+  const currentRow = await requireContextEntryRow(env, id);
+  assertContextVersion(currentRow, expectedVersion);
+  const current = contextEntryFromRow(currentRow);
+  if (archived && current.archivedAt !== null) {
+    throw new ApiError(409, "CONTEXT_ALREADY_ARCHIVED", "Context entry is already archived");
+  }
+  if (!archived && current.archivedAt === null) {
+    throw new ApiError(409, "CONTEXT_NOT_ARCHIVED", "Only archived context entries can be restored");
+  }
+  const nextVersion = expectedVersion + 1;
+  const timestamp = now();
+  const actor = authContext.actor;
+  const results = await env.DB.batch([
+    env.DB.prepare(`
+      INSERT INTO project_context_revisions (
+        id, entry_id, version, title, body, kind, tags,
+        author_id, author_name, created_at
+      )
+      SELECT ?, id, ?, title, body, kind, tags, ?, ?, ?
+      FROM project_context_entries
+      WHERE id = ? AND version = ?
+    `).bind(
+      crypto.randomUUID(),
+      nextVersion,
+      actor.id,
+      actor.name,
+      timestamp,
+      id,
+      expectedVersion,
+    ),
+    env.DB.prepare(`
+      UPDATE project_context_entries
+      SET archived_at = ?, version = version + 1, updated_at = ?
+      WHERE id = ? AND version = ?
+    `).bind(archived ? timestamp : null, timestamp, id, expectedVersion),
+  ]);
+  if (!changed(results[1])) {
+    const latest = await requireContextEntryRow(env, id);
+    throw new ApiError(409, "VERSION_CONFLICT", "Context entry was changed by another client", {
+      expectedVersion,
+      actualVersion: latest.version,
+    });
+  }
+  return contextEntryFromRow(await requireContextEntryRow(env, id));
+}
+
 function parseProjectCreate(body) {
   assertPlainObject(body);
   assertAllowedKeys(body, new Set(["id", "name", "workspacePath"]));
@@ -805,6 +1151,172 @@ function parseVersionMutation(body) {
     version: parseVersion(body.version),
     threadId: parseThreadId(body.threadId),
   };
+}
+
+function parseContextKind(value, name = "kind") {
+  if (!CONTEXT_KINDS.includes(value)) {
+    throw new ApiError(400, "INVALID_FIELD", `'${name}' must be one of: ${CONTEXT_KINDS.join(", ")}`);
+  }
+  return value;
+}
+
+function parseContextSourceType(value, name = "sourceType") {
+  if (!CONTEXT_SOURCE_TYPES.includes(value)) {
+    throw new ApiError(
+      400,
+      "INVALID_FIELD",
+      `'${name}' must be one of: ${CONTEXT_SOURCE_TYPES.join(", ")}`,
+    );
+  }
+  return value;
+}
+
+function parseContextBody(value, name = "body", { required = false } = {}) {
+  if (value === undefined) {
+    if (required) throw new ApiError(400, "INVALID_FIELD", `'${name}' is required`);
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new ApiError(400, "INVALID_FIELD", `'${name}' must be a string`);
+  }
+  if (new TextEncoder().encode(value).byteLength > CONTEXT_BODY_MAX_BYTES) {
+    throw new ApiError(400, "INVALID_FIELD", `'${name}' cannot exceed 65536 UTF-8 bytes`);
+  }
+  return value;
+}
+
+function parseContextTags(value, name = "tags") {
+  if (!Array.isArray(value) || value.length > 20) {
+    throw new ApiError(400, "INVALID_FIELD", `'${name}' must be an array with at most 20 entries`);
+  }
+  const tags = value.map((tag, index) => {
+    if (typeof tag !== "string") throw new ApiError(400, "INVALID_FIELD", `'${name}[${index}]' must be a string`);
+    const normalized = tag.trim();
+    if (normalized.length === 0 || normalized.length > 64) {
+      throw new ApiError(400, "INVALID_FIELD", `'${name}[${index}]' must contain 1 to 64 characters`);
+    }
+    return normalized;
+  });
+  if (new Set(tags).size !== tags.length) {
+    throw new ApiError(400, "INVALID_FIELD", `'${name}' must contain unique values`);
+  }
+  return tags;
+}
+
+function parseContextBoolean(value, name) {
+  if (value === "true" || value === true) return true;
+  if (value === "false" || value === false) return false;
+  throw new ApiError(400, "INVALID_QUERY_PARAMETER", `'${name}' must be true or false`);
+}
+
+function parseContextCreate(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set([
+    "kind", "title", "body", "tags", "sourceType", "sourceId", "sourceThreadId",
+    "pinned", "idempotencyKey",
+  ]));
+  if (body.pinned !== undefined && typeof body.pinned !== "boolean") {
+    throw new ApiError(400, "INVALID_FIELD", "'pinned' must be a boolean");
+  }
+  return {
+    kind: parseContextKind(body.kind),
+    title: stringField(body.title, "title", { required: true, maxLength: 240 }),
+    body: parseContextBody(body.body, "body", { required: true }),
+    tags: body.tags === undefined ? [] : parseContextTags(body.tags),
+    sourceType: body.sourceType === undefined ? "manual" : parseContextSourceType(body.sourceType),
+    sourceId: stringField(body.sourceId ?? null, "sourceId", {
+      required: true,
+      nullable: true,
+      maxLength: 256,
+    }),
+    sourceThreadId: stringField(body.sourceThreadId ?? null, "sourceThreadId", {
+      required: true,
+      nullable: true,
+      maxLength: 256,
+    }),
+    pinned: body.pinned ?? false,
+    idempotencyKey: stringField(body.idempotencyKey ?? null, "idempotencyKey", {
+      required: true,
+      nullable: true,
+      maxLength: 256,
+    }),
+  };
+}
+
+function parseContextPatch(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["version", "kind", "title", "body", "tags", "pinned"]));
+  const version = parseVersion(body.version);
+  const changes = {};
+  if (body.kind !== undefined) changes.kind = parseContextKind(body.kind);
+  if (body.title !== undefined) changes.title = stringField(body.title, "title", { required: true, maxLength: 240 });
+  if (body.body !== undefined) changes.body = parseContextBody(body.body);
+  if (body.tags !== undefined) changes.tags = parseContextTags(body.tags);
+  if (body.pinned !== undefined) {
+    if (typeof body.pinned !== "boolean") throw new ApiError(400, "INVALID_FIELD", "'pinned' must be a boolean");
+    changes.pinned = body.pinned;
+  }
+  if (Object.keys(changes).length === 0) {
+    throw new ApiError(400, "INVALID_BODY", "PATCH requires at least one context field");
+  }
+  return { version, changes };
+}
+
+function parseContextMutation(body, routeLabel) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["version"]));
+  if (body.version === undefined) throw new ApiError(400, "INVALID_FIELD", `'version' is required for ${routeLabel}`);
+  return { version: parseVersion(body.version) };
+}
+
+function parseContextListFilters(url) {
+  const allowed = new Set(["query", "kind", "tag", "pinned", "archived", "limit", "cursor"]);
+  for (const key of url.searchParams.keys()) {
+    if (!allowed.has(key)) throw new ApiError(400, "UNKNOWN_QUERY_PARAMETER", `Unknown query parameter: ${key}`);
+    if (url.searchParams.getAll(key).length > 1) {
+      throw new ApiError(400, "INVALID_QUERY_PARAMETER", `'${key}' cannot be repeated`);
+    }
+  }
+  const rawLimit = url.searchParams.get("limit");
+  const limit = rawLimit === null ? CONTEXT_LIST_DEFAULT_LIMIT : Number(rawLimit);
+  if (!/^\d+$/.test(rawLimit ?? String(CONTEXT_LIST_DEFAULT_LIMIT))
+    || !Number.isSafeInteger(limit)
+    || limit < 1
+    || limit > CONTEXT_LIST_MAX_LIMIT) {
+    throw new ApiError(400, "INVALID_QUERY_PARAMETER", `'limit' must be an integer from 1 to ${CONTEXT_LIST_MAX_LIMIT}`);
+  }
+  const archived = url.searchParams.get("archived") ?? "false";
+  if (!["false", "true", "all"].includes(archived)) {
+    throw new ApiError(400, "INVALID_QUERY_PARAMETER", "'archived' must be false, true, or all");
+  }
+  const query = url.searchParams.get("query");
+  if (query !== null && query.length > 256) throw new ApiError(400, "INVALID_QUERY_PARAMETER", "'query' cannot exceed 256 characters");
+  const rawTag = url.searchParams.get("tag");
+  const tag = rawTag === null ? undefined : stringField(rawTag, "tag", { required: true, maxLength: 64 });
+  const kind = url.searchParams.get("kind");
+  if (kind !== null) parseContextKind(kind);
+  const rawCursor = url.searchParams.get("cursor");
+  let cursor;
+  if (rawCursor !== null) {
+    try {
+      cursor = decodeContextCursor(rawCursor);
+    } catch {
+      throw new ApiError(400, "INVALID_QUERY_PARAMETER", "'cursor' is invalid");
+    }
+  }
+  return {
+    query: query === null ? undefined : query,
+    kind: kind ?? undefined,
+    tag,
+    pinned: url.searchParams.has("pinned") ? parseContextBoolean(url.searchParams.get("pinned"), "pinned") : undefined,
+    archived,
+    limit,
+    cursor,
+  };
+}
+
+function contextAuthContext(actor) {
+  return { mechanism: "basic", actor };
 }
 
 function parseCommentCreate(body) {
@@ -1820,6 +2332,19 @@ function decodePathPart(value, label) {
   return decoded;
 }
 
+function decodeContextPathPart(value, label) {
+  let decoded;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    throw new ApiError(400, "INVALID_PATH", `${label} contains invalid encoding`);
+  }
+  if (decoded.length === 0 || decoded.length > 256 || decoded.includes("\0")) {
+    throw new ApiError(400, "INVALID_PATH", `${label} is invalid`);
+  }
+  return decoded;
+}
+
 async function attachmentContent(env, id, request) {
   const attachment = await requireAttachment(env, id);
   const object = await env.ATTACHMENTS.get(attachment.id);
@@ -1963,6 +2488,35 @@ async function routeApi(request, env, actor, url) {
     methodNotAllowed(["GET", "PUT"]);
   }
 
+  const projectContextBriefMatch = pathname.match(
+    /^\/api\/projects\/([^/]+)\/context\/brief$/,
+  );
+  if (projectContextBriefMatch) {
+    if (request.method !== "GET") methodNotAllowed(["GET"]);
+    requireNoQuery(url, "GET /api/projects/:projectId/context/brief");
+    const projectId = validateProjectId(decodePathPart(projectContextBriefMatch[1], "Project id"));
+    return json(200, await getProjectContextBrief(env, projectId));
+  }
+
+  const projectContextMatch = pathname.match(/^\/api\/projects\/([^/]+)\/context$/);
+  if (projectContextMatch) {
+    const projectId = validateProjectId(decodePathPart(projectContextMatch[1], "Project id"));
+    if (request.method === "GET") {
+      return json(200, await listProjectContext(env, projectId, parseContextListFilters(url)));
+    }
+    if (request.method === "POST") {
+      requireNoQuery(url, "POST /api/projects/:projectId/context");
+      const result = await createContextEntry(
+        env,
+        projectId,
+        parseContextCreate(await readJson(request)),
+        contextAuthContext(actor),
+      );
+      return json(result.created ? 201 : 200, { entry: result.entry });
+    }
+    methodNotAllowed(["GET", "POST"]);
+  }
+
   if (pathname === "/api/tasks") {
     if (request.method === "GET") {
       return json(200, {
@@ -1975,6 +2529,55 @@ async function routeApi(request, env, actor, url) {
       });
     }
     methodNotAllowed(["GET", "POST"]);
+  }
+
+  const contextRevisionsMatch = pathname.match(/^\/api\/context\/([^/]+)\/revisions$/);
+  if (contextRevisionsMatch) {
+    if (request.method !== "GET") methodNotAllowed(["GET"]);
+    requireNoQuery(url, "GET /api/context/:id/revisions");
+    const id = decodeContextPathPart(contextRevisionsMatch[1], "Context entry id");
+    return json(200, { revisions: await listContextRevisions(env, id) });
+  }
+
+  const contextActionMatch = pathname.match(/^\/api\/context\/([^/]+)\/(archive|restore)$/);
+  if (contextActionMatch) {
+    if (request.method !== "POST") methodNotAllowed(["POST"]);
+    requireNoQuery(url, "Context archive/restore routes");
+    const id = decodeContextPathPart(contextActionMatch[1], "Context entry id");
+    const input = parseContextMutation(
+      await readJson(request),
+      `POST /api/context/:id/${contextActionMatch[2]}`,
+    );
+    const entry = await setContextArchived(
+      env,
+      id,
+      input.version,
+      contextAuthContext(actor),
+      contextActionMatch[2] === "archive",
+    );
+    return json(200, { entry });
+  }
+
+  const contextEntryMatch = pathname.match(/^\/api\/context\/([^/]+)$/);
+  if (contextEntryMatch) {
+    requireNoQuery(url, "Context entry routes");
+    const id = decodeContextPathPart(contextEntryMatch[1], "Context entry id");
+    if (request.method === "GET") {
+      return json(200, { entry: contextEntryFromRow(await requireContextEntryRow(env, id)) });
+    }
+    if (request.method === "PATCH") {
+      const input = parseContextPatch(await readJson(request));
+      return json(200, {
+        entry: await updateContextEntry(
+          env,
+          id,
+          input.version,
+          input.changes,
+          contextAuthContext(actor),
+        ),
+      });
+    }
+    methodNotAllowed(["GET", "PATCH"]);
   }
 
   const relationMatch = pathname.match(

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start": "node server/index.mjs",
     "taskctl": "node cli/taskctl.mjs",
     "test": "node --test",
-    "test:cloud": "node --test test/cloud-shared-worker.test.mjs",
+    "test:cloud": "node --test test/cloud-shared-worker.test.mjs test/cloud-project-context.test.mjs",
     "cloud:migrate:local": "wrangler d1 migrations apply codex-taskboard-db --local",
     "cloud:migrate": "wrangler d1 migrations apply codex-taskboard-db --remote",
     "cloud:deploy:dry-run": "npm run build:web && wrangler deploy --dry-run",

--- a/scripts/migrate-to-cloud.mjs
+++ b/scripts/migrate-to-cloud.mjs
@@ -24,7 +24,13 @@ const TABLE_ORDER = [
   "task_relations",
   "attachments",
   "workflow_workspaces",
+  "project_context_entries",
+  "project_context_revisions",
 ];
+const BACKWARD_COMPATIBLE_CONTEXT_TABLES = new Set([
+  "project_context_entries",
+  "project_context_revisions",
+]);
 const LOCAL_WORKFLOW_PATH_FIELDS = new Set(["gitWorktreePath"]);
 const SORT_FIELDS = {
   projects: ["id"],
@@ -33,6 +39,8 @@ const SORT_FIELDS = {
   task_relations: ["source_task_id", "target_task_id", "relation_type"],
   attachments: ["task_id", "comment_id", "created_at", "id"],
   workflow_workspaces: ["project_id"],
+  project_context_entries: ["project_id", "created_at", "id"],
+  project_context_revisions: ["entry_id", "version", "id"],
 };
 function compareValues(left, right) {
   if (left === right) return 0;
@@ -91,6 +99,8 @@ function buildProjectCounts(tables) {
       attachments: 0,
       task_relations: 0,
       workflow_workspaces: 0,
+      project_context_entries: 0,
+      project_context_revisions: 0,
     };
   }
 
@@ -128,6 +138,21 @@ function buildProjectCounts(tables) {
       throw new Error(`Workflow workspace references unknown project '${workspace.project_id}'`);
     }
     counts[workspace.project_id].workflow_workspaces += 1;
+  }
+  const contextProjects = new Map();
+  for (const entry of tables.project_context_entries) {
+    if (!counts[entry.project_id]) {
+      throw new Error(`Context entry '${entry.id}' references unknown project '${entry.project_id}'`);
+    }
+    contextProjects.set(entry.id, entry.project_id);
+    counts[entry.project_id].project_context_entries += 1;
+  }
+  for (const revision of tables.project_context_revisions) {
+    const projectId = contextProjects.get(revision.entry_id);
+    if (!projectId) {
+      throw new Error(`Context revision '${revision.id}' references unknown entry '${revision.entry_id}'`);
+    }
+    counts[projectId].project_context_revisions += 1;
   }
 
   return Object.fromEntries(
@@ -218,12 +243,15 @@ async function readSnapshot(databasePath) {
         `SQLite snapshot failed PRAGMA foreign_key_check (${foreignKeyViolations.length} violation(s))`,
       );
     }
-    const tables = Object.fromEntries(
-      TABLE_ORDER.map((table) => [
-        table,
-        sortRows(table, snapshot.prepare(`SELECT * FROM "${table}"`).all()),
-      ]),
-    );
+    const existingTables = new Set(snapshot.prepare(`
+      SELECT name FROM sqlite_schema WHERE type = 'table'
+    `).all().map((row) => row.name));
+    const tables = Object.fromEntries(TABLE_ORDER.map((table) => {
+      if (!existingTables.has(table) && BACKWARD_COMPATIBLE_CONTEXT_TABLES.has(table)) {
+        return [table, []];
+      }
+      return [table, sortRows(table, snapshot.prepare(`SELECT * FROM "${table}"`).all())];
+    }));
     snapshot.close();
     snapshot = null;
     return tables;
@@ -232,6 +260,20 @@ async function readSnapshot(databasePath) {
     source?.close();
     await rm(snapshotDirectory, { recursive: true, force: true });
   }
+}
+
+function normalizeBackwardCompatibleContextTables(bundle) {
+  if (!bundle || bundle.schemaVersion !== SCHEMA_VERSION) return bundle;
+  bundle.tables ??= {};
+  for (const table of BACKWARD_COMPATIBLE_CONTEXT_TABLES) {
+    if (bundle.tables[table] === undefined) bundle.tables[table] = [];
+  }
+  for (const counts of Object.values(bundle.counts?.byProject ?? {})) {
+    for (const table of BACKWARD_COMPATIBLE_CONTEXT_TABLES) {
+      if (counts[table] === undefined) counts[table] = 0;
+    }
+  }
+  return bundle;
 }
 
 function assertCountsMatch(expected, actual) {
@@ -259,6 +301,7 @@ function validateBundle(bundle) {
   if (!bundle || bundle.schemaVersion !== SCHEMA_VERSION) {
     throw new Error(`Unsupported cloud migration schema version '${bundle?.schemaVersion}'`);
   }
+  normalizeBackwardCompatibleContextTables(bundle);
   for (const table of TABLE_ORDER) {
     if (!Array.isArray(bundle.tables?.[table])) {
       throw new Error(`Cloud migration bundle is missing table '${table}'`);
@@ -362,6 +405,15 @@ const CLOUD_COLUMNS = {
   task_relations: ["relation_type", "source_task_id", "target_task_id", "created_at"],
   attachments: ["id", "task_id", "comment_id", "filename", "content_type", "size", "created_at"],
   workflow_workspaces: ["project_id", "workspace", "version", "updated_at"],
+  project_context_entries: [
+    "id", "project_id", "kind", "title", "body", "tags", "source_type", "source_id",
+    "source_thread_id", "author_type", "author_id", "author_name", "pinned", "archived_at",
+    "version", "idempotency_key", "created_at", "updated_at",
+  ],
+  project_context_revisions: [
+    "id", "entry_id", "version", "title", "body", "kind", "tags", "author_id",
+    "author_name", "created_at",
+  ],
 };
 
 function cloudTaskRow(task) {
@@ -404,6 +456,96 @@ function inlineD1InsertStatement(table, values) {
   return `${insertTableSql(table).replace("?", sqliteString(json))};`;
 }
 
+function contextBodyColumn(table) {
+  return table === "project_context_entries" || table === "project_context_revisions"
+    ? "body"
+    : null;
+}
+
+function contextBodyUpdateStatement(table, column, id, body) {
+  return `UPDATE "${table}" SET "${column}" = "${column}" || ${sqliteString(body)} WHERE "id" = ${sqliteString(id)};`;
+}
+
+function splitContextBodyStatements(table, row) {
+  const column = contextBodyColumn(table);
+  if (!column || typeof row.body !== "string") return null;
+  if (row.body.includes("\0")) {
+    throw new Error("D1 migration context body cannot contain null bytes");
+  }
+
+  const baseRow = { ...row, [column]: "" };
+  const insert = inlineD1InsertStatement(table, [baseRow]);
+  if (Buffer.byteLength(insert, "utf8") >= WRANGLER_D1_STATEMENT_MAX_BYTES) {
+    throw new Error(
+      `D1 import single row '${table}:${row.id ?? "unknown"}' exceeds 90,000 bytes`,
+    );
+  }
+
+  const statements = [insert];
+  let chunk = "";
+  let chunkBytes = 0;
+  const chunks = [];
+  const updateOverhead = Buffer.byteLength(
+    contextBodyUpdateStatement(table, column, row.id, ""),
+    "utf8",
+  );
+  for (const character of Array.from(row.body)) {
+    const characterBytes = Buffer.byteLength(character, "utf8")
+      + (character === "'" ? 1 : 0);
+    if (updateOverhead + chunkBytes + characterBytes < WRANGLER_D1_STATEMENT_MAX_BYTES) {
+      chunk += character;
+      chunkBytes += characterBytes;
+      continue;
+    }
+    if (chunk.length === 0) {
+      throw new Error(
+        `D1 import single row '${table}:${row.id ?? "unknown"}' exceeds 90,000 bytes`,
+      );
+    }
+    chunks.push(chunk);
+    chunk = character;
+    chunkBytes = characterBytes;
+  }
+  if (chunk.length > 0) chunks.push(chunk);
+  for (const part of chunks) {
+    statements.push(contextBodyUpdateStatement(table, column, row.id, part));
+  }
+  return statements;
+}
+
+function inlineD1TableStatements(table, values) {
+  const statements = [];
+  let chunk = [];
+  for (const row of values) {
+    const candidate = [...chunk, row];
+    if (Buffer.byteLength(inlineD1InsertStatement(table, candidate), "utf8") < WRANGLER_D1_STATEMENT_MAX_BYTES) {
+      chunk = candidate;
+      continue;
+    }
+
+    if (chunk.length > 0) {
+      statements.push(inlineD1InsertStatement(table, chunk));
+      chunk = [];
+    }
+    const single = inlineD1InsertStatement(table, [row]);
+    if (Buffer.byteLength(single, "utf8") < WRANGLER_D1_STATEMENT_MAX_BYTES) {
+      chunk = [row];
+      continue;
+    }
+    const split = splitContextBodyStatements(table, row);
+    if (split) {
+      statements.push(...split);
+      continue;
+    }
+    const identity = row.id ?? row.project_id ?? "unknown";
+    throw new Error(
+      `D1 import single row '${table}:${identity}' exceeds 90,000 bytes`,
+    );
+  }
+  if (chunk.length > 0) statements.push(inlineD1InsertStatement(table, chunk));
+  return statements;
+}
+
 export function createCloudD1ImportSql(tables) {
   const statements = [];
   for (const { table, json } of createCloudD1ImportPlan(tables)) {
@@ -412,36 +554,7 @@ export function createCloudD1ImportSql(tables) {
       statements.push(inlineD1InsertStatement(table, values));
       continue;
     }
-
-    let chunk = [];
-    for (const row of values) {
-      const candidate = [...chunk, row];
-      const statement = inlineD1InsertStatement(table, candidate);
-      if (Buffer.byteLength(statement, "utf8") < WRANGLER_D1_STATEMENT_MAX_BYTES) {
-        chunk = candidate;
-        continue;
-      }
-      if (chunk.length === 0) {
-        const identity = row.id ?? row.project_id ?? "unknown";
-        throw new Error(
-          `D1 import single row '${table}:${identity}' exceeds 90,000 bytes`,
-        );
-      }
-      statements.push(inlineD1InsertStatement(table, chunk));
-      chunk = [row];
-      if (
-        Buffer.byteLength(
-          inlineD1InsertStatement(table, chunk),
-          "utf8",
-        ) >= WRANGLER_D1_STATEMENT_MAX_BYTES
-      ) {
-        const identity = row.id ?? row.project_id ?? "unknown";
-        throw new Error(
-          `D1 import single row '${table}:${identity}' exceeds 90,000 bytes`,
-        );
-      }
-    }
-    statements.push(inlineD1InsertStatement(table, chunk));
+    statements.push(...inlineD1TableStatements(table, values));
   }
   return statements.join("\n");
 }
@@ -456,7 +569,12 @@ export const CLOUD_PROJECT_COUNTS_SQL = `
     (SELECT COUNT(*) FROM task_relations r JOIN tasks t ON t.id = r.source_task_id
       WHERE t.project_id = p.id) AS task_relations,
     (SELECT COUNT(*) FROM workflow_workspaces w
-      WHERE w.project_id = p.id) AS workflow_workspaces
+      WHERE w.project_id = p.id) AS workflow_workspaces,
+    (SELECT COUNT(*) FROM project_context_entries e
+      WHERE e.project_id = p.id) AS project_context_entries,
+    (SELECT COUNT(*) FROM project_context_revisions r
+      JOIN project_context_entries e ON e.id = r.entry_id
+      WHERE e.project_id = p.id) AS project_context_revisions
   FROM projects p ORDER BY p.id
 `;
 
@@ -656,6 +774,10 @@ export async function readCloudMigrationBundle(inputDirectory) {
   const tables = {};
   for (const table of TABLE_ORDER) {
     const entry = manifest.tables?.[table];
+    if (!entry?.file && BACKWARD_COMPATIBLE_CONTEXT_TABLES.has(table)) {
+      tables[table] = [];
+      continue;
+    }
     if (!entry?.file) throw new Error(`Cloud migration manifest is missing table '${table}'`);
     const rows = await readJsonFile(
       bundleFile(inputDirectory, entry.file),
@@ -679,6 +801,7 @@ export async function readCloudMigrationBundle(inputDirectory) {
     tables,
     attachments,
   };
+  normalizeBackwardCompatibleContextTables(bundle);
   validateBundle(bundle);
   return bundle;
 }

--- a/scripts/wrangler-cloud-adapter.mjs
+++ b/scripts/wrangler-cloud-adapter.mjs
@@ -129,6 +129,8 @@ export function createWranglerCloudAdapters({
           task_relations: Number(row.task_relations),
           attachments: Number(row.attachments),
           workflow_workspaces: Number(row.workflow_workspaces),
+          project_context_entries: Number(row.project_context_entries),
+          project_context_revisions: Number(row.project_context_revisions),
         },
       ]));
     },

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -717,13 +717,19 @@ function parseContextCreate(body) {
     body: parseContextBody(body.body, "body", { required: true }),
     tags: body.tags === undefined ? [] : parseContextTags(body.tags),
     sourceType: body.sourceType === undefined ? "manual" : parseContextSourceType(body.sourceType),
-    sourceId: stringField(body.sourceId ?? null, "sourceId", { nullable: true, maxLength: 256 }),
+    sourceId: stringField(body.sourceId ?? null, "sourceId", {
+      required: true,
+      nullable: true,
+      maxLength: 256,
+    }),
     sourceThreadId: stringField(body.sourceThreadId ?? null, "sourceThreadId", {
+      required: true,
       nullable: true,
       maxLength: 256,
     }),
     pinned: body.pinned ?? false,
     idempotencyKey: stringField(body.idempotencyKey ?? null, "idempotencyKey", {
+      required: true,
       nullable: true,
       maxLength: 256,
     }),
@@ -1825,15 +1831,15 @@ export function createTaskboardServer(options = {}) {
           ));
         }
         if (request.method === "POST") {
+          assertNoQuery(url.searchParams, "POST /api/projects/:projectId/context");
           const result = database.createContextEntry(
             projectId,
             parseContextCreate(await readJson(request)),
             contextAuthContext(request).actor,
           );
-          events.emit(result.created ? "context.created" : "context.replayed", {
-            projectId,
-            entry: result.entry,
-          });
+          if (result.created) {
+            events.emit("context.created", { projectId, entry: result.entry });
+          }
           return sendJson(response, result.created ? 201 : 200, { entry: result.entry });
         }
         return methodNotAllowed(response, ["GET", "POST"]);

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -15,6 +15,14 @@ import {
   isTaskPriority,
   isTaskStatus,
 } from "../shared/domain.mjs";
+import {
+  CONTEXT_BODY_MAX_BYTES,
+  CONTEXT_KINDS,
+  CONTEXT_LIST_DEFAULT_LIMIT,
+  CONTEXT_LIST_MAX_LIMIT,
+  CONTEXT_SOURCE_TYPES,
+  decodeContextCursor,
+} from "../shared/project-context.mjs";
 import { normalizeWorkflowSnapshot } from "../shared/workflow-control-flow.mjs";
 import { AiChatService } from "./ai-chat.mjs";
 import { createCloudConfigStore } from "./cloud-config.mjs";
@@ -634,6 +642,173 @@ function parseArchive(body) {
   assertPlainObject(body);
   assertAllowedKeys(body, new Set(["version", "threadId"]));
   return { version: parseVersion(body.version), threadId: parseThreadId(body.threadId) };
+}
+
+function parseContextKind(value, name = "kind") {
+  if (!CONTEXT_KINDS.includes(value)) {
+    throw new ApiError(400, "INVALID_FIELD", `'${name}' must be one of: ${CONTEXT_KINDS.join(", ")}`);
+  }
+  return value;
+}
+
+function parseContextSourceType(value, name = "sourceType") {
+  if (!CONTEXT_SOURCE_TYPES.includes(value)) {
+    throw new ApiError(
+      400,
+      "INVALID_FIELD",
+      `'${name}' must be one of: ${CONTEXT_SOURCE_TYPES.join(", ")}`,
+    );
+  }
+  return value;
+}
+
+function parseContextBody(value, name = "body", { required = false } = {}) {
+  if (value === undefined) {
+    if (required) throw new ApiError(400, "INVALID_FIELD", `'${name}' is required`);
+    return undefined;
+  }
+  if (typeof value !== "string") {
+    throw new ApiError(400, "INVALID_FIELD", `'${name}' must be a string`);
+  }
+  if (Buffer.byteLength(value, "utf8") > CONTEXT_BODY_MAX_BYTES) {
+    throw new ApiError(400, "INVALID_FIELD", `'${name}' cannot exceed 65536 UTF-8 bytes`);
+  }
+  return value;
+}
+
+function parseContextTags(value, name = "tags") {
+  if (!Array.isArray(value) || value.length > 20) {
+    throw new ApiError(400, "INVALID_FIELD", `'${name}' must be an array with at most 20 entries`);
+  }
+  const tags = value.map((tag, index) => {
+    if (typeof tag !== "string") {
+      throw new ApiError(400, "INVALID_FIELD", `'${name}[${index}]' must be a string`);
+    }
+    const normalized = tag.trim();
+    if (normalized.length === 0 || normalized.length > 64) {
+      throw new ApiError(400, "INVALID_FIELD", `'${name}[${index}]' must contain 1 to 64 characters`);
+    }
+    return normalized;
+  });
+  if (new Set(tags).size !== tags.length) {
+    throw new ApiError(400, "INVALID_FIELD", `'${name}' must contain unique values`);
+  }
+  return tags;
+}
+
+function parseContextBoolean(value, name) {
+  if (value === "true" || value === true) return true;
+  if (value === "false" || value === false) return false;
+  throw new ApiError(400, "INVALID_QUERY_PARAMETER", `'${name}' must be true or false`);
+}
+
+function parseContextCreate(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set([
+    "kind", "title", "body", "tags", "sourceType", "sourceId", "sourceThreadId",
+    "pinned", "idempotencyKey",
+  ]));
+  if (body.pinned !== undefined && typeof body.pinned !== "boolean") {
+    throw new ApiError(400, "INVALID_FIELD", "'pinned' must be a boolean");
+  }
+  return {
+    kind: parseContextKind(body.kind),
+    title: stringField(body.title, "title", { required: true, maxLength: 240 }),
+    body: parseContextBody(body.body, "body", { required: true }),
+    tags: body.tags === undefined ? [] : parseContextTags(body.tags),
+    sourceType: body.sourceType === undefined ? "manual" : parseContextSourceType(body.sourceType),
+    sourceId: stringField(body.sourceId ?? null, "sourceId", { nullable: true, maxLength: 256 }),
+    sourceThreadId: stringField(body.sourceThreadId ?? null, "sourceThreadId", {
+      nullable: true,
+      maxLength: 256,
+    }),
+    pinned: body.pinned ?? false,
+    idempotencyKey: stringField(body.idempotencyKey ?? null, "idempotencyKey", {
+      nullable: true,
+      maxLength: 256,
+    }),
+  };
+}
+
+function parseContextPatch(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["version", "kind", "title", "body", "tags", "pinned"]));
+  const version = parseVersion(body.version);
+  const changes = {};
+  if (body.kind !== undefined) changes.kind = parseContextKind(body.kind);
+  if (body.title !== undefined) {
+    changes.title = stringField(body.title, "title", { required: true, maxLength: 240 });
+  }
+  if (body.body !== undefined) changes.body = parseContextBody(body.body);
+  if (body.tags !== undefined) changes.tags = parseContextTags(body.tags);
+  if (body.pinned !== undefined) {
+    if (typeof body.pinned !== "boolean") throw new ApiError(400, "INVALID_FIELD", "'pinned' must be a boolean");
+    changes.pinned = body.pinned;
+  }
+  if (Object.keys(changes).length === 0) {
+    throw new ApiError(400, "INVALID_BODY", "PATCH requires at least one context field");
+  }
+  return { version, changes };
+}
+
+function parseContextMutation(body, routeLabel) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["version"]));
+  if (body.version === undefined) {
+    throw new ApiError(400, "INVALID_FIELD", `'version' is required for ${routeLabel}`);
+  }
+  return { version: parseVersion(body.version) };
+}
+
+function parseContextListFilters(searchParams) {
+  assertAllowedQuery(
+    searchParams,
+    new Set(["query", "kind", "tag", "pinned", "archived", "limit", "cursor"]),
+    "GET /api/projects/:projectId/context",
+  );
+  const rawLimit = searchParams.get("limit");
+  const limit = rawLimit === null ? CONTEXT_LIST_DEFAULT_LIMIT : Number(rawLimit);
+  if (!/^\d+$/.test(rawLimit ?? String(CONTEXT_LIST_DEFAULT_LIMIT))
+    || !Number.isSafeInteger(limit)
+    || limit < 1
+    || limit > CONTEXT_LIST_MAX_LIMIT) {
+    throw new ApiError(400, "INVALID_QUERY_PARAMETER", `'limit' must be an integer from 1 to ${CONTEXT_LIST_MAX_LIMIT}`);
+  }
+  const archived = searchParams.get("archived") ?? "false";
+  if (!["false", "true", "all"].includes(archived)) {
+    throw new ApiError(400, "INVALID_QUERY_PARAMETER", "'archived' must be false, true, or all");
+  }
+  const rawPinned = searchParams.get("pinned");
+  const query = searchParams.get("query");
+  if (query !== null && query.length > 256) {
+    throw new ApiError(400, "INVALID_QUERY_PARAMETER", "'query' cannot exceed 256 characters");
+  }
+  const rawTag = searchParams.get("tag");
+  const tag = rawTag === null ? undefined : stringField(rawTag, "tag", { required: true, maxLength: 64 });
+  const kind = searchParams.get("kind");
+  if (kind !== null) parseContextKind(kind, "kind");
+  let cursor;
+  const rawCursor = searchParams.get("cursor");
+  if (rawCursor !== null) {
+    try {
+      cursor = decodeContextCursor(rawCursor);
+    } catch {
+      throw new ApiError(400, "INVALID_QUERY_PARAMETER", "'cursor' is invalid");
+    }
+  }
+  return {
+    query: query === null ? undefined : query,
+    kind: kind ?? undefined,
+    tag,
+    pinned: rawPinned === null ? undefined : parseContextBoolean(rawPinned, "pinned"),
+    archived,
+    limit,
+    cursor,
+  };
+}
+
+function contextAuthContext(request) {
+  return { mechanism: "local", actor: actorFromRequest(request) };
 }
 
 function parseIssueRelationType(value) {
@@ -1628,6 +1803,42 @@ export function createTaskboardServer(options = {}) {
         return methodNotAllowed(response, ["GET", "PUT"]);
       }
 
+      const projectContextBriefRoute = pathname.match(/^\/api\/projects\/([^/]+)\/context\/brief$/);
+      if (projectContextBriefRoute) {
+        if (request.method !== "GET") return methodNotAllowed(response, ["GET"]);
+        assertNoQuery(url.searchParams, "GET /api/projects/:projectId/context/brief");
+        const projectId = validateProjectId(
+          decodeRouteSegment(projectContextBriefRoute[1], "Project id"),
+        );
+        return sendJson(response, 200, database.getProjectContextBrief(projectId));
+      }
+
+      const projectContextRoute = pathname.match(/^\/api\/projects\/([^/]+)\/context$/);
+      if (projectContextRoute) {
+        const projectId = validateProjectId(
+          decodeRouteSegment(projectContextRoute[1], "Project id"),
+        );
+        if (request.method === "GET") {
+          return sendJson(response, 200, database.listProjectContext(
+            projectId,
+            parseContextListFilters(url.searchParams),
+          ));
+        }
+        if (request.method === "POST") {
+          const result = database.createContextEntry(
+            projectId,
+            parseContextCreate(await readJson(request)),
+            contextAuthContext(request).actor,
+          );
+          events.emit(result.created ? "context.created" : "context.replayed", {
+            projectId,
+            entry: result.entry,
+          });
+          return sendJson(response, result.created ? 201 : 200, { entry: result.entry });
+        }
+        return methodNotAllowed(response, ["GET", "POST"]);
+      }
+
       const developmentContextsRoute = pathname.match(/^\/api\/projects\/([^/]+)\/development-contexts$/);
       if (developmentContextsRoute) {
         if (request.method !== "GET") return methodNotAllowed(response, ["GET"]);
@@ -1702,6 +1913,54 @@ export function createTaskboardServer(options = {}) {
         }
         events.connect(request, response);
         return;
+      }
+
+      const contextRevisionsRoute = pathname.match(/^\/api\/context\/([^/]+)\/revisions$/);
+      if (contextRevisionsRoute) {
+        if (request.method !== "GET") return methodNotAllowed(response, ["GET"]);
+        assertNoQuery(url.searchParams, "GET /api/context/:id/revisions");
+        const id = decodeRouteSegment(contextRevisionsRoute[1], "Context entry id");
+        return sendJson(response, 200, { revisions: database.listContextRevisions(id) });
+      }
+
+      const contextActionRoute = pathname.match(/^\/api\/context\/([^/]+)\/(archive|restore)$/);
+      if (contextActionRoute) {
+        if (request.method !== "POST") return methodNotAllowed(response, ["POST"]);
+        assertNoQuery(url.searchParams, "Context archive/restore routes");
+        const id = decodeRouteSegment(contextActionRoute[1], "Context entry id");
+        const { version } = parseContextMutation(
+          await readJson(request),
+          `POST /api/context/:id/${contextActionRoute[2]}`,
+        );
+        const actor = contextAuthContext(request).actor;
+        const entry = contextActionRoute[2] === "archive"
+          ? database.archiveContextEntry(id, version, actor)
+          : database.restoreContextEntry(id, version, actor);
+        events.emit(`context.${contextActionRoute[2]}`, { projectId: entry.projectId, entry });
+        return sendJson(response, 200, { entry });
+      }
+
+      const contextEntryRoute = pathname.match(/^\/api\/context\/([^/]+)$/);
+      if (contextEntryRoute) {
+        assertNoQuery(url.searchParams, "Context entry routes");
+        const id = decodeRouteSegment(contextEntryRoute[1], "Context entry id");
+        if (request.method === "GET") {
+          const entry = database.getContextEntry(id);
+          if (!entry) throw new ApiError(404, "CONTEXT_NOT_FOUND", `Context entry '${id}' does not exist`);
+          return sendJson(response, 200, { entry });
+        }
+        if (request.method === "PATCH") {
+          const patch = parseContextPatch(await readJson(request));
+          const entry = database.updateContextEntry(
+            id,
+            patch.version,
+            patch.changes,
+            contextAuthContext(request).actor,
+          );
+          events.emit("context.updated", { projectId: entry.projectId, entry });
+          return sendJson(response, 200, { entry });
+        }
+        return methodNotAllowed(response, ["GET", "PATCH"]);
       }
 
       const taskRelationRoute = pathname.match(

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -3,6 +3,14 @@ import { mkdirSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
+import {
+  buildProjectContextBrief,
+  contextEntryFromRow,
+  contextRevisionFromRow,
+  encodeContextCursor,
+  sameContextCreatePayload,
+} from "../shared/project-context.mjs";
+
 export class ApiError extends Error {
   constructor(status, code, message, details) {
     super(message);
@@ -113,6 +121,21 @@ function projectFromRow(row) {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
+}
+
+function contextRevisionValues(entry, version, actor, timestamp, id = randomUUID()) {
+  return [
+    id,
+    entry.id,
+    version,
+    entry.title,
+    entry.body,
+    entry.kind,
+    JSON.stringify(entry.tags),
+    actor.id,
+    actor.name,
+    timestamp,
+  ];
 }
 
 function workflowWorkspaceFromRow(row) {
@@ -685,6 +708,296 @@ export class TaskboardDatabase {
         projects.updated_at
     `).get(id);
     return row ? projectFromRow(row) : null;
+  }
+
+  getContextEntry(id) {
+    const row = this.database.prepare(`
+      SELECT * FROM project_context_entries WHERE id = ?
+    `).get(id);
+    return row ? contextEntryFromRow(row) : null;
+  }
+
+  listProjectContext(projectId, filters) {
+    if (!this.getProject(projectId)) {
+      throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${projectId}' does not exist`);
+    }
+
+    const where = ["project_context_entries.project_id = ?"];
+    const values = [projectId];
+    if (filters.archived === "false") {
+      where.push("project_context_entries.archived_at IS NULL");
+    } else if (filters.archived === "true") {
+      where.push("project_context_entries.archived_at IS NOT NULL");
+    }
+    if (filters.kind !== undefined) {
+      where.push("project_context_entries.kind = ?");
+      values.push(filters.kind);
+    }
+    if (filters.tag !== undefined) {
+      where.push(`EXISTS (
+        SELECT 1 FROM json_each(project_context_entries.tags)
+        WHERE json_each.value = ?
+      )`);
+      values.push(filters.tag);
+    }
+    if (filters.pinned !== undefined) {
+      where.push("project_context_entries.pinned = ?");
+      values.push(filters.pinned ? 1 : 0);
+    }
+    if (filters.query !== undefined) {
+      const escaped = filters.query
+        .replaceAll("\\", "\\\\")
+        .replaceAll("%", "\\%")
+        .replaceAll("_", "\\_");
+      const pattern = `%${escaped}%`;
+      where.push(`(
+        project_context_entries.title LIKE ? ESCAPE '\\'
+        OR project_context_entries.body LIKE ? ESCAPE '\\'
+        OR EXISTS (
+          SELECT 1 FROM json_each(project_context_entries.tags)
+          WHERE json_each.value LIKE ? ESCAPE '\\'
+        )
+      )`);
+      values.push(pattern, pattern, pattern);
+    }
+    if (filters.cursor) {
+      where.push(`(
+        project_context_entries.created_at < ?
+        OR (
+          project_context_entries.created_at = ?
+          AND project_context_entries.id < ?
+        )
+      )`);
+      values.push(filters.cursor[0], filters.cursor[0], filters.cursor[1]);
+    }
+
+    const rows = this.database.prepare(`
+      SELECT *
+      FROM project_context_entries
+      WHERE ${where.join(" AND ")}
+      ORDER BY project_context_entries.created_at DESC, project_context_entries.id DESC
+      LIMIT ?
+    `).all(...values, filters.limit + 1);
+    const hasMore = rows.length > filters.limit;
+    const entries = rows.slice(0, filters.limit).map(contextEntryFromRow);
+    return {
+      entries,
+      nextCursor: hasMore
+        ? encodeContextCursor([
+          rows[filters.limit - 1].created_at,
+          rows[filters.limit - 1].id,
+        ])
+        : null,
+    };
+  }
+
+  getProjectContextBrief(projectId) {
+    if (!this.getProject(projectId)) {
+      throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${projectId}' does not exist`);
+    }
+    const entries = this.database.prepare(`
+      SELECT *
+      FROM project_context_entries
+      WHERE project_id = ? AND archived_at IS NULL
+      ORDER BY updated_at DESC, id DESC
+    `).all(projectId).map(contextEntryFromRow);
+    return buildProjectContextBrief(entries);
+  }
+
+  listContextRevisions(id) {
+    const entry = this.getContextEntry(id);
+    if (!entry) {
+      throw new ApiError(404, "CONTEXT_NOT_FOUND", `Context entry '${id}' does not exist`);
+    }
+    return this.database.prepare(`
+      SELECT *
+      FROM project_context_revisions
+      WHERE entry_id = ?
+      ORDER BY version ASC, id ASC
+    `).all(entry.id).map(contextRevisionFromRow);
+  }
+
+  createContextEntry(projectId, input, actor) {
+    this.database.exec("BEGIN IMMEDIATE");
+    try {
+      if (!this.database.prepare("SELECT 1 FROM projects WHERE id = ?").get(projectId)) {
+        throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${projectId}' does not exist`);
+      }
+      if (input.idempotencyKey !== null) {
+        const existingRow = this.database.prepare(`
+          SELECT * FROM project_context_entries
+          WHERE project_id = ? AND idempotency_key = ?
+        `).get(projectId, input.idempotencyKey);
+        if (existingRow) {
+          const existing = contextEntryFromRow(existingRow);
+          if (!sameContextCreatePayload(existing, input)) {
+            throw new ApiError(
+              409,
+              "IDEMPOTENCY_CONFLICT",
+              "Idempotency key was already used with different context content",
+            );
+          }
+          this.database.exec("COMMIT");
+          return { entry: existing, created: false };
+        }
+      }
+
+      const id = randomUUID();
+      const timestamp = now();
+      this.database.prepare(`
+        INSERT INTO project_context_entries (
+          id, project_id, kind, title, body, tags,
+          source_type, source_id, source_thread_id,
+          author_type, author_id, author_name, pinned, archived_at,
+          version, idempotency_key, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, 1, ?, ?, ?)
+      `).run(
+        id,
+        projectId,
+        input.kind,
+        input.title,
+        input.body,
+        JSON.stringify(input.tags),
+        input.sourceType,
+        input.sourceId,
+        input.sourceThreadId,
+        actor.type,
+        actor.id,
+        actor.name,
+        input.pinned ? 1 : 0,
+        input.idempotencyKey,
+        timestamp,
+        timestamp,
+      );
+      const entry = this.getContextEntry(id);
+      this.database.prepare(`
+        INSERT INTO project_context_revisions (
+          id, entry_id, version, title, body, kind, tags,
+          author_id, author_name, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(...contextRevisionValues(entry, 1, actor, timestamp));
+      this.database.exec("COMMIT");
+      return { entry: this.getContextEntry(id), created: true };
+    } catch (error) {
+      this.database.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  updateContextEntry(id, expectedVersion, changes, actor) {
+    this.database.exec("BEGIN IMMEDIATE");
+    try {
+      const current = this.#requireContextEntry(id);
+      this.#requireContextVersion(current, expectedVersion);
+      const next = {
+        ...current,
+        ...changes,
+        version: current.version + 1,
+      };
+      const timestamp = now();
+      this.database.prepare(`
+        INSERT INTO project_context_revisions (
+          id, entry_id, version, title, body, kind, tags,
+          author_id, author_name, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(...contextRevisionValues(next, next.version, actor, timestamp));
+      const assignments = [];
+      const values = [];
+      const columns = {
+        kind: "kind",
+        title: "title",
+        body: "body",
+        tags: "tags",
+        pinned: "pinned",
+      };
+      for (const [key, column] of Object.entries(columns)) {
+        if (!Object.hasOwn(changes, key)) continue;
+        assignments.push(`${column} = ?`);
+        values.push(key === "tags" ? JSON.stringify(changes[key]) : key === "pinned" ? (changes[key] ? 1 : 0) : changes[key]);
+      }
+      assignments.push("version = version + 1", "updated_at = ?");
+      values.push(timestamp, id, expectedVersion);
+      const result = this.database.prepare(`
+        UPDATE project_context_entries
+        SET ${assignments.join(", ")}
+        WHERE id = ? AND version = ?
+      `).run(...values);
+      if (result.changes !== 1) this.#throwContextMissingOrConflict(id, expectedVersion);
+      this.database.exec("COMMIT");
+      return this.getContextEntry(id);
+    } catch (error) {
+      this.database.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  archiveContextEntry(id, expectedVersion, actor) {
+    return this.#setContextArchived(id, expectedVersion, actor, true);
+  }
+
+  restoreContextEntry(id, expectedVersion, actor) {
+    return this.#setContextArchived(id, expectedVersion, actor, false);
+  }
+
+  #setContextArchived(id, expectedVersion, actor, archived) {
+    this.database.exec("BEGIN IMMEDIATE");
+    try {
+      const current = this.#requireContextEntry(id);
+      this.#requireContextVersion(current, expectedVersion);
+      if (archived && current.archivedAt !== null) {
+        throw new ApiError(409, "CONTEXT_ALREADY_ARCHIVED", "Context entry is already archived");
+      }
+      if (!archived && current.archivedAt === null) {
+        throw new ApiError(409, "CONTEXT_NOT_ARCHIVED", "Only archived context entries can be restored");
+      }
+      const timestamp = now();
+      const next = { ...current, version: current.version + 1 };
+      this.database.prepare(`
+        INSERT INTO project_context_revisions (
+          id, entry_id, version, title, body, kind, tags,
+          author_id, author_name, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(...contextRevisionValues(next, next.version, actor, timestamp));
+      const result = this.database.prepare(`
+        UPDATE project_context_entries
+        SET archived_at = ?, version = version + 1, updated_at = ?
+        WHERE id = ? AND version = ?
+      `).run(archived ? timestamp : null, timestamp, id, expectedVersion);
+      if (result.changes !== 1) this.#throwContextMissingOrConflict(id, expectedVersion);
+      this.database.exec("COMMIT");
+      return this.getContextEntry(id);
+    } catch (error) {
+      this.database.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  #requireContextEntry(id) {
+    const entry = this.getContextEntry(id);
+    if (!entry) {
+      throw new ApiError(404, "CONTEXT_NOT_FOUND", `Context entry '${id}' does not exist`);
+    }
+    return entry;
+  }
+
+  #requireContextVersion(entry, expectedVersion) {
+    if (entry.version !== expectedVersion) {
+      throw new ApiError(409, "VERSION_CONFLICT", "Context entry was changed by another client", {
+        expectedVersion,
+        actualVersion: entry.version,
+      });
+    }
+  }
+
+  #throwContextMissingOrConflict(id, expectedVersion) {
+    const entry = this.getContextEntry(id);
+    if (!entry) {
+      throw new ApiError(404, "CONTEXT_NOT_FOUND", `Context entry '${id}' does not exist`);
+    }
+    throw new ApiError(409, "VERSION_CONFLICT", "Context entry was changed by another client", {
+      expectedVersion,
+      actualVersion: entry.version,
+    });
   }
 
   getWorkflowWorkspace(projectId) {

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -138,6 +138,30 @@ function contextRevisionValues(entry, version, actor, timestamp, id = randomUUID
   ];
 }
 
+function sameContextCreatePayloadForExistingEntry(database, entry, input) {
+  if (entry.version <= 1) return sameContextCreatePayload(entry, input);
+  const originalRow = database.prepare(`
+    SELECT *
+    FROM project_context_revisions
+    WHERE entry_id = ? AND version = 1
+  `).get(entry.id);
+  if (!originalRow) return sameContextCreatePayload(entry, input);
+  const original = contextRevisionFromRow(originalRow);
+  // Revision snapshots intentionally follow the public schema and do not carry
+  // the mutable pinned flag. Compare the original create fields, not later edits.
+  return sameContextCreatePayload(
+    {
+      ...entry,
+      kind: original.kind,
+      title: original.title,
+      body: original.body,
+      tags: original.tags,
+    },
+    input,
+    { ignorePinned: true },
+  );
+}
+
 function workflowWorkspaceFromRow(row) {
   return {
     projectId: row.project_id,
@@ -798,8 +822,19 @@ export class TaskboardDatabase {
     const entries = this.database.prepare(`
       SELECT *
       FROM project_context_entries
-      WHERE project_id = ? AND archived_at IS NULL
-      ORDER BY updated_at DESC, id DESC
+      WHERE project_id = ?
+        AND archived_at IS NULL
+        AND (pinned = 1 OR kind IN ('requirement', 'constraint', 'decision', 'risk', 'handoff', 'summary'))
+      ORDER BY
+        CASE
+          WHEN pinned = 1 THEN 0
+          WHEN kind IN ('requirement', 'constraint', 'decision') THEN 1
+          WHEN kind IN ('risk', 'handoff') THEN 2
+          ELSE 3
+        END,
+        updated_at DESC,
+        id ASC
+      LIMIT 1000
     `).all(projectId).map(contextEntryFromRow);
     return buildProjectContextBrief(entries);
   }
@@ -830,7 +865,7 @@ export class TaskboardDatabase {
         `).get(projectId, input.idempotencyKey);
         if (existingRow) {
           const existing = contextEntryFromRow(existingRow);
-          if (!sameContextCreatePayload(existing, input)) {
+          if (!sameContextCreatePayloadForExistingEntry(this.database, existing, input)) {
             throw new ApiError(
               409,
               "IDEMPOTENCY_CONFLICT",

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -270,6 +270,67 @@ export class TaskboardDatabase {
         updated_at TEXT NOT NULL
       );
 
+      CREATE TABLE IF NOT EXISTS project_context_entries (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        kind TEXT NOT NULL CHECK (kind IN (
+          'requirement', 'decision', 'constraint', 'fact', 'risk', 'handoff', 'summary'
+        )),
+        title TEXT NOT NULL,
+        body TEXT NOT NULL CHECK (length(CAST(body AS BLOB)) <= 65536),
+        tags TEXT NOT NULL DEFAULT '[]'
+          CHECK (json_valid(tags) = 1 AND json_type(tags) = 'array'),
+        source_type TEXT NOT NULL CHECK (source_type IN (
+          'manual', 'issue', 'comment', 'thread_summary', 'agent'
+        )),
+        source_id TEXT,
+        source_thread_id TEXT,
+        author_type TEXT NOT NULL CHECK (author_type IN ('user', 'agent')),
+        author_id TEXT NOT NULL,
+        author_name TEXT NOT NULL,
+        pinned INTEGER NOT NULL DEFAULT 0 CHECK (pinned IN (0, 1)),
+        archived_at TEXT,
+        version INTEGER NOT NULL DEFAULT 1 CHECK (version > 0),
+        idempotency_key TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS project_context_entries_project_idempotency
+        ON project_context_entries(project_id, idempotency_key)
+        WHERE idempotency_key IS NOT NULL;
+
+      CREATE INDEX IF NOT EXISTS project_context_entries_project_page
+        ON project_context_entries(project_id, archived_at, created_at DESC, id DESC);
+
+      CREATE INDEX IF NOT EXISTS project_context_entries_project_kind
+        ON project_context_entries(project_id, archived_at, kind, created_at DESC, id DESC);
+
+      CREATE INDEX IF NOT EXISTS project_context_entries_project_pinned
+        ON project_context_entries(project_id, archived_at, pinned DESC, updated_at DESC, id);
+
+      CREATE TABLE IF NOT EXISTS project_context_revisions (
+        id TEXT PRIMARY KEY,
+        entry_id TEXT NOT NULL REFERENCES project_context_entries(id) ON DELETE CASCADE,
+        version INTEGER NOT NULL CHECK (version > 0),
+        title TEXT NOT NULL,
+        body TEXT NOT NULL CHECK (length(CAST(body AS BLOB)) <= 65536),
+        kind TEXT NOT NULL CHECK (kind IN (
+          'requirement', 'decision', 'constraint', 'fact', 'risk', 'handoff', 'summary'
+        )),
+        tags TEXT NOT NULL DEFAULT '[]'
+          CHECK (json_valid(tags) = 1 AND json_type(tags) = 'array'),
+        author_id TEXT NOT NULL,
+        author_name TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS project_context_revisions_entry_version_unique
+        ON project_context_revisions(entry_id, version);
+
+      CREATE INDEX IF NOT EXISTS project_context_revisions_entry_versions
+        ON project_context_revisions(entry_id, version DESC);
+
       CREATE TABLE IF NOT EXISTS ai_chat_threads (
         id TEXT PRIMARY KEY,
         title TEXT NOT NULL,

--- a/shared/project-context.mjs
+++ b/shared/project-context.mjs
@@ -1,0 +1,218 @@
+export const CONTEXT_KINDS = Object.freeze([
+  "requirement",
+  "decision",
+  "constraint",
+  "fact",
+  "risk",
+  "handoff",
+  "summary",
+]);
+
+export const CONTEXT_SOURCE_TYPES = Object.freeze([
+  "manual",
+  "issue",
+  "comment",
+  "thread_summary",
+  "agent",
+]);
+
+export const CONTEXT_BODY_MAX_BYTES = 65_536;
+export const CONTEXT_LIST_DEFAULT_LIMIT = 50;
+export const CONTEXT_LIST_MAX_LIMIT = 100;
+export const CONTEXT_BRIEF_MAX_CHARS = 12_000;
+
+const CONTEXT_CURSOR_VALUE_MAX_CHARS = 512;
+const CONTEXT_CURSOR_MAX_CHARS = 8_192;
+const BRIEF_PRIMARY_KINDS = new Set(["requirement", "constraint", "decision"]);
+const BRIEF_SECONDARY_KINDS = new Set(["risk", "handoff"]);
+
+export function contextEntryFromRow(row) {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    kind: row.kind,
+    title: row.title,
+    body: row.body,
+    tags: parseRowTags(row.tags),
+    sourceType: row.source_type,
+    sourceId: row.source_id ?? null,
+    sourceThreadId: row.source_thread_id ?? null,
+    authorType: row.author_type,
+    authorId: row.author_id,
+    authorName: row.author_name,
+    pinned: row.pinned === true || row.pinned === 1,
+    archivedAt: row.archived_at ?? null,
+    version: row.version,
+    idempotencyKey: row.idempotency_key ?? null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function contextRevisionFromRow(row) {
+  return {
+    id: row.id,
+    entryId: row.entry_id,
+    version: row.version,
+    title: row.title,
+    body: row.body,
+    kind: row.kind,
+    tags: parseRowTags(row.tags),
+    authorId: row.author_id,
+    authorName: row.author_name,
+    createdAt: row.created_at,
+  };
+}
+
+export function encodeContextCursor(tuple) {
+  validateCursorTuple(tuple);
+  const bytes = new TextEncoder().encode(JSON.stringify(tuple));
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/u, "");
+}
+
+export function decodeContextCursor(cursor) {
+  if (
+    typeof cursor !== "string"
+    || cursor.length === 0
+    || cursor.length > CONTEXT_CURSOR_MAX_CHARS
+    || !/^[A-Za-z0-9_-]+$/u.test(cursor)
+    || cursor.length % 4 === 1
+  ) {
+    throw invalidCursorError();
+  }
+
+  try {
+    const base64 = cursor
+      .replaceAll("-", "+")
+      .replaceAll("_", "/")
+      .padEnd(cursor.length + ((4 - (cursor.length % 4)) % 4), "=");
+    const binary = atob(base64);
+    const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+    const value = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes));
+    validateCursorTuple(value);
+    if (encodeContextCursor(value) !== cursor) throw invalidCursorError();
+    return Object.freeze(value);
+  } catch {
+    throw invalidCursorError();
+  }
+}
+
+export function sameContextCreatePayload(entry, input) {
+  return entry.kind === input.kind
+    && entry.title === input.title
+    && entry.body === input.body
+    && sameStringArray(entry.tags ?? [], input.tags ?? [])
+    && entry.sourceType === (input.sourceType ?? "manual")
+    && (entry.sourceId ?? null) === (input.sourceId ?? null)
+    && (entry.sourceThreadId ?? null) === (input.sourceThreadId ?? null)
+    && entry.pinned === (input.pinned ?? false);
+}
+
+export function buildProjectContextBrief(entries) {
+  const selected = entries
+    .filter((entry) => entry.archivedAt == null)
+    .map((entry) => ({ entry, priority: briefPriority(entry) }))
+    .filter(({ priority }) => Number.isFinite(priority))
+    .sort((left, right) => (
+      left.priority - right.priority
+      || compareDescending(left.entry.updatedAt, right.entry.updatedAt)
+      || compareAscending(String(left.entry.id), String(right.entry.id))
+    ));
+
+  const includedEntryIds = [];
+  const seenEntryIds = new Set();
+  let brief = "";
+  let truncated = false;
+
+  for (const { entry } of selected) {
+    if (seenEntryIds.has(entry.id)) continue;
+    seenEntryIds.add(entry.id);
+
+    const block = formatBriefEntry(entry);
+    const separator = brief.length === 0 ? "" : "\n\n";
+    const available = CONTEXT_BRIEF_MAX_CHARS - brief.length;
+    if (separator.length + block.length <= available) {
+      brief += separator + block;
+      includedEntryIds.push(entry.id);
+      continue;
+    }
+
+    truncated = true;
+    const availableForBlock = available - separator.length;
+    if (availableForBlock > 0) {
+      brief += separator + block.slice(0, availableForBlock);
+      includedEntryIds.push(entry.id);
+    }
+    break;
+  }
+
+  return { brief, includedEntryIds, truncated };
+}
+
+function parseRowTags(tags) {
+  return typeof tags === "string" ? JSON.parse(tags) : tags;
+}
+
+function validateCursorTuple(tuple) {
+  if (
+    !Array.isArray(tuple)
+    || tuple.length !== 2
+    || tuple.some((value) => (
+      typeof value !== "string"
+      || value.length === 0
+      || value.length > CONTEXT_CURSOR_VALUE_MAX_CHARS
+    ))
+  ) {
+    throw invalidCursorError();
+  }
+}
+
+function invalidCursorError() {
+  return new Error("Invalid project context cursor");
+}
+
+function sameStringArray(left, right) {
+  return Array.isArray(left)
+    && Array.isArray(right)
+    && left.length === right.length
+    && left.every((value, index) => value === right[index]);
+}
+
+function briefPriority(entry) {
+  if (entry.pinned) return 0;
+  if (BRIEF_PRIMARY_KINDS.has(entry.kind)) return 1;
+  if (BRIEF_SECONDARY_KINDS.has(entry.kind)) return 2;
+  if (entry.kind === "summary") return 3;
+  return Number.POSITIVE_INFINITY;
+}
+
+function compareDescending(left, right) {
+  if (left === right) return 0;
+  return left < right ? 1 : -1;
+}
+
+function compareAscending(left, right) {
+  if (left === right) return 0;
+  return left < right ? -1 : 1;
+}
+
+function formatBriefEntry(entry) {
+  const lines = [`## [${entry.kind}] ${entry.title}`];
+  if (entry.tags.length > 0) {
+    lines.push(`- Tags: ${entry.tags.map((tag) => JSON.stringify(tag)).join(", ")}`);
+  }
+  const source = [entry.sourceType];
+  if (entry.sourceId !== null) source.push(`id=${JSON.stringify(entry.sourceId)}`);
+  if (entry.sourceThreadId !== null) {
+    source.push(`thread=${JSON.stringify(entry.sourceThreadId)}`);
+  }
+  lines.push(`- Source: ${source.join("; ")}`);
+  lines.push(`- Updated: ${entry.updatedAt}`);
+  lines.push("", entry.body);
+  return lines.join("\n");
+}

--- a/shared/project-context.mjs
+++ b/shared/project-context.mjs
@@ -102,7 +102,7 @@ export function decodeContextCursor(cursor) {
   }
 }
 
-export function sameContextCreatePayload(entry, input) {
+export function sameContextCreatePayload(entry, input, { ignorePinned = false } = {}) {
   return entry.kind === input.kind
     && entry.title === input.title
     && entry.body === input.body
@@ -110,7 +110,7 @@ export function sameContextCreatePayload(entry, input) {
     && entry.sourceType === (input.sourceType ?? "manual")
     && (entry.sourceId ?? null) === (input.sourceId ?? null)
     && (entry.sourceThreadId ?? null) === (input.sourceThreadId ?? null)
-    && entry.pinned === (input.pinned ?? false);
+    && (ignorePinned || entry.pinned === (input.pinned ?? false));
 }
 
 export function buildProjectContextBrief(entries) {
@@ -128,9 +128,14 @@ export function buildProjectContextBrief(entries) {
   const seenEntryIds = new Set();
   let brief = "";
   let truncated = false;
+  let unpinnedSummarySelected = false;
 
   for (const { entry } of selected) {
     if (seenEntryIds.has(entry.id)) continue;
+    if (!entry.pinned && entry.kind === "summary") {
+      if (unpinnedSummarySelected) continue;
+      unpinnedSummarySelected = true;
+    }
     seenEntryIds.add(entry.id);
 
     const block = formatBriefEntry(entry);

--- a/test/board-views.test.mjs
+++ b/test/board-views.test.mjs
@@ -16,10 +16,11 @@ const serverSource = await readFile(new URL("../server/app.mjs", import.meta.url
 const styles = await readFile(new URL("../web/src/components/workflow.css", import.meta.url), "utf8");
 const globalStyles = await readFile(new URL("../web/src/styles.css", import.meta.url), "utf8");
 
-test("the taskboard defaults to issues and exposes issue and node mode tabs", () => {
-  assert.match(appSource, /type BoardView = "issues" \| "workflow"/);
+test("the taskboard defaults to issues and exposes issue, context and node mode tabs", () => {
+  assert.match(appSource, /type BoardView = "issues" \| "context" \| "workflow"/);
   assert.match(appSource, /useState<BoardView>\("issues"\)/);
   assert.match(appSource, />\s*议题看板\s*<\/button>/);
+  assert.match(appSource, />\s*Context\s*<\/button>/);
   assert.match(appSource, />\s*节点模式\s*<\/button>/);
   assert.match(appSource, /aria-pressed=\{boardView === "issues"\}/);
   assert.match(appSource, /aria-pressed=\{boardView === "workflow"\}/);

--- a/test/cloud-companion.test.mjs
+++ b/test/cloud-companion.test.mjs
@@ -273,6 +273,12 @@ test("cloud routing keeps machine-specific capability endpoints in the local com
   for (const pathname of [
     "/api/projects",
     "/api/projects/portfolio/workflow-workspace",
+    "/api/projects/portfolio/context",
+    "/api/projects/portfolio/context/brief",
+    "/api/context/context-1",
+    "/api/context/context-1/revisions",
+    "/api/context/context-1/archive",
+    "/api/context/context-1/restore",
     "/api/tasks",
     "/api/tasks/PORTFOLIO-1",
     "/api/comments/comment-1",
@@ -530,6 +536,89 @@ test("configured server proxies business APIs without touching local rows and ad
     assert.equal(upstreamCalls.length, 1);
     assert.equal(upstreamCalls[0].url, "https://tasks.example.test/api/tasks");
     assert.equal(app.database.listTasks({}).length, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("configured server context writes never fall back to or double-write local SQLite", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "taskboard-context-cloud-server-"));
+  temporaryDirectories.push(directory);
+  const configPath = path.join(directory, "companion.json");
+  const { createCloudConfigStore } = await importCloudConfig();
+  await createCloudConfigStore({ configPath }).configure({
+    remoteUrl: "https://tasks.example.test",
+    actorName: "Alice",
+    sharedKey: "two-person-shared-key",
+  });
+  const upstreamCalls = [];
+  let failRemote = false;
+  const remoteEntry = {
+    id: "remote-context",
+    projectId: "portfolio",
+    kind: "decision",
+    title: "Remote only",
+    body: "Cloud owns this row",
+    tags: [],
+    sourceType: "manual",
+    sourceId: null,
+    sourceThreadId: null,
+    authorType: "user",
+    authorId: "basic:alice",
+    authorName: "Alice",
+    pinned: false,
+    archivedAt: null,
+    version: 1,
+    idempotencyKey: "remote-only",
+    createdAt: "2026-08-05T00:00:00.000Z",
+    updatedAt: "2026-08-05T00:00:00.000Z",
+  };
+  const app = createTaskboardServer({
+    dataDirectory: directory,
+    cloudConfigPath: configPath,
+    remoteFetch: async (url, init) => {
+      upstreamCalls.push({ url: url.toString(), init });
+      if (failRemote) throw new Error("cloud unavailable");
+      return jsonResponse({ entry: remoteEntry }, 201);
+    },
+  });
+  const address = await app.listen({ port: 0 });
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  const contextBody = {
+    kind: "decision",
+    title: "Remote only",
+    body: "Cloud owns this row",
+    idempotencyKey: "remote-only",
+  };
+
+  try {
+    const created = await fetch(`${baseUrl}/api/projects/portfolio/context`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(contextBody),
+    });
+    assert.equal(created.status, 201);
+    assert.deepEqual(await created.json(), { entry: remoteEntry });
+    assert.equal(upstreamCalls.length, 1);
+    assert.equal(upstreamCalls[0].url, "https://tasks.example.test/api/projects/portfolio/context");
+    assert.equal(
+      app.database.database.prepare("SELECT COUNT(*) AS count FROM project_context_entries").get().count,
+      0,
+    );
+
+    failRemote = true;
+    const failed = await fetch(`${baseUrl}/api/projects/portfolio/context`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...contextBody, idempotencyKey: "remote-failure" }),
+    });
+    assert.equal(failed.status, 502);
+    assert.equal((await failed.json()).error.code, "REMOTE_UNAVAILABLE");
+    assert.equal(upstreamCalls.length, 2);
+    assert.equal(
+      app.database.database.prepare("SELECT COUNT(*) AS count FROM project_context_entries").get().count,
+      0,
+    );
   } finally {
     await app.close();
   }

--- a/test/cloud-migration.test.mjs
+++ b/test/cloud-migration.test.mjs
@@ -26,6 +26,7 @@ import {
   runCli,
   writeCloudMigrationBundle,
 } from "../scripts/migrate-to-cloud.mjs";
+import { TaskboardDatabase } from "../server/database.mjs";
 import { createCloudWorkerHarness } from "./helpers/cloud-worker-harness.mjs";
 
 const fixtures = [];
@@ -373,6 +374,8 @@ function expectedProjectCounts() {
       attachments: 2,
       task_relations: 1,
       workflow_workspaces: 1,
+      project_context_entries: 0,
+      project_context_revisions: 0,
     },
     beta: {
       projects: 1,
@@ -381,6 +384,8 @@ function expectedProjectCounts() {
       attachments: 1,
       task_relations: 0,
       workflow_workspaces: 0,
+      project_context_entries: 0,
+      project_context_revisions: 0,
     },
   };
 }
@@ -562,6 +567,8 @@ test("cloud import calls D1 and R2 adapters, then verifies project counts and ob
     "task_relations",
     "attachments",
     "workflow_workspaces",
+    "project_context_entries",
+    "project_context_revisions",
   ]);
   assert.deepEqual(result.counts.byProject, expectedProjectCounts());
   assert.equal(result.attachments.verified, 3);
@@ -571,6 +578,82 @@ test("cloud import calls D1 and R2 adapters, then verifies project counts and ob
     assert.deepEqual(object.bytes, Buffer.from(attachment.body));
     assert.equal(object.size, attachment.size);
     assert.equal(object.customMetadata.sha256, attachment.sha256);
+  }
+});
+
+test("context entries and revisions survive a local-to-D1 migration round trip", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "project-context-cloud-migration-"));
+  const databasePath = path.join(directory, "taskboard.sqlite");
+  const attachmentsDirectory = path.join(directory, "attachments");
+  await mkdir(attachmentsDirectory, { recursive: true });
+  const actor = { type: "user", id: "alice", name: "Alice" };
+  let database;
+  try {
+    database = new TaskboardDatabase(databasePath);
+    database.createProject({ id: "context-project", name: "Context project", workspacePath: null });
+    const created = database.createContextEntry("context-project", {
+      kind: "decision",
+      title: "Use D1",
+      body: "Context body",
+      tags: ["migration"],
+      sourceType: "manual",
+      sourceId: null,
+      sourceThreadId: null,
+      pinned: true,
+      idempotencyKey: "migration-context",
+    }, actor).entry;
+    const updated = database.updateContextEntry(created.id, 1, {
+      body: "Updated context body",
+      tags: ["migration", "cloud"],
+    }, actor);
+    const archived = database.archiveContextEntry(updated.id, 2, actor);
+    database.close();
+    database = null;
+
+    const bundle = await createCloudMigrationBundle({
+      databasePath,
+      attachmentsDirectory,
+    });
+    assert.equal(bundle.counts.byProject["context-project"].project_context_entries, 1);
+    assert.equal(bundle.counts.byProject["context-project"].project_context_revisions, 3);
+    assert.equal(bundle.tables.project_context_entries[0].version, 3);
+    assert.equal(bundle.tables.project_context_entries[0].archived_at, archived.archivedAt);
+    assert.deepEqual(
+      bundle.tables.project_context_revisions.map((revision) => revision.version),
+      [1, 2, 3],
+    );
+
+    const cloud = await createCloudWorkerHarness();
+    try {
+      const result = await importCloudMigrationBundle(bundle, createCloudBindingMigrationAdapters({
+        d1: cloud.db,
+        r2: cloud.attachments,
+      }));
+      assert.equal(result.counts.byProject["context-project"].project_context_entries, 1);
+      const entry = await cloud.db.prepare(`
+        SELECT id, version, archived_at, body, tags
+        FROM project_context_entries
+        WHERE project_id = ?
+      `).bind("context-project").first();
+      assert.equal(entry.version, 3);
+      assert.equal(entry.archived_at, archived.archivedAt);
+      assert.equal(entry.body, "Updated context body");
+      assert.deepEqual(JSON.parse(entry.tags), ["migration", "cloud"]);
+      const revisions = await cloud.db.prepare(`
+        SELECT version, body FROM project_context_revisions
+        WHERE entry_id = ? ORDER BY version
+      `).bind(entry.id).all();
+      assert.deepEqual(revisions.results, [
+        { version: 1, body: "Context body" },
+        { version: 2, body: "Updated context body" },
+        { version: 3, body: "Updated context body" },
+      ]);
+    } finally {
+      await cloud.dispose();
+    }
+  } finally {
+    database?.close();
+    await rm(directory, { recursive: true, force: true });
   }
 });
 
@@ -670,7 +753,7 @@ test("D1 binding import uses one JSON statement per table for 100+ rows", async 
   await adapters.d1.importTables(tables);
 
   assert.equal(batches.length, 1);
-  assert.equal(batches[0].length, 6);
+  assert.equal(batches[0].length, 8);
   for (const statement of batches[0]) assert.match(statement.sql, /json_each\(\?\)/);
   assert.equal(JSON.parse(batches[0][1].values[0]).length, 125);
 });
@@ -718,6 +801,126 @@ test("Wrangler D1 SQL chunks large tables below the remote statement byte limit"
     () => createCloudD1ImportSql(oversized),
     /single row.*90,?000 bytes/i,
   );
+
+  const contextTables = structuredClone(bundle.tables);
+  const contextBody = '"'.repeat(65_536);
+  const contextRevisionBody = "'".repeat(65_536);
+  contextTables.project_context_entries = [{
+    id: "context-large",
+    project_id: "alpha",
+    kind: "decision",
+    title: "Large context",
+    body: contextRevisionBody,
+    tags: "[]",
+    source_type: "manual",
+    source_id: null,
+    source_thread_id: null,
+    author_type: "user",
+    author_id: "alice",
+    author_name: "Alice",
+    pinned: 0,
+    archived_at: null,
+    version: 1,
+    idempotency_key: "context-large",
+    created_at: timestamp,
+    updated_at: timestamp,
+  }];
+  contextTables.project_context_revisions = [{
+    id: "context-large-revision",
+    entry_id: "context-large",
+    version: 1,
+    title: "Large context",
+    body: contextBody,
+    kind: "decision",
+    tags: "[]",
+    author_id: "alice",
+    author_name: "Alice",
+    created_at: timestamp,
+  }];
+  const contextSql = createCloudD1ImportSql(contextTables);
+  assert.match(contextSql, /UPDATE "project_context_entries"/);
+  assert.match(contextSql, /UPDATE "project_context_revisions"/);
+  const contextStatements = contextSql
+    .split(/;\n(?=(?:INSERT INTO|UPDATE ))/)
+    .map((statement) => statement.endsWith(";") ? statement : `${statement};`);
+  for (const statement of contextStatements) {
+    assert.ok(
+      Buffer.byteLength(statement, "utf8") < 90_000,
+      `context statement was ${Buffer.byteLength(statement, "utf8")} bytes`,
+    );
+  }
+});
+
+test("Wrangler SQL imports a maximum-size context body without truncation", async () => {
+  const body = '"'.repeat(65_536);
+  const revisionBody = "'".repeat(65_536);
+  const timestamp = "2026-07-24T12:00:00.000Z";
+  const tables = {
+    projects: [{
+      id: "context-project",
+      name: "Context project",
+      workspace_path: null,
+      next_task_number: 1,
+      created_at: timestamp,
+      updated_at: timestamp,
+    }],
+    tasks: [],
+    comments: [],
+    task_relations: [],
+    attachments: [],
+    workflow_workspaces: [],
+    project_context_entries: [{
+      id: "context-large",
+      project_id: "context-project",
+      kind: "decision",
+      title: "Large context",
+      body,
+      tags: "[]",
+      source_type: "manual",
+      source_id: null,
+      source_thread_id: null,
+      author_type: "user",
+      author_id: "alice",
+      author_name: "Alice",
+      pinned: 0,
+      archived_at: null,
+      version: 1,
+      idempotency_key: "context-large",
+      created_at: timestamp,
+      updated_at: timestamp,
+    }],
+    project_context_revisions: [{
+      id: "context-large-revision",
+      entry_id: "context-large",
+      version: 1,
+      title: "Large context",
+      body: revisionBody,
+      kind: "decision",
+      tags: "[]",
+      author_id: "alice",
+      author_name: "Alice",
+      created_at: timestamp,
+    }],
+  };
+  const database = new DatabaseSync(":memory:");
+  try {
+    database.exec(await readFile(path.join(projectRoot, "cloud", "migrations", "0001_initial.sql"), "utf8"));
+    database.exec(await readFile(path.join(projectRoot, "cloud", "migrations", "0002_project_context.sql"), "utf8"));
+    const statements = createCloudD1ImportSql(tables)
+      .split(/;\n(?=(?:INSERT INTO|UPDATE ))/)
+      .map((statement) => statement.endsWith(";") ? statement : `${statement};`);
+    for (const statement of statements) database.exec(statement);
+    const entry = database.prepare(`
+      SELECT body FROM project_context_entries WHERE id = ?
+    `).get("context-large");
+    const revision = database.prepare(`
+      SELECT body FROM project_context_revisions WHERE id = ?
+    `).get("context-large-revision");
+    assert.equal(entry.body, body);
+    assert.equal(revision.body, revisionBody);
+  } finally {
+    database.close();
+  }
 });
 
 test("real D1 batch atomically imports a bundle containing local and maps development fields", async () => {

--- a/test/cloud-project-context.test.mjs
+++ b/test/cloud-project-context.test.mjs
@@ -1,0 +1,333 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+
+import { createCloudWorkerHarness } from "./helpers/cloud-worker-harness.mjs";
+
+let cloud;
+const alice = "Alice";
+const bob = "Bob";
+
+before(async () => {
+  cloud = await createCloudWorkerHarness();
+});
+
+after(async () => {
+  await cloud?.dispose();
+});
+
+async function createProject(id, actorName = alice) {
+  return cloud.request("/api/projects", {
+    method: "POST",
+    actorName,
+    json: { id, name: id.toUpperCase(), workspacePath: `/Users/${actorName}/${id}` },
+  });
+}
+
+async function createEntry(projectId, input, actorName = alice) {
+  return cloud.request(`/api/projects/${projectId}/context`, {
+    method: "POST",
+    actorName,
+    json: {
+      kind: "decision",
+      title: "Default decision",
+      body: "Default body",
+      ...input,
+    },
+  });
+}
+
+async function currentRevision(actorName = alice) {
+  const result = await cloud.request("/api/revisions?since=0", { actorName });
+  assert.equal(result.response.status, 200);
+  return result.body.revision;
+}
+
+test("D1 migration and Basic Auth expose the same trusted context entry contract", async () => {
+  const unauthenticated = await cloud.request("/api/projects/cloud-context/context");
+  assert.equal(unauthenticated.response.status, 401);
+
+  const schema = await cloud.db.prepare(`
+    SELECT name, type FROM sqlite_schema
+    WHERE name LIKE 'project_context_%'
+    ORDER BY name
+  `).all();
+  assert.deepEqual(schema.results.map((row) => row.name), [
+    "project_context_entries",
+    "project_context_entries_global_revision_delete",
+    "project_context_entries_global_revision_insert",
+    "project_context_entries_global_revision_update",
+    "project_context_entries_project_idempotency",
+    "project_context_entries_project_kind",
+    "project_context_entries_project_page",
+    "project_context_entries_project_pinned",
+    "project_context_revisions",
+    "project_context_revisions_entry_version_unique",
+    "project_context_revisions_entry_versions",
+  ]);
+
+  await createProject("cloud-context");
+  const unexpectedQuery = await cloud.request("/api/projects/cloud-context/context?unexpected=1", {
+    method: "POST",
+    actorName: alice,
+    json: {
+      kind: "decision",
+      title: "Rejected query",
+      body: "Should not be created",
+    },
+  });
+  assert.equal(unexpectedQuery.response.status, 400);
+  assert.equal(unexpectedQuery.body.error.code, "UNKNOWN_QUERY_PARAMETER");
+  const unsupportedContentType = await cloud.request("/api/projects/cloud-context/context", {
+    method: "POST",
+    actorName: alice,
+    headers: { "content-type": "application/jsonx" },
+    body: JSON.stringify({ kind: "decision", title: "Bad media", body: "Rejected" }),
+  });
+  assert.equal(unsupportedContentType.response.status, 415);
+  assert.equal(unsupportedContentType.body.error.code, "UNSUPPORTED_MEDIA_TYPE");
+  const injected = await createEntry("cloud-context", {
+    title: "Injected author",
+    authorId: "attacker",
+  });
+  assert.equal(injected.response.status, 400);
+  assert.equal(injected.body.error.code, "UNKNOWN_FIELD");
+
+  const before = await currentRevision();
+  const created = await createEntry("cloud-context", {
+    title: "Choose D1",
+    body: "Shared through the Worker",
+    tags: ["cloud", "decision"],
+    sourceType: "issue",
+    sourceId: "ASH-46",
+    sourceThreadId: "source-only",
+    pinned: true,
+    idempotencyKey: "cloud-decision",
+  });
+  assert.equal(created.response.status, 201);
+  assert.deepEqual(Object.keys(created.body.entry), [
+    "id", "projectId", "kind", "title", "body", "tags", "sourceType", "sourceId",
+    "sourceThreadId", "authorType", "authorId", "authorName", "pinned", "archivedAt",
+    "version", "idempotencyKey", "createdAt", "updatedAt",
+  ]);
+  assert.equal(created.body.entry.authorType, "user");
+  assert.equal(created.body.entry.authorName, alice);
+  assert.match(created.body.entry.authorId, /^basic:/);
+  assert.equal(created.body.entry.pinned, true);
+  assert.doesNotMatch(JSON.stringify(created.body), /\/Users\//);
+  const stored = await cloud.db.prepare(`
+    SELECT * FROM project_context_entries WHERE id = ?
+  `).bind(created.body.entry.id).first();
+  assert.equal(Object.keys(stored).some((key) => /path|workspace|worktree/i.test(key)), false);
+  assert.ok(await currentRevision() > before);
+
+  const replayRevision = await currentRevision();
+  const replay = await createEntry("cloud-context", {
+    title: "Choose D1",
+    body: "Shared through the Worker",
+    tags: ["cloud", "decision"],
+    sourceType: "issue",
+    sourceId: "ASH-46",
+    sourceThreadId: "source-only",
+    pinned: true,
+    idempotencyKey: "cloud-decision",
+  });
+  assert.equal(replay.response.status, 200);
+  assert.equal(replay.body.entry.id, created.body.entry.id);
+  assert.equal(await currentRevision(), replayRevision);
+  const conflict = await createEntry("cloud-context", {
+    title: "Different",
+    idempotencyKey: "cloud-decision",
+  });
+  assert.equal(conflict.response.status, 409);
+  assert.equal(conflict.body.error.code, "IDEMPOTENCY_CONFLICT");
+});
+
+test("Worker context search, cursor, brief, lifecycle and UTF-8 limits match local behavior", async () => {
+  const projectId = "cloud-lifecycle";
+  await createProject(projectId);
+  const pinned = await createEntry(projectId, {
+    kind: "fact",
+    title: "Pinned fact 100%",
+    body: "Pinned first",
+    tags: ["cloud"],
+    pinned: true,
+  });
+  const requirement = await createEntry(projectId, {
+    kind: "requirement",
+    title: "Requirement",
+    body: "Required body",
+    tags: ["launch"],
+    idempotencyKey: "requirement-key",
+  });
+  const risk = await createEntry(projectId, {
+    kind: "risk",
+    title: "Risk",
+    body: "Monitor rollout",
+    tags: ["launch"],
+  });
+  const oldSummary = await createEntry(projectId, {
+    kind: "summary",
+    title: "Old summary",
+    body: "Outdated summary",
+  });
+  const summary = await createEntry(projectId, {
+    kind: "summary",
+    title: "Summary",
+    body: "Summary body",
+  });
+  await createEntry(projectId, { kind: "fact", title: "Excluded", body: "No pin" });
+
+  for (const [query, expected] of [
+    ["query=%25", pinned.body.entry.id],
+    ["query=rollout", risk.body.entry.id],
+    ["kind=requirement", requirement.body.entry.id],
+    ["tag=cloud", pinned.body.entry.id],
+    ["pinned=true", pinned.body.entry.id],
+  ]) {
+    const result = await cloud.request(`/api/projects/${projectId}/context?${query}`, { actorName: alice });
+    assert.equal(result.response.status, 200, query);
+    assert.deepEqual(result.body.entries.map((entry) => entry.id), [expected], query);
+  }
+
+  const paged = [];
+  let cursor = null;
+  do {
+    const page = await cloud.request(
+      `/api/projects/${projectId}/context?limit=2${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""}`,
+      { actorName: alice },
+    );
+    assert.equal(page.response.status, 200);
+    paged.push(...page.body.entries.map((entry) => entry.id));
+    cursor = page.body.nextCursor;
+  } while (cursor);
+  assert.equal(paged.length, 6);
+  assert.equal(new Set(paged).size, paged.length);
+
+  const brief1 = await cloud.request(`/api/projects/${projectId}/context/brief`, { actorName: alice });
+  const brief2 = await cloud.request(`/api/projects/${projectId}/context/brief`, { actorName: bob });
+  assert.deepEqual(brief1.body, brief2.body);
+  assert.deepEqual(brief1.body.includedEntryIds, [
+    pinned.body.entry.id,
+    requirement.body.entry.id,
+    risk.body.entry.id,
+    summary.body.entry.id,
+  ]);
+  assert.equal(brief1.body.includedEntryIds.includes(oldSummary.body.entry.id), false);
+
+  const updated = await cloud.request(`/api/context/${requirement.body.entry.id}`, {
+    method: "PATCH",
+    actorName: bob,
+    json: { version: 1, title: "Updated requirement", pinned: true },
+  });
+  assert.equal(updated.response.status, 200);
+  const replayAfterUpdate = await createEntry(projectId, {
+    kind: "requirement",
+    title: "Requirement",
+    body: "Required body",
+    tags: ["launch"],
+    idempotencyKey: requirement.body.entry.idempotencyKey,
+  }, alice);
+  assert.equal(replayAfterUpdate.response.status, 200);
+  assert.equal(replayAfterUpdate.body.entry.id, requirement.body.entry.id);
+  const changedReplay = await createEntry(projectId, {
+    kind: "requirement",
+    title: "Requirement",
+    body: "Different original body",
+    tags: ["launch"],
+    idempotencyKey: requirement.body.entry.idempotencyKey,
+  }, alice);
+  assert.equal(changedReplay.response.status, 409);
+  assert.equal(changedReplay.body.error.code, "IDEMPOTENCY_CONFLICT");
+  const revisionBeforeStale = await currentRevision();
+  const stale = await cloud.request(`/api/context/${requirement.body.entry.id}`, {
+    method: "PATCH",
+    actorName: alice,
+    json: { version: 1, title: "Stale" },
+  });
+  assert.equal(stale.response.status, 409);
+  assert.deepEqual(stale.body.error.details, { expectedVersion: 1, actualVersion: 2 });
+  assert.equal(await currentRevision(), revisionBeforeStale);
+
+  const archived = await cloud.request(`/api/context/${requirement.body.entry.id}/archive`, {
+    method: "POST",
+    actorName: bob,
+    json: { version: 2 },
+  });
+  assert.equal(archived.response.status, 200);
+  const defaultList = await cloud.request(
+    `/api/projects/${projectId}/context?query=Updated`,
+    { actorName: alice },
+  );
+  assert.deepEqual(defaultList.body.entries, []);
+  const archivedList = await cloud.request(
+    `/api/projects/${projectId}/context?archived=true&query=Updated`,
+    { actorName: alice },
+  );
+  assert.deepEqual(archivedList.body.entries.map((entry) => entry.id), [requirement.body.entry.id]);
+  const restored = await cloud.request(`/api/context/${requirement.body.entry.id}/restore`, {
+    method: "POST",
+    actorName: alice,
+    json: { version: 3 },
+  });
+  assert.equal(restored.body.entry.version, 4);
+  assert.equal(restored.body.entry.archivedAt, null);
+  const revisions = await cloud.request(`/api/context/${requirement.body.entry.id}/revisions`, {
+    actorName: alice,
+  });
+  assert.deepEqual(revisions.body.revisions.map((revision) => revision.version), [1, 2, 3, 4]);
+  assert.equal(revisions.body.revisions[1].authorName, bob);
+
+  const exact = await createEntry(projectId, {
+    title: "Exact bytes",
+    body: "é".repeat(32_768),
+    pinned: true,
+  });
+  assert.equal(exact.response.status, 201);
+  const over = await createEntry(projectId, {
+    title: "Too many bytes",
+    body: "é".repeat(32_769),
+  });
+  assert.equal(over.response.status, 400);
+  const truncated = await cloud.request(`/api/projects/${projectId}/context/brief`, { actorName: alice });
+  assert.equal(truncated.body.truncated, true);
+  assert.ok(truncated.body.brief.length <= 12_000);
+});
+
+test("D1 concurrency permits one idempotent create and one optimistic update winner", async () => {
+  const projectId = "cloud-races";
+  await createProject(projectId);
+  const creates = await Promise.all(Array.from({ length: 8 }, () => createEntry(projectId, {
+    title: "Only once",
+    body: "Idempotent content",
+    tags: ["race"],
+    idempotencyKey: "race-key",
+  })));
+  assert.equal(creates.filter((result) => result.response.status === 201).length, 1);
+  assert.equal(creates.filter((result) => result.response.status === 200).length, 7);
+  assert.equal(new Set(creates.map((result) => result.body.entry.id)).size, 1);
+  const entry = creates[0].body.entry;
+  assert.equal(await cloud.db.prepare(`
+    SELECT COUNT(*) AS count FROM project_context_entries WHERE project_id = ?
+  `).bind(projectId).first("count"), 1);
+  assert.equal(await cloud.db.prepare(`
+    SELECT COUNT(*) AS count FROM project_context_revisions WHERE entry_id = ?
+  `).bind(entry.id).first("count"), 1);
+
+  const updates = await Promise.all([
+    cloud.request(`/api/context/${entry.id}`, {
+      method: "PATCH",
+      actorName: alice,
+      json: { version: 1, title: "Alice wins" },
+    }),
+    cloud.request(`/api/context/${entry.id}`, {
+      method: "PATCH",
+      actorName: bob,
+      json: { version: 1, title: "Bob wins" },
+    }),
+  ]);
+  assert.deepEqual(updates.map((result) => result.response.status).sort(), [200, 409]);
+  const latest = await cloud.request(`/api/context/${entry.id}`, { actorName: alice });
+  assert.equal(latest.body.entry.version, 2);
+  const revisions = await cloud.request(`/api/context/${entry.id}/revisions`, { actorName: alice });
+  assert.deepEqual(revisions.body.revisions.map((revision) => revision.version), [1, 2]);
+});

--- a/test/context-ui.test.mjs
+++ b/test/context-ui.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const typesSource = await readFile(new URL("../web/src/types.ts", import.meta.url), "utf8");
+const apiSource = await readFile(new URL("../web/src/api.ts", import.meta.url), "utf8");
+const viewSource = await readFile(new URL("../web/src/components/ContextView.tsx", import.meta.url), "utf8").catch(() => "");
+const appSource = await readFile(new URL("../web/src/App.tsx", import.meta.url), "utf8");
+const styles = await readFile(new URL("../web/src/styles.css", import.meta.url), "utf8");
+
+test("context client exposes the ASH-46 DTOs and all endpoints", () => {
+  assert.match(typesSource, /ProjectContextEntry/);
+  for (const type of ["ProjectContextEntry", "ProjectContextRevision", "ProjectContextListResponse"]) {
+    assert.match(typesSource, new RegExp(`interface ${type}`));
+  }
+  for (const method of [
+    "listProjectContext", "getProjectContextBrief", "createProjectContextEntry",
+    "getProjectContextEntry", "updateProjectContextEntry", "archiveProjectContextEntry",
+    "restoreProjectContextEntry", "listProjectContextRevisions",
+  ]) {
+    assert.match(apiSource, new RegExp(`export async function ${method}`));
+  }
+  assert.match(apiSource, /query\.set\("kind"/);
+  assert.match(apiSource, /query\.set\("tag"/);
+  assert.match(apiSource, /query\.set\("archived"/);
+});
+
+test("context view uses safe markdown and preserves drafts on version conflict", () => {
+  assert.match(viewSource, /ReactMarkdown/);
+  assert.match(viewSource, /remarkGfm/);
+  assert.doesNotMatch(viewSource, /dangerouslySetInnerHTML|rehypeRaw/);
+  assert.match(viewSource, /getProjectContextEntry/);
+  assert.match(viewSource, /VERSION_CONFLICT/);
+  assert.match(viewSource, /archived: showArchived \? "all" : "false"/);
+  assert.match(viewSource, /sortContextEntries/);
+  assert.match(viewSource, /刷新后重试/);
+  assert.match(viewSource, /sourceThreadId/);
+  assert.match(viewSource, /visibleSourceIdentifier/);
+  assert.doesNotMatch(viewSource, /恢复.*Codex|打开.*会话/);
+});
+
+test("context view is integrated as an accessible project peer tab", () => {
+  assert.match(appSource, /BoardView = "issues" \| "context" \| "workflow"/);
+  assert.match(appSource, /ContextView/);
+  assert.match(appSource, /boardView === "context"/);
+  assert.match(appSource, /context\.created/);
+  assert.match(appSource, /局域网模式未启用账号认证/);
+  assert.match(styles, /\.context-view/);
+  assert.match(styles, /@media \(max-width: 760px\)/);
+});

--- a/test/context-ui.test.mjs
+++ b/test/context-ui.test.mjs
@@ -33,6 +33,11 @@ test("context view uses safe markdown and preserves drafts on version conflict",
   assert.match(viewSource, /VERSION_CONFLICT/);
   assert.match(viewSource, /archived: showArchived \? "all" : "false"/);
   assert.match(viewSource, /sortContextEntries/);
+  assert.match(viewSource, /entryMatchesCurrentFilters/);
+  assert.match(viewSource, /handleMobileBack/);
+  assert.match(viewSource, /archiveTarget/);
+  assert.match(viewSource, /actionConflict/);
+  assert.match(viewSource, /aria-invalid={validationField === "body"}/);
   assert.match(viewSource, /刷新后重试/);
   assert.match(viewSource, /sourceThreadId/);
   assert.match(viewSource, /visibleSourceIdentifier/);
@@ -46,5 +51,6 @@ test("context view is integrated as an accessible project peer tab", () => {
   assert.match(appSource, /context\.created/);
   assert.match(appSource, /局域网模式未启用账号认证/);
   assert.match(styles, /\.context-view/);
+  assert.match(styles, /\.context-editor-field input:focus-visible/);
   assert.match(styles, /@media \(max-width: 760px\)/);
 });

--- a/test/helpers/cloud-worker-harness.mjs
+++ b/test/helpers/cloud-worker-harness.mjs
@@ -1,4 +1,4 @@
-import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { access, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -7,11 +7,28 @@ import { Miniflare } from "miniflare";
 
 const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const ENTRY_PATH = path.join(PROJECT_ROOT, "cloud", "src", "index.mjs");
-const MIGRATION_PATH = path.join(PROJECT_ROOT, "cloud", "migrations", "0001_initial.sql");
+const MIGRATIONS_DIRECTORY = path.join(PROJECT_ROOT, "cloud", "migrations");
+
+async function migrationPaths() {
+  const entries = await readdir(MIGRATIONS_DIRECTORY);
+  const paths = entries
+    .filter((entry) => entry.endsWith(".sql"))
+    .sort()
+    .map((entry) => path.join(MIGRATIONS_DIRECTORY, entry));
+  if (paths.length === 0) throw new Error("Cloud implementation has no D1 migrations");
+  return paths;
+}
 
 async function requireCloudImplementation() {
   const missing = [];
-  for (const filename of [ENTRY_PATH, MIGRATION_PATH]) {
+  let migrations = [];
+  try {
+    migrations = await migrationPaths();
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+    missing.push(path.relative(PROJECT_ROOT, MIGRATIONS_DIRECTORY));
+  }
+  for (const filename of [ENTRY_PATH, ...migrations]) {
     try {
       await access(filename);
     } catch (error) {
@@ -22,12 +39,13 @@ async function requireCloudImplementation() {
   if (missing.length > 0) {
     throw new Error(`Cloud implementation is missing:\n${missing.join("\n")}`);
   }
+  return migrations;
 }
 
 export async function createCloudWorkerHarness({
   sharedSecret = "two-person-shared-secret",
 } = {}) {
-  await requireCloudImplementation();
+  const migrations = await requireCloudImplementation();
   const persistenceRoot = await mkdtemp(path.join(os.tmpdir(), "taskboard-cloud-worker-"));
   const miniflare = new Miniflare({
     modules: true,
@@ -48,7 +66,9 @@ export async function createCloudWorkerHarness({
   try {
     await miniflare.ready;
     const db = await miniflare.getD1Database("DB");
-    await db.exec(await readFile(MIGRATION_PATH, "utf8"));
+    for (const migration of migrations) {
+      await db.exec(await readFile(migration, "utf8"));
+    }
     const attachments = await miniflare.getR2Bucket("ATTACHMENTS");
 
     async function request(pathname, {

--- a/test/project-context.test.mjs
+++ b/test/project-context.test.mjs
@@ -1,0 +1,344 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, test } from "node:test";
+
+import { createTaskboardServer } from "../server/index.mjs";
+import { TaskboardDatabase } from "../server/database.mjs";
+
+const running = [];
+
+afterEach(async () => {
+  while (running.length > 0) {
+    const { app, directory } = running.pop();
+    await app?.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+async function startServer() {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "project-context-local-"));
+  const app = createTaskboardServer({ dataDirectory: directory });
+  const address = await app.listen({ port: 0 });
+  running.push({ app, directory });
+  return { app, baseUrl: `http://127.0.0.1:${address.port}`, directory };
+}
+
+async function request(baseUrl, pathname, { body, headers: inputHeaders, ...init } = {}) {
+  const headers = new Headers(inputHeaders);
+  if (body !== undefined) headers.set("content-type", "application/json");
+  const response = await fetch(`${baseUrl}${pathname}`, {
+    ...init,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  return { response, body: text ? JSON.parse(text) : undefined };
+}
+
+const aliceHeaders = {
+  "x-taskboard-user-id": "alice",
+  "x-taskboard-user-name": encodeURIComponent("Alice"),
+};
+
+async function createEntry(baseUrl, input, headers = aliceHeaders) {
+  return request(baseUrl, "/api/projects/local/context", {
+    method: "POST",
+    headers,
+    body: {
+      kind: "decision",
+      title: "Default decision",
+      body: "Default body",
+      ...input,
+    },
+  });
+}
+
+test("local context migration is repeatable and preserves entries and revisions", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "project-context-migration-"));
+  running.push({ app: null, directory });
+  const databasePath = path.join(directory, "taskboard.sqlite");
+  const input = {
+    kind: "decision",
+    title: "Keep the schema",
+    body: "Migration replay must preserve this entry.",
+    tags: ["migration"],
+    sourceType: "manual",
+    sourceId: null,
+    sourceThreadId: null,
+    pinned: false,
+    idempotencyKey: "migration-entry",
+  };
+  const actor = { type: "user", id: "alice", name: "Alice" };
+
+  let database = new TaskboardDatabase(databasePath);
+  const created = database.createContextEntry("local", input, actor).entry;
+  database.close();
+  database = new TaskboardDatabase(databasePath);
+  assert.equal(database.getContextEntry(created.id).title, input.title);
+  assert.deepEqual(database.listContextRevisions(created.id).map((revision) => revision.version), [1]);
+  const schemaNames = database.database.prepare(`
+    SELECT name FROM sqlite_schema
+    WHERE name LIKE 'project_context_%'
+    ORDER BY name
+  `).all().map((row) => row.name);
+  assert.deepEqual(schemaNames, [
+    "project_context_entries",
+    "project_context_entries_project_idempotency",
+    "project_context_entries_project_kind",
+    "project_context_entries_project_page",
+    "project_context_entries_project_pinned",
+    "project_context_revisions",
+    "project_context_revisions_entry_version_unique",
+    "project_context_revisions_entry_versions",
+  ]);
+  database.close();
+});
+
+test("local context API covers identity, idempotency, filters and stable pagination", async () => {
+  const { baseUrl } = await startServer();
+  const created = await createEntry(baseUrl, {
+    title: "Choose 100% D1",
+    body: "Cloud decision body",
+    tags: ["cloud", "launch"],
+    sourceType: "issue",
+    sourceId: "ASH-46",
+    sourceThreadId: "thread-source-only",
+    pinned: true,
+    idempotencyKey: "decision-1",
+    authorName: "Injected",
+  });
+  assert.equal(created.response.status, 400);
+  assert.equal(created.body.error.code, "UNKNOWN_FIELD");
+  const unexpectedQuery = await request(baseUrl, "/api/projects/local/context?unexpected=1", {
+    method: "POST",
+    headers: aliceHeaders,
+    body: {
+      kind: "decision",
+      title: "Rejected query",
+      body: "Should not be created",
+    },
+  });
+  assert.equal(unexpectedQuery.response.status, 400);
+  assert.equal(unexpectedQuery.body.error.code, "UNKNOWN_QUERY_PARAMETER");
+  const unsupportedContentType = await fetch(`${baseUrl}/api/projects/local/context`, {
+    method: "POST",
+    headers: { ...aliceHeaders, "content-type": "application/jsonx" },
+    body: JSON.stringify({ kind: "decision", title: "Bad media", body: "Rejected" }),
+  });
+  assert.equal(unsupportedContentType.status, 415);
+  assert.equal((await unsupportedContentType.json()).error.code, "UNSUPPORTED_MEDIA_TYPE");
+
+  const first = await createEntry(baseUrl, {
+    title: "Choose 100% D1",
+    body: "Cloud decision body",
+    tags: ["cloud", "launch"],
+    sourceType: "issue",
+    sourceId: "ASH-46",
+    sourceThreadId: "thread-source-only",
+    pinned: true,
+    idempotencyKey: "decision-1",
+  });
+  assert.equal(first.response.status, 201);
+  assert.deepEqual(Object.keys(first.body.entry), [
+    "id", "projectId", "kind", "title", "body", "tags", "sourceType", "sourceId",
+    "sourceThreadId", "authorType", "authorId", "authorName", "pinned", "archivedAt",
+    "version", "idempotencyKey", "createdAt", "updatedAt",
+  ]);
+  assert.equal(first.body.entry.authorId, "alice");
+  assert.equal(first.body.entry.authorName, "Alice");
+  assert.equal(first.body.entry.version, 1);
+  assert.equal(first.body.entry.archivedAt, null);
+
+  const replay = await createEntry(baseUrl, {
+    title: "Choose 100% D1",
+    body: "Cloud decision body",
+    tags: ["cloud", "launch"],
+    sourceType: "issue",
+    sourceId: "ASH-46",
+    sourceThreadId: "thread-source-only",
+    pinned: true,
+    idempotencyKey: "decision-1",
+  });
+  assert.equal(replay.response.status, 200);
+  assert.equal(replay.body.entry.id, first.body.entry.id);
+  const idempotencyConflict = await createEntry(baseUrl, {
+    title: "Different content",
+    idempotencyKey: "decision-1",
+  });
+  assert.equal(idempotencyConflict.response.status, 409);
+  assert.equal(idempotencyConflict.body.error.code, "IDEMPOTENCY_CONFLICT");
+
+  const risk = await createEntry(baseUrl, {
+    kind: "risk",
+    title: "Launch risk",
+    body: "Monitor the rollout",
+    tags: ["launch"],
+  });
+  const fact = await createEntry(baseUrl, {
+    kind: "fact",
+    title: "Unpinned fact",
+    body: "Not selected by brief",
+    tags: ["fact"],
+  });
+  for (const [query, expectedId] of [
+    ["query=%25", first.body.entry.id],
+    ["query=rollout", risk.body.entry.id],
+    ["query=fact", fact.body.entry.id],
+    ["kind=risk", risk.body.entry.id],
+    ["tag=cloud", first.body.entry.id],
+    ["pinned=true", first.body.entry.id],
+  ]) {
+    const listed = await request(baseUrl, `/api/projects/local/context?${query}`);
+    assert.equal(listed.response.status, 200, query);
+    assert.deepEqual(listed.body.entries.map((entry) => entry.id), [expectedId], query);
+  }
+
+  const pagedIds = [];
+  let cursor = null;
+  do {
+    const page = await request(
+      baseUrl,
+      `/api/projects/local/context?limit=1${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""}`,
+    );
+    assert.equal(page.response.status, 200);
+    pagedIds.push(...page.body.entries.map((entry) => entry.id));
+    cursor = page.body.nextCursor;
+  } while (cursor);
+  assert.equal(pagedIds.length, 3);
+  assert.equal(new Set(pagedIds).size, pagedIds.length);
+
+  const invalidCursor = await request(baseUrl, "/api/projects/local/context?cursor=not+base64");
+  assert.equal(invalidCursor.response.status, 400);
+  assert.equal(invalidCursor.body.error.code, "INVALID_QUERY_PARAMETER");
+});
+
+test("local context lifecycle returns 409 without mutation and keeps deterministic revisions", async () => {
+  const { baseUrl } = await startServer();
+  const created = await createEntry(baseUrl, {
+    title: "Original",
+    tags: ["decision"],
+    idempotencyKey: "lifecycle",
+  });
+  const id = created.body.entry.id;
+  const updated = await request(baseUrl, `/api/context/${id}`, {
+    method: "PATCH",
+    headers: aliceHeaders,
+    body: { version: 1, title: "Updated", pinned: true },
+  });
+  assert.equal(updated.response.status, 200);
+  assert.equal(updated.body.entry.version, 2);
+
+  const replayAfterUpdate = await createEntry(baseUrl, {
+    title: "Original",
+    tags: ["decision"],
+    idempotencyKey: "lifecycle",
+  });
+  assert.equal(replayAfterUpdate.response.status, 200);
+  assert.equal(replayAfterUpdate.body.entry.id, id);
+  const changedReplay = await createEntry(baseUrl, {
+    title: "Original",
+    body: "Different original body",
+    tags: ["decision"],
+    idempotencyKey: "lifecycle",
+  });
+  assert.equal(changedReplay.response.status, 409);
+  assert.equal(changedReplay.body.error.code, "IDEMPOTENCY_CONFLICT");
+
+  const stale = await request(baseUrl, `/api/context/${id}`, {
+    method: "PATCH",
+    headers: aliceHeaders,
+    body: { version: 1, title: "Stale" },
+  });
+  assert.equal(stale.response.status, 409);
+  assert.equal(stale.body.error.code, "VERSION_CONFLICT");
+  assert.deepEqual(stale.body.error.details, { expectedVersion: 1, actualVersion: 2 });
+  const afterStale = await request(baseUrl, `/api/context/${id}`);
+  assert.equal(afterStale.body.entry.title, "Updated");
+
+  const archived = await request(baseUrl, `/api/context/${id}/archive`, {
+    method: "POST",
+    headers: aliceHeaders,
+    body: { version: 2 },
+  });
+  assert.equal(archived.response.status, 200);
+  assert.equal(archived.body.entry.version, 3);
+  assert.ok(archived.body.entry.archivedAt);
+  const defaultList = await request(baseUrl, "/api/projects/local/context");
+  assert.deepEqual(defaultList.body.entries, []);
+  const archivedList = await request(baseUrl, "/api/projects/local/context?archived=true");
+  assert.deepEqual(archivedList.body.entries.map((entry) => entry.id), [id]);
+
+  const restored = await request(baseUrl, `/api/context/${id}/restore`, {
+    method: "POST",
+    headers: aliceHeaders,
+    body: { version: 3 },
+  });
+  assert.equal(restored.response.status, 200);
+  assert.equal(restored.body.entry.version, 4);
+  assert.equal(restored.body.entry.archivedAt, null);
+  const revisions = await request(baseUrl, `/api/context/${id}/revisions`);
+  assert.deepEqual(revisions.body.revisions.map((revision) => revision.version), [1, 2, 3, 4]);
+  assert.deepEqual(revisions.body.revisions.map((revision) => revision.title), [
+    "Original", "Updated", "Updated", "Updated",
+  ]);
+});
+
+test("local context brief is deterministic and the Markdown body uses a 64 KiB UTF-8 limit", async () => {
+  const { baseUrl } = await startServer();
+  const pinned = await createEntry(baseUrl, {
+    kind: "fact",
+    title: "Pinned fact",
+    body: "Pinned first",
+    pinned: true,
+  });
+  const requirement = await createEntry(baseUrl, {
+    kind: "requirement",
+    title: "Requirement",
+    body: "Required next",
+  });
+  const risk = await createEntry(baseUrl, {
+    kind: "risk",
+    title: "Risk",
+    body: "Risk after primary",
+  });
+  const oldSummary = await createEntry(baseUrl, {
+    kind: "summary",
+    title: "Old summary",
+    body: "Outdated summary",
+  });
+  const summary = await createEntry(baseUrl, {
+    kind: "summary",
+    title: "Summary",
+    body: "Summary last",
+  });
+  await createEntry(baseUrl, { kind: "fact", title: "Excluded fact", body: "Not pinned" });
+
+  const firstBrief = await request(baseUrl, "/api/projects/local/context/brief");
+  const secondBrief = await request(baseUrl, "/api/projects/local/context/brief");
+  assert.deepEqual(firstBrief.body, secondBrief.body);
+  assert.deepEqual(firstBrief.body.includedEntryIds, [
+    pinned.body.entry.id,
+    requirement.body.entry.id,
+    risk.body.entry.id,
+    summary.body.entry.id,
+  ]);
+  assert.equal(firstBrief.body.includedEntryIds.includes(oldSummary.body.entry.id), false);
+
+  const exact = await createEntry(baseUrl, {
+    title: "Exact byte limit",
+    body: "é".repeat(32_768),
+    pinned: true,
+  });
+  assert.equal(exact.response.status, 201);
+  const over = await createEntry(baseUrl, {
+    title: "Over byte limit",
+    body: "é".repeat(32_769),
+  });
+  assert.equal(over.response.status, 400);
+  assert.equal(over.body.error.code, "INVALID_FIELD");
+  const truncated = await request(baseUrl, "/api/projects/local/context/brief");
+  assert.equal(truncated.body.truncated, true);
+  assert.ok(truncated.body.brief.length <= 12_000);
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -45,6 +45,7 @@ import {
 import { BoardColumn, STATUS_DETAILS } from "./components/BoardColumn";
 import { AiChat } from "./components/AiChat";
 import { BoardSettingsMenu } from "./components/BoardSettingsMenu";
+import { ContextView } from "./components/ContextView";
 import { HiddenColumns } from "./components/HiddenColumns";
 import {
   resolveInlineMediaMarkdown,
@@ -90,7 +91,7 @@ import { createRevisionPoller, getRevisionPollingInterval } from "./revisionPoll
 
 type ConnectionState = "connecting" | "live" | "reconnecting";
 type Theme = "light" | "dark";
-type BoardView = "issues" | "workflow";
+type BoardView = "issues" | "context" | "workflow";
 const SHOW_WORKFLOW_BOARD_ENTRY = false;
 
 const WorkflowBoard = lazy(() => import("./components/WorkflowBoard").then((module) => ({
@@ -219,6 +220,10 @@ const EVENT_NAMES = [
   "attachment.deleted",
   "project.created",
   "workflow.updated",
+  "context.created",
+  "context.updated",
+  "context.archive",
+  "context.restore",
 ] as const;
 
 function isTheme(value: unknown): value is Theme {
@@ -427,6 +432,7 @@ interface LocalRealtimeSyncProps {
   setConnection: Dispatch<SetStateAction<ConnectionState>>;
   setCommentsRevision: Dispatch<SetStateAction<number>>;
   setAttachmentsRevision: Dispatch<SetStateAction<number>>;
+  setContextRevision: Dispatch<SetStateAction<number>>;
 }
 
 function LocalRealtimeSync({
@@ -438,6 +444,7 @@ function LocalRealtimeSync({
   setConnection,
   setCommentsRevision,
   setAttachmentsRevision,
+  setContextRevision,
 }: LocalRealtimeSyncProps) {
   useEffect(() => {
     const source = new EventSource("/api/events");
@@ -482,6 +489,10 @@ function LocalRealtimeSync({
         if (selectedProjectId) void refreshWorkflowOptions(selectedProjectId);
         return;
       }
+      if (event.type.startsWith("context.")) {
+        setContextRevision((current) => current + 1);
+        return;
+      }
       if (event.type.startsWith("comment.")) {
         if (!detailTaskId || !payload.taskId || payload.taskId === detailTaskId) {
           setCommentsRevision((current) => current + 1);
@@ -523,6 +534,7 @@ function LocalRealtimeSync({
     setAttachmentsRevision,
     setCommentsRevision,
     setConnection,
+    setContextRevision,
   ]);
 
   return null;
@@ -560,6 +572,8 @@ export function App() {
   const [commentsRevision, setCommentsRevision] = useState(0);
   const [attachmentsRevision, setAttachmentsRevision] = useState(0);
   const [workflowRevision, setWorkflowRevision] = useState(0);
+  const [contextRevision, setContextRevision] = useState(0);
+  const [contextCreateRequest, setContextCreateRequest] = useState(0);
   const [workflowOptions, setWorkflowOptions] = useState<WorkflowOption[]>(DEFAULT_WORKFLOW_OPTIONS);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const [draggedTaskId, setDraggedTaskId] = useState<string | null>(null);
@@ -1238,6 +1252,7 @@ export function App() {
           void refreshWorkflowOptions(projectId).catch(() => {});
         }
         setWorkflowRevision((current) => current + 1);
+        setContextRevision((current) => current + 1);
         setCommentsRevision((current) => current + 1);
         setAttachmentsRevision((current) => current + 1);
       },
@@ -1324,6 +1339,10 @@ export function App() {
       if (event.key === "/" && !detailTaskId && selectedProjectId && boardView === "issues") {
         event.preventDefault();
         document.getElementById("task-search")?.focus();
+      }
+      if (event.key === "/" && !detailTaskId && selectedProjectId && boardView === "context") {
+        event.preventDefault();
+        document.getElementById("context-search")?.focus();
       }
       if (event.key === "Escape" && detailTaskId) {
         closeTaskDetail();
@@ -1823,6 +1842,7 @@ export function App() {
           setConnection={setConnection}
           setCommentsRevision={setCommentsRevision}
           setAttachmentsRevision={setAttachmentsRevision}
+          setContextRevision={setContextRevision}
         />
       )}
       {!embedded && (
@@ -2000,13 +2020,15 @@ export function App() {
                 onChange={(options) => void saveProjectAutomation(options)}
               />
             )}
-            {selectedProjectId && boardView === "issues" && (
+            {selectedProjectId && (boardView === "issues" || boardView === "context") && (
               <button
                 className="icon-button header-create-button"
                 type="button"
-                onClick={() => setEditor({ task: null, status: "backlog" })}
-                aria-label="新建议题"
-                title="新建议题 (C)"
+                onClick={() => boardView === "context"
+                  ? setContextCreateRequest((current) => current + 1)
+                  : setEditor({ task: null, status: "backlog" })}
+                aria-label={boardView === "context" ? "新建 Context" : "新建议题"}
+                title={boardView === "context" ? "新建 Context" : "新建议题 (C)"}
               >
                 <LinearIcon name="plus" />
               </button>
@@ -2017,8 +2039,15 @@ export function App() {
           <div ref={dragRegionRef} className="home-window-drag-region" aria-hidden="true" />
         )}
 
+        {taskboardMetadata && taskboardMetadata.mode !== "cloud" && (
+          <div className="security-warning" role="status">
+            <LinearIcon name="shieldAlert" />
+            <span>局域网模式未启用账号认证，请仅在可信网络中使用。</span>
+          </div>
+        )}
+
         {selectedProjectId && !detailTask && <div className="board-toolbar">
-          <div className="view-tabs" aria-label="看板视图">
+          <div className="view-tabs" aria-label="项目视图">
             <button
               className={`view-tab${boardView === "issues" ? " active" : ""}`}
               type="button"
@@ -2026,6 +2055,14 @@ export function App() {
               onClick={() => selectBoardView("issues")}
             >
               议题看板
+            </button>
+            <button
+              className={`view-tab${boardView === "context" ? " active" : ""}`}
+              type="button"
+              aria-pressed={boardView === "context"}
+              onClick={() => selectBoardView("context")}
+            >
+              Context
             </button>
             {SHOW_WORKFLOW_BOARD_ENTRY && (
               <button
@@ -2195,6 +2232,14 @@ export function App() {
             onOpenInThread={openTaskInThread}
             openingThread={openingThreadTaskId === detailTask.id}
             onError={setActionError}
+            onAnnounce={setAnnouncement}
+          />
+        ) : boardView === "context" ? (
+          <ContextView
+            key={selectedProject?.id ?? "local"}
+            projectId={selectedProject?.id ?? "local"}
+            revision={contextRevision}
+            createRequest={contextCreateRequest}
             onAnnounce={setAnnouncement}
           />
         ) : boardView === "workflow" ? (

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -11,6 +11,12 @@ import type {
   DevelopmentScan,
   IssueRelationType,
   Project,
+  ProjectContextCreateInput,
+  ProjectContextEntry,
+  ProjectContextFilters,
+  ProjectContextListResponse,
+  ProjectContextPatch,
+  ProjectContextRevision,
   Task,
   TaskboardMetadata,
   TaskDraft,
@@ -280,6 +286,118 @@ export async function listDevelopmentContexts(
     `/api/projects/${encodeURIComponent(projectId)}/development-contexts${suffix}`,
     { signal },
   );
+}
+
+export async function listProjectContext(
+  projectId: string,
+  filters: ProjectContextFilters,
+  signal?: AbortSignal,
+): Promise<ProjectContextListResponse> {
+  const query = new URLSearchParams();
+  if (filters.query !== undefined) query.set("query", filters.query);
+  if (filters.kind !== undefined) query.set("kind", filters.kind);
+  if (filters.tag !== undefined) query.set("tag", filters.tag);
+  if (filters.pinned !== undefined) query.set("pinned", String(filters.pinned));
+  // The API defaults to the active (archived=false) view, so omit that value.
+  if (filters.archived !== undefined && filters.archived !== "false") {
+    query.set("archived", filters.archived);
+  }
+  if (filters.limit !== undefined) query.set("limit", String(filters.limit));
+  if (filters.cursor !== undefined) query.set("cursor", filters.cursor);
+  const suffix = query.size > 0 ? `?${query.toString()}` : "";
+  return request<ProjectContextListResponse>(
+    `/api/projects/${encodeURIComponent(projectId)}/context${suffix}`,
+    { signal },
+  );
+}
+
+export async function getProjectContextBrief(
+  projectId: string,
+  signal?: AbortSignal,
+): Promise<{ brief: string; includedEntryIds: string[]; truncated: boolean }> {
+  return request<{ brief: string; includedEntryIds: string[]; truncated: boolean }>(
+    `/api/projects/${encodeURIComponent(projectId)}/context/brief`,
+    { signal },
+  );
+}
+
+export async function createProjectContextEntry(
+  projectId: string,
+  input: ProjectContextCreateInput,
+): Promise<ProjectContextEntry> {
+  const data = await request<{ entry: ProjectContextEntry }>(
+    `/api/projects/${encodeURIComponent(projectId)}/context`,
+    {
+      method: "POST",
+      body: JSON.stringify(input),
+    },
+  );
+  return data.entry;
+}
+
+export async function getProjectContextEntry(
+  id: string,
+  signal?: AbortSignal,
+): Promise<ProjectContextEntry> {
+  const data = await request<{ entry: ProjectContextEntry }>(
+    `/api/context/${encodeURIComponent(id)}`,
+    { signal },
+  );
+  return data.entry;
+}
+
+export async function updateProjectContextEntry(
+  id: string,
+  version: number,
+  changes: ProjectContextPatch,
+): Promise<ProjectContextEntry> {
+  const data = await request<{ entry: ProjectContextEntry }>(
+    `/api/context/${encodeURIComponent(id)}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify({ version, ...changes }),
+    },
+  );
+  return data.entry;
+}
+
+export async function archiveProjectContextEntry(
+  id: string,
+  version: number,
+): Promise<ProjectContextEntry> {
+  const data = await request<{ entry: ProjectContextEntry }>(
+    `/api/context/${encodeURIComponent(id)}/archive`,
+    {
+      method: "POST",
+      body: JSON.stringify({ version }),
+    },
+  );
+  return data.entry;
+}
+
+export async function restoreProjectContextEntry(
+  id: string,
+  version: number,
+): Promise<ProjectContextEntry> {
+  const data = await request<{ entry: ProjectContextEntry }>(
+    `/api/context/${encodeURIComponent(id)}/restore`,
+    {
+      method: "POST",
+      body: JSON.stringify({ version }),
+    },
+  );
+  return data.entry;
+}
+
+export async function listProjectContextRevisions(
+  id: string,
+  signal?: AbortSignal,
+): Promise<ProjectContextRevision[]> {
+  const data = await request<{ revisions: ProjectContextRevision[] }>(
+    `/api/context/${encodeURIComponent(id)}/revisions`,
+    { signal },
+  );
+  return data.revisions;
 }
 
 export async function listTasks(projectId: string, signal?: AbortSignal): Promise<Task[]> {

--- a/web/src/components/ContextView.tsx
+++ b/web/src/components/ContextView.tsx
@@ -48,6 +48,17 @@ interface ContextConflict {
   baseVersion: number;
 }
 
+type ContextAction = "pin" | "archive" | "restore";
+
+interface ContextActionConflict extends ContextConflict {
+  action: ContextAction;
+}
+
+interface DraftValidationError {
+  field: "title" | "body" | "tags";
+  message: string;
+}
+
 interface ContextViewProps {
   projectId: string;
   revision: number;
@@ -181,12 +192,14 @@ export function ContextView({
   const [draft, setDraft] = useState<ContextDraft>(emptyDraft);
   const [baseVersion, setBaseVersion] = useState<number | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
+  const [validationField, setValidationField] = useState<DraftValidationError["field"] | null>(null);
   const [saving, setSaving] = useState(false);
   const [conflict, setConflict] = useState<ContextConflict | null>(null);
+  const [actionConflict, setActionConflict] = useState<ContextActionConflict | null>(null);
   const [revisions, setRevisions] = useState<ProjectContextRevision[] | null>(null);
   const [revisionsLoading, setRevisionsLoading] = useState(false);
   const [revisionPreview, setRevisionPreview] = useState<ProjectContextRevision | null>(null);
-  const [confirmArchive, setConfirmArchive] = useState(false);
+  const [archiveTarget, setArchiveTarget] = useState<ProjectContextEntry | null>(null);
   const [mobileDetail, setMobileDetail] = useState(false);
   const titleRef = useRef<HTMLInputElement>(null);
   const loadSequence = useRef(0);
@@ -198,12 +211,16 @@ export function ContextView({
   const archiveConfirmRef = useRef<HTMLButtonElement>(null);
   const archiveDialogRef = useRef<HTMLDivElement>(null);
   const savingRef = useRef(saving);
+  const tagsRef = useRef<HTMLInputElement>(null);
+  const bodyRef = useRef<HTMLTextAreaElement>(null);
 
   const selectedFromEntries = useMemo(
     () => entries.find((entry) => entry.id === selectedId) ?? null,
     [entries, selectedId],
   );
-  const selected = editorOpen && editingEntry ? editingEntry : selectedFromEntries;
+  const selected = editorOpen && editingEntry
+    ? editingEntry
+    : actionConflict?.latest ?? selectedFromEntries;
   const availableTags = useMemo(
     () => [...new Set(entries.flatMap((entry) => entry.tags))].sort(),
     [entries],
@@ -211,6 +228,39 @@ export function ContextView({
   const filtersActive = Boolean(query || kind || tag || pinned || showArchived);
   const bodyBytes = byteLength(draft.body);
   const visibleSourceThreadId = visibleSourceIdentifier(selected?.sourceThreadId ?? null);
+  const confirmArchive = archiveTarget !== null;
+
+  function entryMatchesCurrentFilters(entry: ProjectContextEntry): boolean {
+    if (kind && entry.kind !== kind) return false;
+    if (tag.trim() && !entry.tags.includes(tag.trim())) return false;
+    if (pinned === "true" && !entry.pinned) return false;
+    if (pinned === "false" && entry.pinned) return false;
+    if (!showArchived && entry.archivedAt) return false;
+    if (query.trim()) {
+      const needle = query.trim().toLocaleLowerCase();
+      const haystack = [entry.title, entry.body, ...entry.tags].join("\n").toLocaleLowerCase();
+      if (!haystack.includes(needle)) return false;
+    }
+    return true;
+  }
+
+  function invalidateRevisions() {
+    revisionSequence.current += 1;
+    setRevisions(null);
+    setRevisionsLoading(false);
+    setRevisionPreview(null);
+  }
+
+  function applySavedEntry(entry: ProjectContextEntry) {
+    const matches = entryMatchesCurrentFilters(entry);
+    setEntries((current) => {
+      const withoutSaved = current.filter((candidate) => candidate.id !== entry.id);
+      return matches ? sortContextEntries([entry, ...withoutSaved]) : withoutSaved;
+    });
+    setSelectedId(matches ? entry.id : null);
+    if (!matches) setMobileDetail(false);
+    invalidateRevisions();
+  }
 
   async function loadEntries({ append = false, cursor }: { append?: boolean; cursor?: string } = {}) {
     const sequence = ++loadSequence.current;
@@ -273,6 +323,11 @@ export function ContextView({
   }, [projectId, query, kind, tag, pinned, showArchived]);
 
   useEffect(() => {
+    setNextCursor(null);
+    setLoadMoreError(null);
+  }, [projectId, query, kind, tag, pinned, showArchived]);
+
+  useEffect(() => {
     if (revision === 0) return;
     void loadEntries();
   // A realtime refresh updates the list but never resets the editor draft.
@@ -303,7 +358,7 @@ export function ContextView({
     function handleArchiveDialogKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape" && !savingRef.current) {
         event.preventDefault();
-        setConfirmArchive(false);
+        setArchiveTarget(null);
         window.setTimeout(() => archiveTriggerRef.current?.focus(), 0);
         return;
       }
@@ -334,10 +389,13 @@ export function ContextView({
     setCreating(true);
     setEditorOpen(true);
     setEditingEntry(null);
+    setActionConflict(null);
+    setArchiveTarget(null);
     setDraft(emptyDraft());
     setBaseVersion(null);
     setConflict(null);
     setSaveError(null);
+    setValidationField(null);
     setRevisionPreview(null);
     idempotencyKeyRef.current = typeof crypto.randomUUID === "function"
       ? crypto.randomUUID()
@@ -352,10 +410,13 @@ export function ContextView({
     setCreating(false);
     setEditorOpen(false);
     setEditingEntry(null);
+    setActionConflict(null);
+    setArchiveTarget(null);
     setDraft(draftFromEntry(entry));
     setBaseVersion(entry.version);
     setConflict(null);
     setSaveError(null);
+    setValidationField(null);
     setRevisions(null);
     setRevisionPreview(null);
     setMobileDetail(true);
@@ -366,10 +427,13 @@ export function ContextView({
     setCreating(false);
     setEditorOpen(true);
     setEditingEntry(selected);
+    setActionConflict(null);
+    setArchiveTarget(null);
     setDraft(draftFromEntry(selected));
     setBaseVersion(selected.version);
     setConflict(null);
     setSaveError(null);
+    setValidationField(null);
     window.setTimeout(() => titleRef.current?.focus(), 0);
   }
 
@@ -379,17 +443,28 @@ export function ContextView({
     setEditingEntry(null);
     setConflict(null);
     setSaveError(null);
+    setValidationField(null);
     if (selected) setDraft(draftFromEntry(selected));
   }
 
-  function validateDraft(): string | null {
-    if (!draft.title.trim()) return "标题不能为空。";
-    if (draft.title.trim().length > 240) return "标题不能超过 240 个字符。";
-    if (bodyBytes > CONTEXT_BODY_MAX_BYTES) return "正文不能超过 64 KiB，请删减后保存。";
+  function validateDraft(): DraftValidationError | null {
+    if (!draft.title.trim()) return { field: "title", message: "标题不能为空。" };
+    if (draft.title.trim().length > 240) return { field: "title", message: "标题不能超过 240 个字符。" };
+    if (bodyBytes > CONTEXT_BODY_MAX_BYTES) {
+      return { field: "body", message: "正文不能超过 64 KiB，请删减后保存。" };
+    }
     const tags = parseTags(draft.tags);
-    if (tags.length > 20) return "最多添加 20 个标签。";
-    if (tags.some((item) => item.length > 64)) return "每个标签不能超过 64 个字符。";
+    if (tags.length > 20) return { field: "tags", message: "最多添加 20 个标签。" };
+    if (tags.some((item) => item.length > 64)) {
+      return { field: "tags", message: "每个标签不能超过 64 个字符。" };
+    }
     return null;
+  }
+
+  function focusValidationField(field: DraftValidationError["field"]) {
+    if (field === "title") titleRef.current?.focus();
+    if (field === "tags") tagsRef.current?.focus();
+    if (field === "body") bodyRef.current?.focus();
   }
 
   async function refreshConflict(error: ApiError, version: number) {
@@ -405,18 +480,21 @@ export function ContextView({
     }
   }
 
-  async function refreshStaleAction(error: ApiError, entryId: string) {
+  async function refreshStaleAction(error: ApiError, entryId: string, action: ContextAction, baseVersion: number) {
+    if (action === "archive") setArchiveTarget(null);
     try {
       const latest = await getProjectContextEntry(entryId);
       setEntries((current) => {
-        const next = current.some((entry) => entry.id === latest.id)
-          ? current.map((entry) => entry.id === latest.id ? latest : entry)
-          : [latest, ...current];
-        return sortContextEntries(next);
+        const withoutLatest = current.filter((entry) => entry.id !== latest.id);
+        return entryMatchesCurrentFilters(latest)
+          ? sortContextEntries([latest, ...withoutLatest])
+          : withoutLatest;
       });
       setSelectedId(latest.id);
       setBaseVersion(latest.version);
-      setSaveError(`${error.message} 已加载最新版本，请重试。`);
+      setActionConflict({ latest, action, baseVersion });
+      setArchiveTarget(null);
+      setSaveError(null);
     } catch {
       setSaveError(`${error.message} 无法加载最新版本，请刷新后重试。`);
     }
@@ -425,12 +503,14 @@ export function ContextView({
   async function saveDraft() {
     const validation = validateDraft();
     if (validation) {
-      setSaveError(validation);
-      titleRef.current?.focus();
+      setValidationField(validation.field);
+      setSaveError(validation.message);
+      focusValidationField(validation.field);
       return;
     }
     setSaving(true);
     setSaveError(null);
+    setValidationField(null);
     try {
       const values = {
         kind: draft.kind,
@@ -450,18 +530,13 @@ export function ContextView({
           baseVersion ?? selected!.version,
           values satisfies ProjectContextUpdateInput,
         );
-      setEntries((current) => {
-        const next = current.some((entry) => entry.id === saved.id)
-          ? current.map((entry) => entry.id === saved.id ? saved : entry)
-          : [saved, ...current];
-        return sortContextEntries(next);
-      });
-      setSelectedId(saved.id);
+      applySavedEntry(saved);
       setCreating(false);
       setEditorOpen(false);
       setEditingEntry(null);
       setBaseVersion(saved.version);
       setConflict(null);
+      setActionConflict(null);
       setRevisionPreview(null);
       idempotencyKeyRef.current = null;
       onAnnounce(creating ? "Context 已创建。" : "Context 已保存。");
@@ -476,60 +551,71 @@ export function ContextView({
     }
   }
 
-  async function togglePin() {
-    if (!selected || selected.archivedAt) return;
+  async function togglePin(target = selected) {
+    if (!target || target.archivedAt) return;
     setSaving(true);
+    setActionConflict(null);
     try {
-      const saved = await updateProjectContextEntry(selected.id, selected.version, {
-        pinned: !selected.pinned,
+      const saved = await updateProjectContextEntry(target.id, target.version, {
+        pinned: !target.pinned,
       });
-      setEntries((current) => sortContextEntries(current.map((entry) => entry.id === saved.id ? saved : entry)));
+      applySavedEntry(saved);
       setBaseVersion(saved.version);
       onAnnounce(saved.pinned ? "Context 已置顶。" : "Context 已取消置顶。");
     } catch (error) {
       if (isContextVersionConflict(error)) {
-        await refreshStaleAction(error, selected.id);
+        await refreshStaleAction(error, target.id, "pin", target.version);
       } else setSaveError(messageFor(error));
     } finally {
       setSaving(false);
     }
   }
 
-  async function archiveSelected() {
-    if (!selected) return;
+  async function archiveSelected(target = archiveTarget) {
+    if (!target) return;
     setSaving(true);
+    setActionConflict(null);
     try {
-      const saved = await archiveProjectContextEntry(selected.id, selected.version);
-      setConfirmArchive(false);
+      const saved = await archiveProjectContextEntry(target.id, target.version);
+      setArchiveTarget(null);
       setEditingEntry(null);
-      setEntries((current) => showArchived
-        ? sortContextEntries(current.map((entry) => entry.id === saved.id ? saved : entry))
-        : current.filter((entry) => entry.id !== saved.id));
-      setSelectedId((current) => current === saved.id ? null : current);
-      setMobileDetail(false);
+      applySavedEntry(saved);
       onAnnounce("Context 已归档，可通过“显示已归档”查看。");
     } catch (error) {
-      if (isContextVersionConflict(error)) await refreshStaleAction(error, selected.id);
+      if (isContextVersionConflict(error)) await refreshStaleAction(error, target.id, "archive", target.version);
+      else {
+        setArchiveTarget(null);
+        setSaveError(messageFor(error));
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function restoreSelected(target = selected) {
+    if (!target) return;
+    setSaving(true);
+    setActionConflict(null);
+    try {
+      const saved = await restoreProjectContextEntry(target.id, target.version);
+      applySavedEntry(saved);
+      setBaseVersion(saved.version);
+      onAnnounce("Context 已恢复。");
+    } catch (error) {
+      if (isContextVersionConflict(error)) await refreshStaleAction(error, target.id, "restore", target.version);
       else setSaveError(messageFor(error));
     } finally {
       setSaving(false);
     }
   }
 
-  async function restoreSelected() {
-    if (!selected) return;
-    setSaving(true);
-    try {
-      const saved = await restoreProjectContextEntry(selected.id, selected.version);
-      setEntries((current) => sortContextEntries(current.map((entry) => entry.id === saved.id ? saved : entry)));
-      setBaseVersion(saved.version);
-      onAnnounce("Context 已恢复。");
-    } catch (error) {
-      if (isContextVersionConflict(error)) await refreshStaleAction(error, selected.id);
-      else setSaveError(messageFor(error));
-    } finally {
-      setSaving(false);
-    }
+  async function retryActionConflict() {
+    const pending = actionConflict;
+    if (!pending) return;
+    setActionConflict(null);
+    if (pending.action === "pin") await togglePin(pending.latest);
+    if (pending.action === "archive") await archiveSelected(pending.latest);
+    if (pending.action === "restore") await restoreSelected(pending.latest);
   }
 
   async function toggleRevisions() {
@@ -559,6 +645,16 @@ export function ContextView({
     setTag("");
     setPinned("");
     setShowArchived(false);
+  }
+
+  function handleMobileBack() {
+    if (editorOpen) {
+      setSaveError("请先保存或取消当前编辑，草稿仍保留在表单中。");
+      onAnnounce("请先保存或取消当前编辑。");
+      window.setTimeout(() => titleRef.current?.focus(), 0);
+      return;
+    }
+    setMobileDetail(false);
   }
 
   const displayEntry = revisionPreview ?? selected;
@@ -677,7 +773,7 @@ export function ContextView({
               {nextCursor && (
                 <div className="context-load-more">
                   {loadMoreError && <p role="alert">无法加载更多：{loadMoreError}</p>}
-                  <button className="button secondary" type="button" disabled={loadingMore} onClick={() => void loadEntries({ append: true, cursor: nextCursor })}>
+                  <button className="button secondary" type="button" disabled={loading || loadingMore} onClick={() => void loadEntries({ append: true, cursor: nextCursor })}>
                     {loadingMore ? "加载中…" : "加载更多"}
                   </button>
                 </div>
@@ -690,7 +786,7 @@ export function ContextView({
           {(selected || creating) ? (
             <div className="context-detail-scroll">
               <header className="context-detail-header">
-                <button className="detail-back-button context-mobile-back" type="button" aria-label="返回 Context 列表" onClick={() => setMobileDetail(false)}>
+                <button className="detail-back-button context-mobile-back" type="button" aria-label="返回 Context 列表" onClick={handleMobileBack}>
                   <LinearIcon name="chevronLeft" />
                 </button>
                 <div>
@@ -710,7 +806,7 @@ export function ContextView({
                     ) : (
                       <>
                         <button className="button secondary" type="button" onClick={startEdit}>编辑</button>
-                        <button ref={archiveTriggerRef} className="button danger subtle" type="button" disabled={saving} onClick={() => setConfirmArchive(true)}>归档</button>
+                        <button ref={archiveTriggerRef} className="button danger subtle" type="button" disabled={saving} onClick={() => setArchiveTarget(selected)}>归档</button>
                       </>
                     )}
                   </div>
@@ -737,12 +833,36 @@ export function ContextView({
                   <span className="sr-only">刷新后重试</span>
                 </div>
               )}
+              {actionConflict && (
+                <div className="context-conflict-banner" role="alert">
+                  <LinearIcon name="alert" />
+                  <div>
+                    <strong>操作前条目已被更新，已加载最新状态。</strong>
+                    <p>{actionConflict.latest.authorName} 于 {exactTime(actionConflict.latest.updatedAt)} 更新了 v{actionConflict.latest.version}；当前操作基于 v{actionConflict.baseVersion}。</p>
+                    <button className="button primary" type="button" disabled={saving} onClick={() => void retryActionConflict()}>刷新状态后重试</button>
+                  </div>
+                </div>
+              )}
 
               {editorOpen ? (
                 <form className="context-editor" aria-describedby={saveError ? "context-form-error" : undefined} onSubmit={(event) => { event.preventDefault(); void saveDraft(); }}>
                   <label className="context-editor-field">
                     <span>标题</span>
-                    <input ref={titleRef} type="text" required maxLength={240} value={draft.title} onChange={(event) => setDraft((current) => ({ ...current, title: event.target.value }))} />
+                    <input
+                      ref={titleRef}
+                      type="text"
+                      required
+                      maxLength={240}
+                      value={draft.title}
+                      aria-invalid={validationField === "title"}
+                      onChange={(event) => {
+                        setDraft((current) => ({ ...current, title: event.target.value }));
+                        if (validationField === "title") {
+                          setValidationField(null);
+                          setSaveError(null);
+                        }
+                      }}
+                    />
                   </label>
                   <div className="context-editor-grid">
                     <label className="context-editor-field">
@@ -753,7 +873,21 @@ export function ContextView({
                     </label>
                     <label className="context-editor-field">
                       <span>标签</span>
-                      <input type="text" value={draft.tags} placeholder="api, phase-1" aria-describedby="context-tags-help" onChange={(event) => setDraft((current) => ({ ...current, tags: event.target.value }))} />
+                      <input
+                        ref={tagsRef}
+                        type="text"
+                        value={draft.tags}
+                        placeholder="api, phase-1"
+                        aria-describedby="context-tags-help"
+                        aria-invalid={validationField === "tags"}
+                        onChange={(event) => {
+                          setDraft((current) => ({ ...current, tags: event.target.value }));
+                          if (validationField === "tags") {
+                            setValidationField(null);
+                            setSaveError(null);
+                          }
+                        }}
+                      />
                       <small id="context-tags-help">用逗号分隔，最多 20 个</small>
                     </label>
                     <label className="context-pin-toggle">
@@ -763,7 +897,19 @@ export function ContextView({
                   </div>
                   <label className="context-editor-field context-body-field">
                     <span>正文（Markdown）</span>
-                    <textarea value={draft.body} aria-describedby="context-body-counter" onChange={(event) => setDraft((current) => ({ ...current, body: event.target.value }))} />
+                    <textarea
+                      ref={bodyRef}
+                      value={draft.body}
+                      aria-describedby="context-body-counter"
+                      aria-invalid={validationField === "body"}
+                      onChange={(event) => {
+                        setDraft((current) => ({ ...current, body: event.target.value }));
+                        if (validationField === "body") {
+                          setValidationField(null);
+                          setSaveError(null);
+                        }
+                      }}
+                    />
                     <small id="context-body-counter" className={bodyBytes > CONTEXT_BODY_MAX_BYTES ? "is-error" : bodyBytes > CONTEXT_BODY_WARNING_BYTES ? "is-warning" : ""}>{bodyBytes.toLocaleString()} / {CONTEXT_BODY_MAX_BYTES.toLocaleString()} bytes</small>
                   </label>
                   <div className="context-editor-actions">
@@ -820,19 +966,19 @@ export function ContextView({
         </article>
       </div>
 
-      {confirmArchive && selected && (
+      {archiveTarget && (
         <div className="delete-backdrop" role="presentation" onMouseDown={(event) => {
           if (event.target === event.currentTarget && !saving) {
-            setConfirmArchive(false);
+            setArchiveTarget(null);
             window.setTimeout(() => archiveTriggerRef.current?.focus(), 0);
           }
         }}>
           <div ref={archiveDialogRef} className="delete-dialog" role="alertdialog" aria-modal="true" aria-labelledby="archive-context-title">
             <h2 id="archive-context-title">归档这条 Context？</h2>
-            <p>“{selected.title}” 将从默认列表移除，之后可在归档筛选中恢复。</p>
+            <p>“{archiveTarget.title}” 将从默认列表移除，之后可在归档筛选中恢复。</p>
             <div>
               <button className="button secondary" type="button" disabled={saving} onClick={() => {
-                setConfirmArchive(false);
+                setArchiveTarget(null);
                 window.setTimeout(() => archiveTriggerRef.current?.focus(), 0);
               }}>取消</button>
               <button ref={archiveConfirmRef} className="button danger" type="button" disabled={saving} onClick={() => void archiveSelected()}>{saving ? "归档中…" : "归档"}</button>

--- a/web/src/components/ContextView.tsx
+++ b/web/src/components/ContextView.tsx
@@ -1,0 +1,845 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import {
+  ApiError,
+  archiveProjectContextEntry,
+  createProjectContextEntry,
+  getProjectContextEntry,
+  listProjectContext,
+  listProjectContextRevisions,
+  restoreProjectContextEntry,
+  updateProjectContextEntry,
+} from "../api";
+import type {
+  ProjectContextCreateInput,
+  ProjectContextEntry,
+  ProjectContextKind,
+  ProjectContextRevision,
+  ProjectContextUpdateInput,
+} from "../types";
+import { LinearIcon, type LinearIconName } from "./LinearIcon";
+
+const CONTEXT_BODY_MAX_BYTES = 65_536;
+const CONTEXT_BODY_WARNING_BYTES = 60 * 1024;
+
+const KIND_DETAILS: Record<ProjectContextKind, { label: string; icon: LinearIconName }> = {
+  requirement: { label: "需求", icon: "write" },
+  decision: { label: "决策", icon: "check" },
+  constraint: { label: "约束", icon: "shieldAlert" },
+  fact: { label: "事实", icon: "status" },
+  risk: { label: "风险", icon: "alert" },
+  handoff: { label: "交接", icon: "hand" },
+  summary: { label: "总结", icon: "dashboard" },
+};
+
+const CONTEXT_KINDS = Object.keys(KIND_DETAILS) as ProjectContextKind[];
+
+interface ContextDraft {
+  kind: ProjectContextKind;
+  title: string;
+  body: string;
+  tags: string;
+  pinned: boolean;
+}
+
+interface ContextConflict {
+  latest: ProjectContextEntry;
+  baseVersion: number;
+}
+
+interface ContextViewProps {
+  projectId: string;
+  revision: number;
+  createRequest: number;
+  onAnnounce: (message: string) => void;
+}
+
+function emptyDraft(): ContextDraft {
+  return { kind: "decision", title: "", body: "", tags: "", pinned: false };
+}
+
+function draftFromEntry(entry: ProjectContextEntry): ContextDraft {
+  return {
+    kind: entry.kind,
+    title: entry.title,
+    body: entry.body,
+    tags: entry.tags.join(", "),
+    pinned: entry.pinned,
+  };
+}
+
+function parseTags(value: string): string[] {
+  return [...new Set(value.split(/[,，]/u).map((tag) => tag.trim()).filter(Boolean))];
+}
+
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function messageFor(error: unknown): string {
+  if (error instanceof ApiError) return error.message;
+  if (error instanceof Error) return error.message;
+  return "操作未完成，请重试。";
+}
+
+function isContextVersionConflict(error: unknown): error is ApiError {
+  return error instanceof ApiError
+    && error.status === 409
+    && (error.code === "VERSION_CONFLICT" || error.code === "CONTEXT_VERSION_CONFLICT");
+}
+
+function exactTime(value: string): string {
+  return new Intl.DateTimeFormat("zh-CN", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function relativeTime(value: string): string {
+  const seconds = Math.round((new Date(value).getTime() - Date.now()) / 1000);
+  const formatter = new Intl.RelativeTimeFormat("zh-CN", { numeric: "auto" });
+  if (Math.abs(seconds) < 60) return formatter.format(seconds, "second");
+  const minutes = Math.round(seconds / 60);
+  if (Math.abs(minutes) < 60) return formatter.format(minutes, "minute");
+  const hours = Math.round(minutes / 60);
+  if (Math.abs(hours) < 24) return formatter.format(hours, "hour");
+  return formatter.format(Math.round(hours / 24), "day");
+}
+
+function markdownSummary(value: string): string {
+  const plain = value
+    .replace(/```[\s\S]*?```/gu, " ")
+    .replace(/!\[[^\]]*\]\([^)]*\)/gu, " ")
+    .replace(/\[([^\]]+)\]\([^)]*\)/gu, "$1")
+    .replace(/[#>*_~`|\-]/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+  return plain || "无正文";
+}
+
+function sortContextEntries(entries: ProjectContextEntry[]): ProjectContextEntry[] {
+  return [...entries].sort((left, right) => (
+    Number(right.pinned) - Number(left.pinned)
+  ));
+}
+
+function ContextMarkdown({ value }: { value: string }) {
+  return (
+    <div className="issue-description-document context-markdown">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          a: ({ node: _node, ...props }) => <a {...props} target="_blank" rel="noreferrer" />,
+        }}
+      >
+        {value}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+function visibleSourceIdentifier(value: string | null): string | null {
+  if (!value) return null;
+  if (/^(?:\/|[a-z]:[\\/]|\\\\)/iu.test(value)) return null;
+  return value;
+}
+
+function sourceLabel(entry: ProjectContextEntry): string {
+  const labels: Record<ProjectContextEntry["sourceType"], string> = {
+    manual: "手动记录",
+    issue: "议题",
+    comment: "评论",
+    thread_summary: "线程摘要",
+    agent: "Agent",
+  };
+  const sourceId = visibleSourceIdentifier(entry.sourceId);
+  return `${labels[entry.sourceType]}${sourceId ? ` · ${sourceId}` : ""}`;
+}
+
+export function ContextView({
+  projectId,
+  revision,
+  createRequest,
+  onAnnounce,
+}: ContextViewProps) {
+  const [entries, setEntries] = useState<ProjectContextEntry[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [kind, setKind] = useState<ProjectContextKind | "">("");
+  const [tag, setTag] = useState("");
+  const [pinned, setPinned] = useState<"" | "true" | "false">("");
+  const [showArchived, setShowArchived] = useState(false);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [editingEntry, setEditingEntry] = useState<ProjectContextEntry | null>(null);
+  const [draft, setDraft] = useState<ContextDraft>(emptyDraft);
+  const [baseVersion, setBaseVersion] = useState<number | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [conflict, setConflict] = useState<ContextConflict | null>(null);
+  const [revisions, setRevisions] = useState<ProjectContextRevision[] | null>(null);
+  const [revisionsLoading, setRevisionsLoading] = useState(false);
+  const [revisionPreview, setRevisionPreview] = useState<ProjectContextRevision | null>(null);
+  const [confirmArchive, setConfirmArchive] = useState(false);
+  const [mobileDetail, setMobileDetail] = useState(false);
+  const titleRef = useRef<HTMLInputElement>(null);
+  const loadSequence = useRef(0);
+  const loadAbortController = useRef<AbortController | null>(null);
+  const revisionSequence = useRef(0);
+  const previousCreateRequest = useRef(createRequest);
+  const idempotencyKeyRef = useRef<string | null>(null);
+  const archiveTriggerRef = useRef<HTMLButtonElement>(null);
+  const archiveConfirmRef = useRef<HTMLButtonElement>(null);
+  const archiveDialogRef = useRef<HTMLDivElement>(null);
+  const savingRef = useRef(saving);
+
+  const selectedFromEntries = useMemo(
+    () => entries.find((entry) => entry.id === selectedId) ?? null,
+    [entries, selectedId],
+  );
+  const selected = editorOpen && editingEntry ? editingEntry : selectedFromEntries;
+  const availableTags = useMemo(
+    () => [...new Set(entries.flatMap((entry) => entry.tags))].sort(),
+    [entries],
+  );
+  const filtersActive = Boolean(query || kind || tag || pinned || showArchived);
+  const bodyBytes = byteLength(draft.body);
+  const visibleSourceThreadId = visibleSourceIdentifier(selected?.sourceThreadId ?? null);
+
+  async function loadEntries({ append = false, cursor }: { append?: boolean; cursor?: string } = {}) {
+    const sequence = ++loadSequence.current;
+    loadAbortController.current?.abort();
+    const controller = new AbortController();
+    loadAbortController.current = controller;
+    if (append) {
+      setLoadingMore(true);
+      setLoadMoreError(null);
+    } else {
+      setLoading(true);
+      setLoadError(null);
+    }
+    try {
+      const result = await listProjectContext(projectId, {
+        query: query.trim() || undefined,
+        kind: kind || undefined,
+        tag: tag.trim() || undefined,
+        pinned: pinned === "" ? undefined : pinned === "true",
+        archived: showArchived ? "all" : "false",
+        limit: 50,
+        cursor,
+      }, controller.signal);
+      if (sequence !== loadSequence.current) return;
+      const sortedResultEntries = sortContextEntries(result.entries);
+      setEntries((current) => append
+        ? sortContextEntries([
+          ...current,
+          ...result.entries.filter((entry) => !current.some(({ id }) => id === entry.id)),
+        ])
+        : sortedResultEntries);
+      setNextCursor(result.nextCursor);
+      if (!append) {
+        setSelectedId((current) => (
+          current && sortedResultEntries.some((entry) => entry.id === current)
+            ? current
+            : sortedResultEntries[0]?.id ?? null
+        ));
+      }
+    } catch (error) {
+      if ((error as Error).name === "AbortError") return;
+      if (append) setLoadMoreError(messageFor(error));
+      else setLoadError(messageFor(error));
+    } finally {
+      if (sequence === loadSequence.current) {
+        setLoading(false);
+        setLoadingMore(false);
+      }
+      if (loadAbortController.current === controller) loadAbortController.current = null;
+    }
+  }
+
+  useEffect(() => () => loadAbortController.current?.abort(), []);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => void loadEntries(), query ? 240 : 0);
+    return () => window.clearTimeout(timer);
+  // `loadEntries` intentionally reads the current filter values.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId, query, kind, tag, pinned, showArchived]);
+
+  useEffect(() => {
+    if (revision === 0) return;
+    void loadEntries();
+  // A realtime refresh updates the list but never resets the editor draft.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [revision]);
+
+  useEffect(() => {
+    if (createRequest === previousCreateRequest.current) return;
+    previousCreateRequest.current = createRequest;
+    startCreate();
+  }, [createRequest]);
+
+  useEffect(() => {
+    savingRef.current = saving;
+  }, [saving]);
+
+  useEffect(() => {
+    revisionSequence.current += 1;
+    setRevisions(null);
+    setRevisionsLoading(false);
+    setRevisionPreview(null);
+  }, [selectedId]);
+
+  useEffect(() => {
+    if (!confirmArchive) return undefined;
+    window.setTimeout(() => archiveConfirmRef.current?.focus(), 0);
+
+    function handleArchiveDialogKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape" && !savingRef.current) {
+        event.preventDefault();
+        setConfirmArchive(false);
+        window.setTimeout(() => archiveTriggerRef.current?.focus(), 0);
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const buttons = [...(archiveDialogRef.current?.querySelectorAll<HTMLButtonElement>("button:not(:disabled)") ?? [])];
+      if (buttons.length === 0) return;
+      const first = buttons[0];
+      const last = buttons[buttons.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener("keydown", handleArchiveDialogKeyDown);
+    return () => document.removeEventListener("keydown", handleArchiveDialogKeyDown);
+  }, [confirmArchive]);
+
+  function startCreate() {
+    if (editorOpen) {
+      setSaveError("请先保存或取消当前编辑，草稿仍保留在表单中。");
+      onAnnounce("请先保存或取消当前编辑。");
+      return;
+    }
+    setCreating(true);
+    setEditorOpen(true);
+    setEditingEntry(null);
+    setDraft(emptyDraft());
+    setBaseVersion(null);
+    setConflict(null);
+    setSaveError(null);
+    setRevisionPreview(null);
+    idempotencyKeyRef.current = typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    setMobileDetail(true);
+    window.setTimeout(() => titleRef.current?.focus(), 0);
+  }
+
+  function openEntry(entry: ProjectContextEntry) {
+    if (editorOpen) return;
+    setSelectedId(entry.id);
+    setCreating(false);
+    setEditorOpen(false);
+    setEditingEntry(null);
+    setDraft(draftFromEntry(entry));
+    setBaseVersion(entry.version);
+    setConflict(null);
+    setSaveError(null);
+    setRevisions(null);
+    setRevisionPreview(null);
+    setMobileDetail(true);
+  }
+
+  function startEdit() {
+    if (!selected || selected.archivedAt) return;
+    setCreating(false);
+    setEditorOpen(true);
+    setEditingEntry(selected);
+    setDraft(draftFromEntry(selected));
+    setBaseVersion(selected.version);
+    setConflict(null);
+    setSaveError(null);
+    window.setTimeout(() => titleRef.current?.focus(), 0);
+  }
+
+  function cancelEdit() {
+    setEditorOpen(false);
+    setCreating(false);
+    setEditingEntry(null);
+    setConflict(null);
+    setSaveError(null);
+    if (selected) setDraft(draftFromEntry(selected));
+  }
+
+  function validateDraft(): string | null {
+    if (!draft.title.trim()) return "标题不能为空。";
+    if (draft.title.trim().length > 240) return "标题不能超过 240 个字符。";
+    if (bodyBytes > CONTEXT_BODY_MAX_BYTES) return "正文不能超过 64 KiB，请删减后保存。";
+    const tags = parseTags(draft.tags);
+    if (tags.length > 20) return "最多添加 20 个标签。";
+    if (tags.some((item) => item.length > 64)) return "每个标签不能超过 64 个字符。";
+    return null;
+  }
+
+  async function refreshConflict(error: ApiError, version: number) {
+    if (!selected) return;
+    try {
+      const latest = await getProjectContextEntry(selected.id);
+      setConflict({ latest, baseVersion: version });
+      setBaseVersion(latest.version);
+      setEditingEntry(latest);
+      setEntries((current) => sortContextEntries(current.map((entry) => entry.id === latest.id ? latest : entry)));
+    } catch {
+      setSaveError(`${error.message} 你的输入已保留，请刷新后重试。`);
+    }
+  }
+
+  async function refreshStaleAction(error: ApiError, entryId: string) {
+    try {
+      const latest = await getProjectContextEntry(entryId);
+      setEntries((current) => {
+        const next = current.some((entry) => entry.id === latest.id)
+          ? current.map((entry) => entry.id === latest.id ? latest : entry)
+          : [latest, ...current];
+        return sortContextEntries(next);
+      });
+      setSelectedId(latest.id);
+      setBaseVersion(latest.version);
+      setSaveError(`${error.message} 已加载最新版本，请重试。`);
+    } catch {
+      setSaveError(`${error.message} 无法加载最新版本，请刷新后重试。`);
+    }
+  }
+
+  async function saveDraft() {
+    const validation = validateDraft();
+    if (validation) {
+      setSaveError(validation);
+      titleRef.current?.focus();
+      return;
+    }
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const values = {
+        kind: draft.kind,
+        title: draft.title.trim(),
+        body: draft.body,
+        tags: parseTags(draft.tags),
+        pinned: draft.pinned,
+      };
+      const saved = creating
+        ? await createProjectContextEntry(projectId, {
+          ...values,
+          sourceType: "manual",
+          idempotencyKey: idempotencyKeyRef.current,
+        } satisfies ProjectContextCreateInput)
+        : await updateProjectContextEntry(
+          selected!.id,
+          baseVersion ?? selected!.version,
+          values satisfies ProjectContextUpdateInput,
+        );
+      setEntries((current) => {
+        const next = current.some((entry) => entry.id === saved.id)
+          ? current.map((entry) => entry.id === saved.id ? saved : entry)
+          : [saved, ...current];
+        return sortContextEntries(next);
+      });
+      setSelectedId(saved.id);
+      setCreating(false);
+      setEditorOpen(false);
+      setEditingEntry(null);
+      setBaseVersion(saved.version);
+      setConflict(null);
+      setRevisionPreview(null);
+      idempotencyKeyRef.current = null;
+      onAnnounce(creating ? "Context 已创建。" : "Context 已保存。");
+    } catch (error) {
+      if (isContextVersionConflict(error) && !creating && selected) {
+        await refreshConflict(error, baseVersion ?? selected?.version ?? 0);
+      } else {
+        setSaveError(messageFor(error));
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function togglePin() {
+    if (!selected || selected.archivedAt) return;
+    setSaving(true);
+    try {
+      const saved = await updateProjectContextEntry(selected.id, selected.version, {
+        pinned: !selected.pinned,
+      });
+      setEntries((current) => sortContextEntries(current.map((entry) => entry.id === saved.id ? saved : entry)));
+      setBaseVersion(saved.version);
+      onAnnounce(saved.pinned ? "Context 已置顶。" : "Context 已取消置顶。");
+    } catch (error) {
+      if (isContextVersionConflict(error)) {
+        await refreshStaleAction(error, selected.id);
+      } else setSaveError(messageFor(error));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function archiveSelected() {
+    if (!selected) return;
+    setSaving(true);
+    try {
+      const saved = await archiveProjectContextEntry(selected.id, selected.version);
+      setConfirmArchive(false);
+      setEditingEntry(null);
+      setEntries((current) => showArchived
+        ? sortContextEntries(current.map((entry) => entry.id === saved.id ? saved : entry))
+        : current.filter((entry) => entry.id !== saved.id));
+      setSelectedId((current) => current === saved.id ? null : current);
+      setMobileDetail(false);
+      onAnnounce("Context 已归档，可通过“显示已归档”查看。");
+    } catch (error) {
+      if (isContextVersionConflict(error)) await refreshStaleAction(error, selected.id);
+      else setSaveError(messageFor(error));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function restoreSelected() {
+    if (!selected) return;
+    setSaving(true);
+    try {
+      const saved = await restoreProjectContextEntry(selected.id, selected.version);
+      setEntries((current) => sortContextEntries(current.map((entry) => entry.id === saved.id ? saved : entry)));
+      setBaseVersion(saved.version);
+      onAnnounce("Context 已恢复。");
+    } catch (error) {
+      if (isContextVersionConflict(error)) await refreshStaleAction(error, selected.id);
+      else setSaveError(messageFor(error));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function toggleRevisions() {
+    if (revisions) {
+      revisionSequence.current += 1;
+      setRevisions(null);
+      setRevisionPreview(null);
+      return;
+    }
+    if (!selected) return;
+    const sequence = ++revisionSequence.current;
+    setRevisionsLoading(true);
+    setSaveError(null);
+    try {
+      const nextRevisions = await listProjectContextRevisions(selected.id);
+      if (sequence === revisionSequence.current) setRevisions(nextRevisions);
+    } catch (error) {
+      if (sequence === revisionSequence.current) setSaveError(messageFor(error));
+    } finally {
+      if (sequence === revisionSequence.current) setRevisionsLoading(false);
+    }
+  }
+
+  function clearFilters() {
+    setQuery("");
+    setKind("");
+    setTag("");
+    setPinned("");
+    setShowArchived(false);
+  }
+
+  const displayEntry = revisionPreview ?? selected;
+
+  return (
+    <section className={`context-view${mobileDetail ? " is-mobile-detail" : ""}`} aria-label="项目共享 Context">
+      <div className="context-toolbar" aria-label="Context 搜索与筛选">
+        <label className={`search-field context-search${query ? " has-value" : ""}`} title="搜索 Context">
+          <LinearIcon className="search-icon" name="search" />
+          <span className="sr-only">搜索 Context</span>
+          <input
+            id="context-search"
+            type="search"
+            disabled={editorOpen}
+            value={query}
+            maxLength={256}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="搜索 Context…"
+          />
+        </label>
+        <label className="context-filter-field">
+          <span className="sr-only">按类型筛选</span>
+          <select value={kind} disabled={editorOpen} onChange={(event) => setKind(event.target.value as ProjectContextKind | "")}>
+            <option value="">全部类型</option>
+            {CONTEXT_KINDS.map((value) => <option value={value} key={value}>{KIND_DETAILS[value].label}</option>)}
+          </select>
+        </label>
+        <label className="context-filter-field">
+          <span className="sr-only">按标签筛选</span>
+          <select value={tag} disabled={editorOpen} onChange={(event) => setTag(event.target.value)}>
+            <option value="">全部标签</option>
+            {availableTags.map((value) => <option value={value} key={value}>{value}</option>)}
+          </select>
+        </label>
+        <label className="context-filter-field">
+          <span className="sr-only">按置顶状态筛选</span>
+          <select value={pinned} disabled={editorOpen} onChange={(event) => setPinned(event.target.value as typeof pinned)}>
+            <option value="">全部条目</option>
+            <option value="true">仅置顶</option>
+            <option value="false">未置顶</option>
+          </select>
+        </label>
+        <label className="context-archive-toggle">
+          <input type="checkbox" checked={showArchived} disabled={editorOpen} onChange={(event) => setShowArchived(event.target.checked)} />
+          <span>显示已归档</span>
+        </label>
+        {filtersActive && (
+          <button className="clear-filter" type="button" aria-label="清除 Context 筛选" title="清除筛选" disabled={editorOpen} onClick={clearFilters}>
+            <LinearIcon name="close" />
+          </button>
+        )}
+        <button className="button primary context-toolbar-create" type="button" disabled={editorOpen} onClick={startCreate}>
+          <LinearIcon name="plus" />
+          新建
+        </button>
+      </div>
+
+      <div className="context-layout">
+        <div className="context-list-pane">
+          {loading && entries.length === 0 ? (
+            <div className="context-list-loading" aria-label="正在加载 Context" aria-busy="true">
+              <span /><span /><span />
+            </div>
+          ) : loadError && entries.length === 0 ? (
+            <div className="page-empty context-empty" role="alert">
+              <span className="empty-search" aria-hidden="true"><LinearIcon name="alert" /></span>
+              <h2>无法加载 Context</h2>
+              <p>{loadError}</p>
+              <button className="button secondary" type="button" onClick={() => void loadEntries()}>重试</button>
+            </div>
+          ) : entries.length === 0 ? (
+            <div className="page-empty context-empty">
+              <span className="empty-search" aria-hidden="true"><LinearIcon name={filtersActive ? "search" : "dashboard"} /></span>
+              <h2>{filtersActive ? "没有匹配的 Context" : "还没有共享上下文"}</h2>
+              <p>{filtersActive ? "请更换搜索词或清除筛选。" : "记录稳定需求、决策、约束、风险或交接信息。"}</p>
+              <button className="button secondary" type="button" onClick={filtersActive ? clearFilters : startCreate}>
+                {filtersActive ? "清除筛选" : "新增 Context 条目"}
+              </button>
+            </div>
+          ) : (
+            <>
+              {loadError && <div className="context-inline-error" role="alert">刷新失败：{loadError}</div>}
+              <div className="context-entry-list" role="list" aria-label="Context 条目">
+                {entries.map((entry, index) => (
+                  <div key={entry.id} className="context-entry-item" role="listitem">
+                    {entry.pinned && (index === 0 || !entries[index - 1]?.pinned) && <h2 className="context-list-heading">置顶</h2>}
+                    {!entry.pinned && index > 0 && entries[index - 1]?.pinned && <h2 className="context-list-heading">全部 Context</h2>}
+                    <button
+                      className={`context-entry-row${entry.id === selectedId ? " is-selected" : ""}${entry.pinned ? " is-pinned" : ""}${entry.archivedAt ? " is-archived" : ""}`}
+                      type="button"
+                      disabled={editorOpen}
+                      aria-current={entry.id === selectedId ? "true" : undefined}
+                      onClick={() => openEntry(entry)}
+                    >
+                      <span className={`context-kind-glyph is-${entry.kind}`} aria-hidden="true"><LinearIcon name={KIND_DETAILS[entry.kind].icon} /></span>
+                      <span className="context-row-copy">
+                        <span className="context-row-heading">
+                          <strong>{entry.title}</strong>
+                          {entry.archivedAt && <span className="context-archived-label">已归档</span>}
+                        </span>
+                        <span className="context-row-summary">{markdownSummary(entry.body)}</span>
+                        <span className="context-row-meta">
+                          <span>{KIND_DETAILS[entry.kind].label}</span>
+                          {entry.tags.slice(0, 3).map((value) => <span className="label-chip" key={value}>{value}</span>)}
+                          {entry.tags.length > 3 && <span>+{entry.tags.length - 3}</span>}
+                          <span>{entry.authorName}</span>
+                          <time dateTime={entry.updatedAt} title={exactTime(entry.updatedAt)}>{relativeTime(entry.updatedAt)}</time>
+                          <span>v{entry.version}</span>
+                        </span>
+                      </span>
+                      {entry.pinned && <LinearIcon className="context-row-pin" name="favorite" title="已置顶" />}
+                    </button>
+                  </div>
+                ))}
+              </div>
+              {nextCursor && (
+                <div className="context-load-more">
+                  {loadMoreError && <p role="alert">无法加载更多：{loadMoreError}</p>}
+                  <button className="button secondary" type="button" disabled={loadingMore} onClick={() => void loadEntries({ append: true, cursor: nextCursor })}>
+                    {loadingMore ? "加载中…" : "加载更多"}
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        <article className="context-detail-pane" aria-label={creating ? "新建 Context" : selected ? `Context：${selected.title}` : "Context 详情"}>
+          {(selected || creating) ? (
+            <div className="context-detail-scroll">
+              <header className="context-detail-header">
+                <button className="detail-back-button context-mobile-back" type="button" aria-label="返回 Context 列表" onClick={() => setMobileDetail(false)}>
+                  <LinearIcon name="chevronLeft" />
+                </button>
+                <div>
+                  <span>{creating ? "新建 Context" : `v${selected?.version}`}</span>
+                  {!creating && selected && <time dateTime={selected.updatedAt}>更新于 {exactTime(selected.updatedAt)}</time>}
+                </div>
+                {!editorOpen && selected && (
+                  <div className="context-detail-actions">
+                    {!selected.archivedAt && (
+                      <button className={`icon-button${selected.pinned ? " is-active" : ""}`} type="button" aria-label={selected.pinned ? "取消置顶" : "置顶"} aria-pressed={selected.pinned} title={selected.pinned ? "取消置顶" : "置顶"} disabled={saving} onClick={() => void togglePin()}>
+                        <LinearIcon name="favorite" />
+                      </button>
+                    )}
+                    <button className="button secondary" type="button" disabled={saving} onClick={() => void toggleRevisions()}>{revisions ? "收起历史" : "版本历史"}</button>
+                    {selected.archivedAt ? (
+                      <button className="button secondary" type="button" disabled={saving} onClick={() => void restoreSelected()}>恢复</button>
+                    ) : (
+                      <>
+                        <button className="button secondary" type="button" onClick={startEdit}>编辑</button>
+                        <button ref={archiveTriggerRef} className="button danger subtle" type="button" disabled={saving} onClick={() => setConfirmArchive(true)}>归档</button>
+                      </>
+                    )}
+                  </div>
+                )}
+              </header>
+
+              {saveError && <div className="context-save-error" id="context-form-error" role="alert"><LinearIcon name="alert" />{saveError}</div>}
+              {conflict && (
+                <div className="context-conflict-banner" role="alert">
+                  <LinearIcon name="alert" />
+                  <div>
+                    <strong>此条目已被更新，你的输入仍保留。</strong>
+                    <p>{conflict.latest.authorName} 于 {exactTime(conflict.latest.updatedAt)} 更新了 v{conflict.latest.version}；你开始编辑的是 v{conflict.baseVersion}。</p>
+                    <div>
+                      <button className="button primary" type="button" disabled={saving} onClick={() => void saveDraft()}>用当前草稿保存到最新版本</button>
+                      <button className="button secondary" type="button" onClick={() => {
+                        setDraft(draftFromEntry(conflict.latest));
+                        setEditorOpen(false);
+                        setEditingEntry(null);
+                        setConflict(null);
+                      }}>放弃草稿并刷新</button>
+                    </div>
+                  </div>
+                  <span className="sr-only">刷新后重试</span>
+                </div>
+              )}
+
+              {editorOpen ? (
+                <form className="context-editor" aria-describedby={saveError ? "context-form-error" : undefined} onSubmit={(event) => { event.preventDefault(); void saveDraft(); }}>
+                  <label className="context-editor-field">
+                    <span>标题</span>
+                    <input ref={titleRef} type="text" required maxLength={240} value={draft.title} onChange={(event) => setDraft((current) => ({ ...current, title: event.target.value }))} />
+                  </label>
+                  <div className="context-editor-grid">
+                    <label className="context-editor-field">
+                      <span>类型</span>
+                      <select value={draft.kind} onChange={(event) => setDraft((current) => ({ ...current, kind: event.target.value as ProjectContextKind }))}>
+                        {CONTEXT_KINDS.map((value) => <option value={value} key={value}>{KIND_DETAILS[value].label}</option>)}
+                      </select>
+                    </label>
+                    <label className="context-editor-field">
+                      <span>标签</span>
+                      <input type="text" value={draft.tags} placeholder="api, phase-1" aria-describedby="context-tags-help" onChange={(event) => setDraft((current) => ({ ...current, tags: event.target.value }))} />
+                      <small id="context-tags-help">用逗号分隔，最多 20 个</small>
+                    </label>
+                    <label className="context-pin-toggle">
+                      <input type="checkbox" checked={draft.pinned} onChange={(event) => setDraft((current) => ({ ...current, pinned: event.target.checked }))} />
+                      <span>置顶此条目</span>
+                    </label>
+                  </div>
+                  <label className="context-editor-field context-body-field">
+                    <span>正文（Markdown）</span>
+                    <textarea value={draft.body} aria-describedby="context-body-counter" onChange={(event) => setDraft((current) => ({ ...current, body: event.target.value }))} />
+                    <small id="context-body-counter" className={bodyBytes > CONTEXT_BODY_MAX_BYTES ? "is-error" : bodyBytes > CONTEXT_BODY_WARNING_BYTES ? "is-warning" : ""}>{bodyBytes.toLocaleString()} / {CONTEXT_BODY_MAX_BYTES.toLocaleString()} bytes</small>
+                  </label>
+                  <div className="context-editor-actions">
+                    <button className="button secondary" type="button" disabled={saving} onClick={cancelEdit}>取消</button>
+                    <button className="button primary" type="submit" disabled={saving || bodyBytes > CONTEXT_BODY_MAX_BYTES}>{saving ? "正在保存…" : creating ? "创建 Context" : "保存更改"}</button>
+                  </div>
+                </form>
+              ) : displayEntry ? (
+                <div className="context-detail-content">
+                  {revisionPreview && <div className="context-history-preview-heading"><strong>历史预览 · v{revisionPreview.version}</strong><button type="button" onClick={() => setRevisionPreview(null)}>关闭预览</button></div>}
+                  <h1>{displayEntry.title}</h1>
+                  <div className="context-detail-badges">
+                    <span className={`context-kind-badge is-${displayEntry.kind}`}><LinearIcon name={KIND_DETAILS[displayEntry.kind].icon} />{KIND_DETAILS[displayEntry.kind].label}</span>
+                    {displayEntry.tags.map((value) => <span className="label-chip" key={value}>{value}</span>)}
+                    {"pinned" in displayEntry && displayEntry.pinned && <span className="context-pinned-badge"><LinearIcon name="favorite" />已置顶</span>}
+                    {"archivedAt" in displayEntry && displayEntry.archivedAt && <span className="context-archived-label">已归档</span>}
+                  </div>
+                  {displayEntry.body ? <ContextMarkdown value={displayEntry.body} /> : <p className="context-no-body">无正文</p>}
+                </div>
+              ) : null}
+
+              {selected && !creating && (
+                <aside className="context-properties" aria-label="Context 属性">
+                  <dl>
+                    <div><dt>作者</dt><dd>{selected.authorName}<small>{selected.authorId}</small></dd></div>
+                    <div><dt>来源</dt><dd>{sourceLabel(selected)}</dd></div>
+                    {visibleSourceThreadId && <div><dt>来源线程标识</dt><dd><code>{visibleSourceThreadId}</code><small>仅用于标记来源</small></dd></div>}
+                    <div><dt>创建</dt><dd>{exactTime(selected.createdAt)}</dd></div>
+                    <div><dt>更新</dt><dd>{exactTime(selected.updatedAt)}</dd></div>
+                    <div><dt>版本</dt><dd>v{selected.version}</dd></div>
+                  </dl>
+                  {(revisionsLoading || revisions) && (
+                    <section className="context-revisions" aria-label="版本历史" aria-busy={revisionsLoading}>
+                      <h2>版本历史</h2>
+                      {revisionsLoading ? <p>正在加载…</p> : revisions?.map((item) => (
+                        <button type="button" className={revisionPreview?.id === item.id ? "is-selected" : ""} key={item.id} onClick={() => setRevisionPreview(item)}>
+                          <strong>v{item.version} · {item.title}</strong>
+                          <span>{KIND_DETAILS[item.kind].label} · {item.authorName}</span>
+                          <time dateTime={item.createdAt}>{exactTime(item.createdAt)}</time>
+                        </button>
+                      ))}
+                    </section>
+                  )}
+                </aside>
+              )}
+            </div>
+          ) : (
+            <div className="context-detail-empty">
+              <LinearIcon name="dashboard" />
+              <h2>选择一条 Context</h2>
+              <p>在这里查看正文、来源和版本历史。</p>
+            </div>
+          )}
+        </article>
+      </div>
+
+      {confirmArchive && selected && (
+        <div className="delete-backdrop" role="presentation" onMouseDown={(event) => {
+          if (event.target === event.currentTarget && !saving) {
+            setConfirmArchive(false);
+            window.setTimeout(() => archiveTriggerRef.current?.focus(), 0);
+          }
+        }}>
+          <div ref={archiveDialogRef} className="delete-dialog" role="alertdialog" aria-modal="true" aria-labelledby="archive-context-title">
+            <h2 id="archive-context-title">归档这条 Context？</h2>
+            <p>“{selected.title}” 将从默认列表移除，之后可在归档筛选中恢复。</p>
+            <div>
+              <button className="button secondary" type="button" disabled={saving} onClick={() => {
+                setConfirmArchive(false);
+                window.setTimeout(() => archiveTriggerRef.current?.focus(), 0);
+              }}>取消</button>
+              <button ref={archiveConfirmRef} className="button danger" type="button" disabled={saving} onClick={() => void archiveSelected()}>{saving ? "归档中…" : "归档"}</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8455,6 +8455,756 @@ kbd {
   }
 }
 
+/* Shared project context: flat rows and an inline detail surface. */
+.context-view {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  background: var(--bg);
+}
+
+.security-warning {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 7px;
+  min-height: 28px;
+  padding: 5px 16px;
+  border-bottom: var(--border-hairline) solid color-mix(in srgb, var(--warning) 40%, var(--border));
+  background: color-mix(in srgb, var(--warning) 9%, var(--bg));
+  color: color-mix(in srgb, var(--warning) 75%, var(--text-primary));
+  font-size: 10px;
+}
+
+.security-warning svg {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+}
+
+.context-toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  min-height: 48px;
+  gap: 6px;
+  padding: 8px 16px;
+  border-bottom: var(--border-hairline) solid var(--border);
+}
+
+.context-search {
+  flex: 1 1 190px;
+  width: auto;
+  max-width: 360px;
+}
+
+.context-filter-field select,
+.context-archive-toggle {
+  height: 28px;
+  border: var(--border-hairline) solid var(--border);
+  border-radius: 5px;
+  background: var(--surface);
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.context-filter-field select {
+  max-width: 140px;
+  padding: 0 7px;
+}
+
+.context-archive-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px;
+  white-space: nowrap;
+}
+
+.context-archive-toggle input,
+.context-pin-toggle input {
+  accent-color: var(--accent);
+}
+
+.context-toolbar-create {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: auto;
+}
+
+.context-toolbar-create svg {
+  width: 14px;
+  height: 14px;
+}
+
+.context-layout {
+  display: grid;
+  grid-template-columns: minmax(330px, 430px) minmax(0, 1fr);
+  flex: 1;
+  min-height: 0;
+}
+
+.context-list-pane,
+.context-detail-pane {
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+}
+
+.context-list-pane {
+  border-right: var(--border-hairline) solid var(--border);
+}
+
+.context-entry-list {
+  padding: 4px 0 24px;
+}
+
+.context-list-heading {
+  margin: 14px 14px 5px;
+  color: var(--text-tertiary);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.context-entry-row {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  min-height: 86px;
+  gap: 10px;
+  padding: 11px 14px;
+  border: 0;
+  border-bottom: var(--border-hairline) solid var(--border);
+  border-left: 2px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-primary);
+  text-align: left;
+}
+
+.context-entry-row:hover,
+.context-entry-row:focus-visible {
+  background: var(--surface-hover);
+}
+
+.context-entry-row.is-selected {
+  background: var(--accent-soft);
+  border-left-color: var(--accent);
+}
+
+.context-entry-row.is-pinned {
+  border-left-color: color-mix(in srgb, var(--warning) 70%, transparent);
+}
+
+.context-entry-row.is-pinned.is-selected {
+  border-left-color: var(--accent);
+}
+
+.context-entry-row.is-archived {
+  opacity: .62;
+}
+
+.context-entry-row:disabled {
+  cursor: default;
+}
+
+.context-kind-glyph {
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  margin-top: 1px;
+  border-radius: 4px;
+  color: var(--text-tertiary);
+}
+
+.context-kind-glyph.is-risk,
+.context-kind-badge.is-risk {
+  color: var(--danger);
+}
+
+.context-kind-glyph svg,
+.context-kind-badge svg,
+.context-pinned-badge svg,
+.context-row-pin {
+  width: 14px;
+  height: 14px;
+}
+
+.context-row-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.context-row-heading {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 7px;
+}
+
+.context-row-heading strong {
+  min-width: 0;
+  overflow: hidden;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 18px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.context-archived-label {
+  flex: 0 0 auto;
+  color: var(--text-tertiary);
+  font-size: 10px;
+}
+
+.context-row-summary {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 17px;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.context-row-meta {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 6px;
+  overflow: hidden;
+  color: var(--text-tertiary);
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+.context-row-meta > span:not(.label-chip),
+.context-row-meta time {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.context-row-meta .label-chip {
+  height: 18px;
+  max-width: 72px;
+}
+
+.context-row-pin {
+  flex: 0 0 auto;
+  margin-top: 3px;
+  color: var(--warning);
+}
+
+.context-list-loading {
+  display: grid;
+  gap: 1px;
+  padding: 12px;
+}
+
+.context-list-loading span {
+  display: block;
+  height: 76px;
+  border-bottom: var(--border-hairline) solid var(--border);
+  background: linear-gradient(90deg, var(--surface-muted), var(--surface-hover), var(--surface-muted));
+  background-size: 240% 100%;
+  animation: context-loading 1.2s ease-in-out infinite;
+}
+
+@keyframes context-loading {
+  from { background-position: 100% 0; }
+  to { background-position: -100% 0; }
+}
+
+.context-empty {
+  max-width: 360px;
+  margin: 80px auto;
+  padding: 0 20px;
+}
+
+.context-inline-error,
+.context-save-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 7px;
+  margin: 10px 14px;
+  padding: 9px 11px;
+  border: var(--border-hairline) solid color-mix(in srgb, var(--danger) 35%, var(--border));
+  border-radius: 5px;
+  background: var(--danger-soft);
+  color: var(--danger);
+  font-size: 11px;
+}
+
+.context-save-error {
+  margin: 16px 32px 0;
+}
+
+.context-save-error svg,
+.context-conflict-banner > svg {
+  flex: 0 0 auto;
+  width: 15px;
+  height: 15px;
+}
+
+.context-load-more {
+  display: grid;
+  justify-items: center;
+  gap: 5px;
+  padding: 16px;
+}
+
+.context-load-more p {
+  margin: 0;
+  color: var(--danger);
+  font-size: 11px;
+}
+
+.context-detail-pane {
+  overflow: hidden;
+  background: var(--bg);
+}
+
+.context-detail-scroll {
+  height: 100%;
+  overflow: auto;
+  padding-bottom: 48px;
+}
+
+.context-detail-header {
+  display: flex;
+  align-items: center;
+  min-height: 52px;
+  gap: 10px;
+  padding: 12px 32px;
+  border-bottom: var(--border-hairline) solid var(--border);
+}
+
+.context-detail-header > div:first-of-type {
+  display: grid;
+  min-width: 0;
+  gap: 1px;
+  color: var(--text-tertiary);
+  font-size: 10px;
+}
+
+.context-detail-header time {
+  color: var(--text-secondary);
+}
+
+.context-detail-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+}
+
+.context-detail-actions .icon-button.is-active {
+  color: var(--warning);
+}
+
+.context-mobile-back {
+  display: none;
+}
+
+.context-detail-content {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 34px 42px 22px;
+}
+
+.context-detail-content h1 {
+  margin: 0 0 12px;
+  overflow-wrap: anywhere;
+  font-size: 27px;
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.context-detail-badges {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 24px;
+}
+
+.context-kind-badge,
+.context-pinned-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.context-pinned-badge {
+  color: var(--warning);
+}
+
+.context-markdown {
+  user-select: text;
+}
+
+.context-no-body {
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+.context-properties {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 10px 42px 0;
+  border-top: var(--border-hairline) solid var(--border);
+}
+
+.context-properties dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px 24px;
+  margin: 0;
+}
+
+.context-properties dl > div {
+  display: grid;
+  grid-template-columns: 76px minmax(0, 1fr);
+  min-height: 31px;
+  align-items: center;
+  border-bottom: var(--border-hairline) solid var(--border);
+  font-size: 11px;
+}
+
+.context-properties dt {
+  color: var(--text-tertiary);
+}
+
+.context-properties dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--text-secondary);
+}
+
+.context-properties dd small {
+  display: block;
+  color: var(--text-tertiary);
+  font-size: 10px;
+}
+
+.context-properties code {
+  font-size: 10px;
+}
+
+.context-revisions {
+  margin-top: 16px;
+}
+
+.context-revisions h2 {
+  margin: 0 0 6px;
+  color: var(--text-tertiary);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.context-revisions > button {
+  display: grid;
+  width: 100%;
+  gap: 2px;
+  padding: 8px 9px;
+  border: 0;
+  border-bottom: var(--border-hairline) solid var(--border);
+  background: transparent;
+  color: var(--text-secondary);
+  text-align: left;
+}
+
+.context-revisions > button:hover,
+.context-revisions > button.is-selected {
+  background: var(--surface-hover);
+}
+
+.context-revisions > button strong {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.context-revisions > button span,
+.context-revisions > button time {
+  color: var(--text-tertiary);
+  font-size: 10px;
+}
+
+.context-history-preview-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 14px;
+  padding: 8px 10px;
+  border-left: 2px solid var(--accent);
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 11px;
+}
+
+.context-history-preview-heading button {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-decoration: underline;
+}
+
+.context-editor {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 34px 42px 22px;
+}
+
+.context-editor-field {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 18px;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.context-editor-field > span {
+  color: var(--text-tertiary);
+  font-weight: 550;
+}
+
+.context-editor-field input,
+.context-editor-field select,
+.context-editor-field textarea {
+  width: 100%;
+  min-height: 32px;
+  padding: 7px 9px;
+  border: var(--border-hairline) solid var(--border-strong);
+  border-radius: 5px;
+  background: var(--surface);
+  color: var(--text-primary);
+}
+
+.context-editor-field textarea {
+  min-height: 280px;
+  resize: vertical;
+  line-height: 1.6;
+}
+
+.context-editor-field small {
+  color: var(--text-tertiary);
+  font-size: 10px;
+}
+
+.context-editor-field small.is-warning {
+  color: var(--warning);
+}
+
+.context-editor-field small.is-error {
+  color: var(--danger);
+}
+
+.context-editor-grid {
+  display: grid;
+  grid-template-columns: minmax(130px, .7fr) minmax(180px, 1.3fr) auto;
+  align-items: start;
+  gap: 12px;
+}
+
+.context-pin-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 32px;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.context-editor-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.context-conflict-banner {
+  display: flex;
+  align-items: flex-start;
+  max-width: 820px;
+  gap: 9px;
+  margin: 16px auto 0;
+  padding: 12px 14px;
+  border: var(--border-hairline) solid color-mix(in srgb, var(--warning) 50%, var(--border));
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--warning) 10%, var(--surface));
+  color: var(--text-primary);
+}
+
+.context-conflict-banner > svg {
+  color: var(--warning);
+}
+
+.context-conflict-banner strong {
+  font-size: 11px;
+}
+
+.context-conflict-banner p {
+  margin: 4px 0 9px;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.context-conflict-banner .button {
+  margin-right: 6px;
+}
+
+.context-detail-empty {
+  display: grid;
+  place-items: center;
+  align-content: center;
+  height: 100%;
+  gap: 8px;
+  color: var(--text-tertiary);
+  text-align: center;
+}
+
+.context-detail-empty svg {
+  width: 30px;
+  height: 30px;
+  opacity: .55;
+}
+
+.context-detail-empty h2,
+.context-detail-empty p {
+  margin: 0;
+}
+
+@media (max-width: 1040px) {
+  .context-layout {
+    grid-template-columns: minmax(290px, 350px) minmax(0, 1fr);
+  }
+
+  .context-detail-content,
+  .context-editor,
+  .context-properties {
+    padding-right: 24px;
+    padding-left: 24px;
+  }
+}
+
+@media (max-width: 760px) {
+  .context-toolbar {
+    align-items: stretch;
+    padding: 7px 10px;
+  }
+
+  .context-search {
+    flex-basis: calc(100% - 40px);
+    max-width: none;
+  }
+
+  .context-filter-field {
+    flex: 1 1 110px;
+    min-width: 0;
+  }
+
+  .context-filter-field select {
+    width: 100%;
+    max-width: none;
+  }
+
+  .context-archive-toggle {
+    flex: 1 1 135px;
+    justify-content: center;
+  }
+
+  .context-toolbar-create {
+    margin-left: 0;
+  }
+
+  .context-layout {
+    display: block;
+  }
+
+  .context-list-pane {
+    height: 100%;
+    border-right: 0;
+  }
+
+  .context-detail-pane {
+    display: none;
+    height: 100%;
+  }
+
+  .context-view.is-mobile-detail .context-list-pane {
+    display: none;
+  }
+
+  .context-view.is-mobile-detail .context-detail-pane {
+    display: block;
+  }
+
+  .context-mobile-back {
+    display: inline-grid;
+  }
+
+  .context-detail-header,
+  .context-detail-content,
+  .context-editor,
+  .context-properties {
+    padding-right: 14px;
+    padding-left: 14px;
+  }
+
+  .context-detail-content h1 {
+    font-size: 22px;
+  }
+
+  .context-properties dl {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .context-editor-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+
+  .context-pin-toggle {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 480px) {
+  .context-detail-actions .button {
+    padding-right: 7px;
+    padding-left: 7px;
+  }
+
+  .context-row-meta > span:nth-of-type(n + 4),
+  .context-row-meta time {
+    display: none;
+  }
+
+  .context-editor-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .context-pin-toggle {
+    grid-column: auto;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8515,6 +8515,20 @@ kbd {
   padding: 0 7px;
 }
 
+.context-filter-field select:focus-visible,
+.context-editor-field input:focus-visible,
+.context-editor-field select:focus-visible,
+.context-editor-field textarea:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+.context-editor-field input[aria-invalid="true"],
+.context-editor-field textarea[aria-invalid="true"] {
+  border-color: var(--danger);
+  box-shadow: 0 0 0 2px var(--danger-soft);
+}
+
 .context-archive-toggle {
   display: inline-flex;
   align-items: center;
@@ -8526,6 +8540,12 @@ kbd {
 .context-archive-toggle input,
 .context-pin-toggle input {
   accent-color: var(--accent);
+}
+
+.context-archive-toggle input:focus-visible,
+.context-pin-toggle input:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 70%, transparent);
+  outline-offset: 2px;
 }
 
 .context-toolbar-create {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -173,6 +173,94 @@ export interface Project {
   updatedAt: string;
 }
 
+export type ProjectContextKind =
+  | "requirement"
+  | "decision"
+  | "constraint"
+  | "fact"
+  | "risk"
+  | "handoff"
+  | "summary";
+
+export type ProjectContextSourceType =
+  | "manual"
+  | "issue"
+  | "comment"
+  | "thread_summary"
+  | "agent";
+
+export interface ProjectContextEntry {
+  id: string;
+  projectId: string;
+  kind: ProjectContextKind;
+  title: string;
+  body: string;
+  tags: string[];
+  sourceType: ProjectContextSourceType;
+  sourceId: string | null;
+  sourceThreadId: string | null;
+  authorType: ActorType;
+  authorId: string;
+  authorName: string;
+  pinned: boolean;
+  archivedAt: string | null;
+  version: number;
+  idempotencyKey: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProjectContextRevision {
+  id: string;
+  entryId: string;
+  version: number;
+  title: string;
+  body: string;
+  kind: ProjectContextKind;
+  tags: string[];
+  authorId: string;
+  authorName: string;
+  createdAt: string;
+}
+
+export interface ProjectContextListResponse {
+  entries: ProjectContextEntry[];
+  nextCursor: string | null;
+}
+
+export interface ProjectContextFilters {
+  query?: string;
+  kind?: ProjectContextKind;
+  tag?: string;
+  pinned?: boolean;
+  archived?: "false" | "true" | "all";
+  limit?: number;
+  cursor?: string;
+}
+
+export interface ProjectContextCreateInput {
+  kind: ProjectContextKind;
+  title: string;
+  body: string;
+  tags?: string[];
+  sourceType?: ProjectContextSourceType;
+  sourceId?: string | null;
+  sourceThreadId?: string | null;
+  pinned?: boolean;
+  idempotencyKey?: string | null;
+}
+
+export interface ProjectContextPatch {
+  kind?: ProjectContextKind;
+  title?: string;
+  body?: string;
+  tags?: string[];
+  pinned?: boolean;
+}
+
+// Kept as a descriptive alias for the inline editor's existing import.
+export type ProjectContextUpdateInput = ProjectContextPatch;
+
 export interface TaskRelationSummary {
   id: string;
   identifier: string;


### PR DESCRIPTION
## Summary

- Add the project-page Context peer view with search, kind/tag/pinned/archive filters, cursor pagination, inline detail/edit, revisions, pin/archive/restore, and responsive list/detail navigation.
- Consume the ASH-46 client contract and wire Context events/revision polling into the existing shell.
- Preserve editor drafts across `VERSION_CONFLICT` by fetching the latest entry and retrying with the refreshed version; render Markdown through `react-markdown` without raw HTML.

## Dependency

This branch is based on the ASH-45/ASH-46 API commits currently in PR #17. It is intentionally opened against `main` so the dependency commits remain visible until that PR lands.

## Verification

- `npm run typecheck`
- `npm run build`
- `node --test test/context-ui.test.mjs test/board-views.test.mjs` (15/15)
- `npm run check` (344/362 overall; 18 pre-existing failures outside Context)
- Playwright desktop and 720px browser checks: no horizontal overflow; safe Markdown produced no executable `script`/`onerror` nodes; create/search/revisions/409 draft preservation/archive/restore passed; cursor pagination appended 53 unique rows.

No production deployment is included.
