### PR TITLE
fix: preserve historical issue prefixes

### DIFF
--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -1329,7 +1329,37 @@ async function listTasks(env, filters) {
 }
 
 async function createTask(env, input, actor) {
-  await requireProject(env, input.projectId);
+  const project = await env.DB.prepare(`
+    SELECT
+      projects.id,
+      projects.next_task_number,
+      (
+        SELECT tasks.identifier
+        FROM tasks
+        WHERE tasks.project_id = projects.id
+        ORDER BY tasks.created_at, tasks.id
+        LIMIT 1
+      ) AS first_identifier
+    FROM projects
+    WHERE projects.id = ?
+  `).bind(input.projectId).first();
+  if (!project) {
+    throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${input.projectId}' does not exist`);
+  }
+  const prefix = project.first_identifier
+    ? project.first_identifier.replace(/-\d+$/, "")
+    : projectPrefix(project.id);
+  const suffixStart = prefix.length + 2;
+  const maximum = await env.DB.prepare(`
+    SELECT MAX(CAST(substr(identifier, ?) AS INTEGER)) AS number
+    FROM tasks
+    WHERE identifier GLOB ?
+  `).bind(suffixStart, `${prefix}-[0-9]*`).first();
+  const number = Math.max(
+    project.next_task_number,
+    maximum.number === null ? 1 : maximum.number + 1,
+  );
+  const identifier = `${prefix}-${number}`;
   let sortOrder = input.sortOrder;
   if (sortOrder === undefined) {
     const row = await env.DB.prepare(`
@@ -1354,7 +1384,7 @@ async function createTask(env, input, actor) {
       )
       SELECT
         ?,
-        ? || '-' || CAST(next_task_number AS TEXT),
+        ?,
         projects.id,
         ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
         ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
@@ -1363,7 +1393,7 @@ async function createTask(env, input, actor) {
       WHERE projects.id = ?
     `).bind(
       id,
-      projectPrefix(input.projectId),
+      identifier,
       input.title,
       input.description,
       input.status,
@@ -1392,9 +1422,9 @@ async function createTask(env, input, actor) {
     ),
     env.DB.prepare(`
       UPDATE projects
-      SET next_task_number = next_task_number + 1, updated_at = ?
+      SET next_task_number = ?, updated_at = ?
       WHERE id = ?
-    `).bind(timestamp, input.projectId),
+    `).bind(number + 1, timestamp, input.projectId),
   ]);
   if (!changed(results[0]) || !changed(results[1])) {
     throw new ApiError(

--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -1332,7 +1332,6 @@ async function createTask(env, input, actor) {
   const project = await env.DB.prepare(`
     SELECT
       projects.id,
-      projects.next_task_number,
       (
         SELECT tasks.identifier
         FROM tasks
@@ -1350,16 +1349,6 @@ async function createTask(env, input, actor) {
     ? project.first_identifier.replace(/-\d+$/, "")
     : projectPrefix(project.id);
   const suffixStart = prefix.length + 2;
-  const maximum = await env.DB.prepare(`
-    SELECT MAX(CAST(substr(identifier, ?) AS INTEGER)) AS number
-    FROM tasks
-    WHERE identifier GLOB ?
-  `).bind(suffixStart, `${prefix}-[0-9]*`).first();
-  const number = Math.max(
-    project.next_task_number,
-    maximum.number === null ? 1 : maximum.number + 1,
-  );
-  const identifier = `${prefix}-${number}`;
   let sortOrder = input.sortOrder;
   if (sortOrder === undefined) {
     const row = await env.DB.prepare(`
@@ -1384,7 +1373,14 @@ async function createTask(env, input, actor) {
       )
       SELECT
         ?,
-        ?,
+        ? || '-' || CAST(MAX(
+          projects.next_task_number,
+          COALESCE((
+            SELECT MAX(CAST(substr(tasks.identifier, ?) AS INTEGER)) + 1
+            FROM tasks
+            WHERE tasks.identifier GLOB ?
+          ), 1)
+        ) AS TEXT),
         projects.id,
         ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
         ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
@@ -1393,7 +1389,9 @@ async function createTask(env, input, actor) {
       WHERE projects.id = ?
     `).bind(
       id,
-      identifier,
+      prefix,
+      suffixStart,
+      `${prefix}-[0-9]*`,
       input.title,
       input.description,
       input.status,
@@ -1422,9 +1420,15 @@ async function createTask(env, input, actor) {
     ),
     env.DB.prepare(`
       UPDATE projects
-      SET next_task_number = ?, updated_at = ?
+      SET
+        next_task_number = (
+          SELECT CAST(substr(identifier, ?) AS INTEGER) + 1
+          FROM tasks
+          WHERE id = ?
+        ),
+        updated_at = ?
       WHERE id = ?
-    `).bind(number + 1, timestamp, input.projectId),
+    `).bind(suffixStart, id, timestamp, input.projectId),
   ]);
   if (!changed(results[0]) || !changed(results[1])) {
     throw new ApiError(

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -1265,14 +1265,33 @@ export class TaskboardDatabase {
     this.database.exec("BEGIN IMMEDIATE");
     try {
       const project = this.database.prepare(`
-        SELECT id, next_task_number FROM projects WHERE id = ?
+        SELECT
+          projects.id,
+          projects.next_task_number,
+          (
+            SELECT tasks.identifier
+            FROM tasks
+            WHERE tasks.project_id = projects.id
+            ORDER BY tasks.created_at, tasks.id
+            LIMIT 1
+          ) AS first_identifier
+        FROM projects
+        WHERE projects.id = ?
       `).get(input.projectId);
       if (!project) {
         throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${input.projectId}' does not exist`);
       }
 
-      const number = project.next_task_number;
-      const identifier = `${projectPrefix(project.id)}-${number}`;
+      const prefix = project.first_identifier
+        ? project.first_identifier.replace(/-\d+$/, "")
+        : projectPrefix(project.id);
+      const maximum = this.database.prepare(`
+        SELECT MAX(CAST(substr(identifier, ?) AS INTEGER)) AS number
+        FROM tasks
+        WHERE identifier GLOB ?
+      `).get(prefix.length + 2, `${prefix}-[0-9]*`).number;
+      const number = Math.max(project.next_task_number, maximum === null ? 1 : maximum + 1);
+      const identifier = `${prefix}-${number}`;
       const id = randomUUID();
       const timestamp = now();
       let sortOrder = input.sortOrder;
@@ -1286,8 +1305,8 @@ export class TaskboardDatabase {
       }
 
       this.database.prepare(`
-        UPDATE projects SET next_task_number = next_task_number + 1, updated_at = ? WHERE id = ?
-      `).run(timestamp, input.projectId);
+        UPDATE projects SET next_task_number = ?, updated_at = ? WHERE id = ?
+      `).run(number + 1, timestamp, input.projectId);
       this.database.prepare(`
         INSERT INTO tasks (
           id, identifier, project_id, title, description, status, priority, labels,


### PR DESCRIPTION
## 改动

- 新建议题时，优先沿用当前项目最早历史议题的编号前缀。
- 在全库按该前缀取最大序号，并以项目现有计数器为下限，避免共享 `LOCAL` 前缀的项目发生编号冲突。
- 本地 SQLite 和 Cloudflare D1 创建路径保持同一行为。
- 不更新任何已有 `tasks.identifier`，不做历史数据迁移。

## 根因

项目议题迁移会保留原有 `LOCAL-*` 编号，但新建议题一直从内部项目 ID 生成前缀。Codex 项目 ID 是 UUID，因此 `1655e734-40ab-...` 被转换成了 `1655E73440AB-*`。

## 影响

当前 `codex-taskboard` 项目会继续使用既有 `LOCAL` 前缀。按现有数据，下一条议题为 `LOCAL-134`，后续连续递增；历史 `LOCAL-*` 和 `1655E73440AB-*` 均保持不变。

## 直接验证

- 在临时数据库中模拟旧议题跨项目移动：旧编号保持 `LOCAL-1/2/3`，两个项目随后新建得到 `LOCAL-4`、`LOCAL-5`。
- 在当前任务板数据库副本上连续创建：原有 196 个编号全部保留，新编号为 `LOCAL-134`、`LOCAL-135`。
- `node --check server/database.mjs`
- `node --check cloud/src/index.mjs`
- `git diff --check origin/main...HEAD`

云端 Miniflare 临时运行环境卡在启动阶段，未进入本次 SQL；云端文件已完成语法检查。