### PR TITLE
fix: load embedded panel through blob documents (CSP-blocked Codex builds) + injector resilience

### DIFF
--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -59,6 +59,7 @@
   let noDragRight = null;
   let status = null;
   let frameOrigin = "";
+  let frameIsBlob = false;
   let frameReady = false;
   let frameReadyWaiters = new Set();
   let hostRequests = new Map();
@@ -551,7 +552,44 @@
 
   function postToFrame(message) {
     if (!frame?.contentWindow || !frameOrigin) return;
-    frame.contentWindow.postMessage(message, frameOrigin);
+    frame.contentWindow.postMessage(message, frameIsBlob ? "*" : frameOrigin);
+  }
+
+  const TASKBOARD_STORAGE_KEY = "__codexTaskboardEmbeddedStorage__";
+
+  function readTaskboardStorage() {
+    const entries = {};
+    try {
+      const raw = window.localStorage.getItem(TASKBOARD_STORAGE_KEY);
+      if (raw) Object.assign(entries, JSON.parse(raw));
+    } catch (_) {
+      // The Codex page may not expose localStorage; keep session-only state.
+    }
+    return entries;
+  }
+
+  function writeTaskboardStorage(key, value) {
+    if (typeof key !== "string") return;
+    try {
+      const entries = readTaskboardStorage();
+      entries[key] = String(value ?? "");
+      window.localStorage.setItem(TASKBOARD_STORAGE_KEY, JSON.stringify(entries));
+    } catch (_) {}
+  }
+
+  function removeTaskboardStorage(key) {
+    if (typeof key !== "string") return;
+    try {
+      const entries = readTaskboardStorage();
+      delete entries[key];
+      window.localStorage.setItem(TASKBOARD_STORAGE_KEY, JSON.stringify(entries));
+    } catch (_) {}
+  }
+
+  function clearTaskboardStorage() {
+    try {
+      window.localStorage.removeItem(TASKBOARD_STORAGE_KEY);
+    } catch (_) {}
   }
 
   function dispatchHostMessage(message) {
@@ -786,9 +824,33 @@
   }
 
   function onFrameMessage(event) {
-    if (!frame || event.source !== frame.contentWindow || event.origin !== frameOrigin) return;
+    if (!frame || event.source !== frame.contentWindow) return;
+    if (frameIsBlob) {
+      if (event.origin !== "null" && event.origin !== window.location.origin) return;
+    } else if (event.origin !== frameOrigin) {
+      return;
+    }
     const message = event.data;
     if (!message || typeof message !== "object") return;
+    if (message.type === "taskboard:storage-request") {
+      frame.contentWindow.postMessage({
+        type: "taskboard:storage-init",
+        payload: readTaskboardStorage(),
+      }, "*");
+      return;
+    }
+    if (message.type === "taskboard:storage-set") {
+      writeTaskboardStorage(message.payload?.key, message.payload?.value);
+      return;
+    }
+    if (message.type === "taskboard:storage-remove") {
+      removeTaskboardStorage(message.payload?.key);
+      return;
+    }
+    if (message.type === "taskboard:storage-clear") {
+      clearTaskboardStorage();
+      return;
+    }
     if (message.type === "taskboard:ready") {
       frameReady = true;
       frameReadyWaiters.forEach(({ resolve, timer }) => {
@@ -937,11 +999,61 @@
     });
   }
 
+  function taskboardBlobPrelude() {
+    return `<script>
+(() => {
+  const RealURLSearchParams = window.URLSearchParams;
+  class TaskboardURLSearchParams extends RealURLSearchParams {
+    get(name) {
+      return name === "host" ? "codex" : super.get(name);
+    }
+  }
+  window.URLSearchParams = TaskboardURLSearchParams;
+  const store = new Map();
+  const storage = {
+    get length() { return store.size; },
+    key(index) { return Array.from(store.keys())[index] ?? null; },
+    getItem(key) { return store.has(key) ? store.get(key) : null; },
+    setItem(key, value) {
+      store.set(String(key), String(value));
+      window.parent.postMessage({ type: "taskboard:storage-set", payload: { key: String(key), value: String(value) } }, "*");
+    },
+    removeItem(key) {
+      store.delete(String(key));
+      window.parent.postMessage({ type: "taskboard:storage-remove", payload: { key: String(key) } }, "*");
+    },
+    clear() {
+      store.clear();
+      window.parent.postMessage({ type: "taskboard:storage-clear" }, "*");
+    },
+  };
+  window.localStorage = storage;
+  window.addEventListener("message", (event) => {
+    if (event.data && event.data.type === "taskboard:storage-init") {
+      store.clear();
+      for (const [key, value] of Object.entries(event.data.payload || {})) store.set(key, value);
+    }
+  });
+  window.parent.postMessage({ type: "taskboard:storage-request" }, "*");
+})();
+</script>`;
+  }
+
+  function createTaskboardBlobUrl(origin, html) {
+    const base = `<base href="${origin}/">`;
+    const rewritten = String(html)
+      .replace(/^<!doctype[^>]*>/i, "")
+      .replace(/<head[^>]*>/i, (match) => `${match}${base}${taskboardBlobPrelude()}`);
+    const blobHtml = `<!doctype html>${rewritten}`;
+    return URL.createObjectURL(new Blob([blobHtml], { type: "text/html" }));
+  }
+
   function loadTaskboardFrame(cacheBust = false) {
     cancelFrameReadyWaiters(new Error("任务面板正在重新加载"));
     frame?.remove();
     frame = null;
     frameReady = false;
+    frameIsBlob = false;
     if (dragRegion) dragRegion.hidden = true;
     if (noDragLeft) noDragLeft.hidden = true;
     if (noDragRight) noDragRight.hidden = true;
@@ -954,10 +1066,18 @@
     const nextFrame = document.createElement("iframe");
     nextFrame.id = FRAME_ID;
     nextFrame.hidden = true;
-    nextFrame.src = taskboardUrl.href;
     nextFrame.title = "任务面板";
     nextFrame.referrerPolicy = "no-referrer";
     nextFrame.setAttribute("allow", "clipboard-read; clipboard-write");
+    const managedHtml = window.__codexTaskboardHtml__;
+    if (typeof managedHtml === "string" && managedHtml.length > 0) {
+      // Codex renderers whose CSP blocks arbitrary http iframes still allow
+      // blob: frames; load the managed page through a blob document instead.
+      nextFrame.src = createTaskboardBlobUrl(taskboardUrl.origin, managedHtml);
+      frameIsBlob = true;
+    } else {
+      nextFrame.src = taskboardUrl.href;
+    }
     nextFrame.addEventListener("load", postHostContext);
     frame = nextFrame;
     page.appendChild(nextFrame);
@@ -1247,6 +1367,7 @@
     noDragRight = null;
     status = null;
     frameOrigin = "";
+    frameIsBlob = false;
     if (window[SENTINEL_KEY] === api) delete window[SENTINEL_KEY];
   }
 

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -255,11 +255,30 @@ class CdpConnection {
     });
   }
 
-  send(method, params = {}) {
+  send(method, params = {}, timeoutMs = 10_000) {
     const id = ++this.sequence;
     return new Promise((resolve, reject) => {
-      this.pending.set(id, { resolve, reject });
-      this.socket.send(JSON.stringify({ id, method, params }));
+      const timeout = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`CDP request timed out: ${method}`));
+      }, timeoutMs);
+      this.pending.set(id, {
+        resolve: (value) => {
+          clearTimeout(timeout);
+          resolve(value);
+        },
+        reject: (error) => {
+          clearTimeout(timeout);
+          reject(error);
+        },
+      });
+      try {
+        this.socket.send(JSON.stringify({ id, method, params }));
+      } catch (error) {
+        clearTimeout(timeout);
+        this.pending.delete(id);
+        reject(error);
+      }
     });
   }
 
@@ -295,6 +314,7 @@ class CdpConnection {
   }
 
   close() {
+    this.closed = true;
     this.socket.close();
   }
 }
@@ -1036,6 +1056,21 @@ async function registerInjectionSource(cdp, source) {
   return registration.identifier;
 }
 
+async function publishTaskboardHtml(cdp) {
+  try {
+    const response = await fetch(`${taskboardOrigin}/?host=codex`);
+    if (!response.ok) return;
+    const html = await response.text();
+    await cdp.send("Runtime.evaluate", {
+      expression: `window.__codexTaskboardHtml__ = ${JSON.stringify(html)}`,
+      returnByValue: true,
+    });
+  } catch (_) {
+    // The panel falls back to a direct http iframe when the managed HTML is
+    // unavailable (older Codex builds without the CSP restriction).
+  }
+}
+
 async function injectTarget(
   target,
   source,
@@ -1055,6 +1090,7 @@ async function injectTarget(
     await cdp.send("Page.setBypassCSP", { enabled: true });
     await cdp.send("Runtime.enable");
     if (keepAlive) await installTaskboardHostBinding(cdp, supervisor);
+    if (keepAlive) await publishTaskboardHtml(cdp);
     if (keepAlive && attachExisting) {
       const currentStatus = await readInjectionStatus(cdp);
       const reconciled = await reconcileInjectionRuntime({
@@ -1101,6 +1137,7 @@ async function injectTarget(
     await reloaded;
     await evaluateInjectionSource(cdp, source);
     await publishInjectionScriptIdentifier(cdp, scriptIdentifier);
+    if (keepAlive) await publishTaskboardHtml(cdp);
     if (keepAlive) await publishHostHeartbeat(cdp, startupToken);
     if (shouldOpen) {
       await cdp.send("Runtime.evaluate", {
@@ -1264,18 +1301,27 @@ async function main() {
 
     const { source, sourceHash } = await currentInjectionSource();
     const injectedTargets = new Map();
-    const firstResults = await injectAll(
-      options.port,
-      source,
-      sourceHash,
-      options.open,
-      options.screenshot,
-      injectedTargets,
-      options.watch,
-      supervisor,
-      options.attachExisting,
-      options.startupToken,
-    );
+    let firstResults = [];
+    try {
+      firstResults = await injectAll(
+        options.port,
+        source,
+        sourceHash,
+        options.open,
+        options.screenshot,
+        injectedTargets,
+        options.watch,
+        supervisor,
+        options.attachExisting,
+        options.startupToken,
+      );
+    } catch (error) {
+      if (!options.watch) throw error;
+      // In watch mode the renderer may appear a few seconds after CDP starts
+      // listening (fresh app launch); keep the loop running and retry there
+      // instead of exiting into a zombie resident process.
+      console.error(`Waiting for Codex renderer: ${error.message}`);
+    }
     console.log(JSON.stringify({ injected: firstResults }, null, 2));
 
     if (!options.watch) {
@@ -1298,10 +1344,14 @@ async function main() {
       } catch (error) {
         console.error(`Waiting for Taskboard service: ${error.message}`);
       }
-      for (const connection of injectedTargets.values()) {
+      for (const [id, connection] of injectedTargets) {
         try {
           await publishHostHeartbeat(connection, options.startupToken);
-        } catch (_) {}
+        } catch (error) {
+          console.error(`Taskboard host heartbeat failed for ${id}: ${error.message}`);
+          connection.close();
+          injectedTargets.delete(id);
+        }
       }
       try {
         const results = await injectAll(

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -42,7 +42,9 @@ const INLINE_ATTACHMENT_TYPES = new Set([
   "text/plain",
 ]);
 const PROJECT_ID_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
-const TRUSTED_EMBED_ORIGINS = new Set(["app://-"]);
+// "null" is the serialized origin of blob:-document iframes, which the Codex
+// renderer uses to embed the taskboard since its CSP blocks direct http iframes.
+const TRUSTED_EMBED_ORIGINS = new Set(["app://-", "null"]);
 const CODEX_AGENT_ACTOR = {
   type: "agent",
   id: "codex-agent",
@@ -1337,6 +1339,18 @@ export function createTaskboardServer(options = {}) {
   const server = createServer(async (request, response) => {
     response.setHeader("x-content-type-options", "nosniff");
     response.setHeader("referrer-policy", "no-referrer");
+    response.setHeader("access-control-allow-origin", "*");
+    if (request.method === "OPTIONS") {
+      const requestedHeaders = request.headers["access-control-request-headers"];
+      response.writeHead(204, {
+        "access-control-allow-methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+        "access-control-allow-headers": requestedHeaders
+          || "content-type, x-request-id, x-codex-request-id, x-taskboard-user-id, x-taskboard-user-name, x-taskboard-user-avatar",
+        "access-control-max-age": "600",
+      });
+      response.end();
+      return;
+    }
     try {
       assertTrustedNetworkRequest(request);
       const url = new URL(request.url, "http://127.0.0.1");


### PR DESCRIPTION
## What this PR does

Fixes the embedded Codex Taskboard panel on current macOS Codex desktop builds (ChatGPT app framework **151.0.7922.71**), where the panel iframe never loads:

- The renderer meta CSP `child-src` allows only `'self'`, `blob:`, `codex-sandbox://...` and `https://*.web-sandbox` — the local `http://127.0.0.1:47823` taskboard origin is **not** allowed, and `Page.setBypassCSP({enabled:true})` no longer bypasses CSP for the OOPIF navigation (`Network.loadingFailed` → `net::ERR_BLOCKED_BY_CSP`).
- This PR loads the panel through a **`blob:` document** (allowed by the CSP) instead of a direct http iframe.

### How it works

1. The injector fetches the taskboard HTML from the local service and publishes it to the renderer (`window.__codexTaskboardHtml__`), re-published after renderer reloads.
2. The injected script builds a blob document from that HTML with:
   - a `<base href="http://127.0.0.1:47823/">` so relative asset/API URLs resolve correctly;
   - a `URLSearchParams` shim so the app still detects `host=codex` (blob URLs with a query string fail to load, so the query cannot be carried);
   - a `localStorage` bridge that syncs through `postMessage` to the Codex page (blob documents are opaque-origin and have no real storage).
3. Origin checks accept the blob frame (`null` or the app origin), and `postMessage` target origins are relaxed for blob frames.
4. The server sends CORS headers (`access-control-allow-origin: *`), answers OPTIONS preflights by echoing the requested headers (so writes carrying `X-Taskboard-User-*` work), and trusts the `null` origin.

### Also included: resident injector reliability

- `CdpConnection.send()` got a 10s timeout; a half-dead WebSocket previously hung `publishHostHeartbeat` forever and wedged the watch loop (panel stuck on "Taskboard 启动器未运行").
- `close()` marks the connection closed immediately; heartbeat failures now drop the dead connection so the loop re-attaches.
- In watch mode, a failed initial `injectAll` (renderer not yet present right after app launch) is logged and retried instead of leaving an unresponsive process with no sidebar entry.

## Notes

- Falls back to the direct http iframe when `window.__codexTaskboardHtml__` is unavailable, so older Codex builds (where the CSP trick worked) keep working.
- Verified on framework 151.0.7922.71 (Apple Silicon): panel mounts, board renders, heartbeats stay fresh, comments/writes succeed.

Closes #13 (together with #15 for the renderer selector changes).
