### PR TITLE
Pause auto-claim when no Todo remains

### DIFF
--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -12,6 +12,7 @@ import { withoutTaskboardLauncherEnvironment } from "../shared/codex-environment
 import {
   parseTaskboardAutomationHostRequest,
   reconcileTaskboardAutomation,
+  taskboardAutomationPolicyOperation,
 } from "../shared/taskboard-automation.mjs";
 import {
   findResidentInjectorPids,
@@ -794,21 +795,40 @@ async function requestCodexAutomationViaCdp(cdp, executionContextId, method, par
   }
 }
 
-async function applyTaskboardAutomationPolicy(request, rpc, stillCurrent = () => true) {
+async function applyTaskboardAutomationPolicy(
+  request,
+  rpc,
+  stillCurrent = () => true,
+  { explicit = false, previousQuotaState } = {},
+) {
   const quota = request.quotaAware
     ? await readCodexQuotaStatus(request.model)
     : null;
   if (!stillCurrent()) return { quota, stale: true };
-  const shouldRun = request.enabledByUser
-    && (!request.quotaAware || quota?.state === "available");
-  const result = await reconcileTaskboardAutomation(
-    { ...request, operation: shouldRun ? "ensure-active" : "pause" },
-    rpc,
-  );
-  if (result?.error === "not-found") {
-    return { ...(quota ? { quota } : {}) };
+  let listed = null;
+  let currentItem;
+  if (!explicit && request.enabledByUser) {
+    listed = await reconcileTaskboardAutomation({ ...request, operation: "list" }, rpc);
+    const items = Array.isArray(listed.items) ? listed.items : [];
+    currentItem = (
+      request.automationId
+        ? items.find((item) => item.id === request.automationId)
+        : null
+    ) ?? items[0];
   }
-  return { ...result, ...(quota ? { quota } : {}) };
+  const operation = taskboardAutomationPolicyOperation(request, {
+    explicit,
+    previousQuotaState,
+    quotaState: quota?.state,
+    currentStatus: currentItem?.status,
+  });
+  const result = operation === "list"
+    ? { item: currentItem, items: listed.items }
+    : await reconcileTaskboardAutomation({ ...request, operation }, rpc);
+  if (result?.error === "not-found") {
+    return { operation, ...(quota ? { quota } : {}) };
+  }
+  return { ...result, operation, ...(quota ? { quota } : {}) };
 }
 
 function storedAutomationPolicy(request) {
@@ -828,13 +848,16 @@ function storedAutomationPolicy(request) {
 }
 
 function restoredAutomationPolicy(value) {
-  return parseTaskboardAutomationHostRequest({
-    ...value,
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const { quota, ...stored } = value;
+  const request = parseTaskboardAutomationHostRequest({
+    ...stored,
     id: "restored-policy",
     action: "automation",
     requestId: "restored-policy",
     operation: "apply-policy",
   });
+  return request ? { request, ...(quota ? { quota } : {}) } : null;
 }
 
 async function ensureQuotaPoliciesLoaded() {
@@ -848,9 +871,12 @@ async function ensureQuotaPoliciesLoaded() {
     }
     if (!stored || typeof stored !== "object" || Array.isArray(stored)) return;
     for (const value of Object.values(stored)) {
-      const request = restoredAutomationPolicy(value);
-      if (!request) continue;
-      quotaPolicyRecords.set(request.taskboardProjectId, { version: 1, request });
+      const restored = restoredAutomationPolicy(value);
+      if (!restored) continue;
+      quotaPolicyRecords.set(restored.request.taskboardProjectId, {
+        version: 1,
+        ...restored,
+      });
     }
   })();
   return quotaPoliciesLoadPromise;
@@ -860,7 +886,10 @@ function persistQuotaPolicies() {
   const data = Object.fromEntries(
     [...quotaPolicyRecords.entries()].map(([projectId, record]) => [
       projectId,
-      storedAutomationPolicy(record.request),
+      {
+        ...storedAutomationPolicy(record.request),
+        ...(record.quota ? { quota: record.quota } : {}),
+      },
     ]),
   );
   quotaPoliciesWritePromise = quotaPoliciesWritePromise
@@ -924,7 +953,7 @@ function scheduleQuotaPolicyCheck(record, result) {
   quotaPolicyTimers.set(key, timer);
 }
 
-function enqueueQuotaPolicyMutation(record, rpc) {
+function enqueueQuotaPolicyMutation(record, rpc, { explicit = false } = {}) {
   const key = record.request.taskboardProjectId;
   const previous = quotaPolicyQueues.get(key) ?? Promise.resolve();
   const run = previous
@@ -936,12 +965,22 @@ function enqueueQuotaPolicyMutation(record, rpc) {
         current.request,
         rpc,
         () => quotaPolicyRecords.get(key)?.version === current.version,
+        {
+          explicit,
+          previousQuotaState: current.quota?.state,
+        },
       );
       if (result.stale) return result;
-      if (result.item?.id && quotaPolicyRecords.get(key)?.version === current.version) {
-        current.request = { ...current.request, automationId: result.item.id };
-        await persistQuotaPolicies();
+      if (!explicit && result.operation === "list" && result.item?.status === "PAUSED") {
+        current.version += 1;
+        current.request = { ...current.request, enabledByUser: false };
       }
+      if (result.item?.id) {
+        current.request = { ...current.request, automationId: result.item.id };
+      }
+      if (current.request.quotaAware && result.quota) current.quota = result.quota;
+      else delete current.quota;
+      await persistQuotaPolicies();
       scheduleQuotaPolicyCheck(current, result);
       return result;
     });
@@ -958,11 +997,12 @@ async function updateAndApplyQuotaPolicy(request, rpc) {
   const record = {
     version: (previous?.version ?? 0) + 1,
     request,
+    ...(request.quotaAware && previous?.quota ? { quota: previous.quota } : {}),
   };
   quotaPolicyRecords.set(request.taskboardProjectId, record);
   try {
     await persistQuotaPolicies();
-    return await enqueueQuotaPolicyMutation(record, rpc);
+    return await enqueueQuotaPolicyMutation(record, rpc, { explicit: true });
   } catch (error) {
     if (quotaPolicyRecords.get(request.taskboardProjectId)?.version === record.version) {
       if (previous) quotaPolicyRecords.set(request.taskboardProjectId, previous);
@@ -973,10 +1013,17 @@ async function updateAndApplyQuotaPolicy(request, rpc) {
   }
 }
 
-async function readStoredAutomationPolicy(projectId) {
+async function reconcileStoredAutomationPolicy(projectId, rpc) {
   await ensureQuotaPoliciesLoaded();
   const record = quotaPolicyRecords.get(projectId);
-  return record ? storedAutomationPolicy(record.request) : null;
+  if (!record) return null;
+  const result = await enqueueQuotaPolicyMutation(record, rpc);
+  const current = quotaPolicyRecords.get(projectId);
+  return {
+    ...result,
+    policy: storedAutomationPolicy(current.request),
+    ...(current.quota ? { quota: current.quota } : {}),
+  };
 }
 
 async function enqueueCurrentQuotaPolicy(projectId) {
@@ -1106,14 +1153,16 @@ function installTaskboardHostBinding(cdp, supervisor, startupToken) {
             method,
             body,
           );
-          const result = request.operation === "apply-policy"
-            ? await updateAndApplyQuotaPolicy(request, rpc)
-            : await reconcileTaskboardAutomation(request, rpc);
           if (request.operation === "list") {
-            const policy = await readStoredAutomationPolicy(request.taskboardProjectId);
-            return { ...result, ...(policy ? { policy } : {}) };
+            const stored = await reconcileStoredAutomationPolicy(
+              request.taskboardProjectId,
+              rpc,
+            );
+            return stored ?? reconcileTaskboardAutomation(request, rpc);
           }
-          return result;
+          return request.operation === "apply-policy"
+            ? updateAndApplyQuotaPolicy(request, rpc)
+            : reconcileTaskboardAutomation(request, rpc);
         })()
       ),
       prefill: (request) => (

--- a/shared/taskboard-automation.mjs
+++ b/shared/taskboard-automation.mjs
@@ -59,12 +59,16 @@ export function buildTaskboardAutomationName(request) {
 }
 
 export function buildTaskboardAutomationPrompt(request) {
+  const automationName = buildTaskboardAutomationName(request);
   return [
     `[$manage-taskboard](${request.skillPath}) e-taskboard 每 ${request.intervalMinutes} 分钟检查任务面板中的「${request.projectName}」项目（项目 ID：${request.taskboardProjectId}，项目目录：${request.workspacePath}）。`,
-    "每次仅处理一个 todo：先用 issue get 读取最新议题内容，并用 comment list 读取全部评论，确认是否包含已完成后被打回的返工要求。",
+    `开始时先运行 taskctl issue list --project ${request.taskboardProjectId} --status todo --json。若没有 todo，使用 Codex automation_update 将名为「${automationName}」的当前自动化设为 PAUSED，保留其他字段，然后结束；不要创建或打开新的任务会话。`,
+    "每次仅处理一个 todo：选定后用 issue get 读取最新议题内容，并用 comment list 读取全部评论，确认是否包含已完成后被打回的返工要求。",
     "认领时使用最新 version 将议题移动到 in_progress；若发生版本冲突或最新状态已变化，立即跳过，避免多个 Agent 抢同一任务。",
+    "若 issue get 返回 threadId，认领时将 --thread-id 设为该值以保留绑定，再使用 Codex send_message_to_thread 向原会话发送继续处理此议题的指令；当前自动化会话不要重复处理。若没有 threadId，则在当前自动化会话处理。",
     "若议题已绑定 branch 或 worktree，必须在该议题绑定的开发上下文执行，避免并行 Agent 修改同一工作目录。",
     "执行完成并验证后，先用 comment add 记录关键改动、验证结果、执行结果和剩余风险，再使用最新 version 将议题移动到 in_review；不要直接标记为 done。",
+    `本次处理或交接后，再次运行 taskctl issue list --project ${request.taskboardProjectId} --status todo --json。若没有 todo，使用 Codex automation_update 将名为「${automationName}」的当前自动化设为 PAUSED，保留其他字段，避免后续创建空会话。`,
   ].join("\n");
 }
 

--- a/shared/taskboard-automation.mjs
+++ b/shared/taskboard-automation.mjs
@@ -86,6 +86,27 @@ export function buildTaskboardAutomationSpec(request) {
   };
 }
 
+export function taskboardAutomationPolicyOperation(request, {
+  explicit,
+  previousQuotaState,
+  quotaState,
+  currentStatus,
+}) {
+  if (!request.enabledByUser) return "pause";
+  if (
+    !explicit
+    && currentStatus === "PAUSED"
+    && (!request.quotaAware || previousQuotaState === "available")
+  ) return "list";
+  if (request.quotaAware && quotaState !== "available") return "pause";
+  if (
+    explicit
+    || currentStatus === undefined
+    || (request.quotaAware && previousQuotaState !== "available")
+  ) return "ensure-active";
+  return "list";
+}
+
 export async function reconcileTaskboardAutomation(request, rpc) {
   const listed = await rpc("list-automations", {});
   const items = Array.isArray(listed?.items) ? listed.items : [];

--- a/shared/taskboard-automation.mjs
+++ b/shared/taskboard-automation.mjs
@@ -104,7 +104,7 @@ export function taskboardAutomationPolicyOperation(request, {
     || currentStatus === undefined
     || (request.quotaAware && previousQuotaState !== "available")
   ) return "ensure-active";
-  return "list";
+  return "ensure-active";
 }
 
 export async function reconcileTaskboardAutomation(request, rpc) {

--- a/test/injector.test.mjs
+++ b/test/injector.test.mjs
@@ -70,6 +70,18 @@ test("the CDP bridge exposes only the fixed Taskboard automation operations", ()
   assert.doesNotMatch(source, /automations\.toml/);
 });
 
+test("passive automation policy keeps idle pauses and only resumes quota pauses", () => {
+  assert.match(source, /taskboardAutomationPolicyOperation/);
+  assert.match(source, /previousQuotaState: current\.quota\?\.state/);
+  assert.match(source, /enqueueQuotaPolicyMutation\(record, rpc, \{ explicit: true \}\)/);
+  assert.match(
+    source,
+    /!explicit && result\.operation === "list" && result\.item\?\.status === "PAUSED"/,
+  );
+  assert.match(source, /enabledByUser: false/);
+  assert.match(source, /record\.quota \? \{ quota: record\.quota \} : \{\}/);
+});
+
 test("the package injection command remains resident for tab-triggered recovery", () => {
   assert.match(packageJson.scripts["codex:inject"], /--watch/);
   assert.match(packageJson.scripts["codex:daemon"], /--daemon --open/);

--- a/test/project-automation-settings.test.mjs
+++ b/test/project-automation-settings.test.mjs
@@ -145,7 +145,23 @@ test("pending completion reconciles the optimistic draft to confirmed host state
 });
 
 test("opening settings and changing projects reconcile with the host list", () => {
-  assert.match(appSource, /sendAutomationRequest\(\s*stored \? "apply-policy" : "list",\s*options,\s*stored\?\.automationId,\s*\)/);
+  const reconcileSource = appSource.slice(
+    appSource.indexOf("const reconcileProjectAutomation"),
+    appSource.indexOf("const saveProjectAutomation"),
+  );
+  const saveSource = appSource.slice(
+    appSource.indexOf("const saveProjectAutomation"),
+    appSource.indexOf("function openTaskDetail"),
+  );
+  assert.match(
+    reconcileSource,
+    /sendAutomationRequest\(\s*"list",\s*options,\s*stored\?\.automationId,\s*\)/,
+  );
+  assert.doesNotMatch(reconcileSource, /"apply-policy"/);
+  assert.match(
+    saveSource,
+    /sendAutomationRequest\("apply-policy", options, stored\?\.automationId\)/,
+  );
   assert.match(appSource, /const policy = isAutomationHostPolicy\(response\.policy\) \? response\.policy : null/);
   assert.match(appSource, /items\.find\(\(candidate\) => candidate\.id === policy\.automationId\)/);
   assert.match(appSource, /items\.length === 1 \? items\[0\] : undefined/);

--- a/test/project-automation-settings.test.mjs
+++ b/test/project-automation-settings.test.mjs
@@ -163,6 +163,7 @@ test("opening settings and changing projects reconcile with the host list", () =
     /sendAutomationRequest\("apply-policy", options, stored\?\.automationId\)/,
   );
   assert.match(appSource, /const policy = isAutomationHostPolicy\(response\.policy\) \? response\.policy : null/);
+  assert.match(appSource, /const item = \(isAutomationHostItem\(response\.item\) \? response\.item : undefined\)\s*\?\? items\.find\(\(candidate\) => candidate\.id === policy\.automationId\)/);
   assert.match(appSource, /items\.find\(\(candidate\) => candidate\.id === policy\.automationId\)/);
   assert.match(appSource, /items\.length === 1 \? items\[0\] : undefined/);
   assert.match(appSource, /automationId: item\?\.id \?\? policy\.automationId/);

--- a/test/taskboard-automation.test.mjs
+++ b/test/taskboard-automation.test.mjs
@@ -248,12 +248,19 @@ test("passive policy checks resume only after quota recovery", () => {
     ),
     "ensure-active",
   );
+  assert.equal(
+    taskboardAutomationPolicyOperation(
+      { ...baseRequest, quotaAware: false },
+      { ...passiveAvailable, currentStatus: "ACTIVE" },
+    ),
+    "ensure-active",
+  );
 });
 
 test("ensure-active updates a matching automation by id with a complete active spec", async () => {
   const existing = {
     id: "automation-1",
-    status: "PAUSED",
+    status: "ACTIVE",
     kind: "cron",
     name: "Taskboard 自动认领 · ppt-skill",
     prompt: "old prompt",

--- a/test/taskboard-automation.test.mjs
+++ b/test/taskboard-automation.test.mjs
@@ -7,6 +7,7 @@ import {
   buildTaskboardAutomationSpec,
   parseTaskboardAutomationHostRequest,
   reconcileTaskboardAutomation,
+  taskboardAutomationPolicyOperation,
 } from "../shared/taskboard-automation.mjs";
 import {
   AUTOMATION_MODELS,
@@ -210,6 +211,43 @@ test("the generated cron spec uses the selected whitelisted local Codex options"
     reasoningEffort: "medium",
     rrule: "RRULE:FREQ=MINUTELY;INTERVAL=30",
   });
+});
+
+test("passive policy checks resume only after quota recovery", () => {
+  const passiveAvailable = {
+    explicit: false,
+    previousQuotaState: "available",
+    quotaState: "available",
+    currentStatus: "PAUSED",
+  };
+  assert.equal(
+    taskboardAutomationPolicyOperation(
+      { ...baseRequest, quotaAware: true },
+      passiveAvailable,
+    ),
+    "list",
+  );
+  assert.equal(
+    taskboardAutomationPolicyOperation(
+      { ...baseRequest, quotaAware: true },
+      { ...passiveAvailable, quotaState: "unknown" },
+    ),
+    "list",
+  );
+  assert.equal(
+    taskboardAutomationPolicyOperation(
+      { ...baseRequest, quotaAware: true },
+      { ...passiveAvailable, previousQuotaState: "blocked" },
+    ),
+    "ensure-active",
+  );
+  assert.equal(
+    taskboardAutomationPolicyOperation(
+      { ...baseRequest, quotaAware: true },
+      { ...passiveAvailable, explicit: true },
+    ),
+    "ensure-active",
+  );
 });
 
 test("ensure-active updates a matching automation by id with a complete active spec", async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -933,7 +933,8 @@ export function App() {
       const policy = isAutomationHostPolicy(response.policy) ? response.policy : null;
       if (!stored) {
         if (!policy) return;
-        const item = items.find((candidate) => candidate.id === policy.automationId)
+        const item = (isAutomationHostItem(response.item) ? response.item : undefined)
+          ?? items.find((candidate) => candidate.id === policy.automationId)
           ?? (items.length === 1 ? items[0] : undefined);
         writeProjectAutomation(selectedProjectId, {
           automationId: item?.id ?? policy.automationId,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -923,15 +923,15 @@ export function App() {
         ...DEFAULT_AUTOMATION_OPTIONS,
       };
       const response = await sendAutomationRequest(
-        stored ? "apply-policy" : "list",
+        "list",
         options,
         stored?.automationId,
       );
       const items = Array.isArray(response.items)
         ? response.items.filter(isAutomationHostItem)
         : [];
+      const policy = isAutomationHostPolicy(response.policy) ? response.policy : null;
       if (!stored) {
-        const policy = isAutomationHostPolicy(response.policy) ? response.policy : null;
         if (!policy) return;
         const item = items.find((candidate) => candidate.id === policy.automationId)
           ?? (items.length === 1 ? items[0] : undefined);
@@ -941,6 +941,7 @@ export function App() {
           status: item?.status ?? "PAUSED",
           enabledByUser: policy.enabledByUser,
           quotaAware: policy.quotaAware,
+          ...(response.quota ? { quota: response.quota } : {}),
           intervalMinutes: policy.intervalMinutes,
           model: policy.model,
           reasoningEffort: policy.reasoningEffort,
@@ -956,6 +957,8 @@ export function App() {
             ...stored,
             automationId: undefined,
             status: "PAUSED",
+            enabledByUser: policy?.enabledByUser ?? stored.enabledByUser,
+            quotaAware: policy?.quotaAware ?? stored.quotaAware,
             ...(response.quota ? { quota: response.quota } : {}),
           });
         }
@@ -967,9 +970,15 @@ export function App() {
         automationId: item.id,
         codexProjectId: automationProjectContext.codexProjectId,
         status: item.status,
-        enabledByUser: stored.enabledByUser,
-        quotaAware: stored.quotaAware,
-        ...(response.quota ? { quota: response.quota } : {}),
+        enabledByUser: policy?.enabledByUser ?? stored.enabledByUser,
+        quotaAware: policy?.quotaAware ?? stored.quotaAware,
+        ...(
+          response.quota
+            ? { quota: response.quota }
+            : stored.quota
+              ? { quota: stored.quota }
+              : {}
+        ),
         intervalMinutes,
         model: item.model,
         reasoningEffort: item.reasoningEffort,


### PR DESCRIPTION
## 改动

- 自动认领运行开始时先列出项目 Todo；没有 Todo 时暂停当前项目 automation。
- 每次处理或交接后再次检查 Todo；队列已空时立即暂停，避免下一轮创建空会话。
- 议题已有 `threadId` 时保留绑定，并通过 `send_message_to_thread` 让原会话继续处理，不在当前 automation 会话重复处理。
- 关闭开关路径保持不变。现有代码已把 automation 更新为 `PAUSED`，清除后续额度检查，并且不会中断已运行任务。

## 根因

原 cron prompt 没有空 Todo 分支，也没有已绑定会话的交接规则。无任务时 automation 仍保持 `ACTIVE`；认领时默认使用当前 cron 会话的 `CODEX_THREAD_ID`，会覆盖已有绑定。

## 直接验证

- `node --check shared/taskboard-automation.mjs`
- 生成真实 cron prompt，确认包含 Todo 查询、`automation_update`、`send_message_to_thread` 和 `--thread-id`
- 与最新 `origin/main` (`05de40b`) 比较：仅修改 `shared/taskboard-automation.mjs`

按项目规则，本次没有新增或运行回归测试。