### PR TITLE
feat(cli): add built-in help command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ npm run dev
 
 The Vite UI runs at <http://127.0.0.1:5173> and proxies API requests to the local service.
 
+To run several checkouts side by side, give each one its own pair of ports so the UI keeps proxying to its own backend:
+
+```bash
+TASKBOARD_WEB_PORT=5174 CODEX_TASKBOARD_PORT=47901 npm run dev
+```
+
 ## Use the CLI
 
 Run it from the project:
@@ -107,7 +113,8 @@ To use a different UI origin, set `window.__CODEX_TASKBOARD_URL__` before the us
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `CODEX_TASKBOARD_HOST` | `0.0.0.0` | HTTP bind address; use `127.0.0.1` to disable LAN access |
-| `CODEX_TASKBOARD_PORT` | `47823` | Local HTTP port |
+| `CODEX_TASKBOARD_PORT` | `47823` | Local HTTP port; the Vite dev proxy targets it too |
+| `TASKBOARD_WEB_PORT` | `5173` | Vite dev server port |
 | `CODEX_TASKBOARD_DATA_DIR` | `.data` | SQLite data directory |
 | `CODEX_TASKBOARD_URL` | `http://127.0.0.1:47823` | CLI API origin |
 

--- a/cli/taskctl.mjs
+++ b/cli/taskctl.mjs
@@ -16,7 +16,7 @@ import {
 export const SCHEMA_VERSION = 2;
 export const DEFAULT_API_URL = "http://127.0.0.1:47823";
 
-const BOOLEAN_OPTIONS = new Set(["json"]);
+const BOOLEAN_OPTIONS = new Set(["json", "help"]);
 
 const COMMAND_OPTIONS = new Map([
   ["project list", new Set(["json"])],
@@ -79,6 +79,221 @@ const COMMAND_OPTIONS = new Map([
   ["context current", new Set(["cwd", "json"])],
 ]);
 
+// Value placeholders shown in help. Options absent from this map are boolean flags.
+const OPTION_VALUES = new Map([
+  ["id", "ID"],
+  ["name", "NAME"],
+  ["workspace-path", "PATH"],
+  ["url", "HTTPS_ORIGIN"],
+  ["actor-name", "NAME"],
+  ["project", "PROJECT_ID"],
+  ["status", "STATUS"],
+  ["title", "TITLE"],
+  ["description", "TEXT"],
+  ["description-file", "FILE"],
+  ["priority", "PRIORITY"],
+  ["labels", "a,b"],
+  ["thread-id", "ID"],
+  ["git-branch", "BRANCH"],
+  ["worktree-path", "PATH"],
+  ["worktree-branch", "BRANCH"],
+  ["due-date", "YYYY-MM-DD"],
+  ["recurrence-interval", "N"],
+  ["recurrence-unit", "day|week|month|year"],
+  ["if-version", "N"],
+  ["type", "parent|blocks|blocked_by|related"],
+  ["issue", "ISSUE_ID"],
+  ["body", "TEXT"],
+  ["output", "PATH"],
+  ["cwd", "PATH"],
+]);
+
+// Operand signature, summary, and required options per command. The optional
+// options are derived from COMMAND_OPTIONS so help cannot drift from the parser.
+const COMMAND_HELP = new Map([
+  ["project list", { operands: "", summary: "List every project." }],
+  ["project create", { operands: "", summary: "Create a project.", required: ["name"] }],
+  [
+    "project map",
+    {
+      operands: "PROJECT_ID",
+      summary: "Map a project to a local workspace path.",
+      required: ["workspace-path"],
+    },
+  ],
+  [
+    "cloud login",
+    {
+      operands: "",
+      summary: "Point the local companion at a shared cloud board (prompts for the shared key).",
+      required: ["url", "actor-name"],
+    },
+  ],
+  ["cloud status", { operands: "", summary: "Show the current cloud session." }],
+  ["cloud logout", { operands: "", summary: "Clear the stored cloud session." }],
+  ["issue list", { operands: "", summary: "List issues, optionally filtered." }],
+  ["issue get", { operands: "ID", summary: "Read one issue." }],
+  [
+    "issue create",
+    { operands: "", summary: "Create an issue.", required: ["project", "title"] },
+  ],
+  ["issue update", { operands: "ID", summary: "Update issue fields." }],
+  ["issue move", { operands: "ID", summary: "Move an issue to a status.", required: ["status"] }],
+  ["issue archive", { operands: "ID", summary: "Archive an issue." }],
+  ["issue restore", { operands: "ID", summary: "Restore an archived issue." }],
+  [
+    "issue relation",
+    {
+      operands: "add|remove ISSUE_ID",
+      summary: "Add or remove a relation on an issue.",
+      required: ["type", "issue"],
+    },
+  ],
+  ["comment list", { operands: "ISSUE_ID", summary: "List an issue's comments." }],
+  ["comment add", { operands: "ISSUE_ID", summary: "Append a comment.", required: ["body"] }],
+  [
+    "comment update",
+    { operands: "COMMENT_ID", summary: "Edit a comment.", required: ["body", "if-version"] },
+  ],
+  [
+    "comment delete",
+    { operands: "COMMENT_ID", summary: "Delete a comment.", required: ["if-version"] },
+  ],
+  [
+    "attachment download",
+    {
+      operands: "ATTACHMENT_ID",
+      summary: "Download an inline attachment to a local path.",
+      required: ["output"],
+    },
+  ],
+  ["context current", { operands: "", summary: "Report the project for the current directory." }],
+]);
+
+const EXIT_CODE_NOTES = [
+  "Every successful command writes one JSON object with schemaVersion "
+    + `${SCHEMA_VERSION} to stdout; errors write one JSON object to stderr.`,
+  "Exit codes: 0 success, 2 invalid input, 3 service unavailable, 4 API or response error,"
+    + " 5 conflict.",
+];
+
+function optionSignature(name) {
+  const value = OPTION_VALUES.get(name);
+  return value === undefined ? `--${name}` : `--${name} ${value}`;
+}
+
+// COMMAND_OPTIONS is the single source of truth for which commands exist, so a new
+// command shows up in help even before it gains a COMMAND_HELP description.
+function commandSpec(command) {
+  return COMMAND_HELP.get(command) ?? { operands: "", summary: "" };
+}
+
+function partitionOptions(command) {
+  const required = commandSpec(command).required ?? [];
+  return {
+    required,
+    optional: [...COMMAND_OPTIONS.get(command)].filter((name) => !required.includes(name)),
+  };
+}
+
+function renderTopLevelHelp() {
+  const lines = [
+    "taskctl — Taskboard CLI",
+    "",
+    "Usage:",
+    "  taskctl <resource> <action> [operands] [options]",
+    "  taskctl help [<resource> <action>]",
+    "",
+    "Commands:",
+  ];
+  const commands = [...COMMAND_OPTIONS.keys()];
+  const labels = commands.map((command) =>
+    [command, commandSpec(command).operands].filter(Boolean).join(" "));
+  const width = Math.max(...labels.map((label) => label.length));
+  for (const [index, command] of commands.entries()) {
+    lines.push(`  ${labels[index].padEnd(width)}  ${commandSpec(command).summary}`);
+  }
+  lines.push(
+    "",
+    "Global options:",
+    "  --json      Emit machine-readable JSON.",
+    "  -h, --help  Show this help.",
+    "",
+    ...EXIT_CODE_NOTES,
+    "",
+    "Run `taskctl help <resource> <action>` for a command's full option list.",
+  );
+  return `${lines.join("\n")}\n`;
+}
+
+function renderCommandHelp(command) {
+  const spec = commandSpec(command);
+  const { required, optional } = partitionOptions(command);
+  const lines = [
+    spec.summary,
+    "",
+    "Usage:",
+    `  ${["taskctl", command, spec.operands, "[options]"].filter(Boolean).join(" ")}`,
+  ];
+  if (required.length > 0) {
+    lines.push("", "Required options:");
+    for (const name of required) lines.push(`  ${optionSignature(name)}`);
+  }
+  lines.push("", "Optional options:");
+  for (const name of optional) lines.push(`  ${optionSignature(name)}`);
+  lines.push("  -h, --help");
+  return `${lines.join("\n")}\n`;
+}
+
+// `help issue create` parses as resource "help", action "issue", operand "create",
+// while `issue create --help` parses as resource "issue", action "create".
+function resolveHelpTopic(parsed) {
+  const words = parsed.resource === "help"
+    ? [parsed.action, ...parsed.operands]
+    : [parsed.resource, parsed.action];
+  const topic = words.filter(Boolean).join(" ");
+  if (topic === "") return undefined;
+  if (COMMAND_OPTIONS.has(topic)) return topic;
+  // `taskctl issue --help` has no command to scope to; fall back to the full list.
+  if (parsed.resource !== "help") return undefined;
+  throw usageError(`Unknown command: ${topic}. Run \`taskctl help\` for the command list.`);
+}
+
+function helpCommandPayload(command) {
+  const spec = commandSpec(command);
+  const { required, optional } = partitionOptions(command);
+  return {
+    command,
+    summary: spec.summary,
+    operands: spec.operands,
+    options: [...required, ...optional].map((name) => ({
+      name,
+      value: OPTION_VALUES.get(name) ?? null,
+      required: required.includes(name),
+    })),
+  };
+}
+
+function helpPayload(topic) {
+  const commands = topic === undefined ? [...COMMAND_OPTIONS.keys()] : [topic];
+  return {
+    help: {
+      usage: "taskctl <resource> <action> [operands] [options]",
+      commands: commands.map((command) => helpCommandPayload(command)),
+      notes: EXIT_CODE_NOTES,
+    },
+    schemaVersion: SCHEMA_VERSION,
+  };
+}
+
+function writeHelp(stream, topic, asJson) {
+  if (asJson) {
+    writeJson(stream, helpPayload(topic));
+    return;
+  }
+  stream.write(topic === undefined ? renderTopLevelHelp() : renderCommandHelp(topic));
+}
+
 class TaskctlError extends Error {
   constructor(message, { code = "TASKCTL_ERROR", exitCode = 2, details } = {}) {
     super(message);
@@ -102,6 +317,11 @@ export function parseArgs(argv) {
     if (token === "--") {
       positionals.push(...argv.slice(index + 1));
       break;
+    }
+
+    if (token === "-h") {
+      options.help = true;
+      continue;
     }
 
     if (!token.startsWith("--")) {
@@ -154,6 +374,10 @@ export async function main(argv = process.argv.slice(2), overrides = {}) {
 
   try {
     const parsed = parseArgs(argv);
+    if (parsed.options.help || parsed.resource === "help" || parsed.resource === undefined) {
+      writeHelp(stdout, resolveHelpTopic(parsed), parsed.options.json === true);
+      return 0;
+    }
     const result = await execute(parsed, overrides);
     writeJson(stdout, { ...result, schemaVersion: SCHEMA_VERSION });
     return 0;

--- a/shared/thread-instruction.d.mts
+++ b/shared/thread-instruction.d.mts
@@ -1,0 +1,8 @@
+export interface ThreadInstructionInput {
+  readonly identifier: string;
+  readonly projectName?: string | null;
+  readonly projectId?: string | null;
+  readonly workspacePath?: string | null;
+}
+
+export function buildThreadInstruction(input: ThreadInstructionInput): string;

--- a/shared/thread-instruction.mjs
+++ b/shared/thread-instruction.mjs
@@ -1,0 +1,37 @@
+function clean(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * Build the text that prefills the Codex composer when an issue is opened in a
+ * thread. The block names the project, the issue, and the workspace so the
+ * agent knows what it is looking at, then points it at `taskctl` for the title,
+ * the description, and the comments rather than embedding a copy that can go
+ * stale.
+ */
+export function buildThreadInstruction({
+  identifier,
+  projectName,
+  projectId,
+  workspacePath,
+} = {}) {
+  const issue = clean(identifier);
+  const name = clean(projectName);
+  const id = clean(projectId);
+  const workspace = clean(workspacePath);
+
+  const project = name && id ? `${name} (id: ${id})` : name || id;
+  const fields = [
+    project ? `- 项目: ${project}` : "",
+    issue ? `- 议题: ${issue}` : "",
+    workspace ? `- 工作区: ${workspace}` : "",
+  ].filter(Boolean);
+
+  return [
+    "处理下面这个议题：",
+    "",
+    ...fields,
+    "",
+    `先执行 taskctl issue get ${issue} 读取标题、描述与评论，再开始。`,
+  ].join("\n");
+}

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -8,7 +8,21 @@ function capture() {
   return {
     stream: { write(chunk) { value += chunk; } },
     json() { return JSON.parse(value); },
+    text() { return value; },
   };
+}
+
+async function runRaw(argv, overrides = {}) {
+  const stdout = capture();
+  const stderr = capture();
+  const exitCode = await main(argv, {
+    fetch: async () => assert.fail("help must not call the service"),
+    stdout: stdout.stream,
+    stderr: stderr.stream,
+    env: {},
+    ...overrides,
+  });
+  return { exitCode, stdout: stdout.text(), stderr: stderr.text() };
 }
 
 function response(payload, status = 200) {
@@ -503,6 +517,217 @@ test("API conflicts produce stable JSON on stderr and exit code 5", async () => 
     schemaVersion: 2,
     error: { code: "VERSION_CONFLICT", message: "Task changed" },
   });
+});
+
+test("--help prints text help for every command group on stdout and exits 0", async () => {
+  const result = await runRaw(["--help"]);
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.stderr, "");
+  for (const command of [
+    "project list",
+    "project create",
+    "project map",
+    "cloud login",
+    "cloud status",
+    "cloud logout",
+    "issue list",
+    "issue get",
+    "issue create",
+    "issue update",
+    "issue move",
+    "issue archive",
+    "issue restore",
+    "issue relation",
+    "comment list",
+    "comment add",
+    "comment update",
+    "comment delete",
+    "attachment download",
+    "context current",
+  ]) {
+    assert.match(result.stdout, new RegExp(command), `help omits ${command}`);
+  }
+});
+
+test("-h is an alias for --help", async () => {
+  const short = await runRaw(["-h"]);
+  const long = await runRaw(["--help"]);
+
+  assert.equal(short.exitCode, 0);
+  assert.equal(short.stdout, long.stdout);
+});
+
+test("the help subcommand prints the same help as --help", async () => {
+  const subcommand = await runRaw(["help"]);
+  const flag = await runRaw(["--help"]);
+
+  assert.equal(subcommand.exitCode, 0);
+  assert.equal(subcommand.stdout, flag.stdout);
+});
+
+test("a bare invocation prints top-level help instead of erroring", async () => {
+  const bare = await runRaw([]);
+  const flag = await runRaw(["--help"]);
+
+  assert.equal(bare.exitCode, 0);
+  assert.equal(bare.stderr, "");
+  assert.equal(bare.stdout, flag.stdout);
+});
+
+test("help <resource> <action> prints that command's own option list", async () => {
+  const result = await runRaw(["help", "issue", "create"]);
+
+  assert.equal(result.exitCode, 0);
+  assert.match(result.stdout, /taskctl issue create/);
+  for (const signature of [
+    "--project PROJECT_ID",
+    "--title TITLE",
+    "--description TEXT",
+    "--description-file FILE",
+    "--status STATUS",
+    "--priority PRIORITY",
+    "--labels a,b",
+    "--thread-id ID",
+    "--git-branch BRANCH",
+    "--worktree-path PATH",
+    "--worktree-branch BRANCH",
+    "--due-date YYYY-MM-DD",
+    "--recurrence-interval N",
+    "--recurrence-unit day|week|month|year",
+    "--json",
+  ]) {
+    assert.ok(result.stdout.includes(signature), `issue create help omits ${signature}`);
+  }
+  assert.ok(
+    !result.stdout.includes("attachment download"),
+    "command help must not fall back to the full command list",
+  );
+});
+
+test("help for an unknown command reports a usage error on stderr", async () => {
+  const result = await runRaw(["help", "issue", "teleport"]);
+
+  assert.equal(result.exitCode, 2);
+  assert.equal(result.stdout, "");
+  assert.equal(JSON.parse(result.stderr).error.code, "USAGE_ERROR");
+  assert.match(JSON.parse(result.stderr).error.message, /issue teleport/);
+});
+
+test("--help --json emits a structured help object with schemaVersion", async () => {
+  const result = await runRaw(["--help", "--json"]);
+
+  assert.equal(result.exitCode, 0);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.schemaVersion, 2);
+  assert.deepEqual(
+    payload.help.commands.map((entry) => entry.command),
+    [
+      "project list",
+      "project create",
+      "project map",
+      "cloud login",
+      "cloud status",
+      "cloud logout",
+      "issue list",
+      "issue get",
+      "issue create",
+      "issue update",
+      "issue move",
+      "issue archive",
+      "issue restore",
+      "issue relation",
+      "comment list",
+      "comment add",
+      "comment update",
+      "comment delete",
+      "attachment download",
+      "context current",
+    ],
+  );
+
+  const create = payload.help.commands.find((entry) => entry.command === "issue create");
+  assert.deepEqual(create.options.filter((option) => option.required).map((o) => o.name), [
+    "project",
+    "title",
+  ]);
+  assert.deepEqual(create.options.map((option) => option.name).sort(), [
+    "description",
+    "description-file",
+    "due-date",
+    "git-branch",
+    "json",
+    "labels",
+    "priority",
+    "project",
+    "recurrence-interval",
+    "recurrence-unit",
+    "status",
+    "thread-id",
+    "title",
+    "worktree-branch",
+    "worktree-path",
+  ]);
+});
+
+test("every option advertised by help is actually accepted by that command", async () => {
+  const { help } = JSON.parse((await runRaw(["--help", "--json"])).stdout);
+
+  for (const entry of help.commands) {
+    const [resource, action] = entry.command.split(" ");
+    for (const option of entry.options) {
+      const argv = [resource, action, `--${option.name}`];
+      if (option.value !== null) argv.push("placeholder");
+      const result = await run(argv, async () => response({}));
+      if (result.exitCode !== 0) {
+        // "Unknown option" means help advertises an option the command rejects.
+        // "requires a value" means help mis-classified a value option as a flag.
+        assert.ok(
+          !/Unknown option|requires a value/.test(result.stderr.error.message),
+          `${entry.command} rejects the advertised --${option.name}: `
+            + result.stderr.error.message,
+        );
+      }
+    }
+  }
+});
+
+test("--help after a command scopes help to that command", async () => {
+  const flag = await runRaw(["issue", "create", "--help"]);
+  const subcommand = await runRaw(["help", "issue", "create"]);
+
+  assert.equal(flag.exitCode, 0);
+  assert.equal(flag.stdout, subcommand.stdout);
+});
+
+test("help <command> --json narrows the structured payload to that command", async () => {
+  const result = await runRaw(["help", "comment", "update", "--json"]);
+
+  assert.equal(result.exitCode, 0);
+  const payload = JSON.parse(result.stdout);
+  assert.equal(payload.schemaVersion, 2);
+  assert.equal(payload.help.commands.length, 1);
+  assert.equal(payload.help.commands[0].command, "comment update");
+  assert.equal(payload.help.commands[0].operands, "COMMENT_ID");
+  assert.deepEqual(
+    payload.help.commands[0].options.filter((option) => option.required).map((o) => o.name),
+    ["body", "if-version"],
+  );
+});
+
+test("boolean flags parse without a value while value options still require one", () => {
+  assert.deepEqual(parseArgs(["--help"]).options, { help: true });
+  assert.deepEqual(parseArgs(["-h"]).options, { help: true });
+  assert.deepEqual(parseArgs(["issue", "list", "--json"]).options, { json: true });
+  assert.deepEqual(parseArgs(["issue", "list", "--json", "--status", "todo"]).options, {
+    json: true,
+    status: "todo",
+  });
+
+  for (const argv of [["--help=true"], ["issue", "list", "--json=true"]]) {
+    assert.throws(() => parseArgs(argv), /does not accept a value/);
+  }
+  assert.throws(() => parseArgs(["issue", "list", "--status"]), /requires a value/);
 });
 
 test("usage errors are stable and never call the service", async () => {

--- a/test/inject.test.mjs
+++ b/test/inject.test.mjs
@@ -236,8 +236,9 @@ test("issues open an unsent native Codex composer in the exact workspace with a 
   assert.doesNotMatch(webApp, /taskboard:thread-created/);
   assert.match(
     webApp,
-    /const instruction = `e-taskboard Addressing the issues mentioned in \$\{task\.identifier\}`/,
+    /const instruction = buildThreadInstruction\(\{\s*identifier: task\.identifier,\s*projectName: selectedProject\?\.name,\s*projectId: task\.projectId,\s*workspacePath,\s*\}\);/,
   );
+  assert.doesNotMatch(webApp, /e-taskboard Addressing the issues mentioned in/);
   assert.match(
     webApp,
     /const prompt = `\[\$manage-taskboard\]\(\$\{manageTaskboardSkillPath\}\) \$\{instruction\}`/,

--- a/test/thread-instruction.test.mjs
+++ b/test/thread-instruction.test.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildThreadInstruction } from "../shared/thread-instruction.mjs";
+
+test("the instruction carries the project, the issue, and the workspace", () => {
+  const instruction = buildThreadInstruction({
+    identifier: "LOCALFE705C9-8",
+    projectName: "dashi-taskboard",
+    projectId: "local",
+    workspacePath: "/Users/sammore/codeLab/dashi-taskboard",
+  });
+
+  assert.equal(
+    instruction,
+    [
+      "处理下面这个议题：",
+      "",
+      "- 项目: dashi-taskboard (id: local)",
+      "- 议题: LOCALFE705C9-8",
+      "- 工作区: /Users/sammore/codeLab/dashi-taskboard",
+      "",
+      "先执行 taskctl issue get LOCALFE705C9-8 读取标题、描述与评论，再开始。",
+    ].join("\n"),
+  );
+});
+
+test("a missing workspace drops its line instead of leaving a placeholder", () => {
+  const instruction = buildThreadInstruction({
+    identifier: "LOCALFE705C9-8",
+    projectName: "dashi-taskboard",
+    projectId: "local",
+    workspacePath: null,
+  });
+
+  assert.doesNotMatch(instruction, /工作区/);
+  assert.match(instruction, /- 项目: dashi-taskboard \(id: local\)\n- 议题: LOCALFE705C9-8\n\n/);
+});
+
+test("a project without a name falls back to its bare id", () => {
+  const instruction = buildThreadInstruction({
+    identifier: "LOCALFE705C9-8",
+    projectName: undefined,
+    projectId: "local",
+    workspacePath: null,
+  });
+
+  assert.match(instruction, /^- 项目: local$/m);
+});
+
+test("a project without a name or an id drops its line", () => {
+  const instruction = buildThreadInstruction({
+    identifier: "LOCALFE705C9-8",
+    projectName: "   ",
+    projectId: "",
+    workspacePath: null,
+  });
+
+  assert.doesNotMatch(instruction, /项目/);
+  assert.match(instruction, /- 议题: LOCALFE705C9-8/);
+});
+
+test("the instruction tells the agent to read the issue before starting", () => {
+  const instruction = buildThreadInstruction({
+    identifier: "WEB-42",
+    projectName: "www-v3",
+    projectId: "web",
+    workspacePath: "/tmp/www-v3",
+  });
+
+  assert.match(instruction, /taskctl issue get WEB-42/);
+  assert.match(instruction, /读取标题、描述与评论/);
+});
+
+test("the instruction no longer carries the truncated english leftover", () => {
+  const instruction = buildThreadInstruction({
+    identifier: "LOCALFE705C9-8",
+    projectName: "dashi-taskboard",
+    projectId: "local",
+    workspacePath: "/tmp/dashi",
+  });
+
+  assert.doesNotMatch(instruction, /e-taskboard Addressing the issues mentioned in/);
+});
+
+test("every field is trimmed before it reaches the composer", () => {
+  const instruction = buildThreadInstruction({
+    identifier: "  LOCALFE705C9-8  ",
+    projectName: "  dashi-taskboard  ",
+    projectId: "  local  ",
+    workspacePath: "  /tmp/dashi  ",
+  });
+
+  assert.match(instruction, /- 项目: dashi-taskboard \(id: local\)/);
+  assert.match(instruction, /- 议题: LOCALFE705C9-8/);
+  assert.match(instruction, /- 工作区: \/tmp\/dashi/);
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,7 @@ import {
   type AutomationModel,
   type AutomationReasoningEffort,
 } from "../../shared/taskboard-automation-options.mjs";
+import { buildThreadInstruction } from "../../shared/thread-instruction.mjs";
 import {
   ApiError,
   addTaskRelation,
@@ -1699,7 +1700,12 @@ export function App() {
       ?? selectedDeviceWorkspacePath
       ?? developmentScan.workspacePath
       ?? hostContext?.workspacePath;
-    const instruction = `e-taskboard Addressing the issues mentioned in ${task.identifier}`;
+    const instruction = buildThreadInstruction({
+      identifier: task.identifier,
+      projectName: selectedProject?.name,
+      projectId: task.projectId,
+      workspacePath,
+    });
     const prompt = `[$manage-taskboard](${manageTaskboardSkillPath}) ${instruction}`;
 
     if (!embedded || window.parent === window) {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -11,10 +11,12 @@ export default defineConfig({
   },
   server: {
     host: "127.0.0.1",
-    port: 5173,
+    // Keep several worktrees running side by side: override both ports per instance,
+    // e.g. TASKBOARD_WEB_PORT=5174 CODEX_TASKBOARD_PORT=47901 npm run dev
+    port: Number(process.env.TASKBOARD_WEB_PORT ?? 5173),
     strictPort: true,
     proxy: {
-      "/api": "http://127.0.0.1:47823",
+      "/api": `http://127.0.0.1:${Number(process.env.CODEX_TASKBOARD_PORT ?? 47823)}`,
     },
   },
 });


### PR DESCRIPTION
# What

- Add a built-in CLI help command for taskboard usage guidance.

# Why

- Make local CLI usage discoverable without requiring external docs.

# Reference

- Commit: b867fcd feat(cli): add built-in help command