### PR TITLE
fix: secure Codex 151 blob embedding

### DIFF
--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -59,6 +59,7 @@
   let noDragRight = null;
   let status = null;
   let frameOrigin = "";
+  let frameIsBlob = false;
   let frameReady = false;
   let frameReadyWaiters = new Set();
   let hostRequests = new Map();
@@ -551,7 +552,44 @@
 
   function postToFrame(message) {
     if (!frame?.contentWindow || !frameOrigin) return;
-    frame.contentWindow.postMessage(message, frameOrigin);
+    frame.contentWindow.postMessage(message, frameIsBlob ? "*" : frameOrigin);
+  }
+
+  const TASKBOARD_STORAGE_KEY = "__codexTaskboardEmbeddedStorage__";
+
+  function readTaskboardStorage() {
+    const entries = {};
+    try {
+      const raw = window.localStorage.getItem(TASKBOARD_STORAGE_KEY);
+      if (raw) Object.assign(entries, JSON.parse(raw));
+    } catch (_) {
+      // The Codex page may not expose localStorage; keep session-only state.
+    }
+    return entries;
+  }
+
+  function writeTaskboardStorage(key, value) {
+    if (typeof key !== "string") return;
+    try {
+      const entries = readTaskboardStorage();
+      entries[key] = String(value ?? "");
+      window.localStorage.setItem(TASKBOARD_STORAGE_KEY, JSON.stringify(entries));
+    } catch (_) {}
+  }
+
+  function removeTaskboardStorage(key) {
+    if (typeof key !== "string") return;
+    try {
+      const entries = readTaskboardStorage();
+      delete entries[key];
+      window.localStorage.setItem(TASKBOARD_STORAGE_KEY, JSON.stringify(entries));
+    } catch (_) {}
+  }
+
+  function clearTaskboardStorage() {
+    try {
+      window.localStorage.removeItem(TASKBOARD_STORAGE_KEY);
+    } catch (_) {}
   }
 
   function dispatchHostMessage(message) {
@@ -786,9 +824,33 @@
   }
 
   function onFrameMessage(event) {
-    if (!frame || event.source !== frame.contentWindow || event.origin !== frameOrigin) return;
+    if (!frame || event.source !== frame.contentWindow) return;
+    if (frameIsBlob) {
+      if (event.origin !== "null" && event.origin !== window.location.origin) return;
+    } else if (event.origin !== frameOrigin) {
+      return;
+    }
     const message = event.data;
     if (!message || typeof message !== "object") return;
+    if (message.type === "taskboard:storage-request") {
+      frame.contentWindow.postMessage({
+        type: "taskboard:storage-init",
+        payload: readTaskboardStorage(),
+      }, "*");
+      return;
+    }
+    if (message.type === "taskboard:storage-set") {
+      writeTaskboardStorage(message.payload?.key, message.payload?.value);
+      return;
+    }
+    if (message.type === "taskboard:storage-remove") {
+      removeTaskboardStorage(message.payload?.key);
+      return;
+    }
+    if (message.type === "taskboard:storage-clear") {
+      clearTaskboardStorage();
+      return;
+    }
     if (message.type === "taskboard:ready") {
       frameReady = true;
       frameReadyWaiters.forEach(({ resolve, timer }) => {
@@ -937,11 +999,61 @@
     });
   }
 
+  function taskboardBlobPrelude() {
+    return `<script>
+(() => {
+  const RealURLSearchParams = window.URLSearchParams;
+  class TaskboardURLSearchParams extends RealURLSearchParams {
+    get(name) {
+      return name === "host" ? "codex" : super.get(name);
+    }
+  }
+  window.URLSearchParams = TaskboardURLSearchParams;
+  const store = new Map();
+  const storage = {
+    get length() { return store.size; },
+    key(index) { return Array.from(store.keys())[index] ?? null; },
+    getItem(key) { return store.has(key) ? store.get(key) : null; },
+    setItem(key, value) {
+      store.set(String(key), String(value));
+      window.parent.postMessage({ type: "taskboard:storage-set", payload: { key: String(key), value: String(value) } }, "*");
+    },
+    removeItem(key) {
+      store.delete(String(key));
+      window.parent.postMessage({ type: "taskboard:storage-remove", payload: { key: String(key) } }, "*");
+    },
+    clear() {
+      store.clear();
+      window.parent.postMessage({ type: "taskboard:storage-clear" }, "*");
+    },
+  };
+  window.localStorage = storage;
+  window.addEventListener("message", (event) => {
+    if (event.data && event.data.type === "taskboard:storage-init") {
+      store.clear();
+      for (const [key, value] of Object.entries(event.data.payload || {})) store.set(key, value);
+    }
+  });
+  window.parent.postMessage({ type: "taskboard:storage-request" }, "*");
+})();
+</script>`;
+  }
+
+  function createTaskboardBlobUrl(origin, html) {
+    const base = `<base href="${origin}/">`;
+    const rewritten = String(html)
+      .replace(/^<!doctype[^>]*>/i, "")
+      .replace(/<head[^>]*>/i, (match) => `${match}${base}${taskboardBlobPrelude()}`);
+    const blobHtml = `<!doctype html>${rewritten}`;
+    return URL.createObjectURL(new Blob([blobHtml], { type: "text/html" }));
+  }
+
   function loadTaskboardFrame(cacheBust = false) {
     cancelFrameReadyWaiters(new Error("任务面板正在重新加载"));
     frame?.remove();
     frame = null;
     frameReady = false;
+    frameIsBlob = false;
     if (dragRegion) dragRegion.hidden = true;
     if (noDragLeft) noDragLeft.hidden = true;
     if (noDragRight) noDragRight.hidden = true;
@@ -954,10 +1066,18 @@
     const nextFrame = document.createElement("iframe");
     nextFrame.id = FRAME_ID;
     nextFrame.hidden = true;
-    nextFrame.src = taskboardUrl.href;
     nextFrame.title = "任务面板";
     nextFrame.referrerPolicy = "no-referrer";
     nextFrame.setAttribute("allow", "clipboard-read; clipboard-write");
+    const managedHtml = window.__codexTaskboardHtml__;
+    if (typeof managedHtml === "string" && managedHtml.length > 0) {
+      // Codex renderers whose CSP blocks arbitrary http iframes still allow
+      // blob: frames; load the managed page through a blob document instead.
+      nextFrame.src = createTaskboardBlobUrl(taskboardUrl.origin, managedHtml);
+      frameIsBlob = true;
+    } else {
+      nextFrame.src = taskboardUrl.href;
+    }
     nextFrame.addEventListener("load", postHostContext);
     frame = nextFrame;
     page.appendChild(nextFrame);
@@ -1247,6 +1367,7 @@
     noDragRight = null;
     status = null;
     frameOrigin = "";
+    frameIsBlob = false;
     if (window[SENTINEL_KEY] === api) delete window[SENTINEL_KEY];
   }
 

--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -60,6 +60,8 @@
   let status = null;
   let frameOrigin = "";
   let frameIsBlob = false;
+  let frameBlobUrl = "";
+  let frameTaskboardUrl = "";
   let frameReady = false;
   let frameReadyWaiters = new Set();
   let hostRequests = new Map();
@@ -999,21 +1001,54 @@
     });
   }
 
-  function taskboardBlobPrelude() {
+  function taskboardBlobPrelude(origin, embedToken, initialStorage) {
+    const serializedOrigin = JSON.stringify(origin).replace(/</g, "\\u003c");
+    const serializedToken = JSON.stringify(embedToken).replace(/</g, "\\u003c");
+    const serializedStorage = JSON.stringify(initialStorage).replace(/</g, "\\u003c");
     return `<script>
 (() => {
+  const taskboardOrigin = ${serializedOrigin};
+  const embedToken = ${serializedToken};
+  const embedTokenHeader = "x-codex-taskboard-embed-token";
+  const embedTokenQuery = "__codex_taskboard_embed_token";
   const RealURLSearchParams = window.URLSearchParams;
   class TaskboardURLSearchParams extends RealURLSearchParams {
     get(name) {
-      return name === "host" ? "codex" : super.get(name);
+      if (name === "host") return "codex";
+      if (name === "taskboard-origin") return taskboardOrigin;
+      return super.get(name);
     }
   }
   window.URLSearchParams = TaskboardURLSearchParams;
-  const store = new Map();
+
+  const realFetch = window.fetch.bind(window);
+  window.fetch = (input, init) => {
+    const inputUrl = input instanceof Request ? input.url : String(input);
+    const target = new URL(inputUrl, document.baseURI);
+    if (target.origin !== taskboardOrigin) return realFetch(input, init);
+    const headers = new Headers(input instanceof Request ? input.headers : undefined);
+    new Headers(init && init.headers).forEach((value, key) => headers.set(key, value));
+    headers.set(embedTokenHeader, embedToken);
+    return realFetch(input, { ...(init || {}), headers });
+  };
+
+  const RealEventSource = window.EventSource;
+  class TaskboardEventSource extends RealEventSource {
+    constructor(url, options) {
+      const target = new URL(String(url), document.baseURI);
+      if (target.origin === taskboardOrigin) target.searchParams.set(embedTokenQuery, embedToken);
+      super(target.href, options);
+    }
+  }
+  window.EventSource = TaskboardEventSource;
+
+  const store = new Map(Object.entries(${serializedStorage}).map(
+    ([key, value]) => [String(key), String(value)],
+  ));
   const storage = {
     get length() { return store.size; },
     key(index) { return Array.from(store.keys())[index] ?? null; },
-    getItem(key) { return store.has(key) ? store.get(key) : null; },
+    getItem(key) { return store.has(String(key)) ? store.get(String(key)) : null; },
     setItem(key, value) {
       store.set(String(key), String(value));
       window.parent.postMessage({ type: "taskboard:storage-set", payload: { key: String(key), value: String(value) } }, "*");
@@ -1027,7 +1062,7 @@
       window.parent.postMessage({ type: "taskboard:storage-clear" }, "*");
     },
   };
-  window.localStorage = storage;
+  Object.defineProperty(window, "localStorage", { configurable: true, value: storage });
   window.addEventListener("message", (event) => {
     if (event.data && event.data.type === "taskboard:storage-init") {
       store.clear();
@@ -1039,21 +1074,32 @@
 </script>`;
   }
 
-  function createTaskboardBlobUrl(origin, html) {
+  function createTaskboardBlobUrl(origin, html, embedToken) {
     const base = `<base href="${origin}/">`;
     const rewritten = String(html)
       .replace(/^<!doctype[^>]*>/i, "")
-      .replace(/<head[^>]*>/i, (match) => `${match}${base}${taskboardBlobPrelude()}`);
+      .replace(
+        /<head[^>]*>/i,
+        (match) => `${match}${base}${taskboardBlobPrelude(origin, embedToken, readTaskboardStorage())}`,
+      );
     const blobHtml = `<!doctype html>${rewritten}`;
     return URL.createObjectURL(new Blob([blobHtml], { type: "text/html" }));
+  }
+
+  function revokeTaskboardBlobUrl() {
+    if (!frameBlobUrl) return;
+    URL.revokeObjectURL(frameBlobUrl);
+    frameBlobUrl = "";
   }
 
   function loadTaskboardFrame(cacheBust = false) {
     cancelFrameReadyWaiters(new Error("任务面板正在重新加载"));
     frame?.remove();
+    revokeTaskboardBlobUrl();
     frame = null;
     frameReady = false;
     frameIsBlob = false;
+    frameTaskboardUrl = "";
     if (dragRegion) dragRegion.hidden = true;
     if (noDragLeft) noDragLeft.hidden = true;
     if (noDragRight) noDragRight.hidden = true;
@@ -1063,6 +1109,7 @@
       taskboardUrl.searchParams.set(FRAME_REFRESH_PARAM, Date.now().toString(36));
     }
     frameOrigin = taskboardUrl.origin;
+    frameTaskboardUrl = taskboardUrl.href;
     const nextFrame = document.createElement("iframe");
     nextFrame.id = FRAME_ID;
     nextFrame.hidden = true;
@@ -1070,10 +1117,17 @@
     nextFrame.referrerPolicy = "no-referrer";
     nextFrame.setAttribute("allow", "clipboard-read; clipboard-write");
     const managedHtml = window.__codexTaskboardHtml__;
-    if (typeof managedHtml === "string" && managedHtml.length > 0) {
+    const embedToken = window.__codexTaskboardEmbedToken__;
+    if (
+      typeof managedHtml === "string"
+      && managedHtml.length > 0
+      && typeof embedToken === "string"
+      && embedToken.length > 0
+    ) {
       // Codex renderers whose CSP blocks arbitrary http iframes still allow
       // blob: frames; load the managed page through a blob document instead.
-      nextFrame.src = createTaskboardBlobUrl(taskboardUrl.origin, managedHtml);
+      frameBlobUrl = createTaskboardBlobUrl(taskboardUrl.origin, managedHtml, embedToken);
+      nextFrame.src = frameBlobUrl;
       frameIsBlob = true;
     } else {
       nextFrame.src = taskboardUrl.href;
@@ -1168,7 +1222,9 @@
   function frameMatchesTaskboardUrl(taskboardUrl) {
     if (!frame) return false;
     try {
-      const loadedUrl = new URL(frame.getAttribute("src") || frame.src);
+      const loadedUrl = new URL(
+        frameIsBlob ? frameTaskboardUrl : (frame.getAttribute("src") || frame.src),
+      );
       loadedUrl.searchParams.delete(FRAME_REFRESH_PARAM);
       const expectedUrl = new URL(taskboardUrl.href);
       expectedUrl.searchParams.delete(FRAME_REFRESH_PARAM);
@@ -1358,6 +1414,7 @@
     window.removeEventListener("hashchange", onNativeRouteChange);
     window.removeEventListener("resize", scheduleRefresh);
     closeTaskboard(false);
+    revokeTaskboardBlobUrl();
     document.querySelectorAll(`[${OWNED_ATTRIBUTE}="true"]`).forEach((node) => node.remove());
     entry = null;
     page = null;
@@ -1368,6 +1425,7 @@
     status = null;
     frameOrigin = "";
     frameIsBlob = false;
+    frameTaskboardUrl = "";
     if (window[SENTINEL_KEY] === api) delete window[SENTINEL_KEY];
   }
 

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -255,11 +255,30 @@ class CdpConnection {
     });
   }
 
-  send(method, params = {}) {
+  send(method, params = {}, timeoutMs = 10_000) {
     const id = ++this.sequence;
     return new Promise((resolve, reject) => {
-      this.pending.set(id, { resolve, reject });
-      this.socket.send(JSON.stringify({ id, method, params }));
+      const timeout = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`CDP request timed out: ${method}`));
+      }, timeoutMs);
+      this.pending.set(id, {
+        resolve: (value) => {
+          clearTimeout(timeout);
+          resolve(value);
+        },
+        reject: (error) => {
+          clearTimeout(timeout);
+          reject(error);
+        },
+      });
+      try {
+        this.socket.send(JSON.stringify({ id, method, params }));
+      } catch (error) {
+        clearTimeout(timeout);
+        this.pending.delete(id);
+        reject(error);
+      }
     });
   }
 
@@ -295,6 +314,7 @@ class CdpConnection {
   }
 
   close() {
+    this.closed = true;
     this.socket.close();
   }
 }
@@ -1036,6 +1056,21 @@ async function registerInjectionSource(cdp, source) {
   return registration.identifier;
 }
 
+async function publishTaskboardHtml(cdp) {
+  try {
+    const response = await fetch(`${taskboardOrigin}/?host=codex`);
+    if (!response.ok) return;
+    const html = await response.text();
+    await cdp.send("Runtime.evaluate", {
+      expression: `window.__codexTaskboardHtml__ = ${JSON.stringify(html)}`,
+      returnByValue: true,
+    });
+  } catch (_) {
+    // The panel falls back to a direct http iframe when the managed HTML is
+    // unavailable (older Codex builds without the CSP restriction).
+  }
+}
+
 async function injectTarget(
   target,
   source,
@@ -1055,6 +1090,7 @@ async function injectTarget(
     await cdp.send("Page.setBypassCSP", { enabled: true });
     await cdp.send("Runtime.enable");
     if (keepAlive) await installTaskboardHostBinding(cdp, supervisor);
+    if (keepAlive) await publishTaskboardHtml(cdp);
     if (keepAlive && attachExisting) {
       const currentStatus = await readInjectionStatus(cdp);
       const reconciled = await reconcileInjectionRuntime({
@@ -1101,6 +1137,7 @@ async function injectTarget(
     await reloaded;
     await evaluateInjectionSource(cdp, source);
     await publishInjectionScriptIdentifier(cdp, scriptIdentifier);
+    if (keepAlive) await publishTaskboardHtml(cdp);
     if (keepAlive) await publishHostHeartbeat(cdp, startupToken);
     if (shouldOpen) {
       await cdp.send("Runtime.evaluate", {
@@ -1264,18 +1301,27 @@ async function main() {
 
     const { source, sourceHash } = await currentInjectionSource();
     const injectedTargets = new Map();
-    const firstResults = await injectAll(
-      options.port,
-      source,
-      sourceHash,
-      options.open,
-      options.screenshot,
-      injectedTargets,
-      options.watch,
-      supervisor,
-      options.attachExisting,
-      options.startupToken,
-    );
+    let firstResults = [];
+    try {
+      firstResults = await injectAll(
+        options.port,
+        source,
+        sourceHash,
+        options.open,
+        options.screenshot,
+        injectedTargets,
+        options.watch,
+        supervisor,
+        options.attachExisting,
+        options.startupToken,
+      );
+    } catch (error) {
+      if (!options.watch) throw error;
+      // In watch mode the renderer may appear a few seconds after CDP starts
+      // listening (fresh app launch); keep the loop running and retry there
+      // instead of exiting into a zombie resident process.
+      console.error(`Waiting for Codex renderer: ${error.message}`);
+    }
     console.log(JSON.stringify({ injected: firstResults }, null, 2));
 
     if (!options.watch) {
@@ -1298,10 +1344,14 @@ async function main() {
       } catch (error) {
         console.error(`Waiting for Taskboard service: ${error.message}`);
       }
-      for (const connection of injectedTargets.values()) {
+      for (const [id, connection] of injectedTargets) {
         try {
           await publishHostHeartbeat(connection, options.startupToken);
-        } catch (_) {}
+        } catch (error) {
+          console.error(`Taskboard host heartbeat failed for ${id}: ${error.message}`);
+          connection.close();
+          injectedTargets.delete(id);
+        }
       }
       try {
         const results = await injectAll(

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -27,6 +27,8 @@ const automationPoliciesPath = path.join(projectRoot, ".data", "codex-automation
 const taskboardOrigin = `http://127.0.0.1:${resolvePort()}`;
 const taskboardHealthUrl = `${taskboardOrigin}/health`;
 const taskboardPageUrl = `${taskboardOrigin}/?host=codex`;
+const taskboardEmbedToken = randomUUID();
+const taskboardEmbedTokenHeader = "x-codex-taskboard-embed-token";
 const hostBindingName = "__codexTaskboardHostV1";
 const hostHeartbeatName = "__codexTaskboardHostHeartbeatV1";
 const hostStartupTokenName = "__codexTaskboardHostStartupTokenV1";
@@ -1058,14 +1060,23 @@ async function registerInjectionSource(cdp, source) {
 
 async function publishTaskboardHtml(cdp) {
   try {
+    const registration = await fetch(`${taskboardOrigin}/api/local/embed-token`, {
+      method: "POST",
+      headers: { [taskboardEmbedTokenHeader]: taskboardEmbedToken },
+    });
+    if (!registration.ok) {
+      throw new Error(`embed token registration returned ${registration.status}`);
+    }
     const response = await fetch(`${taskboardOrigin}/?host=codex`);
-    if (!response.ok) return;
+    if (!response.ok) throw new Error(`taskboard HTML returned ${response.status}`);
     const html = await response.text();
     await cdp.send("Runtime.evaluate", {
-      expression: `window.__codexTaskboardHtml__ = ${JSON.stringify(html)}`,
+      expression: `window.__codexTaskboardHtml__ = ${JSON.stringify(html)};
+window.__codexTaskboardEmbedToken__ = ${JSON.stringify(taskboardEmbedToken)};`,
       returnByValue: true,
     });
-  } catch (_) {
+  } catch (error) {
+    console.error(`Unable to publish managed Taskboard HTML: ${error.message}`);
     // The panel falls back to a direct http iframe when the managed HTML is
     // unavailable (older Codex builds without the CSP restriction).
   }
@@ -1354,6 +1365,8 @@ async function main() {
         }
       }
       try {
+        // The initial install may reload once; later renderer recovery always
+        // reconciles in place so a lost heartbeat cannot reload the Codex UI.
         const results = await injectAll(
           options.port,
           source,
@@ -1363,7 +1376,7 @@ async function main() {
           injectedTargets,
           true,
           supervisor,
-          options.attachExisting,
+          true,
           options.startupToken,
         );
         if (results.length > 0) console.log(JSON.stringify({ injected: results }, null, 2));

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -42,9 +42,20 @@ const INLINE_ATTACHMENT_TYPES = new Set([
   "text/plain",
 ]);
 const PROJECT_ID_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
-// "null" is the serialized origin of blob:-document iframes, which the Codex
-// renderer uses to embed the taskboard since its CSP blocks direct http iframes.
-const TRUSTED_EMBED_ORIGINS = new Set(["app://-", "null"]);
+const TRUSTED_EMBED_ORIGINS = new Set(["app://-"]);
+const EMBED_TOKEN_HEADER = "x-codex-taskboard-embed-token";
+const EMBED_TOKEN_QUERY = "__codex_taskboard_embed_token";
+const CORS_ALLOWED_HEADERS = [
+  "content-type",
+  "x-request-id",
+  "x-codex-request-id",
+  "x-taskboard-user-id",
+  "x-taskboard-user-name",
+  "x-taskboard-user-avatar",
+  "x-taskboard-filename",
+  "x-taskboard-client",
+  EMBED_TOKEN_HEADER,
+];
 const CODEX_AGENT_ACTOR = {
   type: "agent",
   id: "codex-agent",
@@ -83,7 +94,7 @@ function sendEmpty(response, status, headers = {}) {
   response.end();
 }
 
-function toFetchRequest(request) {
+function toFetchRequest(request, requestUrl = request.url) {
   const headers = new Headers();
   for (const [name, value] of Object.entries(request.headers)) {
     if (Array.isArray(value)) {
@@ -97,7 +108,7 @@ function toFetchRequest(request) {
     init.body = Readable.toWeb(request);
     init.duplex = "half";
   }
-  return new Request(`http://127.0.0.1${request.url}`, init);
+  return new Request(`http://127.0.0.1${requestUrl}`, init);
 }
 
 async function sendFetchResponse(response, upstream) {
@@ -152,7 +163,7 @@ function isTrustedNetworkHost(hostname) {
   return false;
 }
 
-function assertTrustedNetworkRequest(request) {
+function assertTrustedNetworkRequest(request, { allowOpaqueOrigin = false } = {}) {
   let host;
   try {
     host = new URL(`http://${request.headers.host ?? ""}`).hostname;
@@ -165,6 +176,7 @@ function assertTrustedNetworkRequest(request) {
 
   const origin = request.headers.origin;
   if (!origin) return;
+  if (origin === "null" && allowOpaqueOrigin) return;
   if (TRUSTED_EMBED_ORIGINS.has(origin)) return;
   let originHost;
   try {
@@ -174,6 +186,24 @@ function assertTrustedNetworkRequest(request) {
   }
   if (!isTrustedNetworkHost(originHost)) {
     throw new ApiError(403, "INVALID_ORIGIN", "Request Origin must be local or private");
+  }
+}
+
+function setCorsOrigin(request, response) {
+  const origin = request.headers.origin;
+  if (!origin) return;
+  response.setHeader("access-control-allow-origin", origin);
+  response.setHeader("vary", "origin");
+}
+
+function assertAllowedCorsHeaders(request) {
+  const requested = String(request.headers["access-control-request-headers"] ?? "")
+    .split(",")
+    .map((header) => header.trim().toLowerCase())
+    .filter(Boolean);
+  const allowed = new Set(CORS_ALLOWED_HEADERS);
+  if (requested.some((header) => !allowed.has(header))) {
+    throw new ApiError(403, "INVALID_CORS_HEADERS", "CORS request headers are not allowed");
   }
 }
 
@@ -1335,26 +1365,56 @@ export function createTaskboardServer(options = {}) {
     manageTaskboardSkillPath: resolved.skillPath,
   });
   const aiEventResponses = new Set();
+  let taskboardEmbedToken = null;
 
   const server = createServer(async (request, response) => {
     response.setHeader("x-content-type-options", "nosniff");
     response.setHeader("referrer-policy", "no-referrer");
-    response.setHeader("access-control-allow-origin", "*");
-    if (request.method === "OPTIONS") {
-      const requestedHeaders = request.headers["access-control-request-headers"];
-      response.writeHead(204, {
-        "access-control-allow-methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
-        "access-control-allow-headers": requestedHeaders
-          || "content-type, x-request-id, x-codex-request-id, x-taskboard-user-id, x-taskboard-user-name, x-taskboard-user-avatar",
-        "access-control-max-age": "600",
-      });
-      response.end();
-      return;
-    }
     try {
-      assertTrustedNetworkRequest(request);
       const url = new URL(request.url, "http://127.0.0.1");
       const pathname = url.pathname;
+
+      if (request.method === "OPTIONS") {
+        assertTrustedNetworkRequest(request, { allowOpaqueOrigin: true });
+        assertAllowedCorsHeaders(request);
+        setCorsOrigin(request, response);
+        return sendEmpty(response, 204, {
+          "access-control-allow-methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+          "access-control-allow-headers": CORS_ALLOWED_HEADERS.join(", "),
+          "access-control-max-age": "600",
+        });
+      }
+
+      if (pathname === "/api/local/embed-token") {
+        assertTrustedNetworkRequest(request);
+        assertLoopbackRequest(request);
+        if (request.method !== "POST") return methodNotAllowed(response, ["POST"]);
+        if (request.headers.origin) {
+          throw new ApiError(403, "INVALID_ORIGIN", "Embed tokens can only be registered by the local injector");
+        }
+        const token = request.headers[EMBED_TOKEN_HEADER];
+        if (typeof token !== "string" || !/^[a-f0-9-]{36}$/.test(token)) {
+          throw new ApiError(400, "INVALID_EMBED_TOKEN", "Embed token is invalid");
+        }
+        taskboardEmbedToken = token;
+        return sendEmpty(response, 204);
+      }
+
+      const opaqueOrigin = request.headers.origin === "null";
+      const headerToken = request.headers[EMBED_TOKEN_HEADER];
+      const queryToken = request.method === "GET" ? url.searchParams.get(EMBED_TOKEN_QUERY) : null;
+      const hasEmbedToken = opaqueOrigin
+        && taskboardEmbedToken !== null
+        && (headerToken === taskboardEmbedToken || queryToken === taskboardEmbedToken);
+      if (opaqueOrigin && pathname.startsWith("/api/") && !hasEmbedToken) {
+        throw new ApiError(403, "EMBED_TOKEN_REQUIRED", "Opaque embedded API requests require a valid token");
+      }
+      assertTrustedNetworkRequest(request, {
+        allowOpaqueOrigin: opaqueOrigin && (!pathname.startsWith("/api/") || hasEmbedToken),
+      });
+      if (hasEmbedToken) url.searchParams.delete(EMBED_TOKEN_QUERY);
+      setCorsOrigin(request, response);
+
       const isLocalAiRoute = pathname === "/api/local/ai" || pathname.startsWith("/api/local/ai/");
       if (isLocalAiRoute) {
         assertAiLoopbackRequest(request);
@@ -1594,7 +1654,7 @@ export function createTaskboardServer(options = {}) {
           if (!isLocalCompanionRoute(pathname)) {
             return sendFetchResponse(
               response,
-              await cloudProxy.forward(toFetchRequest(request)),
+              await cloudProxy.forward(toFetchRequest(request, `${url.pathname}${url.search}`)),
             );
           }
         }

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -42,7 +42,9 @@ const INLINE_ATTACHMENT_TYPES = new Set([
   "text/plain",
 ]);
 const PROJECT_ID_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
-const TRUSTED_EMBED_ORIGINS = new Set(["app://-"]);
+// "null" is the serialized origin of blob:-document iframes, which the Codex
+// renderer uses to embed the taskboard since its CSP blocks direct http iframes.
+const TRUSTED_EMBED_ORIGINS = new Set(["app://-", "null"]);
 const CODEX_AGENT_ACTOR = {
   type: "agent",
   id: "codex-agent",
@@ -1337,6 +1339,18 @@ export function createTaskboardServer(options = {}) {
   const server = createServer(async (request, response) => {
     response.setHeader("x-content-type-options", "nosniff");
     response.setHeader("referrer-policy", "no-referrer");
+    response.setHeader("access-control-allow-origin", "*");
+    if (request.method === "OPTIONS") {
+      const requestedHeaders = request.headers["access-control-request-headers"];
+      response.writeHead(204, {
+        "access-control-allow-methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+        "access-control-allow-headers": requestedHeaders
+          || "content-type, x-request-id, x-codex-request-id, x-taskboard-user-id, x-taskboard-user-name, x-taskboard-user-avatar",
+        "access-control-max-age": "600",
+      });
+      response.end();
+      return;
+    }
     try {
       assertTrustedNetworkRequest(request);
       const url = new URL(request.url, "http://127.0.0.1");

--- a/test/board-interactions.test.mjs
+++ b/test/board-interactions.test.mjs
@@ -107,6 +107,10 @@ test("review, blocked and canceled statuses round-trip through filter URLs", () 
   assert.match(filterSource, /filters\.statuses\.join\(","\)/);
   assert.match(filterSource, /\.split\(","\)\.filter\(isTaskStatus\)/);
   assert.match(filterSource, /TASK_STATUSES\.includes\(value as TaskStatus\)/);
+  assert.match(filterSource, /new URLSearchParams\(currentTaskboardRouteSearch\(\)\)/);
+  assert.match(filterSource, /const url = currentTaskboardRouteUrl\(\)/);
+  assert.match(filterSource, /replaceTaskboardRoute\(url\)/);
+  assert.doesNotMatch(filterSource, /window\.history\.replaceState/);
 });
 
 test("the column surface wraps its heading and issue list", () => {

--- a/test/inject.test.mjs
+++ b/test/inject.test.mjs
@@ -146,14 +146,16 @@ test("reopening reuses a ready cache-busted iframe without showing the startup p
   assert.doesNotMatch(prepareSource, /async function prepareTaskboard\(generation\) \{\s*showLoading\(\);/);
 });
 
-test("iframe messages require both the exact origin and source window", () => {
+test("iframe messages require the source window and the matching direct or blob origin", () => {
   assert.match(
     source,
-    /event\.source !== frame\.contentWindow \|\| event\.origin !== frameOrigin/,
+    /if \(!frame \|\| event\.source !== frame\.contentWindow\) return;/,
   );
+  assert.match(source, /if \(frameIsBlob\) \{\s*if \(event\.origin !== "null"/);
+  assert.match(source, /else if \(event\.origin !== frameOrigin\)/);
   assert.match(source, /message\.type === "taskboard:open-thread"/);
   assert.match(source, /message\.type === "taskboard:create-thread"/);
-  assert.match(source, /postMessage\(message, frameOrigin\)/);
+  assert.match(source, /postMessage\(message, frameIsBlob \? "\*" : frameOrigin\)/);
 });
 
 test("the iframe automation contract is forwarded through the fixed host binding", () => {
@@ -306,11 +308,18 @@ test("cleanup removes observers, listeners, timers and owned DOM", () => {
 });
 
 test("host integration stays thin", () => {
+  const hostSource = source.replace(
+    source.slice(
+      source.indexOf("function taskboardBlobPrelude"),
+      source.indexOf("function createTaskboardBlobUrl"),
+    ),
+    "",
+  );
   assert.match(source, /new MutationObserver\(scheduleRefresh\)/);
   assert.match(source, /type: "taskboard:host-context"/);
   assert.match(source, /type: "taskboard:theme"/);
   assert.match(source, /type: "navigate-to-route"/);
   assert.doesNotMatch(source, /__codexSessionDeleteBridge/);
   assert.doesNotMatch(source, /import\s*\(/);
-  assert.doesNotMatch(source, /window\.fetch\s*=/);
+  assert.doesNotMatch(hostSource, /window\.fetch\s*=/);
 });

--- a/test/issue-detail-route.test.mjs
+++ b/test/issue-detail-route.test.mjs
@@ -39,7 +39,7 @@ test("closing issue detail removes only the issue route", () => {
 test("the app restores issue detail from the URL and follows browser history", () => {
   assert.match(
     appSource,
-    /useState<string \| null>\(\s*\(\) => readIssueIdentifier\(window\.location\.search\),?\s*\)/,
+    /useState<string \| null>\(\s*\(\) => readIssueIdentifier\(currentTaskboardRouteSearch\(\)\),?\s*\)/,
   );
   assert.match(appSource, /task\.identifier === detailTaskIdentifier/);
   assert.match(appSource, /window\.addEventListener\("popstate", syncRouteFromLocation\)/);
@@ -48,9 +48,17 @@ test("the app restores issue detail from the URL and follows browser history", (
     appSource.indexOf("function openTaskDetail"),
     appSource.indexOf("function closeTaskDetail"),
   );
-  assert.match(openTaskSource, /buildIssueUrl\(window\.location\.href, task\.projectId, null\)/);
-  assert.match(openTaskSource, /window\.history\.replaceState/);
-  assert.match(openTaskSource, /window\.history\.pushState/);
-  assert.match(appSource, /function closeTaskDetail\(\)[\s\S]*?window\.history\.replaceState/);
+  assert.match(openTaskSource, /const currentRoute = currentTaskboardRouteUrl\(\)/);
+  assert.match(openTaskSource, /buildIssueUrl\(currentRoute\.href, task\.projectId, null\)/);
+  assert.match(openTaskSource, /replaceTaskboardRoute\(boardUrl\)/);
+  assert.match(openTaskSource, /pushTaskboardRoute\(detailUrl\)/);
+  assert.match(appSource, /function closeTaskDetail\(\)[\s\S]*?replaceTaskboardRoute\(url\)/);
+  const changeProjectSource = appSource.slice(
+    appSource.indexOf("function changeProject"),
+    appSource.indexOf("function returnToProjectHome"),
+  );
+  assert.match(changeProjectSource, /buildIssueUrl\(currentTaskboardRouteUrl\(\)\.href, projectId, null\)/);
+  assert.match(changeProjectSource, /replaceTaskboardRoute\(url\)/);
+  assert.doesNotMatch(changeProjectSource, /window\.history\.replaceState/);
   assert.match(appSource, /onEdit=\{openTaskDetail\}/);
 });

--- a/test/server.test.mjs
+++ b/test/server.test.mjs
@@ -1053,6 +1053,27 @@ test("accepts private LAN requests and rejects public Host and Origin headers", 
   });
   assert.equal(originResult.response.status, 403);
   assert.equal(originResult.body.error.code, "INVALID_ORIGIN");
+
+  const opaqueApiResult = await request(baseUrl, "/api/projects", {
+    headers: { origin: "null" },
+  });
+  assert.equal(opaqueApiResult.response.status, 403);
+  assert.equal(opaqueApiResult.body.error.code, "EMBED_TOKEN_REQUIRED");
+
+  const embedToken = "12345678-1234-1234-1234-123456789abc";
+  const registration = await request(baseUrl, "/api/local/embed-token", {
+    method: "POST",
+    headers: { "x-codex-taskboard-embed-token": embedToken },
+  });
+  assert.equal(registration.response.status, 204);
+  const embeddedApiResult = await request(baseUrl, "/api/projects", {
+    headers: {
+      origin: "null",
+      "x-codex-taskboard-embed-token": embedToken,
+    },
+  });
+  assert.equal(embeddedApiResult.response.status, 200);
+  assert.equal(embeddedApiResult.response.headers.get("access-control-allow-origin"), "null");
 });
 
 test("project and task CRUD flow", async () => {

--- a/test/taskboard-route.test.mjs
+++ b/test/taskboard-route.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { buildIssueUrl } from "../web/src/issueRoute.ts";
+import {
+  buildTaskboardHistoryUpdate,
+  resolveTaskboardRouteUrl,
+} from "../web/src/taskboardRoute.ts";
+
+const BLOB_URL = "blob:app://-/702e061f-ea75-4125-8298-d3299605b1ea";
+const PROJECT_ID = "e70fb922-5c6b-4d70-8ff6-d793b0c76c94";
+
+test("blob taskboard routes keep the physical URL unchanged", () => {
+  const currentRoute = resolveTaskboardRouteUrl(
+    BLOB_URL,
+    null,
+    "http://127.0.0.1:47823/",
+  );
+  const projectRoute = buildIssueUrl(currentRoute.href, PROJECT_ID, null);
+  const update = buildTaskboardHistoryUpdate(BLOB_URL, null, projectRoute);
+
+  assert.equal(update.url, null);
+  assert.equal(
+    resolveTaskboardRouteUrl(BLOB_URL, update.state, "http://127.0.0.1:47823/").search,
+    `?project=${PROJECT_ID}`,
+  );
+});
+
+test("blob taskboard route updates preserve existing history state", () => {
+  const route = new URL(`http://127.0.0.1:47823/?project=${PROJECT_ID}&issue=LOCAL-72`);
+  const update = buildTaskboardHistoryUpdate(BLOB_URL, { codex: "state" }, route);
+
+  assert.equal(update.url, null);
+  assert.equal(update.state.codex, "state");
+  assert.equal(
+    resolveTaskboardRouteUrl(BLOB_URL, update.state, "http://127.0.0.1:47823/").href,
+    route.href,
+  );
+});
+
+test("http taskboard routes still write the requested URL", () => {
+  const current = "http://127.0.0.1:47823/?host=codex";
+  const route = buildIssueUrl(current, PROJECT_ID, "LOCAL-72");
+  const state = { codex: "state" };
+  const update = buildTaskboardHistoryUpdate(current, state, route);
+
+  assert.equal(update.state, state);
+  assert.equal(update.url?.href, route.href);
+  assert.equal(resolveTaskboardRouteUrl(current, state, current).href, current);
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -531,6 +531,7 @@ function LocalRealtimeSync({
 export function App() {
   const query = useMemo(() => new URLSearchParams(window.location.search), []);
   const embedded = query.get("host") === "codex";
+  const taskboardOrigin = query.get("taskboard-origin") ?? window.location.origin;
   const undoShortcut = navigator.userAgent.includes("Macintosh") ? "⌘Z" : "Ctrl+Z";
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
   const [hostContext, setHostContext] = useState<HostContext | null>(null);
@@ -618,7 +619,7 @@ export function App() {
     if (!embedded || window.parent === window) {
       return { unavailableReason: "仅可在 Codex App 中使用" };
     }
-    if (!isLocalTaskboardOrigin(window.location.origin)) {
+    if (!isLocalTaskboardOrigin(taskboardOrigin)) {
       return { unavailableReason: "仅本地任务面板可用" };
     }
     if (!selectedProject) return { unavailableReason: "请先选择项目" };
@@ -652,6 +653,7 @@ export function App() {
     hostContext,
     manageTaskboardSkillPath,
     selectedProject,
+    taskboardOrigin,
   ]);
   const detailTask = detailTaskIdentifier
     ? tasks.find((task) => task.identifier === detailTaskIdentifier) ?? null

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -59,6 +59,12 @@ import { TaskFilterMenu } from "./components/TaskFilterMenu";
 import { buildIssueUrl, readIssueIdentifier } from "./issueRoute";
 import { DEFAULT_LABELS } from "./labels";
 import {
+  currentTaskboardRouteSearch,
+  currentTaskboardRouteUrl,
+  pushTaskboardRoute,
+  replaceTaskboardRoute,
+} from "./taskboardRoute";
+import {
   EMPTY_TASK_FILTERS,
   matchesTaskFilters,
   matchesTaskSearch,
@@ -556,7 +562,7 @@ export function App() {
   const [boardView, setBoardView] = useState<BoardView>("issues");
   const [editor, setEditor] = useState<EditorState | null>(null);
   const [detailTaskIdentifier, setDetailTaskIdentifier] = useState<string | null>(
-    () => readIssueIdentifier(window.location.search),
+    () => readIssueIdentifier(currentTaskboardRouteSearch()),
   );
   const [commentsRevision, setCommentsRevision] = useState(0);
   const [attachmentsRevision, setAttachmentsRevision] = useState(0);
@@ -918,28 +924,29 @@ export function App() {
     closeContextMenu();
     setProjectMenuOpen(false);
     setDetailTaskIdentifier(task.identifier);
-    const currentIssue = readIssueIdentifier(window.location.search);
-    const boardUrl = buildIssueUrl(window.location.href, task.projectId, null);
+    const currentRoute = currentTaskboardRouteUrl();
+    const currentIssue = readIssueIdentifier(currentRoute.search);
+    const boardUrl = buildIssueUrl(currentRoute.href, task.projectId, null);
     if (!currentIssue) {
-      window.history.replaceState(window.history.state, "", boardUrl);
+      replaceTaskboardRoute(boardUrl);
     }
     const detailUrl = buildIssueUrl(
-      currentIssue ? window.location.href : boardUrl.href,
+      currentIssue ? currentRoute.href : boardUrl.href,
       task.projectId,
       task.identifier,
     );
-    window.history.pushState(window.history.state, "", detailUrl);
+    pushTaskboardRoute(detailUrl);
   }
 
   function closeTaskDetail() {
     setDetailTaskIdentifier(null);
-    const url = buildIssueUrl(window.location.href, selectedProjectId || null, null);
-    window.history.replaceState(window.history.state, "", url);
+    const url = buildIssueUrl(currentTaskboardRouteUrl().href, selectedProjectId || null, null);
+    replaceTaskboardRoute(url);
   }
 
   useEffect(() => {
     function syncRouteFromLocation() {
-      const url = new URL(window.location.href);
+      const url = currentTaskboardRouteUrl();
       const routeProjectId = url.searchParams.get("project") ?? "";
       setDetailTaskIdentifier(readIssueIdentifier(url.search));
       if (routeProjectId === selectedProjectId) return;
@@ -1096,7 +1103,7 @@ export function App() {
       });
       setProjects(nextProjects);
       setSelectedProjectId((current) => {
-        const fromQuery = new URLSearchParams(window.location.search).get("project");
+        const fromQuery = new URLSearchParams(currentTaskboardRouteSearch()).get("project");
         const remembered = window.localStorage.getItem(LAST_PROJECT_KEY);
         if (fromQuery && nextProjects.some((project) => project.id === fromQuery)) return fromQuery;
         if (current && nextProjects.some((project) => project.id === current)) return current;
@@ -1744,8 +1751,8 @@ export function App() {
     setActionError(null);
     undoStackRef.current = [];
     setUndoNotice(null);
-    const url = buildIssueUrl(window.location.href, projectId, null);
-    window.history.replaceState(null, "", url);
+    const url = buildIssueUrl(currentTaskboardRouteUrl().href, projectId, null);
+    replaceTaskboardRoute(url);
   }
 
   function returnToProjectHome() {
@@ -1759,8 +1766,8 @@ export function App() {
     setActionError(null);
     undoStackRef.current = [];
     setUndoNotice(null);
-    const url = buildIssueUrl(window.location.href, null, null);
-    window.history.replaceState(null, "", url);
+    const url = buildIssueUrl(currentTaskboardRouteUrl().href, null, null);
+    replaceTaskboardRoute(url);
     void loadProjectList();
   }
 

--- a/web/src/taskFilters.ts
+++ b/web/src/taskFilters.ts
@@ -5,6 +5,11 @@ import {
   type TaskPriority,
   type TaskStatus,
 } from "./types";
+import {
+  currentTaskboardRouteSearch,
+  currentTaskboardRouteUrl,
+  replaceTaskboardRoute,
+} from "./taskboardRoute";
 
 export type TaskLinkFilter = "all" | "linked" | "unlinked";
 export type TaskFilterKey = "statuses" | "priorities" | "labels" | "link" | "content";
@@ -34,7 +39,7 @@ function isTaskPriority(value: string): value is TaskPriority {
 }
 
 export function readTaskFilters(): TaskFilters {
-  const params = new URLSearchParams(window.location.search);
+  const params = new URLSearchParams(currentTaskboardRouteSearch());
   const statuses = (params.get("status") ?? "").split(",").filter(isTaskStatus);
   const priorities = (params.get("priority") ?? "").split(",").filter(isTaskPriority);
   const linkValue = params.get("linked");
@@ -49,7 +54,7 @@ export function readTaskFilters(): TaskFilters {
 }
 
 export function writeTaskFilters(filters: TaskFilters) {
-  const url = new URL(window.location.href);
+  const url = currentTaskboardRouteUrl();
 
   if (filters.statuses.length) url.searchParams.set("status", filters.statuses.join(","));
   else url.searchParams.delete("status");
@@ -67,7 +72,7 @@ export function writeTaskFilters(filters: TaskFilters) {
   if (filters.content.trim()) url.searchParams.set("content", filters.content.trim());
   else url.searchParams.delete("content");
 
-  window.history.replaceState(null, "", url);
+  replaceTaskboardRoute(url);
 }
 
 export function taskFilterCount(filters: TaskFilters): number {

--- a/web/src/taskboardRoute.ts
+++ b/web/src/taskboardRoute.ts
@@ -1,0 +1,75 @@
+const ROUTE_SEARCH_STATE_KEY = "__codexTaskboardRouteSearch__";
+
+type TaskboardHistoryUpdate = {
+  state: unknown;
+  url: URL | null;
+};
+
+function routeSearchFromState(state: unknown): string {
+  if (!state || typeof state !== "object") return "";
+  const search = (state as Record<string, unknown>)[ROUTE_SEARCH_STATE_KEY];
+  return typeof search === "string" ? search : "";
+}
+
+export function resolveTaskboardRouteUrl(
+  physicalHref: string,
+  historyState: unknown,
+  baseHref: string,
+): URL {
+  const physicalUrl = new URL(physicalHref);
+  if (physicalUrl.protocol !== "blob:") return physicalUrl;
+
+  const routeUrl = new URL(baseHref);
+  routeUrl.search = routeSearchFromState(historyState);
+  return routeUrl;
+}
+
+export function buildTaskboardHistoryUpdate(
+  physicalHref: string,
+  historyState: unknown,
+  routeUrl: URL,
+): TaskboardHistoryUpdate {
+  if (new URL(physicalHref).protocol !== "blob:") {
+    return { state: historyState, url: routeUrl };
+  }
+
+  const currentState = historyState && typeof historyState === "object"
+    ? historyState as Record<string, unknown>
+    : {};
+  return {
+    state: { ...currentState, [ROUTE_SEARCH_STATE_KEY]: routeUrl.search },
+    // Chromium rejects query changes on blob document URLs. Keep that physical
+    // URL untouched and store only the logical Taskboard route in history.state.
+    url: null,
+  };
+}
+
+export function currentTaskboardRouteUrl(): URL {
+  return resolveTaskboardRouteUrl(
+    window.location.href,
+    window.history.state,
+    document.baseURI,
+  );
+}
+
+export function currentTaskboardRouteSearch(): string {
+  return currentTaskboardRouteUrl().search;
+}
+
+function writeTaskboardRoute(method: "pushState" | "replaceState", routeUrl: URL): void {
+  const update = buildTaskboardHistoryUpdate(
+    window.location.href,
+    window.history.state,
+    routeUrl,
+  );
+  if (update.url) window.history[method](update.state, "", update.url);
+  else window.history[method](update.state, "");
+}
+
+export function pushTaskboardRoute(routeUrl: URL): void {
+  writeTaskboardRoute("pushState", routeUrl);
+}
+
+export function replaceTaskboardRoute(routeUrl: URL): void {
+  writeTaskboardRoute("replaceState", routeUrl);
+}


### PR DESCRIPTION
## Summary

- carries forward the two commits from #25 for Codex 151 CSP-compatible blob embedding and resident injector recovery
- requires an injector-registered token for opaque-origin API requests instead of trusting every Origin: null page
- installs the storage, fetch, and EventSource bridges before the React app boots
- preserves the effective local origin for automation checks and reuses/revokes blob frames correctly
- reconciles recovered renderers in place so heartbeat recovery does not reload the Codex UI

This supersedes #25 after addressing the review blockers found while validating it locally. Closes #13.

## Verification

- npm run typecheck
- npm run build:web
- targeted injection and injector tests (5/5)
- network-origin and embed-token server test
- browser render and taskctl project list smoke checks

Review requested from @chuspeeism. Cc @Howard-Jerry for the original #25 implementation.