### PR TITLE
Fix dark theme view tab labels

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -951,7 +951,7 @@ kbd {
   border-radius: 16px;
   outline: 0;
   background: transparent;
-  color: #1b1b1b;
+  color: var(--text-secondary);
   filter: drop-shadow(0 3px 3px rgba(0, 0, 0, .02)) drop-shadow(0 1px .5px rgba(0, 0, 0, .04));
   font: inherit;
   font-size: 10px;
@@ -8854,7 +8854,7 @@ kbd {
   border: .5px solid transparent;
   border-radius: 16px;
   background: transparent;
-  color: #1b1b1b;
+  color: var(--text-secondary);
   font-size: 10px;
   font-weight: 500;
   line-height: 15px;


### PR DESCRIPTION
## Summary

Fixes #38.

Updates the default text color for the top view tabs so inactive labels remain readable in the dark Codex theme without requiring hover.

## Root Cause

The inactive `.view-tab` label color was hard-coded to `#1b1b1b`, which has very low contrast against the dark theme background.

## Changes

- Use `var(--text-secondary)` for inactive top view tab labels.
- Apply the same color fix to both regular and embedded layout tab styles.
- Keep the active tab styling unchanged.

## Validation

- `git diff --check -- web/src/styles.css`
- Previously verified `npm run build:web` with Node 22.22.2; build passed with the existing Vite chunk-size warning.

## Notes

The local worktree still has an unrelated, pre-existing `package-lock.json` modification. It is not included in this PR.