### PR TITLE
启动时同步全局 manage-taskboard Skill

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -107,6 +107,20 @@ fn acquire_instance_lock(path: &Path) -> Result<Option<File>, std::io::Error> {
     }
 }
 
+fn copy_directory(source: &Path, destination: &Path) -> Result<(), std::io::Error> {
+    fs::create_dir_all(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let destination = destination.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_directory(&entry.path(), &destination)?;
+        } else {
+            fs::copy(entry.path(), destination)?;
+        }
+    }
+    Ok(())
+}
+
 fn taskboard_listener(state: &LauncherState) -> Result<(i32, u16), String> {
     let mut listener = state.taskboard_listener.lock().unwrap();
     if listener.is_none() {
@@ -656,6 +670,15 @@ fn main() {
         .setup(|app| {
             app.set_activation_policy(ActivationPolicy::Accessory);
             let home_directory = app.path().home_dir()?;
+            let bundled_skill = app
+                .path()
+                .resource_dir()?
+                .join("app/skills/manage-taskboard");
+            let global_skill = home_directory.join(".agents/skills/manage-taskboard");
+            if global_skill.exists() {
+                fs::remove_dir_all(&global_skill)?;
+            }
+            copy_directory(&bundled_skill, &global_skill)?;
             let data_directory = home_directory.join("Library/Application Support/Codex Taskboard");
             let log_directory = home_directory.join("Library/Logs/Codex Taskboard");
             fs::create_dir_all(&data_directory)?;


### PR DESCRIPTION
## 改动

- 在 macOS App 的 Tauri 启动入口读取 App 内置 `manage-taskboard` Skill。
- 每次 App 启动时覆盖同步到 `~/.agents/skills/manage-taskboard`。
- 在启动 Codex Agent 集成前完成同步。
- 不写入 `~/.codex/skills/manage-taskboard`。
- Web UI、server 和 `taskctl` CLI 保持不变。

## 原因

App 已打包 Skill，但启动器没有把它安装到 Agent 可发现的用户级全局目录。干净用户环境中的原生 Agent 对话因此不能稳定发现工作流。

## 用户影响

首次启动会创建全局副本。App 更新后的首次启动会用当前 App 内置内容更新该副本。不同 Agent 可以引用同一个全局路径。

## 直接验证

- `npm run app:prepare`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- 使用 Rust 1.88 执行 `cargo check --manifest-path src-tauri/Cargo.toml`
- 构建并运行真实 Tauri 启动二进制，使用临时 `HOME` 和预占实例锁：
  - 干净目录首次安装后，目标目录与 App 内置 Skill 完全一致。
  - 制造过期副本后再次启动，目标目录恢复为当前 App 内置内容。
  - 两次都没有创建 `.codex/skills/manage-taskboard`。
  - 开发机现有全局 Skill 未变化。

分支已变基到 `origin/main` 的 `05de40b`。最终差异只有 `src-tauri/src/main.rs`。