### PR TITLE
fix(injector): startup race hardening and Windows Codex page recognition

### DIFF
--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -301,14 +301,55 @@ class CdpConnection {
   }
 }
 
+// 页面识别参考 Codex++：Windows 版主页面可能是 https://chatgpt.com 或标题含 codex，
+// 不一定是 app://；浮层/快捷聊天窗按 initialRoute 排除，避免注入错窗口
+function targetInitialRoute(target) {
+  try {
+    const url = new URL(target.url || "");
+    if (url.protocol !== "app:") return null;
+    return url.searchParams.get("initialRoute")?.toLowerCase() ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function isChatGptDesktopPage(target) {
+  const title = (target.title || "").trim().toLowerCase();
+  const url = (target.url || "").trim().toLowerCase();
+  return (
+    title === "chatgpt" &&
+    (url === "https://chatgpt.com" ||
+      url.startsWith("https://chatgpt.com/") ||
+      url === "https://chat.openai.com" ||
+      url.startsWith("https://chat.openai.com/") ||
+      url.startsWith("data:text/html"))
+  );
+}
+
+function isCodexPageTarget(target) {
+  const haystack = `${target.title || ""} ${target.url || ""}`.toLowerCase();
+  return haystack.includes("codex") || isChatGptDesktopPage(target);
+}
+
+function isExcludedCodexRoute(target) {
+  const route = targetInitialRoute(target);
+  return (
+    route === "/global-dictation" ||
+    route === "/avatar-overlay" ||
+    route === "/chatgpt/quick-chat" ||
+    route === "/chatgpt/quick-chat-prewarm" ||
+    (route?.startsWith("/chatgpt/quick-chat/") ?? false)
+  );
+}
+
 async function codexTargets(port) {
   const targets = await fetchJson(`http://127.0.0.1:${port}/json/list`);
   return targets.filter(
     (target) =>
       target.type === "page" &&
       target.webSocketDebuggerUrl &&
-      !target.url?.includes("initialRoute=%2Fglobal-dictation") &&
-      (target.url?.startsWith("app://") || target.title === "Codex"),
+      !isExcludedCodexRoute(target) &&
+      (target.url?.startsWith("app://") || isCodexPageTarget(target)),
   );
 }
 

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -37,6 +37,8 @@ const codexAutomationMethods = new Set([
   "automation-create",
   "automation-update",
 ]);
+const injectMaxAttempts = 3;
+const injectRetryDelayMs = 2_000;
 let codexAutomationRequestSequence = 0;
 const quotaPolicyTimers = new Map();
 const quotaPolicyRecords = new Map();
@@ -308,6 +310,54 @@ async function codexTargets(port) {
       !target.url?.includes("initialRoute=%2Fglobal-dictation") &&
       (target.url?.startsWith("app://") || target.title === "Codex"),
   );
+}
+
+function logInjector(message) {
+  console.error(`[codex-injector ${new Date().toISOString()}] ${message}`);
+}
+
+async function waitForCodexTargets(port, timeoutMs) {
+  const startedAt = Date.now();
+  const deadline = startedAt + timeoutMs;
+  let announced = false;
+  while (Date.now() < deadline) {
+    const targets = await codexTargets(port);
+    if (targets.length > 0) {
+      if (announced) {
+        logInjector(`Codex renderer ready on port ${port} after ${Date.now() - startedAt}ms (${targets.length} target(s))`);
+      }
+      return targets;
+    }
+    if (!announced) {
+      announced = true;
+      logInjector(`Waiting for Codex renderer target on port ${port} (up to ${timeoutMs}ms)...`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`No Codex renderer target found on port ${port} within ${timeoutMs}ms`);
+}
+
+// 等页面初次加载完成；启动早期 reload 会让 app:// 协议 ERR_FAILED
+async function waitForPageLoad(cdp, timeoutMs) {
+  const startedAt = Date.now();
+  const deadline = startedAt + timeoutMs;
+  let announced = false;
+  while (Date.now() < deadline) {
+    const state = await cdp.send("Runtime.evaluate", {
+      expression: "document.readyState",
+      returnByValue: true,
+    });
+    if (state.result.value === "complete") {
+      if (announced) logInjector(`Codex page finished initial load after ${Date.now() - startedAt}ms`);
+      return;
+    }
+    if (!announced) {
+      announced = true;
+      logInjector(`Waiting for Codex page initial load (up to ${timeoutMs}ms)...`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Codex page did not finish initial load within ${timeoutMs}ms`);
 }
 
 function codexDebuggingPorts(preferredPort) {
@@ -1096,7 +1146,10 @@ async function injectTarget(
     cdp.on("Page.loadEventFired", () => (
       publishInjectionScriptIdentifier(cdp, scriptIdentifier)
     ));
+    await waitForPageLoad(cdp, 20_000);
     const reloaded = cdp.waitFor("Page.loadEventFired", 15_000);
+    // 防止 Page.reload 发送失败时 reloaded 的 rejection 无人接收而崩进程
+    reloaded.catch(() => {});
     await cdp.send("Page.reload");
     await reloaded;
     await evaluateInjectionSource(cdp, source);
@@ -1163,19 +1216,35 @@ async function injectAll(
   for (const target of targets) {
     if (injectedTargets.has(target.id)) continue;
     const firstTarget = injectedTargets.size === 0 && results.length === 0;
-    const { result, connection } = await injectTarget(
-      target,
-      source,
-      sourceHash,
-      shouldOpen && firstTarget,
-      firstTarget ? screenshotPath : null,
-      keepAlive,
-      supervisor,
-      attachExisting,
-      startupToken,
-    );
-    if (connection) injectedTargets.set(target.id, connection);
-    results.push({ targetId: target.id, title: target.title, url: target.url, ...result });
+    let lastError = null;
+    for (let attempt = 1; attempt <= injectMaxAttempts; attempt += 1) {
+      try {
+        const { result, connection } = await injectTarget(
+          target,
+          source,
+          sourceHash,
+          shouldOpen && firstTarget,
+          firstTarget ? screenshotPath : null,
+          keepAlive,
+          supervisor,
+          attachExisting,
+          startupToken,
+        );
+        if (connection) injectedTargets.set(target.id, connection);
+        results.push({ targetId: target.id, title: target.title, url: target.url, ...result });
+        lastError = null;
+        break;
+      } catch (error) {
+        lastError = error;
+        logInjector(
+          `Injection into ${target.url || target.id} failed (attempt ${attempt}/${injectMaxAttempts}): ${error.message}`,
+        );
+        if (attempt < injectMaxAttempts) {
+          await new Promise((resolve) => setTimeout(resolve, injectRetryDelayMs));
+        }
+      }
+    }
+    if (lastError) throw lastError;
   }
   return results;
 }
@@ -1264,18 +1333,35 @@ async function main() {
 
     const { source, sourceHash } = await currentInjectionSource();
     const injectedTargets = new Map();
-    const firstResults = await injectAll(
-      options.port,
-      source,
-      sourceHash,
-      options.open,
-      options.screenshot,
-      injectedTargets,
-      options.watch,
-      supervisor,
-      options.attachExisting,
-      options.startupToken,
-    );
+    // CDP 端口就绪早于 renderer 窗口创建，先等 target 出现再注入；整体失败重试一轮
+    let firstResults = null;
+    let lastError = null;
+    for (let attempt = 1; attempt <= 2; attempt += 1) {
+      try {
+        await waitForCodexTargets(options.port, 15_000);
+        firstResults = await injectAll(
+          options.port,
+          source,
+          sourceHash,
+          options.open,
+          options.screenshot,
+          injectedTargets,
+          options.watch,
+          supervisor,
+          options.attachExisting,
+          options.startupToken,
+        );
+        lastError = null;
+        break;
+      } catch (error) {
+        lastError = error;
+        logInjector(`Initial injection failed (attempt ${attempt}/2): ${error.message}`);
+        if (attempt < 2) {
+          await new Promise((resolve) => setTimeout(resolve, injectRetryDelayMs));
+        }
+      }
+    }
+    if (lastError) throw lastError;
     console.log(JSON.stringify({ injected: firstResults }, null, 2));
 
     if (!options.watch) {

--- a/test/codex-targets-filter.test.mjs
+++ b/test/codex-targets-filter.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+// codexTargets 的页面识别逻辑（参考 Codex++）不导出，从源码抽出函数体测：
+// 改坏过滤器时此测试应失败。fetchJson 以桩注入，返回预设的 CDP 目标列表。
+const src = readFileSync(new URL("../scripts/codex-injector.mjs", import.meta.url), "utf8");
+const start = src.indexOf("function targetInitialRoute");
+const end = src.indexOf("function logInjector");
+assert.ok(start > 0 && end > start, "codexTargets block not found in injector source");
+const build = new Function(
+  "fetchJson",
+  `${src.slice(start, end)}; return { codexTargets };`,
+);
+
+const MAC_CODEX = {
+  type: "page",
+  title: "Codex",
+  url: "app://-/index.html?initialRoute=%2F",
+  webSocketDebuggerUrl: "ws://127.0.0.1/1",
+};
+const WIN_STORE_CHATGPT = {
+  type: "page",
+  title: "ChatGPT",
+  url: "https://chatgpt.com/codex",
+  webSocketDebuggerUrl: "ws://127.0.0.1/2",
+};
+const WIN_TITLE_CODEX = {
+  type: "page",
+  title: "codex",
+  url: "https://chatgpt.com/",
+  webSocketDebuggerUrl: "ws://127.0.0.1/3",
+};
+const QUICK_CHAT_PREWARM = {
+  type: "page",
+  title: "ChatGPT",
+  url: "app://-/index.html?initialRoute=%2Fchatgpt%2Fquick-chat-prewarm",
+  webSocketDebuggerUrl: "ws://127.0.0.1/4",
+};
+const AVATAR_OVERLAY = {
+  type: "page",
+  title: "Codex",
+  url: "app://-/index.html?initialRoute=%2Favatar-overlay",
+  webSocketDebuggerUrl: "ws://127.0.0.1/5",
+};
+const GLOBAL_DICTATION = {
+  type: "page",
+  title: "ChatGPT",
+  url: "app://-/index.html?initialRoute=%2Fglobal-dictation",
+  webSocketDebuggerUrl: "ws://127.0.0.1/6",
+};
+const SERVICE_WORKER = { type: "service_worker", title: "", url: "app://-/sw.js" };
+
+async function pick(targets) {
+  const { codexTargets } = build(async () => targets);
+  return (await codexTargets(9229)).map((t) => t.webSocketDebuggerUrl);
+}
+
+test("macOS app:// 主页面仍然命中（回归）", async () => {
+  assert.deepEqual(await pick([MAC_CODEX, GLOBAL_DICTATION]), [MAC_CODEX.webSocketDebuggerUrl]);
+});
+
+test("Windows 商店版 chatgpt.com 主页面命中", async () => {
+  assert.deepEqual(
+    await pick([WIN_STORE_CHATGPT, WIN_TITLE_CODEX, QUICK_CHAT_PREWARM, AVATAR_OVERLAY, SERVICE_WORKER]),
+    [WIN_STORE_CHATGPT.webSocketDebuggerUrl, WIN_TITLE_CODEX.webSocketDebuggerUrl],
+  );
+});
+
+test("快捷聊天/浮层/听写路由全部排除", async () => {
+  assert.deepEqual(await pick([QUICK_CHAT_PREWARM, AVATAR_OVERLAY, GLOBAL_DICTATION]), []);
+});


### PR DESCRIPTION
Two injector fixes developed and battle-tested in the dashi-taskboard-launcher (shipped as v0.2.5), upstreamed here:

**1. Startup race hardening** (`c8cc067`)
- CDP port becomes ready before the renderer window exists: poll `waitForCodexTargets` (up to 15s) before injecting
- Wait for `document.readyState === "complete"` before `Page.reload` — early reload makes `app://` fail with ERR_FAILED
- Retry per-target injection (3 attempts, 2s apart) plus one full retry of the initial pass
- Timestamped `logInjector` diagnostics; guard the reload waiter against unhandled rejection

**2. Windows Codex page recognition** (`7e6249a`, approach referenced from Codex++)
- Windows store builds serve the main page as `https://chatgpt.com(/codex)` or with a codex title, not `app://`
- `isCodexPageTarget` / `isExcludedCodexRoute` replace the hard-coded filter; quick-chat, avatar-overlay and global-dictation overlay routes are excluded
- New `test/codex-targets-filter.test.mjs` extracts the filter block from source and tests mac/Windows/overlay cases (3 tests, all passing)