### PR TITLE
增加 macOS 状态栏菜单

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ tauri-build = { version = "2.6.0", features = [] }
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tauri = { version = "2.11.5", features = [] }
+tauri = { version = "2.11.5", features = ["tray-icon"] }
 tauri-plugin-dialog = "2.7.2"
 tauri-plugin-updater = "2.10.1"
 uuid = { version = "1", features = ["v4"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -15,7 +15,11 @@ use std::{
     thread,
     time::{Duration, Instant},
 };
-use tauri::{ActivationPolicy, AppHandle, Emitter, Manager};
+use tauri::{
+    menu::{Menu, MenuItem},
+    tray::TrayIconBuilder,
+    ActivationPolicy, AppHandle, Emitter, Manager,
+};
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 use tauri_plugin_updater::{Update, UpdaterExt};
 use uuid::Uuid;
@@ -614,15 +618,29 @@ async fn install_update(
     app.restart()
 }
 
-async fn offer_startup_update(app: &AppHandle, state: &Arc<LauncherState>) {
+async fn offer_update(app: &AppHandle, state: &Arc<LauncherState>, show_current_version: bool) {
     let update = match check_for_startup_update(app, state).await {
         Ok(update) => update,
         Err(error) => {
-            append_log(state, &format!("Startup update check failed: {error}"));
+            append_log(state, &format!("Update check failed: {error}"));
+            if show_current_version {
+                show_error_dialog(
+                    app,
+                    "Codex Taskboard 更新检查失败",
+                    &format!("无法检查更新。请稍后重试。\n\n{error}"),
+                );
+            }
             return;
         }
     };
     let Some(update) = update else {
+        if show_current_version {
+            app.dialog()
+                .message("当前已是最新版本。")
+                .title("Codex Taskboard 更新")
+                .buttons(MessageDialogButtons::Ok)
+                .blocking_show();
+        }
         return;
     };
 
@@ -645,10 +663,7 @@ async fn offer_startup_update(app: &AppHandle, state: &Arc<LauncherState>) {
     }
     append_log(state, &format!("Update {version} accepted by user"));
     if let Err(error) = install_update(app, state, update).await {
-        append_log(
-            state,
-            &format!("Startup update installation failed: {error}"),
-        );
+        append_log(state, &format!("Update installation failed: {error}"));
         let service_recovered = state.snapshot.lock().unwrap().child_pid.is_some();
         let service_message = if service_recovered {
             "任务面板服务已恢复。"
@@ -697,6 +712,52 @@ fn main() {
             ));
             app.manage(state.clone());
 
+            let check_update =
+                MenuItem::with_id(app, "check-update", "检查更新", true, None::<&str>)?;
+            let restart_codex =
+                MenuItem::with_id(app, "restart-codex", "重新启动 Codex", true, None::<&str>)?;
+            let quit = MenuItem::with_id(app, "quit", "退出", true, None::<&str>)?;
+            let tray_menu = Menu::with_items(app, &[&check_update, &restart_codex, &quit])?;
+            TrayIconBuilder::new()
+                .icon(app.default_window_icon().unwrap().clone())
+                .tooltip("Codex Taskboard")
+                .menu(&tray_menu)
+                .on_menu_event(|app, event| match event.id().as_ref() {
+                    "check-update" => {
+                        let Some(state) = app.try_state::<Arc<LauncherState>>() else {
+                            return;
+                        };
+                        let state = Arc::clone(state.inner());
+                        let app = app.clone();
+                        tauri::async_runtime::spawn(async move {
+                            offer_update(&app, &state, true).await;
+                        });
+                    }
+                    "restart-codex" => {
+                        let Some(state) = app.try_state::<Arc<LauncherState>>() else {
+                            return;
+                        };
+                        let state = Arc::clone(state.inner());
+                        let app = app.clone();
+                        tauri::async_runtime::spawn_blocking(move || {
+                            if let Err(error) = restart_launcher(&app, &state) {
+                                append_log(
+                                    &state,
+                                    &format!("Launcher menu restart failed: {error}"),
+                                );
+                                show_error_dialog(
+                                    &app,
+                                    "Codex Taskboard 启动失败",
+                                    &format!("{error}\n\n请确认官方 Codex/ChatGPT App 已安装。"),
+                                );
+                            }
+                        });
+                    }
+                    "quit" => app.exit(0),
+                    _ => {}
+                })
+                .build(app)?;
+
             let app_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
                 if let Err(error) = start_launcher(&app_handle, &state) {
@@ -713,7 +774,7 @@ fn main() {
                         ),
                     );
                 }
-                offer_startup_update(&app_handle, &state).await;
+                offer_update(&app_handle, &state, false).await;
             });
             Ok(())
         })

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -51,6 +51,7 @@ struct LauncherState {
     child: Mutex<Option<u32>>,
     snapshot: Mutex<LauncherSnapshot>,
     intentional_stop: AtomicBool,
+    update_flow_in_progress: AtomicBool,
     update_in_progress: AtomicBool,
     generation: AtomicU64,
     lifecycle: Mutex<()>,
@@ -80,6 +81,7 @@ impl LauncherState {
                 child_pid: None,
             }),
             intentional_stop: AtomicBool::new(false),
+            update_flow_in_progress: AtomicBool::new(false),
             update_in_progress: AtomicBool::new(false),
             generation: AtomicU64::new(0),
             lifecycle: Mutex::new(()),
@@ -618,7 +620,24 @@ async fn install_update(
     app.restart()
 }
 
-async fn offer_update(app: &AppHandle, state: &Arc<LauncherState>, show_current_version: bool) {
+fn finish_update_flow(state: &LauncherState, check_update: &MenuItem<tauri::Wry>) {
+    state.update_flow_in_progress.store(false, Ordering::SeqCst);
+    check_update.set_enabled(true).unwrap();
+}
+
+async fn offer_update(
+    app: &AppHandle,
+    state: &Arc<LauncherState>,
+    check_update: &MenuItem<tauri::Wry>,
+    show_current_version: bool,
+) {
+    if state
+        .update_flow_in_progress
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return;
+    }
     let update = match check_for_startup_update(app, state).await {
         Ok(update) => update,
         Err(error) => {
@@ -630,6 +649,7 @@ async fn offer_update(app: &AppHandle, state: &Arc<LauncherState>, show_current_
                     &format!("无法检查更新。请稍后重试。\n\n{error}"),
                 );
             }
+            finish_update_flow(state, check_update);
             return;
         }
     };
@@ -641,6 +661,7 @@ async fn offer_update(app: &AppHandle, state: &Arc<LauncherState>, show_current_
                 .buttons(MessageDialogButtons::Ok)
                 .blocking_show();
         }
+        finish_update_flow(state, check_update);
         return;
     };
 
@@ -659,6 +680,7 @@ async fn offer_update(app: &AppHandle, state: &Arc<LauncherState>, show_current_
         .blocking_show();
     if !install_now {
         append_log(state, &format!("Update {version} deferred by user"));
+        finish_update_flow(state, check_update);
         return;
     }
     append_log(state, &format!("Update {version} accepted by user"));
@@ -675,6 +697,7 @@ async fn offer_update(app: &AppHandle, state: &Arc<LauncherState>, show_current_
             "Codex Taskboard 更新失败",
             &format!("更新未完成。{service_message}\n\n请稍后重试。详情见启动日志。\n\n{error}"),
         );
+        finish_update_flow(state, check_update);
     }
 }
 
@@ -713,24 +736,27 @@ fn main() {
             app.manage(state.clone());
 
             let check_update =
-                MenuItem::with_id(app, "check-update", "检查更新", true, None::<&str>)?;
+                MenuItem::with_id(app, "check-update", "检查更新", false, None::<&str>)?;
             let restart_codex =
                 MenuItem::with_id(app, "restart-codex", "重新启动 Codex", true, None::<&str>)?;
             let quit = MenuItem::with_id(app, "quit", "退出", true, None::<&str>)?;
             let tray_menu = Menu::with_items(app, &[&check_update, &restart_codex, &quit])?;
+            let check_update_menu = check_update.clone();
             TrayIconBuilder::new()
                 .icon(app.default_window_icon().unwrap().clone())
                 .tooltip("Codex Taskboard")
                 .menu(&tray_menu)
-                .on_menu_event(|app, event| match event.id().as_ref() {
+                .on_menu_event(move |app, event| match event.id().as_ref() {
                     "check-update" => {
                         let Some(state) = app.try_state::<Arc<LauncherState>>() else {
                             return;
                         };
+                        check_update_menu.set_enabled(false).unwrap();
                         let state = Arc::clone(state.inner());
                         let app = app.clone();
+                        let check_update = check_update_menu.clone();
                         tauri::async_runtime::spawn(async move {
-                            offer_update(&app, &state, true).await;
+                            offer_update(&app, &state, &check_update, true).await;
                         });
                     }
                     "restart-codex" => {
@@ -753,12 +779,20 @@ fn main() {
                             }
                         });
                     }
-                    "quit" => app.exit(0),
+                    "quit" => {
+                        let Some(state) = app.try_state::<Arc<LauncherState>>() else {
+                            return;
+                        };
+                        if !state.update_in_progress.load(Ordering::SeqCst) {
+                            app.exit(0);
+                        }
+                    }
                     _ => {}
                 })
                 .build(app)?;
 
             let app_handle = app.handle().clone();
+            let startup_check_update = check_update.clone();
             tauri::async_runtime::spawn(async move {
                 if let Err(error) = start_launcher(&app_handle, &state) {
                     append_log(&state, &format!("Launcher startup failed: {error}"));
@@ -774,7 +808,7 @@ fn main() {
                         ),
                     );
                 }
-                offer_update(&app_handle, &state, false).await;
+                offer_update(&app_handle, &state, &startup_check_update, false).await;
             });
             Ok(())
         })

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -483,7 +483,11 @@ fn restart_launcher(
         return Ok(state.snapshot.lock().unwrap().clone());
     }
     stop_managed_child_locked(app, state);
-    start_launcher_locked(app, state)
+    let result = start_launcher_locked(app, state);
+    if result.is_err() {
+        state.intentional_stop.store(false, Ordering::SeqCst);
+    }
+    result
 }
 
 async fn check_for_startup_update(
@@ -588,6 +592,7 @@ async fn install_update(
         let restart_error = {
             let _lifecycle = state.lifecycle.lock().unwrap();
             let restart_error = start_launcher_locked(app, state).err();
+            state.intentional_stop.store(false, Ordering::SeqCst);
             state.update_in_progress.store(false, Ordering::SeqCst);
             restart_error
         };

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -703,6 +703,7 @@ async fn offer_update(
 
 fn main() {
     let app = tauri::Builder::default()
+        .enable_macos_default_menu(false)
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -577,6 +577,9 @@ async fn install_update(
     });
     {
         let _lifecycle = state.lifecycle.lock().unwrap();
+        if state.intentional_stop.load(Ordering::SeqCst) {
+            return Err("App exit is in progress".into());
+        }
         state.update_in_progress.store(true, Ordering::SeqCst);
         stop_managed_child_locked(app, state);
     }
@@ -784,9 +787,13 @@ fn main() {
                         let Some(state) = app.try_state::<Arc<LauncherState>>() else {
                             return;
                         };
-                        if !state.update_in_progress.load(Ordering::SeqCst) {
-                            app.exit(0);
+                        let lifecycle = state.lifecycle.lock().unwrap();
+                        if state.update_in_progress.load(Ordering::SeqCst) {
+                            return;
                         }
+                        stop_managed_child_locked(app, &state);
+                        drop(lifecycle);
+                        app.exit(0);
                     }
                     _ => {}
                 })
@@ -831,9 +838,16 @@ fn main() {
                 );
             }
         }
-        tauri::RunEvent::ExitRequested { .. } => {
+        tauri::RunEvent::ExitRequested { code, api, .. } => {
             if let Some(state) = app_handle.try_state::<Arc<LauncherState>>() {
-                stop_managed_child(app_handle, &state);
+                let _lifecycle = state.lifecycle.lock().unwrap();
+                if code != Some(tauri::RESTART_EXIT_CODE)
+                    && state.update_in_progress.load(Ordering::SeqCst)
+                {
+                    api.prevent_exit();
+                    return;
+                }
+                stop_managed_child_locked(app_handle, &state);
             }
         }
         tauri::RunEvent::Exit => {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -447,12 +447,17 @@ fn start_launcher_locked(
             return;
         }
         thread::sleep(Duration::from_secs(2));
-        if event_state.intentional_stop.load(Ordering::SeqCst)
-            || event_state.generation.load(Ordering::SeqCst) != generation
-        {
-            return;
-        }
-        if let Err(error) = start_launcher(&event_app, &event_state) {
+        let recovery_result = {
+            let _lifecycle = event_state.lifecycle.lock().unwrap();
+            if event_state.generation.load(Ordering::SeqCst) != generation
+                || event_state.intentional_stop.load(Ordering::SeqCst)
+                || event_state.update_in_progress.load(Ordering::SeqCst)
+            {
+                return;
+            }
+            start_launcher_locked(&event_app, &event_state)
+        };
+        if let Err(error) = recovery_result {
             append_log(&event_state, &format!("Launcher recovery failed: {error}"));
             update_snapshot(&event_app, &event_state, |snapshot| {
                 snapshot.phase = "error".into();
@@ -470,6 +475,11 @@ fn start_launcher_locked(
 
 fn start_launcher(app: &AppHandle, state: &Arc<LauncherState>) -> Result<LauncherSnapshot, String> {
     let _lifecycle = state.lifecycle.lock().unwrap();
+    if state.intentional_stop.load(Ordering::SeqCst)
+        || state.update_in_progress.load(Ordering::SeqCst)
+    {
+        return Ok(state.snapshot.lock().unwrap().clone());
+    }
     start_launcher_locked(app, state)
 }
 
@@ -478,6 +488,9 @@ fn restart_launcher(
     state: &Arc<LauncherState>,
 ) -> Result<LauncherSnapshot, String> {
     let _lifecycle = state.lifecycle.lock().unwrap();
+    if state.intentional_stop.load(Ordering::SeqCst) {
+        return Ok(state.snapshot.lock().unwrap().clone());
+    }
     if state.update_in_progress.load(Ordering::SeqCst) {
         append_log(state, "Launcher reopen ignored during update installation");
         return Ok(state.snapshot.lock().unwrap().clone());


### PR DESCRIPTION
## 变更

- 为 macOS launcher 增加状态栏图标。
- 菜单只包含“检查更新”“重新启动 Codex”“退出”。
- 手动检查更新时，无更新会显示当前已是最新版本；启动自动检查仍保持无更新静默。
- 菜单动作复用现有 updater、launcher 重启和退出清理路径。
- 保持 `ActivationPolicy::Accessory` 和空窗口配置，因此无 Dock 图标、无窗口。

## 原因

launcher 原来没有常驻 UI。用户无法主动检查更新、重新启动受管 Codex 或正常退出 launcher。

## 验证

- 已合入最新 `origin/main@4f66efc`。
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- Rust 1.88：`cargo check --manifest-path src-tauri/Cargo.toml`
- 已静态核对三个菜单 ID 到 updater、`restart_launcher`、`app.exit(0)` 的直接路径。
- 未再次启动真实 launcher。先前真实调试会退出正在运行的 Codex，因此后续按要求停止有副作用的 UI 验证。