### PR TITLE
Fix client interaction state across list and editor

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -645,6 +645,8 @@ export function App() {
   const undoStackRef = useRef<UndoOperation[]>([]);
   const undoInFlightRef = useRef(false);
   const dragRegionRef = useRef<HTMLDivElement>(null);
+  const issueListRef = useRef<HTMLDivElement>(null);
+  const pendingIssueListScrollTopRef = useRef<number | null>(null);
   const selectedProjectIdRef = useRef(selectedProjectId);
   selectedProjectIdRef.current = selectedProjectId;
 
@@ -1037,6 +1039,9 @@ export function App() {
   function openTaskDetail(task: Pick<Task, "identifier" | "projectId">) {
     const fullTask = tasksRef.current.find((candidate) => candidate.identifier === task.identifier);
     if (fullTask) markTaskRead(fullTask);
+    if (issueListRef.current) {
+      pendingIssueListScrollTopRef.current = issueListRef.current.scrollTop;
+    }
     closeContextMenu();
     setProjectMenuOpen(false);
     setDetailTaskIdentifier(task.identifier);
@@ -1058,6 +1063,14 @@ export function App() {
     const url = buildIssueUrl(window.location.href, selectedProjectId || null, null);
     window.history.replaceState(window.history.state, "", url);
   }
+
+  useLayoutEffect(() => {
+    if (detailTaskIdentifier || boardView !== "list") return;
+    const scrollTop = pendingIssueListScrollTopRef.current;
+    if (scrollTop === null || !issueListRef.current) return;
+    issueListRef.current.scrollTop = scrollTop;
+    pendingIssueListScrollTopRef.current = null;
+  }, [boardView, detailTaskIdentifier]);
 
   useEffect(() => {
     function syncRouteFromLocation() {
@@ -2450,6 +2463,7 @@ export function App() {
           />
         ) : boardView === "list" ? (
           <IssueListView
+            scrollRef={issueListRef}
             tasks={filteredTasks}
             presentations={taskPresentations}
             currentUser={currentUser}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -646,7 +646,7 @@ export function App() {
   const undoInFlightRef = useRef(false);
   const dragRegionRef = useRef<HTMLDivElement>(null);
   const issueListRef = useRef<HTMLDivElement>(null);
-  const pendingIssueListScrollTopRef = useRef<number | null>(null);
+  const pendingIssueListScrollRef = useRef<{ projectId: string; scrollTop: number } | null>(null);
   const selectedProjectIdRef = useRef(selectedProjectId);
   selectedProjectIdRef.current = selectedProjectId;
 
@@ -1040,7 +1040,10 @@ export function App() {
     const fullTask = tasksRef.current.find((candidate) => candidate.identifier === task.identifier);
     if (fullTask) markTaskRead(fullTask);
     if (issueListRef.current) {
-      pendingIssueListScrollTopRef.current = issueListRef.current.scrollTop;
+      pendingIssueListScrollRef.current = {
+        projectId: selectedProjectId,
+        scrollTop: issueListRef.current.scrollTop,
+      };
     }
     closeContextMenu();
     setProjectMenuOpen(false);
@@ -1065,18 +1068,30 @@ export function App() {
   }
 
   useLayoutEffect(() => {
-    if (detailTaskIdentifier || boardView !== "list") return;
-    const scrollTop = pendingIssueListScrollTopRef.current;
-    if (scrollTop === null || !issueListRef.current) return;
-    issueListRef.current.scrollTop = scrollTop;
-    pendingIssueListScrollTopRef.current = null;
-  }, [boardView, detailTaskIdentifier]);
+    if (detailTaskIdentifier) return;
+    const pendingScroll = pendingIssueListScrollRef.current;
+    if (!pendingScroll) return;
+    if (boardView !== "list" || pendingScroll.projectId !== selectedProjectId) {
+      pendingIssueListScrollRef.current = null;
+      return;
+    }
+    if (!issueListRef.current) return;
+    issueListRef.current.scrollTop = pendingScroll.scrollTop;
+    pendingIssueListScrollRef.current = null;
+  }, [boardView, detailTaskIdentifier, selectedProjectId]);
 
   useEffect(() => {
     function syncRouteFromLocation() {
       const url = new URL(window.location.href);
       const routeProjectId = url.searchParams.get("project") ?? GLOBAL_PROJECT_ID;
-      setDetailTaskIdentifier(readIssueIdentifier(url.search));
+      const routeIssueIdentifier = readIssueIdentifier(url.search);
+      if (routeIssueIdentifier && issueListRef.current) {
+        pendingIssueListScrollRef.current = {
+          projectId: selectedProjectId,
+          scrollTop: issueListRef.current.scrollTop,
+        };
+      }
+      setDetailTaskIdentifier(routeIssueIdentifier);
       if (routeProjectId === selectedProjectId) return;
       setBoardView(readProjectBoardView(routeProjectId));
       setSelectedProjectId(routeProjectId);

--- a/web/src/components/IssueListView.tsx
+++ b/web/src/components/IssueListView.tsx
@@ -1,4 +1,4 @@
-import { useState, type KeyboardEvent, type MouseEvent } from "react";
+import { useState, type KeyboardEvent, type MouseEvent, type RefObject } from "react";
 import { assigneeTargetForActor } from "../actors";
 import { labelPresentation } from "../labels";
 import type { TaskCardPresentation } from "../taskConversations";
@@ -21,6 +21,7 @@ const PRIORITY_LABELS: Record<TaskPriority, string> = {
 const COLLAPSED_BY_DEFAULT = new Set<TaskStatus>(["backlog", "done", "canceled"]);
 
 interface IssueListViewProps {
+  scrollRef: RefObject<HTMLDivElement | null>;
   tasks: Task[];
   presentations: Record<string, TaskCardPresentation>;
   currentUser: ActorIdentity;
@@ -40,6 +41,7 @@ function calendarDate(value: string) {
 }
 
 export function IssueListView({
+  scrollRef,
   tasks,
   presentations,
   currentUser,
@@ -65,7 +67,7 @@ export function IssueListView({
   }
 
   return (
-    <div className="issue-list-view">
+    <div className="issue-list-view" ref={scrollRef}>
       <div className="issue-list-groups">
         {TASK_STATUSES.map((status) => {
           const statusTasks = tasks.filter((task) => task.status === status);

--- a/web/src/components/TaskEditor.tsx
+++ b/web/src/components/TaskEditor.tsx
@@ -128,6 +128,7 @@ export function TaskEditor({
   onSave,
 }: TaskEditorProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const backdropPointerRef = useRef({ down: false, up: false });
   const titleRef = useRef<HTMLInputElement>(null);
   const descriptionComposerRef = useRef<InlineMediaComposerHandle>(null);
   const createSubmitIntentRef = useRef(false);
@@ -281,8 +282,24 @@ export function TaskEditor({
         event.preventDefault();
         if (!saving) cancelEditor();
       }}
+      onPointerDown={(event) => {
+        backdropPointerRef.current = {
+          down: event.target === event.currentTarget,
+          up: false,
+        };
+      }}
+      onPointerUp={(event) => {
+        backdropPointerRef.current.up = event.target === event.currentTarget;
+      }}
+      onPointerCancel={() => {
+        backdropPointerRef.current = { down: false, up: false };
+      }}
       onClick={(event) => {
-        if (event.target === event.currentTarget && !saving) cancelEditor();
+        const backdropClick = backdropPointerRef.current.down
+          && backdropPointerRef.current.up
+          && event.target === event.currentTarget;
+        backdropPointerRef.current = { down: false, up: false };
+        if (backdropClick && !saving) cancelEditor();
       }}
     >
       <form className="task-form" onSubmit={handleSubmit} onKeyDown={handleKeyDown}>


### PR DESCRIPTION
## What changed

- Preserve the list view scroll position when opening an issue detail and returning.
- Close TaskEditor from the backdrop only when pointer down, pointer up, and click all occur on the backdrop.
- Rechecked the Gantt-to-other-view path on the latest main baseline. The target view renders and no console error occurs, so this PR does not add a speculative Gantt change.

## Root cause

The list DOM is unmounted while issue detail is open, so its scrollTop was lost. TaskEditor checked only the final click target, so a drag that started in an input and ended on the dialog backdrop could be treated as a backdrop click.

## Direct verification

- List scrollTop stayed at 420 after opening an issue detail and returning.
- Input pointerdown followed by backdrop pointerup/click kept TaskEditor open and preserved its title.
- A complete backdrop pointerdown/pointerup/click closed TaskEditor.
- Gantt switched to List successfully with no page or console errors.
- `npm run typecheck`
- `npm run build:web`