### PR TITLE
feat: 接入 Codex 原生任务自动化与 Taskboard 系统启动器

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ The Skill teaches Codex to inspect an issue, move it to `in_progress`, use optim
 
 ## Embed in Codex
 
+### Replace the system ChatGPT entry
+
+Install a Taskboard launcher at the standard ChatGPT application path:
+
+```bash
+npm run codex:install-launcher
+```
+
+The installer preserves the signed official app at `/Applications/.ChatGPT Official.app` and places a same-icon launcher at `/Applications/ChatGPT.app`. Opening ChatGPT from Finder, Launchpad, or Spotlight then launches the official app with a loopback-only CDP port and starts the resident Taskboard injector. The official app bundle is not modified.
+
+Restore the original application entry with:
+
+```bash
+npm run codex:uninstall-launcher
+```
+
 ### Recommended: keep your current window and open a separate Taskboard window
 
 Keep the existing Codex window open. From the Taskboard repository, start a second Codex instance with a dedicated CDP port:

--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -1,7 +1,7 @@
 (() => {
   "use strict";
 
-  const VERSION = "0.6.8";
+  const VERSION = "0.6.9";
   const SOURCE_HASH = window.__CODEX_TASKBOARD_SOURCE_HASH__;
   const SENTINEL_KEY = "__codexTaskboardInjection__";
   const DEFAULT_TASKBOARD_URL = "http://127.0.0.1:47823/?host=codex";
@@ -594,6 +594,23 @@
     return `/local/${encodeURIComponent(threadId)}`;
   }
 
+  function targetThreadIsActive(threadId) {
+    const expectedThreadId = normalizeThreadId(threadId);
+    const activeThreadId = normalizeThreadId(
+      activeThreadRow()?.getAttribute("data-app-action-sidebar-thread-id"),
+    );
+    return activeThreadId === expectedThreadId;
+  }
+
+  async function waitForTargetThread(threadId, timeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+    do {
+      if (targetThreadIsActive(threadId)) return true;
+      await new Promise((resolve) => window.setTimeout(resolve, 40));
+    } while (Date.now() < deadline);
+    return targetThreadIsActive(threadId);
+  }
+
   async function openThread(threadId) {
     if (typeof threadId !== "string" || !threadId.trim()) return;
     const normalizedThreadId = normalizeThreadId(threadId);
@@ -603,14 +620,15 @@
 
     if (row?.isConnected) {
       row.click?.();
-      return;
+      if (await waitForTargetThread(normalizedThreadId, 800)) return;
     }
 
     try {
-      await dispatchHostMessage({
+      dispatchHostMessage({
         type: "navigate-to-route",
         path: routeForThread(normalizedThreadId),
       });
+      await waitForTargetThread(normalizedThreadId, 1_200);
     } catch (_) {}
   }
 

--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -65,6 +65,7 @@
   let hostRequestSequence = 0;
   let observer = null;
   let reattachTimer = null;
+  let mountRetryTimer = null;
   let lastFocusedElement = null;
   let hostContextSnapshot = null;
   let mutedNativeSelections = new Map();
@@ -307,20 +308,30 @@
     const viewportRect = viewport.getBoundingClientRect();
     const headerBottom = document.querySelector("main > header")?.getBoundingClientRect().bottom
       ?? viewportRect.top;
-    return Array.from(viewport.children).find((candidate) => {
-      const rect = candidate.getBoundingClientRect();
-      return rect.width >= viewportRect.width * 0.8
-        && rect.height >= viewportRect.height * 0.7
-        && rect.top >= headerBottom - 1;
-    }) || null;
+    const findCandidate = (minWidthRatio, minHeightRatio) => (
+      Array.from(viewport.children).find((candidate) => {
+        const rect = candidate.getBoundingClientRect();
+        return rect.width > 0
+          && rect.height > 0
+          && rect.width >= viewportRect.width * minWidthRatio
+          && rect.height >= viewportRect.height * minHeightRatio
+          && rect.top >= headerBottom - 1;
+      }) || null
+    );
+    return findCandidate(0.8, 0.7)
+      || findCandidate(0.5, 0.5)
+      || viewport.querySelector("main")
+      || viewport;
   }
 
   function findPageMount() {
     const frameHost = findPageHost();
     const viewport = frameHost?.closest?.("[data-app-shell-main-content-layout]");
     const surface = viewport?.parentElement;
-    if (!frameHost || !viewport || !surface || !surface.closest("main")) return null;
-    return { frameHost, surface };
+    if (frameHost && surface?.closest("main")) return { frameHost, surface };
+    const main = document.querySelector("main");
+    if (!main) return null;
+    return { frameHost: frameHost ?? main, surface: main };
   }
 
   function muteNativeSelection() {
@@ -1136,6 +1147,10 @@
     if (!active && page?.hidden !== false) return;
     openGeneration += 1;
     active = false;
+    if (mountRetryTimer !== null) {
+      window.clearTimeout(mountRetryTimer);
+      mountRetryTimer = null;
+    }
     if (page) page.hidden = true;
     restoreNativeContent();
     restoreNativeSelection();
@@ -1144,6 +1159,16 @@
     if (restoreFocus) lastFocusedElement?.focus?.();
     lastFocusedElement = null;
     hostContextSnapshot = null;
+  }
+
+  function retryMountActivePage(generation, attemptsLeft = 25) {
+    if (destroyed || !active || generation !== openGeneration) return;
+    mountActivePage();
+    if (page?.isConnected || attemptsLeft <= 0) return;
+    mountRetryTimer = window.setTimeout(
+      () => retryMountActivePage(generation, attemptsLeft - 1),
+      80,
+    );
   }
 
   function openTaskboard() {
@@ -1157,7 +1182,11 @@
     ensureEntry();
     mountActivePage();
     syncEntryState();
-    void prepareTaskboard(generation);
+    if (page?.isConnected) {
+      void prepareTaskboard(generation);
+    } else {
+      retryMountActivePage(generation);
+    }
   }
 
   function isNativePageNavigation(target) {
@@ -1222,6 +1251,8 @@
     destroyed = true;
     if (reattachTimer !== null) window.clearTimeout(reattachTimer);
     reattachTimer = null;
+    if (mountRetryTimer !== null) window.clearTimeout(mountRetryTimer);
+    mountRetryTimer = null;
     observer?.disconnect();
     observer = null;
     cancelFrameReadyWaiters(new Error("任务面板已关闭"));

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "codex": "node scripts/codex-injector.mjs --launch --watch --open",
     "codex:inject": "node scripts/codex-injector.mjs --watch",
     "codex:daemon": "node scripts/codex-injector.mjs --daemon --open",
+    "codex:install-launcher": "node scripts/install-chatgpt-launcher.mjs",
+    "codex:uninstall-launcher": "node scripts/install-chatgpt-launcher.mjs --uninstall",
     "codex:refresh": "node scripts/codex-injector.mjs --refresh",
     "dev": "node scripts/dev.mjs",
     "dev:server": "node --watch server/index.mjs --dev",

--- a/scripts/codex-injector-runtime.mjs
+++ b/scripts/codex-injector-runtime.mjs
@@ -146,8 +146,12 @@ export async function restartResidentInjector(port, handlers) {
 
   for (const pid of previousPids) await handlers.stopResident(pid);
   const startupToken = handlers.createStartupToken();
-  const started = handlers.startResident(port, startupToken);
-  await handlers.waitUntilReady(port, started.pid, startupToken);
+  const started = await handlers.startResident(port, startupToken);
+  await handlers.waitUntilReady(
+    port,
+    started.pid,
+    started.started ? startupToken : null,
+  );
   return {
     previousPids,
     pid: started.pid,

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -23,7 +23,10 @@ const injectorPath = fileURLToPath(import.meta.url);
 const projectRoot = path.resolve(path.dirname(injectorPath), "..");
 const defaultCodexDebuggingPort = 9229;
 const injectionPath = path.join(projectRoot, "inject", "codex-taskboard.user.js");
-const automationPoliciesPath = path.join(projectRoot, ".data", "codex-automation-policies.json");
+const taskboardDataDirectory = process.env.CODEX_TASKBOARD_DATA_DIR
+  ? path.resolve(process.env.CODEX_TASKBOARD_DATA_DIR)
+  : path.join(projectRoot, ".data");
+const automationPoliciesPath = path.join(taskboardDataDirectory, "codex-automation-policies.json");
 const taskboardOrigin = `http://127.0.0.1:${resolvePort()}`;
 const taskboardHealthUrl = `${taskboardOrigin}/health`;
 const taskboardPageUrl = `${taskboardOrigin}/?host=codex`;
@@ -115,15 +118,19 @@ async function waitUntilReachable(url, timeoutMs) {
   throw new Error(`Timed out waiting for ${url}`);
 }
 
-function startTaskboard({ detached }) {
+function startTaskboard({ detached, codexDebugPort }) {
   return spawn(process.execPath, [path.join(projectRoot, "server", "index.mjs")], {
     cwd: projectRoot,
     detached,
+    env: {
+      ...process.env,
+      CODEX_TASKBOARD_CODEX_DEBUG_PORT: String(codexDebugPort),
+    },
     stdio: detached ? "ignore" : "inherit",
   });
 }
 
-function createTaskboardSupervisor({ detached }) {
+function createTaskboardSupervisor({ detached, codexDebugPort }) {
   let child = null;
   let ensureInFlight = null;
   let retryAfter = 0;
@@ -146,7 +153,7 @@ function createTaskboardSupervisor({ detached }) {
         } catch (_) {}
       }
 
-      const started = startTaskboard({ detached });
+      const started = startTaskboard({ detached, codexDebugPort });
       child = started;
       if (detached) started.unref();
       started.once("error", (error) => {
@@ -306,8 +313,18 @@ async function codexTargets(port) {
       target.type === "page" &&
       target.webSocketDebuggerUrl &&
       !target.url?.includes("initialRoute=%2Fglobal-dictation") &&
+      !target.url?.includes("initialRoute=%2Favatar-overlay") &&
       (target.url?.startsWith("app://") || target.title === "Codex"),
   );
+}
+
+async function waitUntilCodexTargets(port, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if ((await codexTargets(port)).length > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error("Timed out waiting for a Codex renderer target");
 }
 
 function codexDebuggingPorts(preferredPort) {
@@ -381,6 +398,16 @@ function startResidentInjector(
   return { pid: child.pid, started: true };
 }
 
+async function startResidentInjectorAfterManagedRestart(port, startupToken) {
+  const deadline = Date.now() + 1_000;
+  while (Date.now() < deadline) {
+    const [existingPid] = residentInjectorPids(port);
+    if (existingPid) return { pid: existingPid, started: false };
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return startResidentInjector(port, false, true, startupToken);
+}
+
 async function stopResidentInjector(pid) {
   process.kill(pid, "SIGTERM");
   const deadline = Date.now() + 5_000;
@@ -434,9 +461,7 @@ async function restartResidentInjectorForRefresh(port) {
     findResidents: residentInjectorPids,
     stopResident: stopResidentInjector,
     createStartupToken: randomUUID,
-    startResident: (targetPort, startupToken) => (
-      startResidentInjector(targetPort, false, true, startupToken)
-    ),
+    startResident: startResidentInjectorAfterManagedRestart,
     waitUntilReady: (targetPort, pid, startupToken) => (
       waitForResidentInjectorReady(targetPort, pid, startupToken, sourceHash)
     ),
@@ -1240,7 +1265,10 @@ async function main() {
   }
 
   let codexProcess = null;
-  const supervisor = createTaskboardSupervisor({ detached: !options.watch });
+  const supervisor = createTaskboardSupervisor({
+    detached: !options.watch,
+    codexDebugPort: options.port,
+  });
 
   try {
     const cdpReachable = await isReachable(cdpVersionUrl);
@@ -1260,6 +1288,7 @@ async function main() {
     if (!cdpReachable) {
       codexProcess = launchCodex(options.appPath, options.port);
       await waitUntilReachable(cdpVersionUrl, 30_000);
+      await waitUntilCodexTargets(options.port, 30_000);
     }
 
     const { source, sourceHash } = await currentInjectionSource();

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -263,10 +263,18 @@ class CdpConnection {
   }
 
   send(method, params = {}) {
+    if (this.closed || this.socket.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error("CDP WebSocket is closed"));
+    }
     const id = ++this.sequence;
     return new Promise((resolve, reject) => {
       this.pending.set(id, { resolve, reject });
-      this.socket.send(JSON.stringify({ id, method, params }));
+      try {
+        this.socket.send(JSON.stringify({ id, method, params }));
+      } catch (error) {
+        this.pending.delete(id);
+        reject(error);
+      }
     });
   }
 
@@ -1137,10 +1145,20 @@ async function injectTarget(
       });
       await new Promise((resolve) => setTimeout(resolve, 500));
     }
-    const status = await waitForInjectionStatus(cdp, shouldOpen, sourceHash, 15_000);
-    const frameLoaded = status.frameUrl
+    let status = await waitForInjectionStatus(cdp, shouldOpen, sourceHash, 15_000);
+    let frameLoaded = status.frameUrl
       ? await waitForFrame(cdp, status.frameUrl, 15_000)
       : false;
+    if (shouldOpen && !frameLoaded) {
+      await cdp.send("Runtime.evaluate", {
+        expression: "window.__codexTaskboardInjection__?.open()",
+        returnByValue: true,
+      });
+      status = await waitForInjectionStatus(cdp, true, sourceHash, 15_000);
+      frameLoaded = status.frameUrl
+        ? await waitForFrame(cdp, status.frameUrl, 15_000)
+        : false;
+    }
     if (shouldOpen && !frameLoaded) {
       throw new Error("Taskboard iframe did not finish loading in the Codex renderer");
     }

--- a/scripts/install-chatgpt-launcher.mjs
+++ b/scripts/install-chatgpt-launcher.mjs
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import {
+  access,
+  chmod,
+  copyFile,
+  mkdir,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const projectRoot = path.resolve(path.dirname(scriptPath), "..");
+const launcherApp = "/Applications/ChatGPT.app";
+const officialApp = "/Applications/.ChatGPT Official.app";
+const officialBundleId = "com.openai.codex";
+const launcherBundleId = "com.dashi.taskboard.chatgpt-launcher";
+const launcherExecutable = "taskboard-chatgpt-launcher";
+const debuggingPort = 9231;
+const launchServices = "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister";
+
+function parseArgs(argv) {
+  const options = { uninstall: false };
+  for (const arg of argv) {
+    if (arg === "--uninstall") options.uninstall = true;
+    else throw new Error(`Unknown option: ${arg}`);
+  }
+  return options;
+}
+
+async function exists(target) {
+  try {
+    await access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readBundleId(appPath) {
+  const result = spawnSync(
+    "/usr/bin/plutil",
+    ["-extract", "CFBundleIdentifier", "raw", path.join(appPath, "Contents", "Info.plist")],
+    { encoding: "utf8" },
+  );
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", `'\\''`)}'`;
+}
+
+function xmlEscape(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+function launcherPlist() {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key>
+  <string>ChatGPT</string>
+  <key>CFBundleExecutable</key>
+  <string>${xmlEscape(launcherExecutable)}</string>
+  <key>CFBundleIconFile</key>
+  <string>app.icns</string>
+  <key>CFBundleIdentifier</key>
+  <string>${xmlEscape(launcherBundleId)}</string>
+  <key>CFBundleName</key>
+  <string>ChatGPT</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>13.0</string>
+  <key>LSUIElement</key>
+  <true/>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+</dict>
+</plist>
+`;
+}
+
+function launcherScript() {
+  const injectorPath = path.join(projectRoot, "scripts", "codex-injector.mjs");
+  const logPath = path.join(projectRoot, ".data", "chatgpt-launcher.log");
+  return `#!/bin/zsh
+set -u
+
+OFFICIAL_APP=${shellQuote(officialApp)}
+NODE_BIN=${shellQuote(process.execPath)}
+INJECTOR=${shellQuote(injectorPath)}
+PROJECT_ROOT=${shellQuote(projectRoot)}
+LOG_PATH=${shellQuote(logPath)}
+DEBUG_PORT=${debuggingPort}
+
+/bin/mkdir -p "$PROJECT_ROOT/.data"
+exec >>"$LOG_PATH" 2>&1
+echo "[$(/bin/date '+%Y-%m-%d %H:%M:%S')] launcher invoked"
+
+if [[ ! -d "$OFFICIAL_APP" ]]; then
+  echo "Official ChatGPT app is missing: $OFFICIAL_APP"
+  /usr/bin/osascript -e 'display notification "找不到官方 ChatGPT 应用" with title "Taskboard 启动失败"'
+  exit 1
+fi
+
+if ! /usr/bin/curl -fsS --max-time 1 "http://127.0.0.1:$DEBUG_PORT/json/version" >/dev/null 2>&1; then
+  existing_chatgpt_pids=$(/usr/bin/pgrep -x ChatGPT || true)
+  if [[ -n "$existing_chatgpt_pids" ]]; then
+    echo "Restarting ChatGPT so Taskboard can enable the CDP port"
+    /usr/bin/osascript -e 'tell application id "com.openai.codex" to quit'
+    stopped=false
+    for _ in {1..80}; do
+      if ! /usr/bin/pgrep -x ChatGPT >/dev/null 2>&1; then
+        stopped=true
+        break
+      fi
+      /bin/sleep 0.25
+    done
+    if [[ "$stopped" != true ]]; then
+      echo "Timed out waiting for the existing ChatGPT process to quit"
+      /usr/bin/osascript -e 'display notification "请完全退出 ChatGPT 后重试" with title "Taskboard 启动失败"'
+      exit 1
+    fi
+  fi
+
+  /usr/bin/open -n -a "$OFFICIAL_APP" --args \
+    "--remote-debugging-port=$DEBUG_PORT" \
+    "--remote-allow-origins=http://127.0.0.1:$DEBUG_PORT"
+
+  ready=false
+  for _ in {1..120}; do
+    if /usr/bin/curl -fsS --max-time 1 "http://127.0.0.1:$DEBUG_PORT/json/version" >/dev/null 2>&1; then
+      ready=true
+      break
+    fi
+    /bin/sleep 0.25
+  done
+  if [[ "$ready" != true ]]; then
+    echo "Timed out waiting for ChatGPT CDP on port $DEBUG_PORT"
+    /usr/bin/osascript -e 'display notification "ChatGPT 调试端口未就绪" with title "Taskboard 启动失败"'
+    exit 1
+  fi
+fi
+
+if ! CODEX_TASKBOARD_HOST=127.0.0.1 "$NODE_BIN" "$INJECTOR" \
+  --daemon --port "$DEBUG_PORT" --open; then
+  echo "Failed to start the resident Taskboard injector"
+  /usr/bin/osascript -e 'display notification "注入器启动失败，请查看启动日志" with title "Taskboard 启动失败"'
+  exit 1
+fi
+
+/usr/bin/open -a "$OFFICIAL_APP"
+echo "Taskboard launcher completed"
+`;
+}
+
+function registerApplication(appPath) {
+  spawnSync(launchServices, ["-f", appPath], { stdio: "ignore" });
+}
+
+async function install() {
+  const launcherExists = await exists(launcherApp);
+  const officialExists = await exists(officialApp);
+  const currentBundleId = launcherExists ? readBundleId(launcherApp) : null;
+
+  if (launcherExists && currentBundleId === officialBundleId) {
+    if (officialExists) {
+      throw new Error(`${officialApp} already exists; refusing to overwrite it`);
+    }
+    await rename(launcherApp, officialApp);
+  } else if (launcherExists && currentBundleId !== launcherBundleId) {
+    throw new Error(`${launcherApp} is not the official ChatGPT app or the Taskboard launcher`);
+  }
+
+  if (readBundleId(officialApp) !== officialBundleId) {
+    throw new Error(`Official ChatGPT app was not found at ${officialApp}`);
+  }
+
+  if (await exists(launcherApp)) await rm(launcherApp, { recursive: true });
+  const contents = path.join(launcherApp, "Contents");
+  const macOS = path.join(contents, "MacOS");
+  const resources = path.join(contents, "Resources");
+  await mkdir(macOS, { recursive: true });
+  await mkdir(resources, { recursive: true });
+  await writeFile(path.join(contents, "Info.plist"), launcherPlist());
+  await writeFile(path.join(macOS, launcherExecutable), launcherScript());
+  await chmod(path.join(macOS, launcherExecutable), 0o755);
+  await copyFile(path.join(officialApp, "Contents", "Resources", "app.icns"), path.join(resources, "app.icns"));
+  registerApplication(launcherApp);
+
+  console.log(`Installed Taskboard launcher at ${launcherApp}`);
+  console.log(`Official ChatGPT app is preserved at ${officialApp}`);
+}
+
+async function uninstall() {
+  if (readBundleId(launcherApp) !== launcherBundleId) {
+    throw new Error(`Taskboard launcher was not found at ${launcherApp}`);
+  }
+  if (readBundleId(officialApp) !== officialBundleId) {
+    throw new Error(`Official ChatGPT app was not found at ${officialApp}`);
+  }
+
+  await rm(launcherApp, { recursive: true });
+  await rename(officialApp, launcherApp);
+  registerApplication(launcherApp);
+  console.log(`Restored official ChatGPT app at ${launcherApp}`);
+}
+
+const options = parseArgs(process.argv.slice(2));
+if (options.uninstall) await uninstall();
+else await install();

--- a/server/ai-chat-process.mjs
+++ b/server/ai-chat-process.mjs
@@ -434,8 +434,12 @@ export function spawnCodexTurn({
     }
   }
 
-  child.stdout.on("data", consumeChunk);
-  child.stdout.on("end", finishStdout);
+  if (onRawEvent) {
+    child.stdout.on("data", consumeChunk);
+    child.stdout.on("end", finishStdout);
+  } else {
+    child.stdout.resume();
+  }
   child.stderr.on("data", (chunk) => {
     if (stderrBuffer.length >= STDERR_LIMIT) return;
     const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
@@ -446,7 +450,7 @@ export function spawnCodexTurn({
   });
   child.on("error", rejectWithDiagnostic);
   child.on("close", (exitCode, signal) => {
-    finishStdout();
+    if (onRawEvent) finishStdout();
     if (settled) return;
     settled = true;
     if (fatalError) {
@@ -456,7 +460,11 @@ export function spawnCodexTurn({
       rejectCompletion(fatalError);
       return;
     }
-    resolveCompletion({ exitCode, signal });
+    resolveCompletion({
+      exitCode,
+      signal,
+      stderr: stderrBuffer.toString("utf8"),
+    });
   });
   child.stdin.on("error", () => {});
   child.stdin.end(prompt);

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -16,7 +16,9 @@ import {
   isTaskStatus,
 } from "../shared/domain.mjs";
 import { normalizeWorkflowSnapshot } from "../shared/workflow-control-flow.mjs";
+import { isSupportedModelEffort } from "../shared/taskboard-automation-options.mjs";
 import { AiChatService } from "./ai-chat.mjs";
+import { AutomationScheduler } from "./automation.mjs";
 import { createCloudConfigStore } from "./cloud-config.mjs";
 import {
   CloudProxyError,
@@ -275,6 +277,53 @@ function pathField(value, name) {
     throw new ApiError(400, "INVALID_FIELD", `'${name}' cannot contain null bytes`);
   }
   return normalized;
+}
+
+function parseProjectAutomation(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set([
+    "codexProjectId",
+    "projectName",
+    "workspacePath",
+    "skillPath",
+    "enabledByUser",
+    "quotaAware",
+    "intervalSeconds",
+    "model",
+    "reasoningEffort",
+  ]));
+  if (typeof body.enabledByUser !== "boolean") {
+    throw new ApiError(400, "INVALID_FIELD", "'enabledByUser' must be a boolean");
+  }
+  if (typeof body.quotaAware !== "boolean") {
+    throw new ApiError(400, "INVALID_FIELD", "'quotaAware' must be a boolean");
+  }
+  if (![5, 300, 600, 900, 1800, 3600].includes(body.intervalSeconds)) {
+    throw new ApiError(400, "INVALID_FIELD", "'intervalSeconds' must be 5, 300, 600, 900, 1800 or 3600");
+  }
+  const model = stringField(body.model, "model", { required: true, maxLength: 64 });
+  const reasoningEffort = stringField(body.reasoningEffort, "reasoningEffort", { required: true, maxLength: 32 });
+  if (!isSupportedModelEffort(model, reasoningEffort)) {
+    throw new ApiError(400, "INVALID_FIELD", `Reasoning effort '${reasoningEffort}' is not supported by model '${model}'`);
+  }
+  const parseAbsolutePath = (value, name) => {
+    const normalized = stringField(value, name, { required: true, maxLength: 4096 });
+    if (!path.isAbsolute(normalized)) {
+      throw new ApiError(400, "INVALID_FIELD", `'${name}' must be an absolute path`);
+    }
+    return normalized;
+  };
+  return {
+    codexProjectId: stringField(body.codexProjectId, "codexProjectId", { required: true, maxLength: 256 }),
+    projectName: stringField(body.projectName, "projectName", { required: true, maxLength: 200 }),
+    workspacePath: parseAbsolutePath(body.workspacePath, "workspacePath"),
+    skillPath: parseAbsolutePath(body.skillPath, "skillPath"),
+    enabledByUser: body.enabledByUser,
+    quotaAware: body.quotaAware,
+    intervalSeconds: body.intervalSeconds,
+    model,
+    reasoningEffort,
+  };
 }
 
 function parseDueDate(value, name = "dueDate") {
@@ -1332,6 +1381,10 @@ export function createTaskboardServer(options = {}) {
     codexStatePath: resolved.codexStatePath,
     manageTaskboardSkillPath: resolved.skillPath,
   });
+  const automationScheduler = new AutomationScheduler({
+    database,
+    codexExecutable: resolved.codexExecutable,
+  });
   const aiEventResponses = new Set();
 
   const server = createServer(async (request, response) => {
@@ -1425,6 +1478,40 @@ export function createTaskboardServer(options = {}) {
         }
         await cloudConfig.setProjectWorkspace(projectId, workspacePath);
         return sendJson(response, 200, { projectId, workspacePath });
+      }
+
+      const automationsRoute = pathname.match(/^\/api\/local\/automations(?:\/([^/]+))?$/);
+      if (automationsRoute) {
+        assertNoQuery(url.searchParams, "GET /api/local/automations[/:projectId]");
+        const projectSegment = automationsRoute[1];
+        if (!projectSegment) {
+          if (request.method !== "GET") return methodNotAllowed(response, ["GET"]);
+          return sendJson(response, 200, { automations: automationScheduler.list() });
+        }
+        const projectId = validateProjectId(decodeRouteSegment(projectSegment, "Project id"));
+        if (request.method === "GET") {
+          const automation = automationScheduler.get(projectId);
+          if (!automation) {
+            throw new ApiError(404, "AUTOMATION_NOT_FOUND", `No automation for project '${projectId}'`);
+          }
+          return sendJson(response, 200, { automation });
+        }
+        if (request.method === "PUT") {
+          const body = await readJson(request);
+          const input = {
+            ...parseProjectAutomation(body),
+            taskboardProjectId: projectId,
+          };
+          return sendJson(response, 200, { automation: automationScheduler.setProjectAutomation(input) });
+        }
+        if (request.method === "DELETE") {
+          const removed = automationScheduler.deleteProjectAutomation(projectId);
+          if (!removed) {
+            throw new ApiError(404, "AUTOMATION_NOT_FOUND", `No automation for project '${projectId}'`);
+          }
+          return sendJson(response, 200, { automation: removed });
+        }
+        return methodNotAllowed(response, ["GET", "PUT", "DELETE"]);
       }
 
       if (pathname === "/api/meta") {
@@ -2047,6 +2134,7 @@ export function createTaskboardServer(options = {}) {
   return {
     database,
     aiChat,
+    automationScheduler,
     server,
     options: resolved,
     async listen({ host = "127.0.0.1", port = resolvePort() } = {}) {
@@ -2067,6 +2155,7 @@ export function createTaskboardServer(options = {}) {
         server.listen(port, host);
       });
       listening = true;
+      automationScheduler.start();
       return server.address();
     },
     async close() {
@@ -2078,6 +2167,7 @@ export function createTaskboardServer(options = {}) {
       events.close();
       for (const response of aiEventResponses) response.end();
       aiEventResponses.clear();
+      await automationScheduler.stop();
       await aiChat.close();
       await serverClosed;
       listening = false;

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -1089,6 +1089,22 @@ async function readCodexProjectWorkspaces(codexStatePath) {
   }
 }
 
+async function assertAutomationProjectMapping(input, codexStatePath) {
+  if (!input.enabledByUser) return;
+  const workspaces = await readCodexProjectWorkspaces(codexStatePath);
+  const mappedWorkspace = workspaces[input.codexProjectId];
+  if (
+    !mappedWorkspace
+    || path.resolve(mappedWorkspace) !== path.resolve(input.workspacePath)
+  ) {
+    throw new ApiError(
+      400,
+      "AUTOMATION_PROJECT_NOT_MAPPED",
+      "Add the Codex project and map its workspace directory before enabling automation",
+    );
+  }
+}
+
 function latestThreadCwd(value, threadId) {
   const matches = [];
   const stack = [value];
@@ -1502,6 +1518,7 @@ export function createTaskboardServer(options = {}) {
             ...parseProjectAutomation(body),
             taskboardProjectId: projectId,
           };
+          await assertAutomationProjectMapping(input, resolved.codexStatePath);
           return sendJson(response, 200, { automation: automationScheduler.setProjectAutomation(input) });
         }
         if (request.method === "DELETE") {

--- a/server/automation.mjs
+++ b/server/automation.mjs
@@ -2,24 +2,37 @@ import { readCodexQuotaStatus } from "../scripts/codex-rate-limits.mjs";
 import { buildTaskboardAutomationPrompt } from "../shared/taskboard-automation.mjs";
 import {
   assignThreadToCodexProject,
+  resumeCodexDesktopTask,
   runCodexDesktopTask,
 } from "./codex-app-task.mjs";
+
+const CODEX_AGENT_ACTOR = {
+  type: "agent",
+  id: "codex-agent",
+  name: "Codex Agent",
+  avatarUrl: null,
+};
 
 export class AutomationScheduler {
   constructor({
     database,
     processEnv,
     runTask = runCodexDesktopTask,
+    resumeTask = resumeCodexDesktopTask,
     assignThread = assignThreadToCodexProject,
+    readQuota = readCodexQuotaStatus,
   }) {
     this.database = database;
     this.processEnv = processEnv ?? process.env;
     this.runTask = runTask;
+    this.resumeTask = resumeTask;
     this.assignThread = assignThread;
+    this.readQuota = readQuota;
     this.codexDebugPort = this.processEnv.CODEX_TASKBOARD_CODEX_DEBUG_PORT ?? "9229";
     this.timers = new Map();
     this.inFlight = new Map();
     this.controllers = new Map();
+    this.quotaStatuses = new Map();
     this.started = false;
   }
 
@@ -28,6 +41,7 @@ export class AutomationScheduler {
     this.started = true;
     for (const record of this.database.listProjectAutomations()) {
       this.#schedule(record);
+      this.#resumeInProgress(record);
     }
   }
 
@@ -53,23 +67,25 @@ export class AutomationScheduler {
   }
 
   list() {
-    return this.database.listProjectAutomations();
+    return this.database.listProjectAutomations().map((record) => this.#withQuota(record));
   }
 
   get(taskboardProjectId) {
-    return this.database.getProjectAutomation(taskboardProjectId);
+    return this.#withQuota(this.database.getProjectAutomation(taskboardProjectId));
   }
 
   setProjectAutomation(input) {
     const record = this.database.upsertProjectAutomation(input);
+    this.quotaStatuses.delete(input.taskboardProjectId);
     this.#schedule(record);
-    return record;
+    return this.#withQuota(record);
   }
 
   deleteProjectAutomation(taskboardProjectId) {
     const timer = this.timers.get(taskboardProjectId);
     if (timer) clearInterval(timer);
     this.timers.delete(taskboardProjectId);
+    this.quotaStatuses.delete(taskboardProjectId);
     return this.database.deleteProjectAutomation(taskboardProjectId);
   }
 
@@ -98,7 +114,8 @@ export class AutomationScheduler {
     if (this.inFlight.has(key)) return;
     try {
       if (record.quotaAware) {
-        const quota = await readCodexQuotaStatus(record.model);
+        const quota = await this.readQuota(record.model);
+        this.quotaStatuses.set(key, quota);
         if (quota?.state !== "available") return;
       }
       const candidate = this.database.listTasks({
@@ -168,14 +185,102 @@ export class AutomationScheduler {
           `Taskboard automation dispatch failed for ${record.taskboardProjectId} `
           + `(${result.status ?? "unknown"})${result.error ? `: ${JSON.stringify(result.error)}` : ""}`,
         );
+        this.#settleFailure(candidate, result.status ?? "unknown", result.error);
         return;
       }
-      const current = this.database.getTask(candidate.id);
-      if (current?.status === "in_progress") {
-        this.database.moveTask(current.id, current.version, "in_review", undefined, current.threadId);
-      }
+      this.#settleCompleted(candidate);
+    } catch (error) {
+      if (controller.signal.aborted && !this.started) return;
+      this.#settleFailure(candidate, "desktop_unavailable", error);
+      throw error;
     } finally {
       this.controllers.delete(record.taskboardProjectId);
     }
+  }
+
+  #resumeInProgress(record) {
+    const candidate = this.database.listTasks({
+      projectId: record.taskboardProjectId,
+      status: "in_progress",
+      archived: "false",
+    })[0];
+    if (!candidate || this.inFlight.has(record.taskboardProjectId)) return;
+    if (!candidate.threadId) {
+      this.#settleFailure(candidate, "missing_thread", new Error("The original Codex thread is missing"));
+      return;
+    }
+
+    const key = record.taskboardProjectId;
+    const controller = new AbortController();
+    this.controllers.set(key, controller);
+    const recovery = this.#monitorExisting(record, candidate, controller).finally(() => {
+      if (this.controllers.get(key) === controller) this.controllers.delete(key);
+      this.inFlight.delete(key);
+    });
+    this.inFlight.set(key, recovery);
+  }
+
+  async #monitorExisting(record, candidate, controller) {
+    try {
+      const result = await this.resumeTask({
+        debugPort: this.codexDebugPort,
+        threadId: candidate.threadId,
+        signal: controller.signal,
+      });
+      if (result.status === "completed") {
+        this.#settleCompleted(candidate);
+      } else {
+        this.#settleFailure(candidate, result.status ?? "unknown", result.error);
+      }
+    } catch (error) {
+      if (!(controller.signal.aborted && !this.started)) {
+        this.#settleFailure(candidate, "desktop_unavailable", error);
+        console.error(
+          `Taskboard automation recovery failed for ${record.taskboardProjectId}: ${error.message}`,
+        );
+      }
+    }
+  }
+
+  #settleCompleted(candidate) {
+    const current = this.database.getTask(candidate.id);
+    if (current?.status === "in_progress") {
+      this.database.moveTask(current.id, current.version, "in_review", undefined, current.threadId);
+    }
+  }
+
+  #settleFailure(candidate, status, error) {
+    const current = this.database.getTask(candidate.id);
+    if (current?.status !== "in_progress") return;
+    const reason = this.#failureReason(error);
+    this.database.createComment(current.id, {
+      body: [
+        "自动化执行未完成。",
+        `- 状态：${status}`,
+        `- 原因：${reason}`,
+        "- 重新执行：确认 Codex Desktop 可用后，将任务移回“待办事项”。",
+      ].join("\n"),
+      threadId: current.threadId,
+      actor: CODEX_AGENT_ACTOR,
+    });
+    const latest = this.database.getTask(current.id);
+    if (latest?.status === "in_progress") {
+      this.database.moveTask(latest.id, latest.version, "blocked", undefined, latest.threadId);
+    }
+  }
+
+  #failureReason(error) {
+    const value = error instanceof Error
+      ? error.message
+      : error && typeof error === "object" && typeof error.message === "string"
+        ? error.message
+        : "Codex Desktop did not return a successful result";
+    return value.replaceAll("\0", "").slice(0, 500);
+  }
+
+  #withQuota(record) {
+    if (!record) return null;
+    const quota = this.quotaStatuses.get(record.taskboardProjectId);
+    return quota ? { ...record, quota } : record;
   }
 }

--- a/server/automation.mjs
+++ b/server/automation.mjs
@@ -1,0 +1,181 @@
+import { readCodexQuotaStatus } from "../scripts/codex-rate-limits.mjs";
+import { buildTaskboardAutomationPrompt } from "../shared/taskboard-automation.mjs";
+import {
+  assignThreadToCodexProject,
+  runCodexDesktopTask,
+} from "./codex-app-task.mjs";
+
+export class AutomationScheduler {
+  constructor({
+    database,
+    processEnv,
+    runTask = runCodexDesktopTask,
+    assignThread = assignThreadToCodexProject,
+  }) {
+    this.database = database;
+    this.processEnv = processEnv ?? process.env;
+    this.runTask = runTask;
+    this.assignThread = assignThread;
+    this.codexDebugPort = this.processEnv.CODEX_TASKBOARD_CODEX_DEBUG_PORT ?? "9229";
+    this.timers = new Map();
+    this.inFlight = new Map();
+    this.controllers = new Map();
+    this.started = false;
+  }
+
+  start() {
+    if (this.started) return;
+    this.started = true;
+    for (const record of this.database.listProjectAutomations()) {
+      this.#schedule(record);
+    }
+  }
+
+  async stop() {
+    this.started = false;
+    for (const timer of this.timers.values()) clearInterval(timer);
+    this.timers.clear();
+    for (const controller of this.controllers.values()) {
+      controller.abort(new Error("Taskboard automation stopped"));
+    }
+    const inFlight = [...this.inFlight.values()];
+    if (inFlight.length > 0) {
+      await Promise.race([
+        Promise.allSettled(inFlight),
+        new Promise((resolve) => {
+          const timer = setTimeout(resolve, 1_000);
+          timer.unref();
+        }),
+      ]);
+    }
+    this.inFlight.clear();
+    this.controllers.clear();
+  }
+
+  list() {
+    return this.database.listProjectAutomations();
+  }
+
+  get(taskboardProjectId) {
+    return this.database.getProjectAutomation(taskboardProjectId);
+  }
+
+  setProjectAutomation(input) {
+    const record = this.database.upsertProjectAutomation(input);
+    this.#schedule(record);
+    return record;
+  }
+
+  deleteProjectAutomation(taskboardProjectId) {
+    const timer = this.timers.get(taskboardProjectId);
+    if (timer) clearInterval(timer);
+    this.timers.delete(taskboardProjectId);
+    return this.database.deleteProjectAutomation(taskboardProjectId);
+  }
+
+  async runOnce(taskboardProjectId) {
+    const record = this.database.getProjectAutomation(taskboardProjectId);
+    if (!record) return null;
+    return this.#tick(record);
+  }
+
+  #schedule(record) {
+    const key = record.taskboardProjectId;
+    const previous = this.timers.get(key);
+    if (previous) clearInterval(previous);
+    this.timers.delete(key);
+    if (!record.enabledByUser) return;
+    const timer = setInterval(
+      () => void this.#tick(record),
+      record.intervalSeconds * 1_000,
+    );
+    timer.unref();
+    this.timers.set(key, timer);
+  }
+
+  async #tick(record) {
+    const key = record.taskboardProjectId;
+    if (this.inFlight.has(key)) return;
+    try {
+      if (record.quotaAware) {
+        const quota = await readCodexQuotaStatus(record.model);
+        if (quota?.state !== "available") return;
+      }
+      const candidate = this.database.listTasks({
+        projectId: key,
+        status: "todo",
+        archived: "false",
+      })[0];
+      if (!candidate) return;
+      const claimed = this.database.moveTask(
+        candidate.id,
+        candidate.version,
+        "in_progress",
+        undefined,
+        candidate.threadId,
+      );
+      const dispatch = this.#dispatch(record, claimed).finally(() => {
+        this.inFlight.delete(key);
+      });
+      this.inFlight.set(key, dispatch);
+      await dispatch;
+    } catch (error) {
+      console.error(`Taskboard automation tick failed for ${key}: ${error.message}`);
+    }
+  }
+
+  async #dispatch(record, candidate) {
+    const request = {
+      taskboardProjectId: record.taskboardProjectId,
+      codexProjectId: record.codexProjectId,
+      projectName: record.projectName,
+      workspacePath: record.workspacePath,
+      skillPath: record.skillPath,
+      taskId: candidate.id,
+      taskIdentifier: candidate.identifier,
+      intervalSeconds: record.intervalSeconds,
+      model: record.model,
+      reasoningEffort: record.reasoningEffort,
+    };
+    const prompt = buildTaskboardAutomationPrompt(request);
+    const controller = new AbortController();
+    this.controllers.set(record.taskboardProjectId, controller);
+    try {
+      const result = await this.runTask({
+        debugPort: this.codexDebugPort,
+        workspacePath: record.workspacePath,
+        model: record.model,
+        reasoningEffort: record.reasoningEffort,
+        title: `${candidate.identifier} · ${candidate.title}`,
+        prompt,
+        signal: controller.signal,
+        onThreadStarted: async (threadId) => {
+          const current = this.database.getTask(candidate.id);
+          if (current?.status !== "in_progress") {
+            throw new Error(`Task ${candidate.identifier} is no longer in progress`);
+          }
+          this.database.updateTask(current.id, current.version, {}, threadId);
+          await this.assignThread({
+            debugPort: this.codexDebugPort,
+            threadId,
+            projectId: record.codexProjectId,
+            cwd: record.workspacePath,
+          });
+        },
+      });
+      if (result.status !== "completed") {
+        console.error(
+          `Taskboard automation dispatch failed for ${record.taskboardProjectId} `
+          + `(${result.status ?? "unknown"})${result.error ? `: ${JSON.stringify(result.error)}` : ""}`,
+        );
+        return;
+      }
+      const current = this.database.getTask(candidate.id);
+      if (current?.status === "in_progress") {
+        this.database.moveTask(current.id, current.version, "in_review", undefined, current.threadId);
+      }
+    } finally {
+      this.controllers.delete(record.taskboardProjectId);
+    }
+  }
+}

--- a/server/codex-app-task.mjs
+++ b/server/codex-app-task.mjs
@@ -1,0 +1,259 @@
+const CODEX_HOST_ID = "local";
+const MCP_REQUEST_TIMEOUT_MS = 30_000;
+const TURN_POLL_INTERVAL_MS = 1_000;
+const TERMINAL_TURN_STATUSES = new Set(["completed", "failed", "interrupted", "cancelled"]);
+
+function validatedDebugPort(debugPort) {
+  const port = Number(debugPort);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error("Codex debugging port is invalid");
+  }
+  return port;
+}
+
+function delay(milliseconds, signal) {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new Error("Codex task was stopped"));
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal.reason ?? new Error("Codex task was stopped"));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, milliseconds);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+export async function runCodexDesktopTask({
+  debugPort,
+  workspacePath,
+  model,
+  reasoningEffort,
+  title,
+  prompt,
+  onThreadStarted,
+  signal,
+}) {
+  const started = await requestCodexAppServer(debugPort, "thread/start", {
+    cwd: workspacePath,
+    model,
+    approvalPolicy: "never",
+    sandbox: "workspace-write",
+    threadSource: "automation",
+    serviceName: "codex-taskboard",
+  });
+  const threadId = started?.thread?.id;
+  if (typeof threadId !== "string" || !threadId) {
+    throw new Error("Codex Desktop started a task without returning a thread id");
+  }
+
+  await requestCodexAppServer(debugPort, "thread/name/set", { threadId, name: title });
+  await onThreadStarted(threadId);
+  const turnStarted = await requestCodexAppServer(debugPort, "turn/start", {
+    threadId,
+    input: [{ type: "text", text: prompt }],
+    cwd: workspacePath,
+    model,
+    effort: reasoningEffort,
+    approvalPolicy: "never",
+    sandboxPolicy: {
+      type: "workspaceWrite",
+      writableRoots: [workspacePath],
+      networkAccess: true,
+    },
+  });
+  const turnId = turnStarted?.turn?.id;
+  if (typeof turnId !== "string" || !turnId) {
+    throw new Error("Codex Desktop started a turn without returning a turn id");
+  }
+
+  while (true) {
+    await delay(TURN_POLL_INTERVAL_MS, signal);
+    const snapshot = await requestCodexAppServer(debugPort, "thread/read", {
+      threadId,
+      includeTurns: true,
+    });
+    const turn = snapshot?.thread?.turns?.find((candidate) => candidate.id === turnId);
+    if (!turn || !TERMINAL_TURN_STATUSES.has(turn.status)) continue;
+    return {
+      threadId,
+      turnId,
+      status: turn.status,
+      error: turn.error ?? null,
+    };
+  }
+}
+
+function codexPageTarget(target) {
+  return target?.type === "page"
+    && typeof target.webSocketDebuggerUrl === "string"
+    && (target.title === "Codex" || target.url?.startsWith("app://"));
+}
+
+async function evaluateInCodex(debugPort, expression, timeoutMs = 10_000) {
+  const response = await fetch(`http://127.0.0.1:${debugPort}/json/list`, {
+    signal: AbortSignal.timeout(3_000),
+  });
+  if (!response.ok) throw new Error(`Codex debugging endpoint returned ${response.status}`);
+  const targets = await response.json();
+  const target = Array.isArray(targets) ? targets.find(codexPageTarget) : null;
+  if (!target) throw new Error("No debuggable Codex window is available");
+
+  const socket = new WebSocket(target.webSocketDebuggerUrl);
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Timed out connecting to Codex")), 3_000);
+    socket.addEventListener("open", () => {
+      clearTimeout(timeout);
+      resolve();
+    }, { once: true });
+    socket.addEventListener("error", () => {
+      clearTimeout(timeout);
+      reject(new Error("Could not connect to Codex"));
+    }, { once: true });
+  });
+
+  try {
+    return await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("Codex Desktop request timed out")), timeoutMs);
+      socket.addEventListener("message", (event) => {
+        const message = JSON.parse(String(event.data));
+        if (message.id !== 1) return;
+        clearTimeout(timeout);
+        if (message.result?.exceptionDetails) {
+          reject(new Error(message.result.result?.description || "Codex project assignment failed"));
+          return;
+        }
+        resolve(message.result?.result?.value);
+      });
+      socket.send(JSON.stringify({
+        id: 1,
+        method: "Runtime.evaluate",
+        params: { expression, awaitPromise: true, returnByValue: true },
+      }));
+    });
+  } finally {
+    socket.close();
+  }
+}
+
+async function requestCodexAppServer(debugPort, method, params) {
+  const port = validatedDebugPort(debugPort);
+  const expression = `(() => new Promise((resolve) => {
+    const bridge = window.electronBridge;
+    if (!bridge || typeof bridge.sendMessageFromView !== "function") {
+      resolve({ ok: false, error: "Codex Desktop host bridge is unavailable" });
+      return;
+    }
+    const id = "taskboard-mcp-" + crypto.randomUUID();
+    const finish = (result) => {
+      clearTimeout(timeout);
+      window.removeEventListener("message", onMessage);
+      resolve(result);
+    };
+    const onMessage = (event) => {
+      const response = event.data;
+      if (
+        !response
+        || response.type !== "mcp-response"
+        || response.hostId !== ${JSON.stringify(CODEX_HOST_ID)}
+        || String(response.message?.id) !== id
+      ) return;
+      finish({ ok: true, message: response.message });
+    };
+    const timeout = setTimeout(
+      () => finish({ ok: false, error: "Codex Desktop App Server did not respond" }),
+      ${MCP_REQUEST_TIMEOUT_MS},
+    );
+    window.addEventListener("message", onMessage);
+    Promise.resolve(bridge.sendMessageFromView({
+      type: "mcp-request",
+      request: {
+        id,
+        method: ${JSON.stringify(method)},
+        params: ${JSON.stringify(params)},
+      },
+      hostId: ${JSON.stringify(CODEX_HOST_ID)},
+      priority: "critical",
+      source: ${JSON.stringify(method.startsWith("turn/") ? "turn" : "thread")},
+      timeoutMs: ${MCP_REQUEST_TIMEOUT_MS},
+      expiresAtMs: Date.now() + ${MCP_REQUEST_TIMEOUT_MS},
+    })).catch((error) => {
+      finish({ ok: false, error: error instanceof Error ? error.message : String(error) });
+    });
+  }))()`;
+  const response = await evaluateInCodex(
+    port,
+    expression,
+    MCP_REQUEST_TIMEOUT_MS + 5_000,
+  );
+  if (!response?.ok) throw new Error(response?.error || "Codex Desktop App Server request failed");
+  if (response.message?.error) {
+    throw new Error(response.message.error.message || `Codex Desktop rejected ${method}`);
+  }
+  return response.message?.result;
+}
+
+export async function assignThreadToCodexProject({ debugPort, threadId, projectId, cwd }) {
+  const port = validatedDebugPort(debugPort);
+  const expression = `(() => {
+    const hostFetch = (method, params) => new Promise((resolve, reject) => {
+      const requestId = "taskboard-project-" + crypto.randomUUID();
+      const cleanup = () => {
+        clearTimeout(timeout);
+        window.removeEventListener("message", onMessage);
+      };
+      const onMessage = (event) => {
+        const message = event.data;
+        if (!message || message.type !== "fetch-response" || message.requestId !== requestId) return;
+        cleanup();
+        if (message.responseType === "error" || message.status < 200 || message.status >= 300) {
+          reject(new Error(message.bodyJsonString || "Codex host request failed"));
+          return;
+        }
+        resolve(message.bodyJsonString ? JSON.parse(message.bodyJsonString) : {});
+      };
+      const timeout = setTimeout(() => {
+        cleanup();
+        reject(new Error("Codex host request timed out"));
+      }, 5000);
+      window.addEventListener("message", onMessage);
+      const bridge = window.electronBridge;
+      if (!bridge || typeof bridge.sendMessageFromView !== "function") {
+        cleanup();
+        reject(new Error("Codex host bridge is unavailable"));
+        return;
+      }
+      Promise.resolve(bridge.sendMessageFromView({
+        type: "fetch",
+        requestId,
+        method: "POST",
+        url: "vscode://codex/" + method,
+        body: JSON.stringify(params),
+      })).catch((error) => {
+        cleanup();
+        reject(error);
+      });
+    });
+    return (async () => {
+      const key = "thread-project-assignments";
+      const current = await hostFetch("get-global-state", { key });
+      const assignments = current.value && typeof current.value === "object"
+        ? current.value
+        : {};
+      assignments[${JSON.stringify(threadId)}] = {
+        projectKind: "local",
+        projectId: ${JSON.stringify(projectId)},
+        cwd: ${JSON.stringify(cwd)},
+        pendingCoreUpdate: false,
+      };
+      return hostFetch("set-global-state", { key, value: assignments });
+    })();
+  })()`;
+  const result = await evaluateInCodex(port, expression);
+  if (result?.success !== true) throw new Error("Codex rejected the project assignment");
+}

--- a/server/codex-app-task.mjs
+++ b/server/codex-app-task.mjs
@@ -89,6 +89,29 @@ export async function runCodexDesktopTask({
   }
 }
 
+export async function resumeCodexDesktopTask({ debugPort, threadId, signal }) {
+  while (true) {
+    const snapshot = await requestCodexAppServer(debugPort, "thread/read", {
+      threadId,
+      includeTurns: true,
+    });
+    const turns = snapshot?.thread?.turns;
+    const turn = Array.isArray(turns) ? turns.at(-1) : null;
+    if (!turn) {
+      throw new Error(`Codex Desktop task '${threadId}' has no turn to resume`);
+    }
+    if (TERMINAL_TURN_STATUSES.has(turn.status)) {
+      return {
+        threadId,
+        turnId: turn.id,
+        status: turn.status,
+        error: turn.error ?? null,
+      };
+    }
+    await delay(TURN_POLL_INTERVAL_MS, signal);
+  }
+}
+
 function codexPageTarget(target) {
   return target?.type === "page"
     && typeof target.webSocketDebuggerUrl === "string"

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -171,6 +171,23 @@ function aiChatEventFromRow(row) {
   };
 }
 
+function projectAutomationFromRow(row) {
+  return {
+    taskboardProjectId: row.taskboard_project_id,
+    codexProjectId: row.codex_project_id,
+    projectName: row.project_name,
+    workspacePath: row.workspace_path,
+    skillPath: row.skill_path,
+    enabledByUser: row.enabled_by_user === 1,
+    quotaAware: row.quota_aware === 1,
+    intervalSeconds: row.interval_seconds,
+    model: row.model,
+    reasoningEffort: row.reasoning_effort,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
 function projectPrefix(projectId) {
   const prefix = projectId.toUpperCase().replace(/[^A-Z0-9]+/g, "");
   return (prefix || "TASK").slice(0, 12);
@@ -325,7 +342,33 @@ export class TaskboardDatabase {
       CREATE INDEX IF NOT EXISTS ai_chat_events_thread_created
         ON ai_chat_events(thread_id, created_at, id);
 
+      CREATE TABLE IF NOT EXISTS project_automations (
+        taskboard_project_id TEXT PRIMARY KEY REFERENCES projects(id) ON DELETE CASCADE,
+        codex_project_id TEXT NOT NULL,
+        project_name TEXT NOT NULL,
+        workspace_path TEXT NOT NULL,
+        skill_path TEXT NOT NULL,
+        enabled_by_user INTEGER NOT NULL DEFAULT 0,
+        quota_aware INTEGER NOT NULL DEFAULT 0,
+        interval_minutes INTEGER NOT NULL CHECK (interval_minutes IN (5, 10, 15, 30, 60)),
+        interval_seconds INTEGER NOT NULL DEFAULT 300 CHECK (interval_seconds IN (5, 300, 600, 900, 1800, 3600)),
+        model TEXT NOT NULL,
+        reasoning_effort TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
     `);
+
+    const automationColumns = this.database.prepare("PRAGMA table_info(project_automations)").all();
+    if (!automationColumns.some((column) => column.name === "interval_seconds")) {
+      this.database.exec(`
+        ALTER TABLE project_automations
+        ADD COLUMN interval_seconds INTEGER NOT NULL DEFAULT 300
+        CHECK (interval_seconds IN (5, 300, 600, 900, 1800, 3600));
+        UPDATE project_automations SET interval_seconds = interval_minutes * 60;
+      `);
+    }
 
     const projectColumns = this.database.prepare("PRAGMA table_info(projects)").all();
     if (!projectColumns.some((column) => column.name === "workspace_path")) {
@@ -754,6 +797,69 @@ export class TaskboardDatabase {
       throw new ApiError(404, "AI_CHAT_THREAD_NOT_FOUND", `AI chat thread '${id}' does not exist`);
     }
     this.database.prepare("DELETE FROM ai_chat_threads WHERE id = ?").run(id);
+    return current;
+  }
+
+  getProjectAutomation(taskboardProjectId) {
+    const row = this.database.prepare(
+      "SELECT * FROM project_automations WHERE taskboard_project_id = ?",
+    ).get(taskboardProjectId);
+    return row ? projectAutomationFromRow(row) : null;
+  }
+
+  listProjectAutomations() {
+    return this.database.prepare(
+      "SELECT * FROM project_automations ORDER BY taskboard_project_id, created_at",
+    ).all().map(projectAutomationFromRow);
+  }
+
+  upsertProjectAutomation(input) {
+    const timestamp = now();
+    const legacyIntervalMinutes = input.intervalSeconds === 5
+      ? 5
+      : input.intervalSeconds / 60;
+    this.database.prepare(`
+      INSERT INTO project_automations (
+        taskboard_project_id, codex_project_id, project_name, workspace_path, skill_path,
+        enabled_by_user, quota_aware, interval_minutes, interval_seconds, model, reasoning_effort,
+        created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(taskboard_project_id) DO UPDATE SET
+        codex_project_id = excluded.codex_project_id,
+        project_name = excluded.project_name,
+        workspace_path = excluded.workspace_path,
+        skill_path = excluded.skill_path,
+        enabled_by_user = excluded.enabled_by_user,
+        quota_aware = excluded.quota_aware,
+        interval_minutes = excluded.interval_minutes,
+        interval_seconds = excluded.interval_seconds,
+        model = excluded.model,
+        reasoning_effort = excluded.reasoning_effort,
+        updated_at = excluded.updated_at
+    `).run(
+      input.taskboardProjectId,
+      input.codexProjectId,
+      input.projectName,
+      input.workspacePath,
+      input.skillPath,
+      input.enabledByUser ? 1 : 0,
+      input.quotaAware ? 1 : 0,
+      legacyIntervalMinutes,
+      input.intervalSeconds,
+      input.model,
+      input.reasoningEffort,
+      timestamp,
+      timestamp,
+    );
+    return this.getProjectAutomation(input.taskboardProjectId);
+  }
+
+  deleteProjectAutomation(taskboardProjectId) {
+    const current = this.getProjectAutomation(taskboardProjectId);
+    if (!current) return null;
+    this.database.prepare(
+      "DELETE FROM project_automations WHERE taskboard_project_id = ?",
+    ).run(taskboardProjectId);
     return current;
   }
 

--- a/shared/taskboard-automation.mjs
+++ b/shared/taskboard-automation.mjs
@@ -59,10 +59,25 @@ export function buildTaskboardAutomationName(request) {
 }
 
 export function buildTaskboardAutomationPrompt(request) {
+  const intervalLabel = request.intervalSeconds === undefined
+    ? `${request.intervalMinutes} 分钟`
+    : request.intervalSeconds < 60
+      ? `${request.intervalSeconds} 秒`
+      : `${request.intervalSeconds / 60} 分钟`;
+  const taskInstructions = request.taskIdentifier
+    ? [
+      `本轮仅处理已由调度器认领的任务 ${request.taskIdentifier}${request.taskId ? `（任务 ID：${request.taskId}）` : ""}；该任务已移动到 in_progress，不要因为它不再是 todo 而跳过。`,
+      "先用 issue get 读取该议题最新内容，并用 comment list 读取全部评论，确认本轮需要完成的返工要求。",
+      "读取后使用最新 version 保持议题为 in_progress，并绑定当前 Codex thread ID；若版本冲突或状态已变化，立即停止处理。",
+    ]
+    : [
+      "每次仅处理一个 todo：先用 issue get 读取最新议题内容，并用 comment list 读取全部评论，确认是否包含已完成后被打回的返工要求。",
+      "认领时使用最新 version 将议题移动到 in_progress；若发生版本冲突或最新状态已变化，立即跳过，避免多个 Agent 抢同一任务。",
+    ];
   return [
-    `[$manage-taskboard](${request.skillPath}) e-taskboard 每 ${request.intervalMinutes} 分钟检查任务面板中的「${request.projectName}」项目（项目 ID：${request.taskboardProjectId}，项目目录：${request.workspacePath}）。`,
-    "每次仅处理一个 todo：先用 issue get 读取最新议题内容，并用 comment list 读取全部评论，确认是否包含已完成后被打回的返工要求。",
-    "认领时使用最新 version 将议题移动到 in_progress；若发生版本冲突或最新状态已变化，立即跳过，避免多个 Agent 抢同一任务。",
+    `[$manage-taskboard](${request.skillPath}) e-taskboard 每 ${intervalLabel}检查任务面板中的「${request.projectName}」项目（项目 ID：${request.taskboardProjectId}，项目目录：${request.workspacePath}）。`,
+    "本次调用只执行一轮：处理完一个任务或确认没有 todo 后立即结束，不要在进程内循环或等待下一次检查；检查间隔由外部调度器负责。",
+    ...taskInstructions,
     "若议题已绑定 branch 或 worktree，必须在该议题绑定的开发上下文执行，避免并行 Agent 修改同一工作目录。",
     "执行完成并验证后，先用 comment add 记录关键改动、验证结果、执行结果和剩余风险，再使用最新 version 将议题移动到 in_review；不要直接标记为 done。",
   ].join("\n");

--- a/test/automation-scheduler.test.mjs
+++ b/test/automation-scheduler.test.mjs
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { appendFile, mkdtemp, mkdir, readFile, realpath, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { AutomationScheduler } from "../server/automation.mjs";
+import { TaskboardDatabase } from "../server/database.mjs";
+
+async function waitFor(predicate, timeout = 4_000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const value = await predicate();
+    if (value) return value;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+const ACTOR = { type: "user", id: "local-user", name: "本地用户", avatarUrl: null };
+
+function automationConfig(overrides = {}) {
+  return {
+    taskboardProjectId: "project",
+    codexProjectId: "codex-project",
+    projectName: "Project",
+    workspacePath: "/fixture/workspace",
+    skillPath: "/fixture/skills/manage-taskboard/SKILL.md",
+    enabledByUser: true,
+    quotaAware: false,
+    intervalSeconds: 300,
+    model: "gpt-5.5",
+    reasoningEffort: "high",
+    ...overrides,
+  };
+}
+
+async function createFixture() {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "taskboard-automation-"));
+  const workspacePath = path.join(directory, "workspace");
+  await mkdir(workspacePath);
+  const resolvedWorkspace = await realpath(workspacePath);
+  const capturePath = path.join(directory, "capture.jsonl");
+  const databasePath = path.join(directory, "taskboard.sqlite");
+  const database = new TaskboardDatabase(databasePath);
+  database.createProject({ id: "project", name: "Project", workspacePath: resolvedWorkspace });
+  return {
+    directory,
+    database,
+    capturePath,
+    workspacePath: resolvedWorkspace,
+  };
+}
+
+async function capturedTurns(capturePath) {
+  try {
+    const content = await readFile(capturePath, "utf8");
+    return content.trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+  } catch {
+    return [];
+  }
+}
+
+function createScheduler(fixture) {
+  return new AutomationScheduler({
+    database: fixture.database,
+    processEnv: { ...process.env, CODEX_TASKBOARD_CODEX_DEBUG_PORT: "9231" },
+    runTask: async (request) => {
+      await request.onThreadStarted("codex-thread-1");
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      await appendFile(fixture.capturePath, `${JSON.stringify({
+        debugPort: request.debugPort,
+        workspacePath: request.workspacePath,
+        model: request.model,
+        reasoningEffort: request.reasoningEffort,
+        title: request.title,
+        prompt: request.prompt,
+      })}\n`);
+      return { status: "completed", threadId: "codex-thread-1", turnId: "turn-1" };
+    },
+    assignThread: async () => {},
+  });
+}
+
+async function withFixture(run) {
+  const fixture = await createFixture();
+  try {
+    await run(fixture);
+  } finally {
+    await fixture.database.close();
+    await rm(fixture.directory, { recursive: true, force: true });
+  }
+}
+
+test("a tick with no todo never starts a Codex Desktop task", async () => {
+  await withFixture(async (fixture) => {
+    fixture.database.upsertProjectAutomation(automationConfig({ workspacePath: fixture.workspacePath }));
+    const scheduler = createScheduler(fixture);
+    try {
+      await scheduler.runOnce("project");
+      assert.deepEqual(await capturedTurns(fixture.capturePath), []);
+    } finally {
+      await scheduler.stop();
+    }
+  });
+});
+
+test("a tick with a todo dispatches one native Codex Desktop turn", async () => {
+  await withFixture(async (fixture) => {
+    fixture.database.upsertProjectAutomation(automationConfig({ workspacePath: fixture.workspacePath }));
+    fixture.database.createTask({
+      projectId: "project",
+      title: "Todo task",
+      description: "",
+      status: "todo",
+      priority: "high",
+      labels: [],
+      workflowId: null,
+      dueDate: null,
+      actor: ACTOR,
+      assignee: ACTOR,
+    });
+    const scheduler = createScheduler(fixture);
+    try {
+      await scheduler.runOnce("project");
+      const turns = await waitFor(async () => {
+        const current = await capturedTurns(fixture.capturePath);
+        return current.length >= 1 ? current : null;
+      });
+      assert.equal(turns.length, 1);
+      const { debugPort, workspacePath, model, reasoningEffort, prompt } = turns[0];
+      assert.equal(debugPort, "9231");
+      assert.equal(workspacePath, fixture.workspacePath);
+      assert.equal(model, "gpt-5.5");
+      assert.equal(reasoningEffort, "high");
+      assert.match(prompt, /\[\$manage-taskboard\]/);
+      assert.ok(prompt.includes("Project"));
+      assert.ok(prompt.includes("project"));
+      const [task] = fixture.database.listTasks({ projectId: "project" });
+      assert.equal(task.status, "in_review");
+      assert.equal(task.threadId, "codex-thread-1");
+    } finally {
+      await scheduler.stop();
+    }
+  });
+});
+
+test("an in-flight dispatch skips a concurrent tick", async () => {
+  await withFixture(async (fixture) => {
+    fixture.database.upsertProjectAutomation(automationConfig({ workspacePath: fixture.workspacePath }));
+    fixture.database.createTask({
+      projectId: "project",
+      title: "Todo task",
+      description: "",
+      status: "todo",
+      priority: "high",
+      labels: [],
+      workflowId: null,
+      dueDate: null,
+      actor: ACTOR,
+      assignee: ACTOR,
+    });
+    const scheduler = createScheduler(fixture);
+    try {
+      await Promise.all([scheduler.runOnce("project"), scheduler.runOnce("project")]);
+      const turns = await waitFor(async () => {
+        const current = await capturedTurns(fixture.capturePath);
+        return current.length >= 1 ? current : null;
+      });
+      assert.equal(turns.length, 1, "only one dispatch should spawn");
+    } finally {
+      await scheduler.stop();
+    }
+  });
+});
+
+test("disabled and deleted configurations stop their timers", async () => {
+  await withFixture(async (fixture) => {
+    const scheduler = createScheduler(fixture);
+    try {
+      scheduler.setProjectAutomation(automationConfig({ workspacePath: fixture.workspacePath }));
+      assert.ok(scheduler.timers.has("project"), "enabled config schedules a timer");
+
+      scheduler.setProjectAutomation(automationConfig({
+        workspacePath: fixture.workspacePath,
+        enabledByUser: false,
+      }));
+      assert.equal(scheduler.timers.has("project"), false, "disabled config clears the timer");
+
+      scheduler.setProjectAutomation(automationConfig({ workspacePath: fixture.workspacePath }));
+      assert.ok(scheduler.timers.has("project"));
+
+      scheduler.deleteProjectAutomation("project");
+      assert.equal(scheduler.timers.has("project"), false, "deleting clears the timer");
+    } finally {
+      await scheduler.stop();
+    }
+  });
+});
+
+test("start reloads persisted configs and stop clears every timer", async () => {
+  await withFixture(async (fixture) => {
+    fixture.database.upsertProjectAutomation(automationConfig({ workspacePath: fixture.workspacePath }));
+    const scheduler = createScheduler(fixture);
+    scheduler.start();
+    assert.ok(scheduler.timers.has("project"));
+    await scheduler.stop();
+    assert.equal(scheduler.timers.size, 0);
+  });
+});

--- a/test/automation-scheduler.test.mjs
+++ b/test/automation-scheduler.test.mjs
@@ -61,7 +61,7 @@ async function capturedTurns(capturePath) {
   }
 }
 
-function createScheduler(fixture) {
+function createScheduler(fixture, overrides = {}) {
   return new AutomationScheduler({
     database: fixture.database,
     processEnv: { ...process.env, CODEX_TASKBOARD_CODEX_DEBUG_PORT: "9231" },
@@ -79,6 +79,7 @@ function createScheduler(fixture) {
       return { status: "completed", threadId: "codex-thread-1", turnId: "turn-1" };
     },
     assignThread: async () => {},
+    ...overrides,
   });
 }
 
@@ -206,5 +207,217 @@ test("start reloads persisted configs and stop clears every timer", async () => 
     assert.ok(scheduler.timers.has("project"));
     await scheduler.stop();
     assert.equal(scheduler.timers.size, 0);
+  });
+});
+
+test("quota-aware scheduling exposes pause state and resumes when quota recovers", async () => {
+  await withFixture(async (fixture) => {
+    let quota = { state: "blocked", checkedAt: 100, resetsAt: 200 };
+    let turns = 0;
+    fixture.database.upsertProjectAutomation(automationConfig({
+      workspacePath: fixture.workspacePath,
+      quotaAware: true,
+    }));
+    const task = fixture.database.createTask({
+      projectId: "project",
+      title: "Quota task",
+      description: "",
+      status: "todo",
+      priority: "high",
+      labels: [],
+      workflowId: null,
+      dueDate: null,
+      actor: ACTOR,
+      assignee: ACTOR,
+    });
+    const scheduler = createScheduler(fixture, {
+      readQuota: async () => quota,
+      runTask: async (request) => {
+        turns += 1;
+        await request.onThreadStarted("quota-thread");
+        return { status: "completed", threadId: "quota-thread", turnId: "quota-turn" };
+      },
+    });
+    try {
+      await scheduler.runOnce("project");
+      assert.equal(fixture.database.getTask(task.id).status, "todo");
+      assert.deepEqual(scheduler.get("project").quota, quota);
+      assert.deepEqual(scheduler.list()[0].quota, quota);
+
+      quota = { state: "available", checkedAt: 300 };
+      await scheduler.runOnce("project");
+      assert.equal(fixture.database.getTask(task.id).status, "in_review");
+      assert.equal(turns, 1);
+      assert.deepEqual(scheduler.get("project").quota, quota);
+    } finally {
+      await scheduler.stop();
+    }
+  });
+});
+
+test("a Desktop launch failure blocks the task with a visible retry comment", async () => {
+  await withFixture(async (fixture) => {
+    fixture.database.upsertProjectAutomation(automationConfig({ workspacePath: fixture.workspacePath }));
+    const task = fixture.database.createTask({
+      projectId: "project",
+      title: "Unavailable Desktop",
+      description: "",
+      status: "todo",
+      priority: "high",
+      labels: [],
+      workflowId: null,
+      dueDate: null,
+      actor: ACTOR,
+      assignee: ACTOR,
+    });
+    const scheduler = createScheduler(fixture, {
+      runTask: async () => {
+        throw new Error("No debuggable Codex window is available");
+      },
+    });
+    try {
+      await scheduler.runOnce("project");
+      assert.equal(fixture.database.getTask(task.id).status, "blocked");
+      const comments = fixture.database.listComments(task.id);
+      assert.equal(comments.length, 1);
+      assert.match(comments[0].body, /desktop_unavailable/);
+      assert.match(comments[0].body, /移回“待办事项”/);
+    } finally {
+      await scheduler.stop();
+    }
+  });
+});
+
+for (const terminalStatus of ["failed", "interrupted", "cancelled"]) {
+  test(`a ${terminalStatus} turn blocks the task and records its reason`, async () => {
+    await withFixture(async (fixture) => {
+      fixture.database.upsertProjectAutomation(automationConfig({ workspacePath: fixture.workspacePath }));
+      const task = fixture.database.createTask({
+        projectId: "project",
+        title: `${terminalStatus} turn`,
+        description: "",
+        status: "todo",
+        priority: "high",
+        labels: [],
+        workflowId: null,
+        dueDate: null,
+        actor: ACTOR,
+        assignee: ACTOR,
+      });
+      const scheduler = createScheduler(fixture, {
+        runTask: async (request) => {
+          await request.onThreadStarted(`${terminalStatus}-thread`);
+          return {
+            status: terminalStatus,
+            threadId: `${terminalStatus}-thread`,
+            turnId: `${terminalStatus}-turn`,
+            error: { message: `${terminalStatus} reason` },
+          };
+        },
+      });
+      try {
+        await scheduler.runOnce("project");
+        const current = fixture.database.getTask(task.id);
+        assert.equal(current.status, "blocked");
+        assert.equal(current.threadId, `${terminalStatus}-thread`);
+        assert.match(fixture.database.listComments(task.id)[0].body, new RegExp(terminalStatus));
+      } finally {
+        await scheduler.stop();
+      }
+    });
+  });
+}
+
+test("restart resumes the original in-progress thread and settles its completed turn", async () => {
+  await withFixture(async (fixture) => {
+    fixture.database.upsertProjectAutomation(automationConfig({ workspacePath: fixture.workspacePath }));
+    const task = fixture.database.createTask({
+      projectId: "project",
+      title: "Restarted task",
+      description: "",
+      status: "in_progress",
+      priority: "high",
+      labels: [],
+      workflowId: null,
+      dueDate: null,
+      threadId: "original-thread",
+      actor: ACTOR,
+      assignee: ACTOR,
+    });
+    let resumedThreadId = null;
+    let newTurns = 0;
+    const scheduler = createScheduler(fixture, {
+      runTask: async () => {
+        newTurns += 1;
+        return { status: "completed" };
+      },
+      resumeTask: async ({ threadId }) => {
+        resumedThreadId = threadId;
+        return { status: "completed", threadId, turnId: "original-turn" };
+      },
+    });
+    scheduler.start();
+    try {
+      await waitFor(() => fixture.database.getTask(task.id).status === "in_review");
+      assert.equal(resumedThreadId, "original-thread");
+      assert.equal(newTurns, 0);
+    } finally {
+      await scheduler.stop();
+    }
+  });
+});
+
+test("a graceful stop preserves the active task for same-thread recovery after restart", async () => {
+  await withFixture(async (fixture) => {
+    fixture.database.upsertProjectAutomation(automationConfig({ workspacePath: fixture.workspacePath }));
+    const task = fixture.database.createTask({
+      projectId: "project",
+      title: "Active during restart",
+      description: "",
+      status: "todo",
+      priority: "high",
+      labels: [],
+      workflowId: null,
+      dueDate: null,
+      actor: ACTOR,
+      assignee: ACTOR,
+    });
+    const firstScheduler = createScheduler(fixture, {
+      runTask: async (request) => {
+        await request.onThreadStarted("preserved-thread");
+        await new Promise((resolve, reject) => {
+          const onAbort = () => reject(request.signal.reason);
+          request.signal.addEventListener("abort", onAbort, { once: true });
+        });
+      },
+    });
+
+    const firstRun = firstScheduler.runOnce("project");
+    await waitFor(() => fixture.database.getTask(task.id).threadId === "preserved-thread");
+    await firstScheduler.stop();
+    await firstRun;
+    assert.equal(fixture.database.getTask(task.id).status, "in_progress");
+    assert.equal(fixture.database.listComments(task.id).length, 0);
+
+    let resumedThreadId = null;
+    let newTurns = 0;
+    const restartedScheduler = createScheduler(fixture, {
+      runTask: async () => {
+        newTurns += 1;
+        return { status: "completed" };
+      },
+      resumeTask: async ({ threadId }) => {
+        resumedThreadId = threadId;
+        return { status: "completed", threadId, turnId: "preserved-turn" };
+      },
+    });
+    restartedScheduler.start();
+    try {
+      await waitFor(() => fixture.database.getTask(task.id).status === "in_review");
+      assert.equal(resumedThreadId, "preserved-thread");
+      assert.equal(newTurns, 0);
+    } finally {
+      await restartedScheduler.stop();
+    }
   });
 });

--- a/test/board-interactions.test.mjs
+++ b/test/board-interactions.test.mjs
@@ -39,9 +39,10 @@ test("dragging previews the insertion rank before committing it", () => {
   assert.match(styles, /\.task-card\.is-settling \{[\s\S]*?task-card-settle 200ms/);
 });
 
-test("text selection is reserved for editable fields", () => {
+test("text selection is available in editable fields and rendered comments", () => {
   assert.match(styles, /body \{[^}]*user-select: none/);
   assert.match(styles, /input,[\s\S]*?textarea,[\s\S]*?\[contenteditable="true"\][\s\S]*?user-select: text/);
+  assert.match(styles, /\.comment-body \{[^}]*user-select: text/);
 });
 
 test("issue cards omit redundant metadata and keep three compact, well-spaced rows", () => {

--- a/test/inject.test.mjs
+++ b/test/inject.test.mjs
@@ -192,6 +192,8 @@ test("complete App automation payloads cross the injected forwarder into the cur
     intervalMinutes: 10,
     model: "gpt-5.6-sol",
     reasoningEffort: "ultra",
+    enabledByUser: true,
+    quotaAware: false,
   };
 
   for (const operation of ["list", "pause", "ensure-active"]) {

--- a/test/inject.test.mjs
+++ b/test/inject.test.mjs
@@ -12,7 +12,7 @@ const webApp = await readFile(new URL("../web/src/App.tsx", import.meta.url), "u
 
 test("injection is an idempotent IIFE guarded by its current source hash", () => {
   assert.match(source, /^\(\(\) => \{/);
-  assert.match(source, /const VERSION = "0\.6\.8"/);
+  assert.match(source, /const VERSION = "0\.6\.9"/);
   assert.match(source, /const SOURCE_HASH = window\.__CODEX_TASKBOARD_SOURCE_HASH__/);
   assert.match(source, /const SENTINEL_KEY = "__codexTaskboardInjection__"/);
   assert.match(source, /previous\?\.sourceHash === SOURCE_HASH/);
@@ -261,11 +261,34 @@ test("the injected app opens an existing local Codex task instead of a new compo
     source.indexOf("async function openThread"),
     source.indexOf("function projectRowById"),
   );
-  assert.match(openThreadSource, /if \(row\?\.isConnected\) \{\s*row\.click\?\.\(\);\s*return;/);
-  assert.match(openThreadSource, /await dispatchHostMessage\(\{\s*type: "navigate-to-route",\s*path: routeForThread\(normalizedThreadId\)/);
+  assert.match(openThreadSource, /if \(row\?\.isConnected\) \{\s*row\.click\?\.\(\);\s*if \(await waitForTargetThread\(normalizedThreadId, 800\)\) return;/);
+  assert.match(openThreadSource, /dispatchHostMessage\(\{\s*type: "navigate-to-route",\s*path: routeForThread\(normalizedThreadId\)/);
+  assert.match(openThreadSource, /await waitForTargetThread\(normalizedThreadId, 1_200\)/);
+  assert.match(source, /return activeThreadId === expectedThreadId/);
   assert.match(source, /return `\/local\/\$\{encodeURIComponent\(threadId\)\}`/);
   assert.doesNotMatch(source, /return `\/thread\/\$\{encodeURIComponent\(threadId\)\}`/);
   assert.doesNotMatch(openThreadSource, /focusComposerNonce/);
+});
+
+test("thread navigation completes only when the native active row matches the target", () => {
+  const functionSource = source.slice(
+    source.indexOf("function targetThreadIsActive"),
+    source.indexOf("async function waitForTargetThread"),
+  );
+  const evaluate = (activeThreadId, targetThreadId) => {
+    const targetThreadIsActive = vm.runInNewContext(`(${functionSource})`, {
+      activeThreadRow: () => ({
+        getAttribute: (name) => (
+          name === "data-app-action-sidebar-thread-id" ? activeThreadId : null
+        ),
+      }),
+      normalizeThreadId: (value) => String(value || "").trim().replace(/^(?:local|cloud):/i, ""),
+    });
+    return targetThreadIsActive(targetThreadId);
+  };
+
+  assert.equal(evaluate("local:target-thread", "target-thread"), true);
+  assert.equal(evaluate("local:other-thread", "target-thread"), false);
 });
 
 test("host navigation follows Codex's renderer message bus", () => {

--- a/test/injector-host-runtime.test.mjs
+++ b/test/injector-host-runtime.test.mjs
@@ -185,3 +185,28 @@ test("refresh stops every stale resident before starting one token-verified repl
     ["ready", 9231, 9876, startupToken],
   ]);
 });
+
+test("refresh accepts a replacement that Codex restarted before the launcher", async () => {
+  const calls = [];
+  const replacement = await restartResidentInjector(9231, {
+    findResidents: () => [4321],
+    stopResident: async (pid) => calls.push(["stop", pid]),
+    createStartupToken: () => "unused-token",
+    startResident: (port, token) => {
+      calls.push(["start", port, token]);
+      return { pid: 9876, started: false };
+    },
+    waitUntilReady: async (port, pid, token) => calls.push(["ready", port, pid, token]),
+  });
+
+  assert.deepEqual(replacement, {
+    previousPids: [4321],
+    pid: 9876,
+    restarted: true,
+  });
+  assert.deepEqual(calls, [
+    ["stop", 4321],
+    ["start", 9231, "unused-token"],
+    ["ready", 9231, 9876, null],
+  ]);
+});

--- a/test/issue-detail-route.test.mjs
+++ b/test/issue-detail-route.test.mjs
@@ -34,6 +34,7 @@ test("closing issue detail removes only the issue route", () => {
   assert.equal(url.searchParams.get("project"), "local");
   assert.equal(url.searchParams.get("host"), "codex");
   assert.deepEqual(url.searchParams.getAll("label"), ["缺陷"]);
+  assert.match(appSource, /aria-label="关闭详情并返回看板"[\s\S]*?onClick=\{closeTaskDetail\}[\s\S]*?<LinearIcon name="close"/);
 });
 
 test("the app restores issue detail from the URL and follows browser history", () => {

--- a/test/project-automation-settings.test.mjs
+++ b/test/project-automation-settings.test.mjs
@@ -144,6 +144,7 @@ test("opening settings and changing projects reconcile with the stored server co
   assert.match(appSource, /const config = await getProjectAutomation\(selectedProjectId\)/);
   assert.match(appSource, /automationId: config\.taskboardProjectId/);
   assert.match(appSource, /status: config\.enabledByUser \? "ACTIVE" : "PAUSED"/);
+  assert.match(appSource, /\.\.\.\(config\.quota \? \{ quota: config\.quota \} : \{\}\)/);
   assert.match(appSource, /writeProjectAutomation\(selectedProjectId, null\)/);
   assert.match(appSource, /writeProjectAutomation\(selectedProjectId, previousRecord\)/);
 });

--- a/test/project-automation-settings.test.mjs
+++ b/test/project-automation-settings.test.mjs
@@ -22,28 +22,27 @@ test("project automation state is device-local and scoped by taskboard project",
   assert.match(appSource, /type ProjectAutomationStatus = "ACTIVE" \| "PAUSED"/);
   assert.match(appSource, /automationId\?: string/);
   assert.match(appSource, /codexProjectId: string/);
-  assert.match(appSource, /type AutomationIntervalMinutes = 5 \| 10 \| 15 \| 30 \| 60/);
+  assert.match(appSource, /type AutomationIntervalSeconds = 5 \| 300 \| 600 \| 900 \| 1800 \| 3600/);
   assert.match(appSource, /DEFAULT_AUTOMATION_OPTIONS[\s\S]*?model: "gpt-5\.5"[\s\S]*?reasoningEffort: "high"/);
   assert.match(appSource, /localStorage\.getItem\(PROJECT_AUTOMATIONS_KEY\)/);
   assert.match(appSource, /localStorage\.setItem\(PROJECT_AUTOMATIONS_KEY, JSON\.stringify\(next\)\)/);
   assert.match(appSource, /projectAutomations\[selectedProjectId\]/);
 });
 
-test("automation requests use the exact Codex host message contract", () => {
-  assert.match(appSource, /type: "taskboard:automation-request"/);
-  assert.match(appSource, /operation: "ensure-active" \| "pause" \| "list"/);
-  assert.match(appSource, /taskboardProjectId: selectedProjectId/);
-  assert.match(appSource, /codexProjectId/);
+test("automation settings sync through the local server API instead of the Codex host", () => {
+  assert.doesNotMatch(appSource, /type: "taskboard:automation-request"/);
+  assert.doesNotMatch(appSource, /pendingAutomationRequestsRef/);
+  assert.doesNotMatch(appSource, /message\.type === "taskboard:automation-response"/);
+  assert.match(appSource, /getProjectAutomation\(selectedProjectId\)/);
+  assert.match(appSource, /upsertProjectAutomation\(selectedProjectId/);
+  assert.match(appSource, /codexProjectId: automationProjectContext\.codexProjectId/);
   assert.match(appSource, /projectName: selectedProject\.name/);
-  assert.match(appSource, /workspacePath/);
+  assert.match(appSource, /workspacePath: automationProjectContext\.workspacePath/);
   assert.match(appSource, /skillPath: manageTaskboardSkillPath/);
-  assert.match(appSource, /intervalMinutes: options\.intervalMinutes/);
+  assert.match(appSource, /intervalSeconds: options\.intervalSeconds/);
   assert.match(appSource, /model: options\.model/);
   assert.match(appSource, /reasoningEffort: options\.reasoningEffort/);
-  assert.match(appSource, /message\.type === "taskboard:automation-response"/);
-  assert.match(appSource, /pendingAutomationRequestsRef/);
-  assert.match(appSource, /requestId/);
-  assert.match(appSource, /window\.setTimeout/);
+  assert.match(appSource, /enabledByUser \? "ACTIVE" : "PAUSED"/);
 });
 
 test("project mapping is based on exact ids and workspace paths, never project names", () => {
@@ -62,7 +61,8 @@ test("the project navigation automation menu owns the icon, fields, and accessib
   assert.match(menuSource, /无自动化/);
   assert.doesNotMatch(menuSource, /已开启自动认领|自动认领未开启/);
   assert.match(menuSource, /自动认领开关/);
-  assert.match(menuSource, /5, 10, 15, 30, 60/);
+  assert.match(menuSource, /<option value=\{5\}>5 秒<\/option>/);
+  assert.match(menuSource, /\[5, 10, 15, 30, 60\]\.map/);
   assert.match(menuSource, /AUTOMATION_MODELS\.map/);
   assert.match(menuSource, /EFFORT_LABELS\[effort\]/);
   assert.match(menuSource, /createPortal/);
@@ -96,9 +96,9 @@ test("automation play and pause retain Linear's 16px filled presentation", () =>
 });
 
 test("the automation menu reuses the Linear switch and keeps form focus chrome suppressed", () => {
-  assert.match(menuSource, /className=\{`board-setting-switch\$\{draft\.status === "ACTIVE" \? " is-on" : ""\}`\}/);
+  assert.match(menuSource, /className=\{`board-setting-switch\$\{draft\.enabledByUser \? " is-on" : ""\}`\}/);
   assert.match(menuSource, /role="switch"/);
-  assert.match(menuSource, /aria-checked=\{draft\.status === "ACTIVE"\}/);
+  assert.match(menuSource, /aria-checked=\{draft\.enabledByUser\}/);
   assert.doesNotMatch(menuSource, /type="checkbox"/);
   assert.match(styles, /\.project-automation-field select:focus-visible\s*\{[^}]*outline:\s*0;[^}]*box-shadow:\s*none;/s);
   assert.doesNotMatch(styles, /\.project-automation-switch input:focus-visible/);
@@ -107,16 +107,9 @@ test("the automation menu reuses the Linear switch and keeps form focus chrome s
 test("unavailable automation state has one notice, clears stale errors, and cannot change", () => {
   assert.match(menuSource, /error && error !== unavailableReason/);
   assert.match(menuSource, /const disabled = pending \|\| Boolean\(unavailableReason\)/);
-  assert.equal(menuSource.match(/disabled=\{disabled\}/g)?.length, 4);
-  const reconcileSource = appSource.slice(
-    appSource.indexOf("const reconcileProjectAutomation"),
-    appSource.indexOf("const saveProjectAutomation"),
-  );
-  assert.match(
-    reconcileSource,
-    /automationProjectContext\.unavailableReason[\s\S]*?\) \{\s*setAutomationError\(null\);\s*return;/,
-  );
-  assert.doesNotMatch(reconcileSource, /setAutomationError\(automationProjectContext\.unavailableReason/);
+  assert.equal(menuSource.match(/disabled=\{disabled\}/g)?.length, 5);
+  assert.match(appSource, /setAutomationError\(null\)/);
+  assert.doesNotMatch(appSource, /setAutomationError\(automationProjectContext\.unavailableReason/);
 });
 
 test("automation changes submit immediately with model-specific effort normalization", () => {
@@ -147,12 +140,10 @@ test("pending completion reconciles the optimistic draft to confirmed host state
   assert.match(menuSource, /disabled=\{disabled\}/);
 });
 
-test("opening settings and changing projects reconcile with the host list", () => {
-  assert.match(appSource, /sendAutomationRequest\("list", options, stored\?\.automationId\)/);
-  assert.match(appSource, /items\.find\(\(item\) => item\.id === stored\?\.automationId\)/);
-  assert.match(appSource, /items\.length === 1 \? items\[0\] : undefined/);
-  assert.match(appSource, /status: item\.status/);
-  assert.match(appSource, /automationId: undefined/);
-  assert.match(appSource, /options\.status === "PAUSED" && !stored\?\.automationId/);
+test("opening settings and changing projects reconcile with the stored server config", () => {
+  assert.match(appSource, /const config = await getProjectAutomation\(selectedProjectId\)/);
+  assert.match(appSource, /automationId: config\.taskboardProjectId/);
+  assert.match(appSource, /status: config\.enabledByUser \? "ACTIVE" : "PAUSED"/);
+  assert.match(appSource, /writeProjectAutomation\(selectedProjectId, null\)/);
   assert.match(appSource, /writeProjectAutomation\(selectedProjectId, previousRecord\)/);
 });

--- a/test/server.test.mjs
+++ b/test/server.test.mjs
@@ -1876,7 +1876,15 @@ test("task changes from one LAN client are broadcast to another client", async (
 });
 
 test("project automation configs round-trip through the local API", async () => {
-  const baseUrl = await startServer();
+  const baseUrl = await startServer(async (directory) => {
+    const codexStatePath = path.join(directory, "codex-state.json");
+    await writeFile(codexStatePath, JSON.stringify({
+      "local-projects": {
+        "codex-project": { rootPaths: ["/tmp/workspace"] },
+      },
+    }));
+    return { codexStatePath };
+  });
   const input = {
     codexProjectId: "codex-project",
     projectName: "Local",
@@ -1917,6 +1925,46 @@ test("project automation configs round-trip through the local API", async () => 
 
   const missing = await request(baseUrl, "/api/local/automations/local");
   assert.equal(missing.response.status, 404);
+});
+
+test("project automation rejects missing and mismatched Codex project mappings", async () => {
+  const baseUrl = await startServer(async (directory) => {
+    const codexStatePath = path.join(directory, "codex-state.json");
+    await writeFile(codexStatePath, JSON.stringify({
+      "local-projects": {
+        "codex-project": { rootPaths: ["/tmp/workspace"] },
+      },
+    }));
+    return { codexStatePath };
+  });
+  const input = {
+    codexProjectId: "missing-project",
+    projectName: "Local",
+    workspacePath: "/tmp/workspace",
+    skillPath: "/tmp/skills/manage-taskboard/SKILL.md",
+    enabledByUser: true,
+    quotaAware: false,
+    intervalSeconds: 5,
+    model: "gpt-5.5",
+    reasoningEffort: "high",
+  };
+
+  const missing = await request(baseUrl, "/api/local/automations/local", {
+    method: "PUT",
+    body: input,
+  });
+  assert.equal(missing.response.status, 400);
+  assert.equal(missing.body.error.code, "AUTOMATION_PROJECT_NOT_MAPPED");
+
+  const mismatched = await request(baseUrl, "/api/local/automations/local", {
+    method: "PUT",
+    body: { ...input, codexProjectId: "codex-project", workspacePath: "/tmp/other" },
+  });
+  assert.equal(mismatched.response.status, 400);
+  assert.equal(mismatched.body.error.code, "AUTOMATION_PROJECT_NOT_MAPPED");
+
+  const missingConfig = await request(baseUrl, "/api/local/automations/local");
+  assert.equal(missingConfig.response.status, 404);
 });
 
 test("project automation rejects invalid models, intervals and unknown fields", async () => {

--- a/test/server.test.mjs
+++ b/test/server.test.mjs
@@ -1874,3 +1874,86 @@ test("task changes from one LAN client are broadcast to another client", async (
   assert.equal(listResult.body.tasks.some((task) => task.id === createResult.body.task.id), true);
   await reader.cancel();
 });
+
+test("project automation configs round-trip through the local API", async () => {
+  const baseUrl = await startServer();
+  const input = {
+    codexProjectId: "codex-project",
+    projectName: "Local",
+    workspacePath: "/tmp/workspace",
+    skillPath: "/tmp/skills/manage-taskboard/SKILL.md",
+    enabledByUser: true,
+    quotaAware: false,
+    intervalSeconds: 5,
+    model: "gpt-5.5",
+    reasoningEffort: "high",
+  };
+
+  const created = await request(baseUrl, "/api/local/automations/local", { method: "PUT", body: input });
+  assert.equal(created.response.status, 200);
+  assert.equal(created.body.automation.taskboardProjectId, "local");
+  assert.equal(created.body.automation.enabledByUser, true);
+  assert.equal(created.body.automation.model, "gpt-5.5");
+
+  const listed = await request(baseUrl, "/api/local/automations");
+  assert.equal(listed.response.status, 200);
+  assert.equal(listed.body.automations.length, 1);
+  assert.equal(listed.body.automations[0].taskboardProjectId, "local");
+
+  const got = await request(baseUrl, "/api/local/automations/local");
+  assert.equal(got.response.status, 200);
+  assert.equal(got.body.automation.intervalSeconds, 5);
+
+  const updated = await request(baseUrl, "/api/local/automations/local", {
+    method: "PUT",
+    body: { ...input, enabledByUser: false, model: "gpt-5.6-terra" },
+  });
+  assert.equal(updated.response.status, 200);
+  assert.equal(updated.body.automation.enabledByUser, false);
+  assert.equal(updated.body.automation.model, "gpt-5.6-terra");
+
+  const deleted = await request(baseUrl, "/api/local/automations/local", { method: "DELETE" });
+  assert.equal(deleted.response.status, 200);
+
+  const missing = await request(baseUrl, "/api/local/automations/local");
+  assert.equal(missing.response.status, 404);
+});
+
+test("project automation rejects invalid models, intervals and unknown fields", async () => {
+  const baseUrl = await startServer();
+  const base = {
+    codexProjectId: "codex-project",
+    projectName: "Local",
+    workspacePath: "/tmp/workspace",
+    skillPath: "/tmp/skills/manage-taskboard/SKILL.md",
+    enabledByUser: true,
+    quotaAware: false,
+    intervalSeconds: 5,
+    model: "gpt-5.5",
+    reasoningEffort: "high",
+  };
+
+  const badModel = await request(baseUrl, "/api/local/automations/local", {
+    method: "PUT",
+    body: { ...base, model: "gpt-future" },
+  });
+  assert.equal(badModel.response.status, 400);
+
+  const badEffort = await request(baseUrl, "/api/local/automations/local", {
+    method: "PUT",
+    body: { ...base, model: "gpt-5.4", reasoningEffort: "ultra" },
+  });
+  assert.equal(badEffort.response.status, 400);
+
+  const badInterval = await request(baseUrl, "/api/local/automations/local", {
+    method: "PUT",
+    body: { ...base, intervalSeconds: 7 },
+  });
+  assert.equal(badInterval.response.status, 400);
+
+  const unknownField = await request(baseUrl, "/api/local/automations/local", {
+    method: "PUT",
+    body: { ...base, extra: true },
+  });
+  assert.equal(unknownField.response.status, 400);
+});

--- a/test/taskboard-automation.test.mjs
+++ b/test/taskboard-automation.test.mjs
@@ -27,6 +27,8 @@ const baseRequest = {
   intervalMinutes: 5,
   model: "gpt-5.5",
   reasoningEffort: "high",
+  enabledByUser: true,
+  quotaAware: false,
 };
 
 test("the automation model catalog matches Codex and normalizes unsupported efforts", () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1719,17 +1719,6 @@ export function App() {
           <header className="workspace-header">
           <div className="workspace-title">
             <div className="workspace-kicker">
-              {detailTask && (
-                <button
-                  className="detail-back-button"
-                  type="button"
-                  aria-label="关闭详情并返回看板"
-                  title="关闭详情并返回看板 (Esc)"
-                  onClick={closeTaskDetail}
-                >
-                  <LinearIcon name="close" />
-                </button>
-              )}
               {embedded && hostContext?.sidebarCollapsed && (
                 <button
                   className="detail-back-button codex-sidebar-expand-button"
@@ -1808,7 +1797,7 @@ export function App() {
                   <strong>项目</strong>
                 </>
               )}
-              {!detailTask && selectedProjectId && (
+              {selectedProjectId && (
                 <button
                   className={`favorite-button${favoriteProjectIds.has(selectedProjectId) ? " active" : ""}`}
                   type="button"
@@ -1820,7 +1809,7 @@ export function App() {
                   <LinearIcon className="favorite-icon" name="favorite" />
                 </button>
               )}
-              {!detailTask && selectedProjectId && embedded && contextName && <span className="codex-context">{contextName}</span>}
+              {selectedProjectId && embedded && contextName && <span className="codex-context">{contextName}</span>}
             </div>
           </div>
 
@@ -1854,7 +1843,7 @@ export function App() {
           <div ref={dragRegionRef} className="home-window-drag-region" aria-hidden="true" />
         )}
 
-        {selectedProjectId && !detailTask && <div className="board-toolbar">
+        {selectedProjectId && <div className="board-toolbar">
           <div className="view-tabs" aria-label="看板视图">
             <button
               className={`view-tab${boardView === "issues" ? " active" : ""}`}
@@ -2008,32 +1997,6 @@ export function App() {
               </div>
             )}
           </section>
-        ) : detailTask && selectedProject ? (
-          <TaskDetail
-            key={detailTask.id}
-            task={detailTask}
-            tasks={tasks}
-            currentUser={currentUser}
-            availableLabels={availableLabels}
-            workflows={workflowOptions}
-            developmentScan={developmentScan}
-            developmentScanLoading={developmentScanLoading}
-            commentsRevision={commentsRevision}
-            attachmentsRevision={attachmentsRevision}
-            onUpdate={(current, changes) => updateTaskProperties(current, changes)}
-            onOpenTask={openTaskDetail}
-            onAddRelation={(current, type, relatedTaskId) => (
-              mutateTaskRelation("add", current, type, relatedTaskId)
-            )}
-            onRemoveRelation={(current, type, relatedTaskId) => (
-              mutateTaskRelation("remove", current, type, relatedTaskId)
-            )}
-            onOpenThread={openThread}
-            onOpenInThread={openTaskInThread}
-            openingThread={openingThreadTaskId === detailTask.id}
-            onError={setActionError}
-            onAnnounce={setAnnouncement}
-          />
         ) : boardView === "workflow" ? (
           <Suspense fallback={<div className="workflow-board-loading">正在打开节点模式…</div>}>
             <WorkflowBoard
@@ -2122,6 +2085,65 @@ export function App() {
           </div>
         )}
       </main>
+
+      {detailTask && selectedProject && (
+        <div
+          className="issue-detail-backdrop"
+          role="presentation"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) closeTaskDetail();
+          }}
+        >
+          <section
+            className="issue-detail-dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="issue-detail-dialog-title"
+          >
+            <header className="issue-detail-dialog-header">
+              <div>
+                <strong id="issue-detail-dialog-title">{detailTask.identifier}</strong>
+                <span>议题详情</span>
+              </div>
+              <button
+                className="icon-button issue-detail-dialog-close"
+                type="button"
+                aria-label="关闭详情并返回看板"
+                title="关闭详情并返回看板 (Esc)"
+                onClick={closeTaskDetail}
+                autoFocus
+              >
+                <LinearIcon name="close" />
+              </button>
+            </header>
+            <TaskDetail
+              key={detailTask.id}
+              task={detailTask}
+              tasks={tasks}
+              currentUser={currentUser}
+              availableLabels={availableLabels}
+              workflows={workflowOptions}
+              developmentScan={developmentScan}
+              developmentScanLoading={developmentScanLoading}
+              commentsRevision={commentsRevision}
+              attachmentsRevision={attachmentsRevision}
+              onUpdate={(current, changes) => updateTaskProperties(current, changes)}
+              onOpenTask={openTaskDetail}
+              onAddRelation={(current, type, relatedTaskId) => (
+                mutateTaskRelation("add", current, type, relatedTaskId)
+              )}
+              onRemoveRelation={(current, type, relatedTaskId) => (
+                mutateTaskRelation("remove", current, type, relatedTaskId)
+              )}
+              onOpenThread={openThread}
+              onOpenInThread={openTaskInThread}
+              openingThread={openingThreadTaskId === detailTask.id}
+              onError={setActionError}
+              onAnnounce={setAnnouncement}
+            />
+          </section>
+        </div>
+      )}
 
       {editor && (
         <TaskEditor

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -26,6 +26,7 @@ import {
   createTask as createTaskRequest,
   getTaskboardRevision,
   getWorkflowWorkspace,
+  getProjectAutomation,
   getTaskboardMetadata,
   listDevelopmentContexts,
   listDeviceWorkspaces,
@@ -37,6 +38,7 @@ import {
   setCurrentUserActor,
   uploadAttachment,
   updateTask as updateTaskRequest,
+  upsertProjectAutomation,
 } from "./api";
 import {
   actorForAssigneeTarget,
@@ -130,7 +132,7 @@ interface UndoNotice {
 type ColumnVisibilityByProject = Record<string, Partial<Record<TaskStatus, boolean>>>;
 type ProjectAutomationStatus = "ACTIVE" | "PAUSED";
 type AutomationQuotaState = "available" | "blocked" | "unknown" | "unavailable";
-type AutomationIntervalMinutes = 5 | 10 | 15 | 30 | 60;
+type AutomationIntervalSeconds = 5 | 300 | 600 | 900 | 1800 | 3600;
 
 interface AutomationQuotaStatus {
   state: AutomationQuotaState;
@@ -146,43 +148,12 @@ interface ProjectAutomationRecord {
   enabledByUser: boolean;
   quotaAware: boolean;
   quota?: AutomationQuotaStatus;
-  intervalMinutes: AutomationIntervalMinutes;
+  intervalSeconds: AutomationIntervalSeconds;
   model: AutomationModel;
   reasoningEffort: AutomationReasoningEffort;
 }
 
 type ProjectAutomations = Record<string, ProjectAutomationRecord>;
-
-interface AutomationHostItem {
-  id: string;
-  status: ProjectAutomationStatus;
-  model: AutomationModel;
-  reasoningEffort: AutomationReasoningEffort;
-  rrule: string;
-}
-
-interface AutomationHostResponse {
-  requestId: string;
-  ok: boolean;
-  item?: AutomationHostItem;
-  items?: AutomationHostItem[];
-  quota?: AutomationQuotaStatus;
-  policy?: {
-    automationId?: string;
-    enabledByUser: boolean;
-    quotaAware: boolean;
-    intervalMinutes: AutomationIntervalMinutes;
-    model: AutomationModel;
-    reasoningEffort: AutomationReasoningEffort;
-  };
-  error?: string;
-}
-
-interface PendingAutomationRequest {
-  resolve: (response: AutomationHostResponse) => void;
-  reject: (error: Error) => void;
-  timeoutId: number;
-}
 
 const DEFAULT_USER_ACTOR: ActorIdentity = {
   type: "user",
@@ -200,7 +171,7 @@ const PROJECT_AUTOMATIONS_KEY = "taskboard.projectAutomations.v1";
 const DEFAULT_AUTOMATION_OPTIONS = {
   enabledByUser: false,
   quotaAware: false,
-  intervalMinutes: 5,
+  intervalSeconds: 300,
   model: "gpt-5.5",
   reasoningEffort: "high",
 } as const;
@@ -270,11 +241,13 @@ function readProjectAutomations(): ProjectAutomations {
       const reasoningEffort = candidate.reasoningEffort ?? "high";
       const enabledByUser = candidate.enabledByUser ?? candidate.status === "ACTIVE";
       const quotaAware = candidate.quotaAware ?? false;
+      const intervalSeconds = candidate.intervalSeconds
+        ?? ((candidate as Partial<ProjectAutomationRecord> & { intervalMinutes?: number }).intervalMinutes ?? 5) * 60;
       if (
         (candidate.automationId !== undefined && typeof candidate.automationId !== "string")
         || typeof candidate.codexProjectId !== "string"
         || (candidate.status !== "ACTIVE" && candidate.status !== "PAUSED")
-        || !isAutomationIntervalMinutes(candidate.intervalMinutes ?? 5)
+        || !isAutomationIntervalSeconds(intervalSeconds)
         || !isAutomationModel(model)
         || !isAutomationReasoningEffort(reasoningEffort)
         || !isSupportedModelEffort(model, reasoningEffort)
@@ -290,7 +263,7 @@ function readProjectAutomations(): ProjectAutomations {
         enabledByUser,
         quotaAware,
         ...(quota ? { quota } : {}),
-        intervalMinutes: candidate.intervalMinutes ?? 5,
+        intervalSeconds,
         model,
         reasoningEffort,
       };
@@ -315,28 +288,8 @@ function isAutomationQuotaStatus(value: unknown): value is AutomationQuotaStatus
   );
 }
 
-function isAutomationHostPolicy(
-  value: AutomationHostResponse["policy"] | undefined,
-): value is NonNullable<AutomationHostResponse["policy"]> {
-  return Boolean(
-    value
-    && (value.automationId === undefined || typeof value.automationId === "string")
-    && typeof value.enabledByUser === "boolean"
-    && typeof value.quotaAware === "boolean"
-    && isAutomationIntervalMinutes(value.intervalMinutes)
-    && isAutomationModel(value.model)
-    && isAutomationReasoningEffort(value.reasoningEffort)
-    && isSupportedModelEffort(value.model, value.reasoningEffort),
-  );
-}
-
-function isAutomationIntervalMinutes(value: unknown): value is AutomationIntervalMinutes {
-  return value === 5 || value === 10 || value === 15 || value === 30 || value === 60;
-}
-
-function intervalMinutesFromRrule(value: string): AutomationIntervalMinutes | null {
-  const match = /^RRULE:FREQ=MINUTELY;INTERVAL=(5|10|15|30|60)$/.exec(value);
-  return match ? Number(match[1]) as AutomationIntervalMinutes : null;
+function isAutomationIntervalSeconds(value: unknown): value is AutomationIntervalSeconds {
+  return value === 5 || value === 300 || value === 600 || value === 900 || value === 1800 || value === 3600;
 }
 
 function readColumnVisibilityByProject(): ColumnVisibilityByProject {
@@ -369,20 +322,6 @@ function errorMessage(error: unknown): string {
   if (error instanceof ApiError) return error.message;
   if (error instanceof Error) return error.message;
   return "Something went wrong while loading your issues.";
-}
-
-function isAutomationHostItem(value: unknown): value is AutomationHostItem {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
-  const item = value as Partial<AutomationHostItem>;
-  return (
-    typeof item.id === "string"
-    && (item.status === "ACTIVE" || item.status === "PAUSED")
-    && isAutomationModel(item.model)
-    && isAutomationReasoningEffort(item.reasoningEffort)
-    && isSupportedModelEffort(item.model, item.reasoningEffort)
-    && typeof item.rrule === "string"
-    && intervalMinutesFromRrule(item.rrule) !== null
-  );
 }
 
 function isLocalTaskboardOrigin(origin: string): boolean {
@@ -587,7 +526,6 @@ export function App() {
   selectedProjectIdRef.current = selectedProjectId;
 
   const revisionPollingInterval = getRevisionPollingInterval(taskboardMetadata);
-  const pendingAutomationRequestsRef = useRef(new Map<string, PendingAutomationRequest>());
   const automationRequestInFlightRef = useRef(false);
   const projectAutomationsRef = useRef(projectAutomations);
 
@@ -712,16 +650,19 @@ export function App() {
   ) => {
     setProjectAutomations((current) => {
       if (
-        record
-        && current[projectId]?.automationId === record.automationId
-        && current[projectId]?.codexProjectId === record.codexProjectId
-        && current[projectId]?.status === record.status
-        && current[projectId]?.enabledByUser === record.enabledByUser
-        && current[projectId]?.quotaAware === record.quotaAware
-        && JSON.stringify(current[projectId]?.quota) === JSON.stringify(record.quota)
-        && current[projectId]?.intervalMinutes === record.intervalMinutes
-        && current[projectId]?.model === record.model
-        && current[projectId]?.reasoningEffort === record.reasoningEffort
+        (!record && !(projectId in current))
+        || (
+          record
+          && current[projectId]?.automationId === record.automationId
+          && current[projectId]?.codexProjectId === record.codexProjectId
+          && current[projectId]?.status === record.status
+          && current[projectId]?.enabledByUser === record.enabledByUser
+          && current[projectId]?.quotaAware === record.quotaAware
+          && JSON.stringify(current[projectId]?.quota) === JSON.stringify(record.quota)
+          && current[projectId]?.intervalSeconds === record.intervalSeconds
+          && current[projectId]?.model === record.model
+          && current[projectId]?.reasoningEffort === record.reasoningEffort
+        )
       ) {
         return current;
       }
@@ -734,123 +675,26 @@ export function App() {
     });
   }, []);
 
-  const sendAutomationRequest = useCallback((
-    operation: "ensure-active" | "pause" | "list" | "apply-policy",
-    options: Pick<
-      ProjectAutomationRecord,
-      "enabledByUser" | "quotaAware" | "intervalMinutes" | "model" | "reasoningEffort"
-    >,
-    automationId?: string,
-  ) => {
-    if (
-      !selectedProject
-      || !automationProjectContext.codexProjectId
-      || !automationProjectContext.workspacePath
-    ) {
-      return Promise.reject(new Error(
-        automationProjectContext.unavailableReason ?? "无法读取项目自动化信息",
-      ));
-    }
-    const requestId = window.crypto.randomUUID();
-    const response = new Promise<AutomationHostResponse>((resolve, reject) => {
-      const timeoutId = window.setTimeout(() => {
-        pendingAutomationRequestsRef.current.delete(requestId);
-        reject(new Error("Codex 自动化没有响应，请稍后重试"));
-      }, 10_000);
-      pendingAutomationRequestsRef.current.set(requestId, { resolve, reject, timeoutId });
-    });
-    window.parent.postMessage({
-      type: "taskboard:automation-request",
-      payload: {
-        requestId,
-        operation,
-        taskboardProjectId: selectedProjectId,
-        codexProjectId: automationProjectContext.codexProjectId,
-        projectName: selectedProject.name,
-        workspacePath: automationProjectContext.workspacePath,
-        skillPath: manageTaskboardSkillPath,
-        ...(automationId ? { automationId } : {}),
-        enabledByUser: options.enabledByUser,
-        quotaAware: options.quotaAware,
-        intervalMinutes: options.intervalMinutes,
-        model: options.model,
-        reasoningEffort: options.reasoningEffort,
-      },
-    }, "*");
-    return response;
-  }, [
-    automationProjectContext,
-    manageTaskboardSkillPath,
-    selectedProject,
-    selectedProjectId,
-  ]);
-
   const reconcileProjectAutomation = useCallback(async () => {
-    if (automationProjectContext.unavailableReason) {
-      setAutomationError(null);
-      return;
-    }
-    if (!selectedProjectId || !automationProjectContext.codexProjectId || automationRequestInFlightRef.current) return;
-    const stored = projectAutomationsRef.current[selectedProjectId];
+    if (!selectedProjectId || automationRequestInFlightRef.current) return;
     automationRequestInFlightRef.current = true;
     setAutomationPending(true);
     setAutomationError(null);
     try {
-      const options = stored ?? {
-        status: "PAUSED" as const,
-        ...DEFAULT_AUTOMATION_OPTIONS,
-      };
-      const response = await sendAutomationRequest(
-        stored ? "apply-policy" : "list",
-        options,
-        stored?.automationId,
-      );
-      const items = Array.isArray(response.items)
-        ? response.items.filter(isAutomationHostItem)
-        : [];
-      if (!stored) {
-        const policy = isAutomationHostPolicy(response.policy) ? response.policy : null;
-        if (!policy) return;
-        const item = items.find((candidate) => candidate.id === policy.automationId)
-          ?? (items.length === 1 ? items[0] : undefined);
-        writeProjectAutomation(selectedProjectId, {
-          automationId: item?.id ?? policy.automationId,
-          codexProjectId: automationProjectContext.codexProjectId,
-          status: item?.status ?? "PAUSED",
-          enabledByUser: policy.enabledByUser,
-          quotaAware: policy.quotaAware,
-          intervalMinutes: policy.intervalMinutes,
-          model: policy.model,
-          reasoningEffort: policy.reasoningEffort,
-        });
+      const config = await getProjectAutomation(selectedProjectId);
+      if (!config) {
+        writeProjectAutomation(selectedProjectId, null);
         return;
       }
-      const item = (isAutomationHostItem(response.item) ? response.item : undefined)
-        ?? items.find((item) => item.id === stored?.automationId)
-        ?? (items.length === 1 ? items[0] : undefined);
-      if (!item) {
-        if (stored) {
-          writeProjectAutomation(selectedProjectId, {
-            ...stored,
-            automationId: undefined,
-            status: "PAUSED",
-            ...(response.quota ? { quota: response.quota } : {}),
-          });
-        }
-        return;
-      }
-      const intervalMinutes = intervalMinutesFromRrule(item.rrule);
-      if (!intervalMinutes) return;
       writeProjectAutomation(selectedProjectId, {
-        automationId: item.id,
-        codexProjectId: automationProjectContext.codexProjectId,
-        status: item.status,
-        enabledByUser: stored.enabledByUser,
-        quotaAware: stored.quotaAware,
-        ...(response.quota ? { quota: response.quota } : {}),
-        intervalMinutes,
-        model: item.model,
-        reasoningEffort: item.reasoningEffort,
+        automationId: config.taskboardProjectId,
+        codexProjectId: automationProjectContext.codexProjectId ?? config.codexProjectId,
+        status: config.enabledByUser ? "ACTIVE" : "PAUSED",
+        enabledByUser: config.enabledByUser,
+        quotaAware: config.quotaAware,
+        intervalSeconds: config.intervalSeconds as AutomationIntervalSeconds,
+        model: config.model as AutomationModel,
+        reasoningEffort: config.reasoningEffort as AutomationReasoningEffort,
       });
     } catch (error) {
       setAutomationError(error instanceof Error ? error.message : "无法读取自动化状态");
@@ -861,22 +705,23 @@ export function App() {
   }, [
     automationProjectContext,
     selectedProjectId,
-    sendAutomationRequest,
     writeProjectAutomation,
   ]);
 
   const saveProjectAutomation = useCallback(async (options: {
     enabledByUser: boolean;
     quotaAware: boolean;
-    intervalMinutes: AutomationIntervalMinutes;
+    intervalSeconds: AutomationIntervalSeconds;
     model: AutomationModel;
     reasoningEffort: AutomationReasoningEffort;
   }) => {
     const stored = projectAutomations[selectedProjectId];
     if (
       !selectedProjectId
+      || !selectedProject
       || automationProjectContext.unavailableReason
       || !automationProjectContext.codexProjectId
+      || !automationProjectContext.workspacePath
       || automationRequestInFlightRef.current
     ) return;
     const previousRecord = stored;
@@ -884,16 +729,24 @@ export function App() {
     setAutomationPending(true);
     setAutomationError(null);
     try {
-      const response = await sendAutomationRequest("apply-policy", options, stored?.automationId);
-      const item = isAutomationHostItem(response.item) ? response.item : undefined;
-      writeProjectAutomation(selectedProjectId, {
-        automationId: item?.id,
+      await upsertProjectAutomation(selectedProjectId, {
         codexProjectId: automationProjectContext.codexProjectId,
-        status: item?.status ?? "PAUSED",
+        projectName: selectedProject.name,
+        workspacePath: automationProjectContext.workspacePath,
+        skillPath: manageTaskboardSkillPath,
         enabledByUser: options.enabledByUser,
         quotaAware: options.quotaAware,
-        ...(response.quota ? { quota: response.quota } : {}),
-        intervalMinutes: options.intervalMinutes,
+        intervalSeconds: options.intervalSeconds,
+        model: options.model,
+        reasoningEffort: options.reasoningEffort,
+      });
+      writeProjectAutomation(selectedProjectId, {
+        automationId: selectedProjectId,
+        codexProjectId: automationProjectContext.codexProjectId,
+        status: options.enabledByUser ? "ACTIVE" : "PAUSED",
+        enabledByUser: options.enabledByUser,
+        quotaAware: options.quotaAware,
+        intervalSeconds: options.intervalSeconds,
         model: options.model,
         reasoningEffort: options.reasoningEffort,
       });
@@ -906,9 +759,10 @@ export function App() {
     }
   }, [
     automationProjectContext,
+    manageTaskboardSkillPath,
     projectAutomations,
+    selectedProject,
     selectedProjectId,
-    sendAutomationRequest,
     writeProjectAutomation,
   ]);
 
@@ -995,20 +849,6 @@ export function App() {
       if (event.source !== window.parent || !event.data || typeof event.data !== "object") return;
       const message = event.data as { type?: string; payload?: unknown; theme?: unknown };
 
-      if (message.type === "taskboard:automation-response" && message.payload) {
-        const payload = message.payload as Partial<AutomationHostResponse>;
-        if (typeof payload.requestId !== "string") return;
-        const pending = pendingAutomationRequestsRef.current.get(payload.requestId);
-        if (!pending) return;
-        window.clearTimeout(pending.timeoutId);
-        pendingAutomationRequestsRef.current.delete(payload.requestId);
-        if (payload.ok) pending.resolve(payload as AutomationHostResponse);
-        else pending.reject(new Error(
-          typeof payload.error === "string" ? payload.error : "Codex 无法更新自动化",
-        ));
-        return;
-      }
-
       if (message.type === "taskboard:theme" && isTheme(message.theme)) {
         setTheme(message.theme);
         return;
@@ -1037,10 +877,6 @@ export function App() {
     window.parent.postMessage({ type: "taskboard:ready" }, "*");
     return () => {
       window.removeEventListener("message", receiveHostMessage);
-      for (const pending of pendingAutomationRequestsRef.current.values()) {
-        window.clearTimeout(pending.timeoutId);
-      }
-      pendingAutomationRequestsRef.current.clear();
     };
   }, [embedded]);
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -692,6 +692,7 @@ export function App() {
         status: config.enabledByUser ? "ACTIVE" : "PAUSED",
         enabledByUser: config.enabledByUser,
         quotaAware: config.quotaAware,
+        ...(config.quota ? { quota: config.quota } : {}),
         intervalSeconds: config.intervalSeconds as AutomationIntervalSeconds,
         model: config.model as AutomationModel,
         reasoningEffort: config.reasoningEffort as AutomationReasoningEffort,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1723,11 +1723,11 @@ export function App() {
                 <button
                   className="detail-back-button"
                   type="button"
-                  aria-label="返回议题看板"
-                  title="返回议题看板 (Esc)"
+                  aria-label="关闭详情并返回看板"
+                  title="关闭详情并返回看板 (Esc)"
                   onClick={closeTaskDetail}
                 >
-                  <LinearIcon name="chevronLeft" />
+                  <LinearIcon name="close" />
                 </button>
               )}
               {embedded && hostContext?.sidebarCollapsed && (

--- a/web/src/aiChatState.ts
+++ b/web/src/aiChatState.ts
@@ -17,6 +17,45 @@ export interface AiChatRouteState {
 
 export const AI_CHAT_SKILL_MARKER = "\uFFFC";
 
+export const AI_CHAT_PREFERENCE_KEY = "taskboard.aiChat.preference.v1";
+
+export interface AiChatPreference {
+  model: string;
+  reasoningEffort: string;
+}
+
+export function readAiChatPreference(storage?: Pick<Storage, "getItem">): AiChatPreference | null {
+  if (!storage?.getItem) return null;
+  try {
+    const raw = storage.getItem(AI_CHAT_PREFERENCE_KEY);
+    if (!raw) return null;
+    const value = JSON.parse(raw) as unknown;
+    if (
+      !value
+      || typeof value !== "object"
+      || Array.isArray(value)
+      || typeof (value as AiChatPreference).model !== "string"
+      || !(value as AiChatPreference).model.trim()
+      || typeof (value as AiChatPreference).reasoningEffort !== "string"
+    ) {
+      return null;
+    }
+    return {
+      model: (value as AiChatPreference).model,
+      reasoningEffort: (value as AiChatPreference).reasoningEffort,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function writeAiChatPreference(
+  pref: AiChatPreference,
+  storage?: Pick<Storage, "setItem">,
+): void {
+  storage?.setItem?.(AI_CHAT_PREFERENCE_KEY, JSON.stringify(pref));
+}
+
 export function parseAiChatComposerFragment(
   raw: string,
   validSkillIds: Iterable<string>,
@@ -97,6 +136,15 @@ export function reasoningEffortForModel(
       || left.index - right.index
     ))[0];
   return nearestEffort?.effort ?? model.defaultReasoningEffort;
+}
+
+export function settingsForNewAiThread(
+  catalogProjectId: string | null,
+  draftProjectId: string | null,
+  settings: { model: string; reasoningEffort: string; sandbox: AiChatSandbox } | undefined,
+): Partial<{ model: string; reasoningEffort: string; sandbox: AiChatSandbox }> {
+  if (!catalogProjectId || catalogProjectId !== draftProjectId || !settings) return {};
+  return settings;
 }
 
 export function buildTurnInput(
@@ -205,6 +253,34 @@ export function patchAiChatSnapshot(
 ): AiChatThreadSnapshot | null {
   if (!current || current.thread.id !== threadId) return current;
   return { ...current, thread };
+}
+
+export interface SkillMentionMatch {
+  start: number;
+  end: number;
+  query: string;
+}
+
+export function readSkillMention(text: string, offset: number): SkillMentionMatch | null {
+  const prefix = text.slice(0, offset);
+  const match = /(?:^|\s)@([^\s@]*)$/.exec(prefix);
+  if (!match) return null;
+  return {
+    start: prefix.lastIndexOf("@"),
+    end: offset,
+    query: match[1],
+  };
+}
+
+export function insertSkillMention(
+  text: string,
+  start: number,
+  end: number,
+  skill: { id: string; label: string },
+): { value: string; caret: number; skillId: string } {
+  const label = skill.label;
+  const value = `${text.slice(0, start)}@${label}${text.slice(end)}`;
+  return { value, caret: start + 1 + label.length, skillId: skill.id };
 }
 
 export function createAiSnapshotRefreshQueue(

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -175,6 +175,12 @@ export interface ProjectAutomationConfig {
   skillPath: string;
   enabledByUser: boolean;
   quotaAware: boolean;
+  quota?: {
+    state: "available" | "blocked" | "unknown" | "unavailable";
+    checkedAt: number;
+    resetsAt?: number;
+    reason?: "api-key";
+  };
   intervalSeconds: number;
   model: string;
   reasoningEffort: string;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -167,6 +167,76 @@ export async function deleteAiChatThread(threadId: string): Promise<void> {
   );
 }
 
+export interface ProjectAutomationConfig {
+  taskboardProjectId: string;
+  codexProjectId: string;
+  projectName: string;
+  workspacePath: string;
+  skillPath: string;
+  enabledByUser: boolean;
+  quotaAware: boolean;
+  intervalSeconds: number;
+  model: string;
+  reasoningEffort: string;
+}
+
+export interface ProjectAutomationInput {
+  codexProjectId: string;
+  projectName: string;
+  workspacePath: string;
+  skillPath: string;
+  enabledByUser: boolean;
+  quotaAware: boolean;
+  intervalSeconds: number;
+  model: string;
+  reasoningEffort: string;
+}
+
+export async function listProjectAutomations(signal?: AbortSignal): Promise<ProjectAutomationConfig[]> {
+  const data = await request<{ automations: ProjectAutomationConfig[] }>(
+    "/api/local/automations",
+    { signal },
+  );
+  return data.automations;
+}
+
+export async function getProjectAutomation(
+  projectId: string,
+  signal?: AbortSignal,
+): Promise<ProjectAutomationConfig | null> {
+  try {
+    const data = await request<{ automation: ProjectAutomationConfig }>(
+      `/api/local/automations/${encodeURIComponent(projectId)}`,
+      { signal },
+    );
+    return data.automation;
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) return null;
+    throw error;
+  }
+}
+
+export async function upsertProjectAutomation(
+  projectId: string,
+  input: ProjectAutomationInput,
+): Promise<ProjectAutomationConfig> {
+  const data = await request<{ automation: ProjectAutomationConfig }>(
+    `/api/local/automations/${encodeURIComponent(projectId)}`,
+    {
+      method: "PUT",
+      body: JSON.stringify(input),
+    },
+  );
+  return data.automation;
+}
+
+export async function deleteProjectAutomation(projectId: string): Promise<void> {
+  await request<void>(
+    `/api/local/automations/${encodeURIComponent(projectId)}`,
+    { method: "DELETE" },
+  );
+}
+
 export async function startAiChatTurn(
   threadId: string,
   input: {

--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -37,7 +37,10 @@ import {
   normalizeChatSelection,
   parseAiChatComposerFragment,
   patchAiChatSnapshot,
+  readAiChatPreference,
   reasoningEffortForModel,
+  settingsForNewAiThread,
+  writeAiChatPreference,
 } from "../aiChatState";
 import type {
   AiChatCatalog,
@@ -966,8 +969,10 @@ export function AiChat({ available, projectId, issueId }: AiChatProps) {
   const [composerSkillTokens, setComposerSkillTokens] = useState<ComposerSkillToken[]>([]);
   const [pendingDangerInput, setPendingDangerInput] = useState<PendingDangerInput | null>(null);
   const [unread, setUnread] = useState(false);
-  const [draftModel, setDraftModel] = useState("");
-  const [draftEffort, setDraftEffort] = useState("");
+  const [draftModel, setDraftModel] = useState(() => readAiChatPreference()?.model ?? "");
+  const [draftEffort, setDraftEffort] = useState(
+    () => readAiChatPreference()?.reasoningEffort ?? "",
+  );
   const [draftSandbox, setDraftSandbox] = useState<AiChatSandbox>("workspace-write");
   const [settingsSaving, setSettingsSaving] = useState(false);
   const [deletingThreadId, setDeletingThreadId] = useState<string | null>(null);
@@ -984,6 +989,8 @@ export function AiChat({ available, projectId, issueId }: AiChatProps) {
   const messagesRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLElement>(null);
   const panelResizeSessionRef = useRef<PanelResizeSession | null>(null);
+  const draftSettingsManuallyChangedRef = useRef(0);
+  const lastRestoredThreadIdRef = useRef<string | null>(null);
   const selectedThreadRef = useRef(selectedThreadId);
   const draftReturnThreadIdRef = useRef<string | null>(null);
   const panelOpenRef = useRef(panelOpen);
@@ -1289,6 +1296,13 @@ export function AiChat({ available, projectId, issueId }: AiChatProps) {
   }, [available, catalogProjectId]);
 
   const restoreDraftSettings = useCallback((thread: AiChatThread) => {
+    if (
+      thread.id === lastRestoredThreadIdRef.current
+      && Date.now() - draftSettingsManuallyChangedRef.current < 3_000
+    ) {
+      return;
+    }
+    lastRestoredThreadIdRef.current = thread.id;
     setDraftModel(thread.model);
     setDraftEffort(thread.reasoningEffort);
     setDraftSandbox(thread.sandbox);
@@ -1300,7 +1314,11 @@ export function AiChat({ available, projectId, issueId }: AiChatProps) {
       restoreDraftSettings(thread);
       return;
     }
-    const normalized = normalizeChatSelection(activeCatalog?.models ?? [], draftModel, draftEffort);
+    const preference = readAiChatPreference();
+    const normalized = preference
+      && activeCatalog?.models.some((model) => model.slug === preference.model)
+      ? normalizeChatSelection(activeCatalog.models, preference.model, preference.reasoningEffort)
+      : normalizeChatSelection(activeCatalog?.models ?? [], draftModel, draftEffort);
     if (normalized) {
       setDraftModel(normalized.model);
       setDraftEffort(normalized.reasoningEffort);
@@ -1473,11 +1491,11 @@ export function AiChat({ available, projectId, issueId }: AiChatProps) {
       setError("请先进入一个已映射的项目，再新建对话");
       return null;
     }
-    const inheritedSettings = {
-      model: draftModel,
-      reasoningEffort: draftEffort,
-      sandbox: draftSandbox,
-    };
+    const inheritedSettings = settingsForNewAiThread(
+      catalogProjectId,
+      input.projectId,
+      { model: draftModel, reasoningEffort: draftEffort, sandbox: draftSandbox },
+    );
     setLoading(true);
     try {
       const targetCatalog = catalogLoadedProjectId === input.projectId && activeCatalog
@@ -1488,14 +1506,15 @@ export function AiChat({ available, projectId, issueId }: AiChatProps) {
         inheritedSettings.model,
         inheritedSettings.reasoningEffort,
       );
-      const sandbox = targetCatalog.sandboxes.includes(inheritedSettings.sandbox)
+      const sandbox = inheritedSettings.sandbox
+        && targetCatalog.sandboxes.includes(inheritedSettings.sandbox)
         ? inheritedSettings.sandbox
         : targetCatalog.sandboxes.find(
           (candidate): candidate is AiChatSandbox => candidate === "workspace-write",
-        ) ?? targetCatalog.sandboxes.find(isAiChatSandbox) ?? inheritedSettings.sandbox;
+        ) ?? "workspace-write";
       const settings = {
-        model: normalized?.model ?? inheritedSettings.model,
-        reasoningEffort: normalized?.reasoningEffort ?? inheritedSettings.reasoningEffort,
+        model: normalized?.model ?? inheritedSettings.model ?? "",
+        reasoningEffort: normalized?.reasoningEffort ?? inheritedSettings.reasoningEffort ?? "",
         sandbox,
       };
       const thread = await createAiChatThread({
@@ -1568,6 +1587,8 @@ export function AiChat({ available, projectId, issueId }: AiChatProps) {
     setMenu(null);
     setDraftModel(model.slug);
     setDraftEffort(reasoningEffort);
+    draftSettingsManuallyChangedRef.current = Date.now();
+    writeAiChatPreference({ model: model.slug, reasoningEffort });
     await saveThreadSettings({
       model: model.slug,
       reasoningEffort,
@@ -1577,12 +1598,15 @@ export function AiChat({ available, projectId, issueId }: AiChatProps) {
   async function chooseEffort(reasoningEffort: string) {
     setMenu(null);
     setDraftEffort(reasoningEffort);
+    draftSettingsManuallyChangedRef.current = Date.now();
+    writeAiChatPreference({ model: draftModel, reasoningEffort });
     await saveThreadSettings({ reasoningEffort });
   }
 
   async function chooseSandbox(sandbox: AiChatSandbox) {
     setMenu(null);
     setDraftSandbox(sandbox);
+    draftSettingsManuallyChangedRef.current = Date.now();
     await saveThreadSettings({ sandbox });
   }
 

--- a/web/src/components/ProjectAutomationMenu.tsx
+++ b/web/src/components/ProjectAutomationMenu.tsx
@@ -11,12 +11,12 @@ import { LinearIcon } from "./LinearIcon";
 
 type AutomationStatus = "ACTIVE" | "PAUSED";
 type AutomationQuotaState = "available" | "blocked" | "unknown" | "unavailable";
-type IntervalMinutes = 5 | 10 | 15 | 30 | 60;
+type IntervalSeconds = 5 | 300 | 600 | 900 | 1800 | 3600;
 
 interface AutomationOptions {
   enabledByUser: boolean;
   quotaAware: boolean;
-  intervalMinutes: IntervalMinutes;
+  intervalSeconds: IntervalSeconds;
   model: AutomationModel;
   reasoningEffort: AutomationReasoningEffort;
 }
@@ -43,7 +43,7 @@ interface ProjectAutomationMenuProps {
 const DEFAULT_OPTIONS: AutomationOptions = {
   enabledByUser: false,
   quotaAware: false,
-  intervalMinutes: 5,
+  intervalSeconds: 300,
   model: "gpt-5.5",
   reasoningEffort: "high",
 };
@@ -202,20 +202,23 @@ export function ProjectAutomationMenu({
               ? "API Key 模式不支持读取 Codex App 额度"
               : "当前账户无法读取额度"
           )}
-          {(!quota || quota.state === "unknown") && "额度状态未知，自动认领已暂停"}
+          {(!quota || quota.state === "unknown") && "启用后按本机 Codex 额度自动启停（由服务端判断）"}
         </div>
       )}
       <label className="project-automation-field">
         <span>间隔</span>
         <select
-          value={draft.intervalMinutes}
+          value={draft.intervalSeconds}
           disabled={disabled}
           onChange={(event) => submitChange({
             ...draft,
-            intervalMinutes: Number(event.target.value) as IntervalMinutes,
+            intervalSeconds: Number(event.target.value) as IntervalSeconds,
           })}
         >
-          {[5, 10, 15, 30, 60].map((minutes) => <option key={minutes} value={minutes}>{minutes} 分钟</option>)}
+          <option value={5}>5 秒</option>
+          {[5, 10, 15, 30, 60].map((minutes) => (
+            <option key={minutes} value={minutes * 60}>{minutes} 分钟</option>
+          ))}
         </select>
       </label>
       <label className="project-automation-field">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2440,6 +2440,70 @@ kbd {
   height: 14px;
 }
 
+.issue-detail-backdrop {
+  position: fixed;
+  z-index: 30;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(13, 14, 16, 0.32);
+  backdrop-filter: blur(1px);
+}
+
+.issue-detail-dialog {
+  display: flex;
+  flex-direction: column;
+  width: min(1280px, 100%);
+  height: min(880px, 100%);
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  border: var(--border-hairline) solid var(--border-strong);
+  border-radius: 8px;
+  background: var(--bg);
+  box-shadow: var(--dialog-shadow);
+}
+
+.issue-detail-dialog-header {
+  display: flex;
+  flex: 0 0 44px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 12px 0 16px;
+  border-bottom: var(--border-hairline) solid var(--border);
+  background: var(--header-bg);
+}
+
+.issue-detail-dialog-header > div {
+  display: flex;
+  align-items: baseline;
+  min-width: 0;
+  gap: 8px;
+}
+
+.issue-detail-dialog-header strong {
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.issue-detail-dialog-header span {
+  color: var(--text-tertiary);
+  font-size: 10px;
+}
+
+.issue-detail-dialog-close {
+  width: 28px;
+  height: 28px;
+}
+
+.issue-detail-dialog-close svg {
+  width: 16px;
+  height: 16px;
+}
+
 .issue-detail {
   display: flex;
   flex: 1;
@@ -8227,12 +8291,7 @@ kbd {
   width: min(140px, 20vw);
 }
 
-@media (max-width: 1040px) {
-  .workflow-board {
-    --workflow-library-width: 190px;
-    --workflow-inspector-width: 240px;
-  }
-
+@media (max-width: 1240px) {
   .issue-detail-layout {
     grid-template-columns: minmax(0, 1fr) 260px;
     gap: 40px;
@@ -8241,7 +8300,24 @@ kbd {
   }
 }
 
+@media (max-width: 1040px) {
+  .workflow-board {
+    --workflow-library-width: 190px;
+    --workflow-inspector-width: 240px;
+  }
+}
+
 @media (max-width: 760px) {
+  .issue-detail-backdrop {
+    padding: 8px;
+  }
+
+  .issue-detail-dialog {
+    width: 100%;
+    height: 100%;
+    border-radius: 6px;
+  }
+
   .issue-detail-layout {
     display: flex;
     flex-direction: column;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3632,6 +3632,9 @@ kbd {
   font-size: 15px;
   line-height: 24px;
   overflow-wrap: anywhere;
+  -webkit-user-select: text;
+  user-select: text;
+  cursor: text;
 }
 
 .comment-body .issue-description-document {


### PR DESCRIPTION
## 概述

本次合并为 Taskboard 接入 Codex Desktop 原生任务执行能力，并完善系统启动、任务恢复、目标会话导航和议题详情交互。

## 主要改动

### UI改动
- 将议题详情改成弹窗

### Codex 原生任务自动化

- 支持按项目启用自动任务，可配置执行间隔、模型和推理强度。
- 新增 5 秒执行间隔选项。
- 自动认领待办议题并创建 Codex 原生任务。
- 将运行中的任务和目标 Codex 会话绑定并展示在项目中。
- 任务完成后自动进入“审核中”。
- 失败、中断或取消时将议题转为“已阻塞”，并记录可见原因。
- 服务重启后恢复原任务和原会话，避免重复创建任务。
- 支持 Codex 额度不足时暂停调度，额度恢复后继续执行。

### 会话导航与任务恢复

- “查看对话”会等待 Codex 确认目标会话已激活。
- 首次未命中时补发精确会话路由，避免进入错误会话。
- 修复任务长时间停留在“进行中”而不继续下一步的问题。
- 修复从“审核中”拉回“待办事项”后定时任务未继续执行的问题。

### Taskboard 系统启动器

- 新增 macOS ChatGPT 系统入口安装和卸载命令。
- 系统入口可自动启用本地 CDP、启动 Taskboard 服务并完成页面注入。
- 保留官方签名应用，不直接修改官方应用包。
- 修复首次 iframe 加载竞态和 ChatGPT 重启后的 CDP 重连问题。

安装：

```bash
npm run codex:install-launcher