### PR TITLE
Fix dark theme surfaces and archived task cleanup

### DIFF
--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -1693,6 +1693,27 @@ async function restoreTask(env, id, input, actor) {
   return getTask(env, current.id);
 }
 
+async function deleteArchivedTask(env, id, expectedVersion) {
+  const current = await requireTaskRow(env, id);
+  assertTaskVersion(current, expectedVersion);
+  if (current.archived_at === null) {
+    throw new ApiError(409, "TASK_NOT_ARCHIVED", "Only archived tasks can be deleted");
+  }
+  const attachmentIds = (await all(
+    env.DB.prepare("SELECT id FROM attachments WHERE task_id = ?").bind(current.id),
+  )).map((attachment) => attachment.id);
+  const result = await env.DB.prepare(`
+    DELETE FROM tasks
+    WHERE id = ? AND version = ? AND archived_at IS NOT NULL
+  `).bind(current.id, expectedVersion).run();
+  if (!changed(result)) {
+    const latest = await requireTaskRow(env, current.id);
+    assertTaskVersion(latest, expectedVersion);
+    throw new ApiError(409, "TASK_NOT_ARCHIVED", "Only archived tasks can be deleted");
+  }
+  await Promise.all(attachmentIds.map((attachmentId) => env.ATTACHMENTS.delete(attachmentId)));
+}
+
 function relationEndpoints(type, taskId, relatedTaskId) {
   if (type === "parent") {
     return {
@@ -2563,6 +2584,11 @@ async function routeApi(request, env, actor, url) {
         ),
       });
     }
+    if (!action && request.method === "DELETE") {
+      const { version } = parseVersionMutation(await readJson(request));
+      await deleteArchivedTask(env, taskId, version);
+      return empty(204);
+    }
     if (action === "move" && request.method === "POST") {
       return json(200, {
         task: await moveTask(env, taskId, parseMove(await readJson(request)), actor),
@@ -2588,7 +2614,7 @@ async function routeApi(request, env, actor, url) {
         ),
       });
     }
-    methodNotAllowed(action ? ["POST"] : ["GET", "PATCH"]);
+    methodNotAllowed(action ? ["POST"] : ["GET", "PATCH", "DELETE"]);
   }
 
   throw new ApiError(404, "NOT_FOUND", "API route not found");

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -2477,6 +2477,19 @@ export function createTaskboardServer(options = {}) {
           events.emit("task.updated", { task });
           return sendJson(response, 200, { task });
         }
+        if (!action && request.method === "DELETE") {
+          const { version } = parseArchive(await readJson(request));
+          const deleted = database.deleteArchivedTask(id, version);
+          for (const attachmentId of deleted.attachmentIds) {
+            try {
+              await unlink(path.join(resolved.attachmentsDirectory, attachmentId));
+            } catch (error) {
+              if (error.code !== "ENOENT") throw error;
+            }
+          }
+          events.emit("task.deleted", { task: deleted.task });
+          return sendEmpty(response, 204);
+        }
         if (action === "move" && request.method === "POST") {
           const move = parseMove(await readJson(request));
           const task = database.moveTask(
@@ -2502,7 +2515,7 @@ export function createTaskboardServer(options = {}) {
           events.emit("task.restored", { task });
           return sendJson(response, 200, { task });
         }
-        return methodNotAllowed(response, action ? ["POST"] : ["GET", "PATCH"]);
+        return methodNotAllowed(response, action ? ["POST"] : ["GET", "PATCH", "DELETE"]);
       }
 
       if (pathname.startsWith("/api/")) {

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -1561,6 +1561,22 @@ export class TaskboardDatabase {
     return this.getTask(current.id);
   }
 
+  deleteArchivedTask(id, version) {
+    const current = this.#requireTask(id);
+    this.#requireVersion(current, version);
+    if (current.archivedAt === null) {
+      throw new ApiError(409, "TASK_NOT_ARCHIVED", "Only archived tasks can be deleted");
+    }
+    const attachmentIds = this.database.prepare(
+      "SELECT id FROM attachments WHERE task_id = ? ORDER BY created_at, id",
+    ).all(current.id).map((attachment) => attachment.id);
+    const result = this.database.prepare(
+      "DELETE FROM tasks WHERE id = ? AND version = ? AND archived_at IS NOT NULL",
+    ).run(current.id, version);
+    if (result.changes !== 1) this.#throwMissingOrConflict(id, version);
+    return { task: current, attachmentIds };
+  }
+
   addTaskRelation(id, version, type, relatedId, threadId, actor) {
     this.database.exec("BEGIN IMMEDIATE");
     try {

--- a/test/other-tasks-panel.test.mjs
+++ b/test/other-tasks-panel.test.mjs
@@ -36,9 +36,9 @@ test("the issue workspace projects the seven statuses into adaptive main and sec
   assert.match(boardColumnSource, /in_review: \{ label: "等你确认", tone: "review" \}/);
 });
 
-test("other tasks is a closed-by-default non-modal panel with three counted tabs", () => {
+test("other tasks is a closed-by-default non-modal panel with four counted tabs", () => {
   assert.match(appSource, /useState\(false\)/);
-  assert.match(appSource, /useState<SecondaryTaskStatus>\("backlog"\)/);
+  assert.match(appSource, /useState<OtherTaskTab>\("backlog"\)/);
   assert.match(appSource, /className=\{`other-tasks-trigger\$\{otherTasksOpen \? " is-open" : ""\}`\}/);
   assert.match(appSource, /aria-controls="other-tasks-panel"/);
   assert.match(appSource, /aria-expanded=\{otherTasksOpen\}/);
@@ -47,9 +47,10 @@ test("other tasks is a closed-by-default non-modal panel with three counted tabs
   assert.match(panelSource, /<aside[\s\S]*?id="other-tasks-panel"/);
   assert.match(panelSource, /aria-hidden=\{!open\}/);
   assert.match(panelSource, /role="tablist"/);
-  assert.match(panelSource, /SECONDARY_STATUSES\.map\(\(status\) =>/);
+  assert.match(statusSource, /OTHER_TASK_TABS = \[[\s\S]*?\.\.\.SECONDARY_STATUSES,[\s\S]*?"archived"/);
+  assert.match(panelSource, /OTHER_TASK_TABS\.map\(\(tab\) =>/);
   assert.match(panelSource, /aria-selected=\{selected\}/);
-  assert.match(panelSource, /tasksByStatus\[status\]\.length/);
+  assert.match(panelSource, /const count = tab === "archived" \? archivedTasks\.length : tasksByStatus\[tab\]\.length/);
   assert.doesNotMatch(panelSource, /createPortal|role="dialog"|backdrop|overlay/);
   assert.match(cssBlock(".issue-board-layout"), /display: grid/);
   assert.match(cssBlock(".issue-board-layout.has-other-tasks"), /minmax\(0, 1fr\)/);
@@ -62,16 +63,20 @@ test("other tasks is a closed-by-default non-modal panel with three counted tabs
 
 test("search and filters feed the same status buckets used by the board and panel", () => {
   assert.match(appSource, /const filteredTasks = useMemo\([\s\S]*?matchesTaskSearch\(task, search\) && matchesTaskFilters\(task, filters\)/);
+  assert.match(appSource, /const filteredArchivedTasks = useMemo\([\s\S]*?matchesTaskSearch\(task, search\) && matchesTaskFilters\(task, filters\)/);
   assert.match(appSource, /TASK_STATUSES\.map\(\(status\) => \[status, filteredTasks\.filter\(\(task\) => task\.status === status\)\]\)/);
   assert.match(appSource, /tasks=\{tasksByStatus\[status\]\}/);
   assert.match(appSource, /tasksByStatus=\{tasksByStatus\}/);
+  assert.match(appSource, /archivedTasks=\{filteredArchivedTasks\}/);
   assert.match(appSource, /hasActiveFilters=\{hasActiveTaskFilters\}/);
-  assert.match(panelSource, /const tasks = tasksByStatus\[activeStatus\]/);
+  assert.match(panelSource, /const archived = activeTab === "archived"/);
+  assert.match(panelSource, /const tasks = archived \? archivedTasks : tasksByStatus\[activeTab\]/);
   assert.match(panelSource, /hasActiveFilters \? "当前筛选下无匹配议题"/);
   assert.match(boardColumnSource, /tasks\.length === 0 && <div className="column-empty">\{emptyMessage\}<\/div>/);
 });
 
-test("panel cards reuse TaskCard and the existing ranked board drop path", () => {
+test("active panel cards reuse TaskCard and ranked drops while archived cards use their own branch", () => {
+  assert.match(panelSource, /\{archived \? archivedTasks\.map\(\(task\) => \([\s\S]*?<ArchivedTaskCard[\s\S]*?\)\) : tasks\.map\(\(task\) =>/);
   assert.match(panelSource, /<TaskCard/);
   assert.match(panelSource, /variant="sidebar"/);
   assert.match(panelSource, /presentation=\{presentations\[task\.id\]\}/);
@@ -86,7 +91,8 @@ test("panel cards reuse TaskCard and the existing ranked board drop path", () =>
   assert.match(boardColumnSource, /findDropBefore\(event\.currentTarget, event\.clientY\)/);
   assert.match(boardColumnSource, /onDrop\(status, taskId, findDropBefore/);
   assert.match(panelSource, /findDropBefore\(event\.currentTarget, event\.clientY\)/);
-  assert.match(panelSource, /onDrop\(activeStatus, taskId, findDropBefore/);
+  assert.match(panelSource, /if \(archived\) return/);
+  assert.match(panelSource, /onDrop\(activeTab, taskId, findDropBefore/);
   assert.match(appSource, /onDrop=\{finishTaskDrop\}/);
   assert.match(appSource, /moveTask\(task, destination, beforeTaskId, true\)/);
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -24,12 +24,14 @@ import {
   archiveTask as archiveTaskRequest,
   createProject as createProjectRequest,
   createTask as createTaskRequest,
+  deleteArchivedTask as deleteArchivedTaskRequest,
   deleteProject as deleteProjectRequest,
   getCodexThreadProgress,
   getHostRuntime,
   getTaskboardRevision,
   getWorkflowWorkspace,
   getTaskboardMetadata,
+  listArchivedTasks,
   listDevelopmentContexts,
   listDeviceWorkspaces,
   listProjects,
@@ -73,7 +75,7 @@ import {
 import { buildIssueUrl, readIssueIdentifier } from "./issueRoute";
 import {
   MAIN_STATUSES,
-  type SecondaryTaskStatus,
+  type OtherTaskTab,
 } from "./issueBoardStatuses";
 import { DEFAULT_LABELS } from "./labels";
 import {
@@ -277,6 +279,7 @@ const EVENT_NAMES = [
   "task.moved",
   "task.archived",
   "task.restored",
+  "task.deleted",
   "task.relation.updated",
   "comment.created",
   "comment.updated",
@@ -590,6 +593,7 @@ export function App() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [selectedProjectId, setSelectedProjectId] = useState(initialProjectId);
   const [tasks, setTasks] = useState<Task[]>([]);
+  const [archivedTasks, setArchivedTasks] = useState<Task[]>([]);
   const [tasksLoading, setTasksLoading] = useState(false);
   const [hasLoadedTasks, setHasLoadedTasks] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -606,7 +610,10 @@ export function App() {
   const [otherTasksOpen, setOtherTasksOpen] = useState(false);
   const [otherTasksMounted, setOtherTasksMounted] = useState(false);
   const [otherTasksVisible, setOtherTasksVisible] = useState(false);
-  const [otherTasksStatus, setOtherTasksStatus] = useState<SecondaryTaskStatus>("backlog");
+  const [otherTasksTab, setOtherTasksTab] = useState<OtherTaskTab>("backlog");
+  const [restoringTaskId, setRestoringTaskId] = useState<string | null>(null);
+  const [pendingArchivedTaskDelete, setPendingArchivedTaskDelete] = useState<Task | null>(null);
+  const [deletingArchivedTaskId, setDeletingArchivedTaskId] = useState<string | null>(null);
   const [editor, setEditor] = useState<EditorState | null>(null);
   const [newTaskDraft, setNewTaskDraft] = useState<NewTaskEditorDraft | null>(null);
   const [detailTaskIdentifier, setDetailTaskIdentifier] = useState<string | null>(
@@ -1322,9 +1329,13 @@ export function App() {
     if (!options.quiet) setTasksLoading(true);
     setLoadError(null);
     try {
-      const nextTasks = await listTasks(projectId, options.signal);
+      const [nextTasks, nextArchivedTasks] = await Promise.all([
+        listTasks(projectId, options.signal),
+        listArchivedTasks(projectId, options.signal),
+      ]);
       if (requestId !== tasksRequestRef.current) return;
       setTasks(sortTasks(nextTasks));
+      setArchivedTasks(sortTasks(nextArchivedTasks));
       setHasLoadedTasks(true);
     } catch (error) {
       if ((error as Error).name !== "AbortError" && requestId === tasksRequestRef.current) {
@@ -1338,6 +1349,7 @@ export function App() {
   useEffect(() => {
     if (!selectedProjectId) {
       setTasks([]);
+      setArchivedTasks([]);
       setHasLoadedTasks(false);
       return;
     }
@@ -1536,6 +1548,10 @@ export function App() {
       (task) => matchesTaskSearch(task, search) && matchesTaskFilters(task, filters),
     );
   }, [filters, search, tasks]);
+
+  const filteredArchivedTasks = useMemo(() => archivedTasks.filter(
+    (task) => matchesTaskSearch(task, search) && matchesTaskFilters(task, filters),
+  ), [archivedTasks, filters, search]);
 
   const activeFilterCount = taskFilterCount(filters);
   const hasActiveTaskFilters = Boolean(search.trim()) || activeFilterCount > 0;
@@ -1907,8 +1923,13 @@ export function App() {
     try {
       const archived = await archiveTaskRequest(task);
       setTasks((current) => current.filter((candidate) => candidate.id !== task.id));
+      setArchivedTasks((current) => sortTasks([
+        ...current.filter((candidate) => candidate.id !== archived.id),
+        archived,
+      ]));
       pushUndo(`${task.identifier} 已归档。`, async () => {
         const restored = await restoreTaskRequest(archived);
+        setArchivedTasks((current) => current.filter((candidate) => candidate.id !== restored.id));
         setTasks((current) => sortTasks([
           ...current.filter((candidate) => candidate.id !== restored.id),
           restored,
@@ -1919,6 +1940,47 @@ export function App() {
         ? "该议题已在其他位置更新，看板已重新同步。"
         : errorMessage(error));
       if (selectedProjectId) void refreshTasks(selectedProjectId, { quiet: true });
+    }
+  }
+
+  async function restoreArchivedTask(task: Task) {
+    setActionError(null);
+    setRestoringTaskId(task.id);
+    try {
+      const restored = await restoreTaskRequest(task);
+      setArchivedTasks((current) => current.filter((candidate) => candidate.id !== restored.id));
+      setTasks((current) => sortTasks([
+        ...current.filter((candidate) => candidate.id !== restored.id),
+        restored,
+      ]));
+      setAnnouncement(`${restored.identifier} 已恢复。`);
+    } catch (error) {
+      setActionError(error instanceof ApiError && error.code === "VERSION_CONFLICT"
+        ? "该议题已在其他位置更新，看板已重新同步。"
+        : errorMessage(error));
+      if (selectedProjectId) void refreshTasks(selectedProjectId, { quiet: true });
+    } finally {
+      setRestoringTaskId(null);
+    }
+  }
+
+  async function deletePendingArchivedTask() {
+    if (!pendingArchivedTaskDelete || deletingArchivedTaskId) return;
+    const task = pendingArchivedTaskDelete;
+    setActionError(null);
+    setDeletingArchivedTaskId(task.id);
+    try {
+      await deleteArchivedTaskRequest(task);
+      setArchivedTasks((current) => current.filter((candidate) => candidate.id !== task.id));
+      setPendingArchivedTaskDelete(null);
+      setAnnouncement(`${task.identifier} 已永久删除。`);
+    } catch (error) {
+      setActionError(error instanceof ApiError && error.code === "VERSION_CONFLICT"
+        ? "该议题已在其他位置更新，看板已重新同步。"
+        : errorMessage(error));
+      if (selectedProjectId) void refreshTasks(selectedProjectId, { quiet: true });
+    } finally {
+      setDeletingArchivedTaskId(null);
     }
   }
 
@@ -2542,12 +2604,13 @@ export function App() {
                 {otherTasksMounted && (
                   <OtherTasksPanel
                     open={otherTasksVisible}
-                    activeStatus={otherTasksStatus}
+                    activeTab={otherTasksTab}
                     tasksByStatus={tasksByStatus}
+                    archivedTasks={filteredArchivedTasks}
                     presentations={taskPresentations}
                     now={processingNow}
                     hasActiveFilters={hasActiveTaskFilters}
-                    isDropTarget={dropTarget === otherTasksStatus}
+                    isDropTarget={otherTasksTab !== "archived" && dropTarget === otherTasksTab}
                     draggedTaskId={draggedTaskId}
                     draggedTaskHeight={draggedTaskHeight}
                     movingTaskId={movingTaskId}
@@ -2555,8 +2618,12 @@ export function App() {
                     contextMenuTaskId={contextMenu?.taskId ?? null}
                     availableLabels={availableLabels}
                     currentUser={currentUser}
-                    onStatusChange={setOtherTasksStatus}
+                    restoringTaskId={restoringTaskId}
+                    deletingTaskId={deletingArchivedTaskId}
+                    onTabChange={setOtherTasksTab}
                     onCreate={(initialStatus) => setEditor({ task: null, status: initialStatus })}
+                    onRestore={(task) => void restoreArchivedTask(task)}
+                    onDelete={setPendingArchivedTaskDelete}
                     onEdit={openTaskDetail}
                     onUpdate={updateTaskProperties}
                     onContextMenu={(task, position) => setContextMenu({ taskId: task.id, ...position })}
@@ -2698,6 +2765,50 @@ export function App() {
                 </div>
               </>
             )}
+          </div>
+        </div>
+      )}
+
+      {pendingArchivedTaskDelete && (
+        <div
+          className="delete-backdrop"
+          onPointerDown={(event) => {
+            if (event.target === event.currentTarget && !deletingArchivedTaskId) {
+              setPendingArchivedTaskDelete(null);
+            }
+          }}
+        >
+          <div
+            className="delete-dialog"
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="archived-task-delete-title"
+            onKeyDown={(event) => {
+              if (event.key === "Escape" && !deletingArchivedTaskId) {
+                setPendingArchivedTaskDelete(null);
+              }
+            }}
+          >
+            <h2 id="archived-task-delete-title">永久删除 {pendingArchivedTaskDelete.identifier}？</h2>
+            <p>“{pendingArchivedTaskDelete.title}”及其评论和附件将被永久删除，此操作无法撤销。</p>
+            <div>
+              <button
+                className="button secondary"
+                type="button"
+                disabled={deletingArchivedTaskId !== null}
+                onClick={() => setPendingArchivedTaskDelete(null)}
+              >
+                取消
+              </button>
+              <button
+                className="button danger"
+                type="button"
+                disabled={deletingArchivedTaskId !== null}
+                onClick={() => void deletePendingArchivedTask()}
+              >
+                {deletingArchivedTaskId ? "删除中…" : "永久删除"}
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -344,10 +344,22 @@ export async function listDevelopmentContexts(
   );
 }
 
-export async function listTasks(projectId: string, signal?: AbortSignal): Promise<Task[]> {
-  const params = new URLSearchParams({ projectId, archived: "false" });
+async function listTasksByArchive(
+  projectId: string,
+  archived: "true" | "false",
+  signal?: AbortSignal,
+): Promise<Task[]> {
+  const params = new URLSearchParams({ projectId, archived });
   const data = await request<{ tasks: Task[] }>(`/api/tasks?${params}`, { signal });
   return data.tasks;
+}
+
+export function listTasks(projectId: string, signal?: AbortSignal): Promise<Task[]> {
+  return listTasksByArchive(projectId, "false", signal);
+}
+
+export function listArchivedTasks(projectId: string, signal?: AbortSignal): Promise<Task[]> {
+  return listTasksByArchive(projectId, "true", signal);
 }
 
 export async function createTask(projectId: string, draft: TaskDraft, threadId?: string): Promise<Task> {
@@ -402,6 +414,13 @@ export async function restoreTask(task: Task, threadId?: string): Promise<Task> 
     },
   );
   return data.task;
+}
+
+export async function deleteArchivedTask(task: Task): Promise<void> {
+  await request(`/api/tasks/${encodeURIComponent(task.id)}`, {
+    method: "DELETE",
+    body: JSON.stringify({ version: task.version }),
+  });
 }
 
 export async function addTaskRelation(

--- a/web/src/components/DashboardView.css
+++ b/web/src/components/DashboardView.css
@@ -1,7 +1,20 @@
 .dashboard-view.dashboard-view {
+  --dashboard-summary-text: #502bf5;
+  --dashboard-contribution-1: #f9e1d7;
+  --dashboard-contribution-2: #f6c5b1;
+  --dashboard-contribution-3: #f8aa89;
+  --dashboard-contribution-4: #e98155;
   padding: 16px 8px 64px;
   background: transparent;
   scrollbar-width: none;
+}
+
+:root[data-theme="dark"] .dashboard-view.dashboard-view {
+  --dashboard-summary-text: color-mix(in srgb, var(--accent) 55%, var(--text-primary));
+  --dashboard-contribution-1: color-mix(in srgb, #e98155 22%, var(--surface-muted));
+  --dashboard-contribution-2: color-mix(in srgb, #e98155 42%, var(--surface-muted));
+  --dashboard-contribution-3: color-mix(in srgb, #e98155 68%, var(--surface-muted));
+  --dashboard-contribution-4: #e98155;
 }
 
 .dashboard-view.dashboard-view::-webkit-scrollbar,
@@ -41,7 +54,7 @@
 
 .dashboard-view .dashboard-heading h1 {
   margin: 0;
-  color: #1b1b1b;
+  color: var(--text-primary);
   font-size: 36px;
   font-weight: 650;
   letter-spacing: -.8909px;
@@ -73,7 +86,7 @@
   min-width: 0;
   overflow: hidden;
   padding: 0;
-  color: #9e9ea1;
+  color: var(--text-tertiary);
   font-size: 12px;
   font-weight: 520;
   line-height: 18px;
@@ -123,7 +136,7 @@
 
 .dashboard-view .dashboard-summary-bubble p {
   margin: 0;
-  color: #502bf5;
+  color: var(--dashboard-summary-text);
   font-size: 16px;
   font-weight: 520;
   letter-spacing: normal;
@@ -162,10 +175,10 @@
   gap: 0;
   overflow: hidden;
   margin-bottom: 14px;
-  border: .5px solid #e1e1e1;
+  border: .5px solid var(--border);
   border-radius: 12px;
-  background: #fff;
-  box-shadow: 0 3px 6px -2px rgba(0, 0, 0, .02), 0 1px 1px rgba(0, 0, 0, .04);
+  background: var(--surface);
+  box-shadow: var(--card-shadow);
 }
 
 .dashboard-view .dashboard-analysis-heading {
@@ -180,7 +193,7 @@
 
 .dashboard-view .dashboard-analysis-heading h2 {
   margin: 0;
-  color: #1b1b1b;
+  color: var(--text-primary);
   font-size: 18px;
   font-weight: 620;
   letter-spacing: -.8895px;
@@ -188,7 +201,7 @@
 }
 
 .dashboard-view .dashboard-metric {
-  --metric-color: #9e9ea1;
+  --metric-color: var(--text-tertiary);
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -198,7 +211,7 @@
   gap: 12px;
   padding: 20px 22px;
   border: 0;
-  border-left: .5px solid #e1e1e1;
+  border-left: .5px solid var(--border);
   border-radius: 0;
   background: transparent;
   box-shadow: none;
@@ -208,14 +221,14 @@
   border-left: 0;
 }
 
-.dashboard-view .dashboard-metric.tone-progress { --metric-color: #f0bf00; }
-.dashboard-view .dashboard-metric.tone-review { --metric-color: #43bc58; }
+.dashboard-view .dashboard-metric.tone-progress { --metric-color: var(--status-progress); }
+.dashboard-view .dashboard-metric.tone-review { --metric-color: var(--status-review); }
 .dashboard-view .dashboard-metric.tone-blocked,
-.dashboard-view .dashboard-metric.tone-overdue { --metric-color: #f34e52; }
-.dashboard-view .dashboard-metric.tone-backlog { --metric-color: #fe6c2e; }
+.dashboard-view .dashboard-metric.tone-overdue { --metric-color: var(--status-blocked); }
+.dashboard-view .dashboard-metric.tone-backlog { --metric-color: var(--priority-high); }
 
 .dashboard-view .dashboard-metric-label {
-  color: #5d5d5f;
+  color: var(--text-secondary);
   font-size: 12px;
   font-weight: 560;
   line-height: 18px;
@@ -231,7 +244,7 @@
 }
 
 .dashboard-view .dashboard-metric-value strong {
-  color: #1b1b1b;
+  color: var(--text-primary);
   font-size: 30px;
   font-weight: 630;
   letter-spacing: -.9px;
@@ -252,7 +265,7 @@
   flex: 0 0 8px;
   overflow: hidden;
   border-radius: 999px;
-  background: #f3f3f4;
+  background: var(--surface-muted);
 }
 
 .dashboard-view .dashboard-metric-meter i {
@@ -280,7 +293,7 @@
 }
 
 .dashboard-view .dashboard-progress-title > span {
-  color: #1b1b1b;
+  color: var(--text-primary);
   font-size: 12px;
   font-weight: 600;
   line-height: 18px;
@@ -301,7 +314,7 @@
   align-items: center;
   gap: 7px;
   min-width: 74px;
-  color: #5d5d5f;
+  color: var(--text-secondary);
   font-size: 12px;
   font-weight: 600;
   line-height: 18px;
@@ -315,13 +328,13 @@
 }
 
 .dashboard-view .dashboard-progress-legend strong {
-  color: #1b1b1b;
+  color: var(--text-primary);
   font-size: 12px;
   font-weight: 620;
   line-height: 18px;
 }
 
-.dashboard-view .dashboard-progress-legend .tone-scope { color: #d3d3d3; }
+.dashboard-view .dashboard-progress-legend .tone-scope { color: var(--text-quaternary); }
 .dashboard-view .dashboard-progress-legend .tone-started { color: #6a79ff; }
 .dashboard-view .dashboard-progress-legend .tone-completed { color: #22b889; }
 
@@ -345,7 +358,7 @@
 }
 
 .dashboard-view .dashboard-progress-baseline {
-  stroke: #eeeeef;
+  stroke: var(--border);
   stroke-width: .75;
 }
 
@@ -364,7 +377,7 @@
   stroke-width: 4;
 }
 
-.dashboard-view .dashboard-progress-line.tone-scope { stroke: #d3d3d3; }
+.dashboard-view .dashboard-progress-line.tone-scope { stroke: var(--text-quaternary); }
 .dashboard-view .dashboard-progress-line.tone-started { stroke: #6a79ff; }
 .dashboard-view .dashboard-progress-line.tone-completed { stroke: #22b889; }
 
@@ -382,22 +395,22 @@
 }
 
 .dashboard-view .dashboard-progress-now-line {
-  stroke: #d4d4d6;
+  stroke: var(--border-strong);
   stroke-width: .75;
 }
 
 .dashboard-view .dashboard-progress-point {
-  stroke: #fff;
+  stroke: var(--surface);
   stroke-width: 1.1;
 }
 
-.dashboard-view .dashboard-progress-point.tone-scope { fill: #d3d3d3; }
+.dashboard-view .dashboard-progress-point.tone-scope { fill: var(--text-quaternary); }
 .dashboard-view .dashboard-progress-point.tone-started { fill: #6a79ff; }
 .dashboard-view .dashboard-progress-point.tone-completed { fill: #22b889; }
 
 .dashboard-view .dashboard-progress-hover-line {
   pointer-events: none;
-  stroke: #9e9ea1;
+  stroke: var(--text-tertiary);
   stroke-dasharray: 4 4;
   stroke-width: 1;
 }
@@ -407,26 +420,26 @@
 }
 
 .dashboard-view .dashboard-progress-tooltip rect {
-  fill: #fff;
-  stroke: #dedee0;
+  fill: var(--surface-raised);
+  stroke: var(--border);
   stroke-width: .75;
   filter: drop-shadow(0 4px 10px rgba(0, 0, 0, .08));
 }
 
 .dashboard-view .dashboard-progress-tooltip text {
-  fill: #5d5d5f;
+  fill: var(--text-secondary);
   font-size: 10px;
   font-weight: 520;
 }
 
 .dashboard-view .dashboard-progress-tooltip .dashboard-progress-tooltip-date {
-  fill: #1b1b1b;
+  fill: var(--text-primary);
   font-size: 11px;
   font-weight: 620;
 }
 
 .dashboard-view .dashboard-progress-tooltip .dashboard-progress-tooltip-delta {
-  fill: #9e9ea1;
+  fill: var(--text-tertiary);
   text-anchor: start;
 }
 
@@ -436,13 +449,13 @@
 }
 
 .dashboard-view .dashboard-progress-axis-label {
-  fill: #9e9ea1;
+  fill: var(--text-tertiary);
   font-size: 10px;
   font-weight: 500;
 }
 
 .dashboard-view .dashboard-progress-axis-label.is-current {
-  fill: #5d5d5f;
+  fill: var(--text-secondary);
   font-weight: 600;
 }
 
@@ -457,10 +470,10 @@
   flex-direction: column;
   min-width: 0;
   overflow: hidden;
-  border: .5px solid #e1e1e1;
+  border: .5px solid var(--border);
   border-radius: 12px;
-  background: #fff;
-  box-shadow: 0 3px 6px -2px rgba(0, 0, 0, .02), 0 1px 1px rgba(0, 0, 0, .04);
+  background: var(--surface);
+  box-shadow: var(--card-shadow);
 }
 
 .dashboard-view .dashboard-primary-panel {
@@ -514,11 +527,11 @@
   min-height: 46px;
   gap: 12px;
   padding: 12px 19px 12.5px;
-  border-bottom: .5px solid #e1e1e1;
+  border-bottom: .5px solid var(--border);
 }
 
 .dashboard-view .dashboard-panel > header span {
-  color: #1b1b1b;
+  color: var(--text-primary);
   font-size: 12px;
   font-weight: 600;
   line-height: 18px;
@@ -529,7 +542,7 @@
   padding: 0;
   border-radius: 0;
   background: transparent;
-  color: #9e9ea1;
+  color: var(--text-tertiary);
   font-size: 12px;
   font-weight: 520;
   line-height: 18px;
@@ -539,7 +552,7 @@
   min-width: 25px;
   padding: 3px 7px;
   border-radius: 999px;
-  background: #f3f3f4;
+  background: var(--surface-muted);
   font-size: 9px;
   font-weight: 600;
   line-height: 13.5px;
@@ -592,7 +605,7 @@
   height: 6px;
   overflow: hidden;
   border-radius: 999px;
-  background: #f3f3f4;
+  background: var(--surface-muted);
 }
 
 .dashboard-view .dashboard-priority-track i {
@@ -604,7 +617,7 @@
 }
 
 .dashboard-view .dashboard-priority-row > strong {
-  color: #5d5d5f;
+  color: var(--text-secondary);
   font-size: 11px;
   font-weight: 560;
   line-height: 17px;
@@ -630,9 +643,9 @@
   width: 100%;
   gap: 8px;
   padding: 12.5px;
-  border: .5px solid #fcfcfd;
+  border: .5px solid var(--border);
   border-radius: 10px;
-  background: #f7f7f7;
+  background: var(--surface-hover);
   color: inherit;
   text-align: left;
   transition: background 120ms ease;
@@ -640,7 +653,7 @@
 
 .dashboard-view .dashboard-attention-row:hover,
 .dashboard-view .dashboard-upcoming-row:hover {
-  background: #f3f3f4;
+  background: var(--surface-muted);
 }
 
 .dashboard-view .dashboard-attention-row {
@@ -659,14 +672,14 @@
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: #317cff;
+  background: var(--accent);
 }
 
 .dashboard-view .dashboard-attention-row strong,
 .dashboard-view .dashboard-upcoming-row strong {
   min-width: 0;
   overflow: hidden;
-  color: #1b1b1b;
+  color: var(--text-primary);
   font-size: 11px;
   font-weight: 520;
   letter-spacing: .06px;
@@ -677,7 +690,7 @@
 
 .dashboard-view .dashboard-attention-row small,
 .dashboard-view .dashboard-upcoming-row time {
-  color: #9e9ea1;
+  color: var(--text-tertiary);
   font-size: 9px;
   font-weight: 400;
   letter-spacing: .17px;
@@ -693,10 +706,10 @@
   min-height: 80px;
   gap: 10px;
   padding: 16px;
-  border: .5px solid #fcfcfd;
+  border: .5px solid var(--border);
   border-radius: 12px;
-  background: #f7f7f7;
-  box-shadow: 0 3px 6px -2px rgba(0, 0, 0, .02), 0 1px 1px rgba(0, 0, 0, .04);
+  background: var(--surface-hover);
+  box-shadow: var(--card-shadow);
 }
 
 .dashboard-view .dashboard-running-open {
@@ -712,7 +725,7 @@
 }
 
 .dashboard-view .dashboard-running-open small {
-  color: #9e9ea1;
+  color: var(--text-tertiary);
   font-size: 11px;
   font-weight: 400;
   line-height: 16.5px;
@@ -720,7 +733,7 @@
 
 .dashboard-view .dashboard-running-open strong {
   overflow: hidden;
-  color: #1b1b1b;
+  color: var(--text-primary);
   font-size: 13px;
   font-weight: 520;
   line-height: 19.5px;
@@ -761,7 +774,7 @@
   gap: 1px;
   overflow: hidden;
   border-radius: 999px;
-  background: #f3f3f4;
+  background: var(--surface-muted);
 }
 
 .dashboard-view .dashboard-role-stack i {
@@ -796,7 +809,7 @@
   align-items: center;
   min-height: 50px;
   gap: 9px;
-  border-bottom: .5px solid #e1e1e1;
+  border-bottom: .5px solid var(--border);
 }
 
 .dashboard-view .dashboard-role-row:last-child {
@@ -817,7 +830,7 @@
 
 .dashboard-view .dashboard-role-copy strong {
   overflow: hidden;
-  color: #1b1b1b;
+  color: var(--text-primary);
   font-size: 11px;
   font-weight: 600;
   line-height: 16.5px;
@@ -826,7 +839,7 @@
 }
 
 .dashboard-view .dashboard-role-copy small {
-  color: #9e9ea1;
+  color: var(--text-tertiary);
   font-size: 9px;
   font-weight: 400;
   line-height: 13.5px;
@@ -862,7 +875,7 @@
   min-width: 0;
   gap: var(--contribution-gap);
   margin-left: 25px;
-  color: #9e9ea1;
+  color: var(--text-tertiary);
   font-size: 8px;
   line-height: 1;
 }
@@ -882,7 +895,7 @@
 .dashboard-view .dashboard-contribution-weekdays {
   display: grid;
   grid-template-rows: repeat(7, minmax(0, 1fr));
-  color: #9e9ea1;
+  color: var(--text-tertiary);
   font-size: 8px;
   line-height: 1;
 }
@@ -905,13 +918,13 @@
   min-width: 0;
   aspect-ratio: 1;
   border-radius: 2.5px;
-  background: #f3f3f4;
+  background: var(--surface-muted);
 }
 
-.dashboard-view .dashboard-contribution-cell.level-1 { background: #f9e1d7; }
-.dashboard-view .dashboard-contribution-cell.level-2 { background: #f6c5b1; }
-.dashboard-view .dashboard-contribution-cell.level-3 { background: #f8aa89; }
-.dashboard-view .dashboard-contribution-cell.level-4 { background: #e98155; }
+.dashboard-view .dashboard-contribution-cell.level-1 { background: var(--dashboard-contribution-1); }
+.dashboard-view .dashboard-contribution-cell.level-2 { background: var(--dashboard-contribution-2); }
+.dashboard-view .dashboard-contribution-cell.level-3 { background: var(--dashboard-contribution-3); }
+.dashboard-view .dashboard-contribution-cell.level-4 { background: var(--dashboard-contribution-4); }
 
 .dashboard-view .dashboard-contribution-cell.is-future {
   visibility: hidden;
@@ -923,7 +936,7 @@
   justify-content: flex-end;
   height: 22px;
   gap: 4px;
-  color: #9e9ea1;
+  color: var(--text-tertiary);
   font-size: 8px;
   line-height: 12px;
 }
@@ -945,6 +958,10 @@
   height: 14px;
 }
 
+:root[data-theme="dark"] .dashboard-view .dashboard-upcoming-row img {
+  filter: invert(1);
+}
+
 .dashboard-view .dashboard-label-chart {
   display: grid;
   grid-template-columns: max-content max-content minmax(0, 1fr);
@@ -962,7 +979,7 @@
 
 .dashboard-view .dashboard-label-chart-row > strong {
   justify-self: end;
-  color: #5d5d5f;
+  color: var(--text-secondary);
   font-size: 11px;
   font-weight: 520;
   letter-spacing: .06px;
@@ -973,7 +990,7 @@
 .dashboard-view .dashboard-label-chart-row > span {
   align-self: center;
   justify-self: start;
-  color: #9e9ea1;
+  color: var(--text-tertiary);
   font-size: 9px;
   font-weight: 500;
   letter-spacing: .17px;
@@ -999,7 +1016,7 @@
   align-items: center;
   justify-content: center;
   min-height: 104px;
-  color: #9e9ea1;
+  color: var(--text-tertiary);
   font-size: 9px;
 }
 
@@ -1024,8 +1041,8 @@
 
   .dashboard-view .dashboard-metric {
     min-height: 120px;
-    border-top: .5px solid #e1e1e1;
-    border-left: .5px solid #e1e1e1;
+    border-top: .5px solid var(--border);
+    border-left: .5px solid var(--border);
   }
 
   .dashboard-view .dashboard-metric:nth-child(-n+2) {
@@ -1117,7 +1134,7 @@
   .dashboard-view .dashboard-metric,
   .dashboard-view .dashboard-metric:nth-child(-n+2),
   .dashboard-view .dashboard-metric:nth-child(odd) {
-    border-top: .5px solid #e1e1e1;
+    border-top: .5px solid var(--border);
     border-left: 0;
   }
 

--- a/web/src/components/OtherTasksPanel.tsx
+++ b/web/src/components/OtherTasksPanel.tsx
@@ -3,18 +3,79 @@ import type { DragEvent } from "react";
 import type { ActorIdentity, Task, TaskDraft, TaskStatus } from "../types";
 import type { TaskCardPresentation, TaskConversationItem } from "../taskConversations";
 import {
-  SECONDARY_STATUSES,
-  type SecondaryTaskStatus,
+  OTHER_TASK_TABS,
+  type OtherTaskTab,
 } from "../issueBoardStatuses";
 import { STATUS_DETAILS } from "./BoardColumn";
-import { LinearIcon } from "./LinearIcon";
+import { LinearIcon, LinearStatusIcon } from "./LinearIcon";
 import { TaskCard } from "./TaskCard";
 import { TaskboardIcon } from "./TaskboardIcon";
 
+const ARCHIVED_DATE_FORMATTER = new Intl.DateTimeFormat("zh-CN", {
+  month: "numeric",
+  day: "numeric",
+});
+
+function archivedDate(value: string | null) {
+  return value ? `${ARCHIVED_DATE_FORMATTER.format(new Date(value))}归档` : "";
+}
+
+interface ArchivedTaskCardProps {
+  task: Task;
+  busy: boolean;
+  restoring: boolean;
+  onRestore: (task: Task) => void;
+  onDelete: (task: Task) => void;
+}
+
+function ArchivedTaskCard({
+  task,
+  busy,
+  restoring,
+  onRestore,
+  onDelete,
+}: ArchivedTaskCardProps) {
+  return (
+    <article className={`task-card task-card-sidebar archived-task-card status-${task.status}`}>
+      <div className="card-topline">
+        <span className="task-identifier">ID: {task.identifier}</span>
+        <span className="archived-task-date">{archivedDate(task.archivedAt)}</span>
+      </div>
+      <h3>{task.title}</h3>
+      <div className="archived-task-footer">
+        <span className="archived-task-status">
+          <LinearStatusIcon status={task.status} />
+          {STATUS_DETAILS[task.status].label}
+        </span>
+        <button
+          className="archived-task-action archived-task-restore"
+          type="button"
+          disabled={busy}
+          onClick={() => onRestore(task)}
+        >
+          <LinearIcon name="recurrence" />
+          {restoring ? "恢复中…" : "恢复"}
+        </button>
+        <button
+          className="archived-task-action archived-task-delete"
+          type="button"
+          aria-label={`永久删除 ${task.identifier}`}
+          title="永久删除"
+          disabled={busy}
+          onClick={() => onDelete(task)}
+        >
+          <LinearIcon name="trash" />
+        </button>
+      </div>
+    </article>
+  );
+}
+
 interface OtherTasksPanelProps {
   open: boolean;
-  activeStatus: SecondaryTaskStatus;
+  activeTab: OtherTaskTab;
   tasksByStatus: Record<TaskStatus, Task[]>;
+  archivedTasks: Task[];
   presentations: Record<string, TaskCardPresentation>;
   now: number;
   hasActiveFilters: boolean;
@@ -26,8 +87,12 @@ interface OtherTasksPanelProps {
   contextMenuTaskId: string | null;
   availableLabels: string[];
   currentUser: ActorIdentity;
-  onStatusChange: (status: SecondaryTaskStatus) => void;
-  onCreate: (status: SecondaryTaskStatus) => void;
+  restoringTaskId: string | null;
+  deletingTaskId: string | null;
+  onTabChange: (tab: OtherTaskTab) => void;
+  onCreate: (status: Exclude<OtherTaskTab, "archived">) => void;
+  onRestore: (task: Task) => void;
+  onDelete: (task: Task) => void;
   onEdit: (task: Task) => void;
   onUpdate: (task: Task, changes: Partial<TaskDraft>) => Promise<Task>;
   onContextMenu: (task: Task, position: { x: number; y: number }) => void;
@@ -40,8 +105,9 @@ interface OtherTasksPanelProps {
 
 export function OtherTasksPanel({
   open,
-  activeStatus,
+  activeTab,
   tasksByStatus,
+  archivedTasks,
   presentations,
   now,
   hasActiveFilters,
@@ -53,8 +119,12 @@ export function OtherTasksPanel({
   contextMenuTaskId,
   availableLabels,
   currentUser,
-  onStatusChange,
+  restoringTaskId,
+  deletingTaskId,
+  onTabChange,
   onCreate,
+  onRestore,
+  onDelete,
   onEdit,
   onUpdate,
   onContextMenu,
@@ -64,7 +134,8 @@ export function OtherTasksPanel({
   onDrop,
   onOpenConversation,
 }: OtherTasksPanelProps) {
-  const tasks = tasksByStatus[activeStatus];
+  const archived = activeTab === "archived";
+  const tasks = archived ? archivedTasks : tasksByStatus[activeTab];
   const [dropBeforeTaskId, setDropBeforeTaskId] = useState<string | null | undefined>();
   const taskIndexes = new Map(tasks.map((task, index) => [task.id, index]));
   const remainingTasks = tasks.filter((task) => task.id !== draggedTaskId);
@@ -89,10 +160,11 @@ export function OtherTasksPanel({
 
   function handleDrop(event: DragEvent<HTMLElement>) {
     event.preventDefault();
+    if (archived) return;
     const taskId =
       event.dataTransfer.getData("application/x-taskboard-task") ||
       event.dataTransfer.getData("text/plain");
-    if (taskId) onDrop(activeStatus, taskId, findDropBefore(event.currentTarget, event.clientY));
+    if (taskId) onDrop(activeTab, taskId, findDropBefore(event.currentTarget, event.clientY));
     setDropBeforeTaskId(undefined);
   }
 
@@ -115,50 +187,56 @@ export function OtherTasksPanel({
       aria-hidden={!open}
     >
       <div className="other-tasks-tabs" role="tablist" aria-label="其他任务状态">
-        {SECONDARY_STATUSES.map((status) => {
-          const details = STATUS_DETAILS[status];
-          const selected = status === activeStatus;
+        {OTHER_TASK_TABS.map((tab) => {
+          const label = tab === "archived" ? "已归档" : STATUS_DETAILS[tab].label;
+          const count = tab === "archived" ? archivedTasks.length : tasksByStatus[tab].length;
+          const selected = tab === activeTab;
           return (
             <button
               className={`other-tasks-tab${selected ? " is-active" : ""}`}
-              id={`other-tasks-tab-${status}`}
-              key={status}
+              id={`other-tasks-tab-${tab}`}
+              key={tab}
               type="button"
               role="tab"
               aria-selected={selected}
               aria-controls="other-tasks-list"
-              title={`${details.label} ${tasksByStatus[status].length}`}
-              onClick={() => onStatusChange(status)}
+              title={`${label} ${count}`}
+              onClick={() => onTabChange(tab)}
             >
-              <span className="other-tasks-tab-label">{details.label}</span>
-              <span className="other-tasks-tab-count" aria-label={`${tasksByStatus[status].length} 个议题`}>
-                {tasksByStatus[status].length}
+              <span className="other-tasks-tab-label">{label}</span>
+              <span className="other-tasks-tab-count" aria-label={`${count} 个议题`}>
+                {count}
               </span>
             </button>
           );
         })}
       </div>
 
-      <button
-        className="other-tasks-add"
-        type="button"
-        aria-label={`在${STATUS_DETAILS[activeStatus].label}中新建议题`}
-        title={`添加到${STATUS_DETAILS[activeStatus].label}`}
-        onClick={() => onCreate(activeStatus)}
-      >
-        <TaskboardIcon name="sidebarAdd" />
-      </button>
+      {!archived && (
+        <button
+          className="other-tasks-add"
+          type="button"
+          aria-label={`在${STATUS_DETAILS[activeTab].label}中新建议题`}
+          title={`添加到${STATUS_DETAILS[activeTab].label}`}
+          onClick={() => onCreate(activeTab)}
+        >
+          <TaskboardIcon name="sidebarAdd" />
+        </button>
+      )}
 
       <div
-        className="other-tasks-list"
+        className={`other-tasks-list${archived ? " is-archived" : ""}`}
         id="other-tasks-list"
         role="tabpanel"
-        aria-labelledby={`other-tasks-tab-${activeStatus}`}
-        onDragEnter={() => onDragEnter(activeStatus)}
+        aria-labelledby={`other-tasks-tab-${activeTab}`}
+        onDragEnter={() => {
+          if (!archived) onDragEnter(activeTab);
+        }}
         onDragOver={(event) => {
+          if (archived) return;
           event.preventDefault();
           event.dataTransfer.dropEffect = "move";
-          onDragEnter(activeStatus);
+          onDragEnter(activeTab);
           setDropBeforeTaskId(findDropBefore(event.currentTarget, event.clientY));
         }}
         onDragLeave={(event) => {
@@ -168,7 +246,16 @@ export function OtherTasksPanel({
         }}
         onDrop={handleDrop}
       >
-        {tasks.map((task) => {
+        {archived ? archivedTasks.map((task) => (
+          <ArchivedTaskCard
+            key={task.id}
+            task={task}
+            busy={restoringTaskId !== null || deletingTaskId !== null}
+            restoring={restoringTaskId === task.id}
+            onRestore={onRestore}
+            onDelete={onDelete}
+          />
+        )) : tasks.map((task) => {
           const dragShift = getTaskDragShift(task);
           return (
             <TaskCard
@@ -195,9 +282,15 @@ export function OtherTasksPanel({
         })}
         {tasks.length === 0 && (
           <div className="other-tasks-empty">
-            <LinearIcon name={hasActiveFilters ? "search" : "panel"} />
+            <LinearIcon name={hasActiveFilters ? "search" : archived ? "trash" : "panel"} />
             <strong>{hasActiveFilters ? "当前筛选下无匹配议题" : "暂无议题"}</strong>
-            <span>{hasActiveFilters ? "搜索和筛选会同步作用于所有状态。" : `没有${STATUS_DETAILS[activeStatus].label}。`}</span>
+            <span>
+              {hasActiveFilters
+                ? "搜索和筛选会同步作用于所有状态。"
+                : archived
+                  ? "没有已归档议题。"
+                  : `没有${STATUS_DETAILS[activeTab].label}。`}
+            </span>
           </div>
         )}
       </div>

--- a/web/src/components/TaskboardIcon.tsx
+++ b/web/src/components/TaskboardIcon.tsx
@@ -63,6 +63,27 @@ const TASKBOARD_ICONS = {
 
 export type TaskboardIconName = keyof typeof TASKBOARD_ICONS;
 
+const MONOCHROME_ICONS = new Set<TaskboardIconName>([
+  "aiLauncher",
+  "automationPlay",
+  "breadcrumb",
+  "calendar",
+  "columnAdd",
+  "conversation",
+  "create",
+  "dropdown",
+  "filter",
+  "home",
+  "panel",
+  "projectFolder",
+  "search",
+  "sidebarAdd",
+  "statusBlocked",
+  "statusProgress",
+  "statusReview",
+  "statusTodo",
+]);
+
 export function taskboardIconSource(name: TaskboardIconName) {
   return TASKBOARD_ICONS[name];
 }
@@ -72,10 +93,16 @@ interface TaskboardIconProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, "
 }
 
 export function TaskboardIcon({ name, className, ...props }: TaskboardIconProps) {
+  const classes = [
+    "taskboard-icon",
+    MONOCHROME_ICONS.has(name) ? "taskboard-icon-monochrome" : "",
+    className ?? "",
+  ].filter(Boolean).join(" ");
+
   return (
     <img
       {...props}
-      className={`taskboard-icon${className ? ` ${className}` : ""}`}
+      className={classes}
       src={TASKBOARD_ICONS[name]}
       alt=""
       aria-hidden="true"

--- a/web/src/issueBoardStatuses.ts
+++ b/web/src/issueBoardStatuses.ts
@@ -13,5 +13,11 @@ export const SECONDARY_STATUSES = [
   "canceled",
 ] as const satisfies readonly TaskStatus[];
 
+export const OTHER_TASK_TABS = [
+  ...SECONDARY_STATUSES,
+  "archived",
+] as const;
+
 export type MainTaskStatus = (typeof MAIN_STATUSES)[number];
 export type SecondaryTaskStatus = (typeof SECONDARY_STATUSES)[number];
+export type OtherTaskTab = (typeof OTHER_TASK_TABS)[number];

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -127,6 +127,12 @@
   object-fit: contain;
 }
 
+:root[data-theme="dark"] .taskboard-icon-monochrome,
+:root[data-theme="dark"] .detail-copy-action-icon img,
+:root[data-theme="dark"] .gantt_tree_icon img {
+  filter: invert(1);
+}
+
 html,
 body,
 #root {
@@ -951,7 +957,7 @@ kbd {
   border-radius: 16px;
   outline: 0;
   background: transparent;
-  color: #1b1b1b;
+  color: var(--text-secondary);
   filter: drop-shadow(0 3px 3px rgba(0, 0, 0, .02)) drop-shadow(0 1px .5px rgba(0, 0, 0, .04));
   font: inherit;
   font-size: 10px;
@@ -976,10 +982,10 @@ kbd {
 }
 
 .view-tab.active {
-  border-color: #e1e1e1;
-  background: #fff;
-  box-shadow: 0 3px 6px -2px rgba(0, 0, 0, .02), 0 1px 1px rgba(0, 0, 0, .04);
-  color: #1b1b1b;
+  border-color: var(--border);
+  background: var(--surface);
+  box-shadow: var(--card-shadow);
+  color: var(--text-primary);
   filter: none;
   font-weight: 500;
 }
@@ -1742,7 +1748,7 @@ kbd {
 
 .other-tasks-tabs {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   flex: 0 0 auto;
   gap: 2px;
   padding: 7px 8px;
@@ -8854,7 +8860,7 @@ kbd {
   border: .5px solid transparent;
   border-radius: 16px;
   background: transparent;
-  color: #1b1b1b;
+  color: var(--text-secondary);
   font-size: 10px;
   font-weight: 500;
   line-height: 15px;
@@ -8875,10 +8881,10 @@ kbd {
 
 .view-tab.active,
 .view-tab.active:hover {
-  border-color: #e1e1e1;
-  background: #fff;
-  box-shadow: 0 3px 6px -2px rgba(0, 0, 0, .02), 0 1px 1px rgba(0, 0, 0, .04);
-  color: #1b1b1b;
+  border-color: var(--border);
+  background: var(--surface);
+  box-shadow: var(--card-shadow);
+  color: var(--text-primary);
   filter: none;
   font-weight: 500;
 }
@@ -8956,7 +8962,7 @@ kbd {
   padding: 0 18px;
   column-gap: 0;
   overflow: hidden;
-  background: #fff;
+  background: var(--surface);
   transition:
     grid-template-columns 320ms var(--panel-spring),
     column-gap 320ms var(--panel-spring);
@@ -9057,6 +9063,11 @@ kbd {
   pointer-events: none;
 }
 
+:root[data-theme="dark"] .board-column:not(:first-child) .column-header::before {
+  filter: invert(1);
+  opacity: .45;
+}
+
 .column-heading {
   gap: 6px;
 }
@@ -9135,7 +9146,7 @@ kbd {
   overflow-x: hidden;
   overflow-y: auto;
   border-radius: 18px;
-  background: #f8f8f9;
+  background: var(--column-header);
   overscroll-behavior-y: contain;
 }
 
@@ -9145,17 +9156,17 @@ kbd {
   gap: 10px;
   padding: 16px;
   overflow: hidden;
-  border: 1px solid rgba(0, 0, 0, .1);
+  border: 1px solid var(--border);
   border-radius: 12px;
-  background: #fff;
-  box-shadow: 0 3px 6px -2px rgba(0, 0, 0, .02), 0 1px 1px rgba(0, 0, 0, .04);
+  background: var(--surface);
+  box-shadow: var(--card-shadow);
 }
 
 .task-card:hover,
 .task-card.is-context-open {
-  border-color: rgba(0, 0, 0, .14);
-  background: #fff;
-  box-shadow: 0 3px 6px -2px rgba(0, 0, 0, .06), 0 1px 1px rgba(0, 0, 0, .08);
+  border-color: var(--border-strong);
+  background: var(--surface-raised);
+  box-shadow: var(--card-shadow);
 }
 
 .task-card-open {
@@ -9213,7 +9224,7 @@ kbd {
 }
 
 .task-identifier {
-  color: #9e9ea1;
+  color: var(--text-tertiary);
   font-size: 11px;
   font-weight: 500;
   line-height: 15px;
@@ -9232,9 +9243,9 @@ kbd {
   width: 100%;
   padding: 0;
   overflow: hidden;
-  border: 1px solid rgba(0, 0, 0, .05);
+  border: 1px solid var(--border);
   border-radius: 8px;
-  background: #e9e9e9;
+  background: var(--surface-muted);
 }
 
 .task-card-media img {
@@ -9298,9 +9309,9 @@ kbd {
   height: 20px;
   gap: 4px;
   padding: 0 7px;
-  border: .5px solid #e1e1e1;
+  border: .5px solid var(--border);
   border-radius: 999px;
-  background: #fff;
+  background: var(--surface);
   color: var(--text-tertiary);
   font-size: 10px;
   font-weight: 450;
@@ -9332,9 +9343,9 @@ kbd {
   gap: 4px;
   padding: 0 7px;
   overflow: hidden;
-  border: .5px solid #e1e1e1;
+  border: .5px solid var(--border);
   border-radius: 999px;
-  background: #fff;
+  background: var(--surface);
   color: var(--text-secondary);
   font-size: 10px;
   font-weight: 450;
@@ -9541,7 +9552,7 @@ kbd {
   justify-content: space-between;
   min-height: 21px;
   padding-top: 8px;
-  border-top: .5px solid rgba(0, 0, 0, .1);
+  border-top: .5px solid var(--border);
 }
 
 .task-participants {
@@ -9569,7 +9580,7 @@ kbd {
   height: 16px;
   border-width: 1px;
   font-size: 7px;
-  box-shadow: 0 0 0 1px rgba(255, 255, 255, .85);
+  box-shadow: 0 0 0 1px var(--surface);
 }
 
 .task-participant-avatar + .task-participant-avatar {
@@ -9580,9 +9591,9 @@ kbd {
   box-sizing: border-box;
   overflow: hidden;
   padding: 1px;
-  border: 1px solid #fff;
+  border: 1px solid var(--surface);
   border-radius: 50%;
-  background: #fff;
+  background: var(--surface);
   filter: none;
   box-shadow: none;
 }
@@ -9606,9 +9617,9 @@ kbd {
   gap: 3px;
   margin-left: auto;
   padding: 0 5px;
-  border: .5px solid #e1e1e1;
+  border: .5px solid var(--border);
   border-radius: 999px;
-  background: #fff;
+  background: var(--surface);
   color: var(--text-secondary);
   font-size: 9px;
   font-variant-numeric: tabular-nums;
@@ -9773,7 +9784,7 @@ kbd {
   overflow: hidden;
   border: 0;
   border-radius: 18px;
-  background: #f8f8f9;
+  background: var(--column-header);
   visibility: hidden;
   transform: translateX(calc(100% + 18px));
   pointer-events: none;
@@ -9795,7 +9806,7 @@ kbd {
 
 .other-tasks-tabs {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   flex: 0 0 48px;
   gap: 3px;
   height: 48px;
@@ -9885,6 +9896,88 @@ kbd {
 .other-tasks-list .task-card h3 {
   font-size: 13px;
   line-height: 18px;
+}
+
+.other-tasks-list.is-archived {
+  padding-top: 0;
+}
+
+.archived-task-card {
+  cursor: default;
+}
+
+.archived-task-card .card-topline {
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.archived-task-date {
+  margin-left: auto;
+  color: var(--text-quaternary);
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+.archived-task-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.archived-task-status {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--text-tertiary);
+  font-size: 10px;
+}
+
+.archived-task-status svg,
+.archived-task-restore svg {
+  width: 13px;
+  height: 13px;
+}
+
+.archived-task-action {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  height: 24px;
+  padding: 0 8px;
+  border: var(--border-hairline) solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text-secondary);
+  font-size: 10px;
+  pointer-events: auto;
+}
+
+.archived-task-restore {
+  min-width: 58px;
+  margin-left: auto;
+}
+
+.archived-task-delete {
+  width: 24px;
+  padding: 0;
+  color: var(--danger);
+}
+
+.archived-task-action:hover:not(:disabled) {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.archived-task-delete:hover:not(:disabled) {
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+.archived-task-action:disabled {
+  cursor: wait;
+  opacity: .6;
 }
 
 .ai-chat-launcher {


### PR DESCRIPTION
## 变更

- 修复普通页面和 Codex 内嵌页面共用的暗色视觉问题：顶部视图标签、议题看板表面与卡片、Dashboard 面板和灰阶图标。
- 新增“已归档”任务页签、直接恢复和永久删除入口。
- 本地服务删除归档任务时清理任务附件与评论附件的物理文件；Cloud Worker 同步清理 D1 元数据和 R2 对象。
- 保留现有主题系统和现有归档/恢复 API，不引入第二套实现。
- 未移植 PR #2 的原生 `select option` 样式：当前根节点已有暗色 `color-scheme`，普通页和内嵌页未复现不可读问题。

## 根因

看板和 Dashboard 的部分组件仍使用固定白色、黑色和浅色边框，没有使用现有主题变量。归档后只有即时撤销入口，前端没有持久归档列表；后端也没有仅限归档任务的永久删除与附件实体清理路径。

## 直接验证

- `npm run build:web`
- `npm run typecheck`
- `node --check server/app.mjs`
- `node --check server/database.mjs`
- `node --check cloud/src/index.mjs`
- Playwright 视觉复核：普通页与 Codex 内嵌页的议题看板、Dashboard；普通页的列表、甘特图、详情；标签选中、未选中和悬停状态。
- 隔离临时数据库直验：归档列表可见 → UI 恢复 → 再归档 → UI 永久删除；删除后任务 GET 为 404，任务/评论/附件元数据计数均为 0，任务附件和评论附件文件均消失。

## 范围

关联 #38、#42，并收敛审计 PR #2、#39、#40 后当前 `main` 仍缺失的最小生产改动。没有直接合并外部 PR，也没有新增测试。