### PR TITLE
修复看板箭头与任务图片尺寸

### DIFF
--- a/web/src/assets/figma-taskboard/column-flow-arrow.svg
+++ b/web/src/assets/figma-taskboard/column-flow-arrow.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4.5 4.5 8 8l-3.5 3.5M8.5 4.5 12 8l-3.5 3.5" stroke="#A5A5A5" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -83,16 +83,26 @@ function firstTaskImage(task: Task) {
 }
 
 function TaskCardMedia({ src }: { src: string }) {
-  const [clamped, setClamped] = useState(false);
+  const [presentation, setPresentation] = useState<{ width: number; clamped: boolean } | null>(null);
+  const clamped = presentation?.clamped ?? false;
 
   return (
-    <div className={`task-card-media${clamped ? " is-clamped" : ""}`}>
+    <div
+      className={`task-card-media${clamped ? " is-clamped" : ""}`}
+      style={presentation ? { width: presentation.width } : undefined}
+    >
       <img
         src={src}
         alt=""
         loading="lazy"
         onLoad={(event) => {
-          setClamped(event.currentTarget.naturalWidth / event.currentTarget.naturalHeight < 3 / 4);
+          const { naturalWidth, naturalHeight } = event.currentTarget;
+          const availableWidth = event.currentTarget.parentElement?.clientWidth ?? naturalWidth;
+          const renderedWidth = Math.min(naturalWidth, availableWidth);
+          setPresentation({
+            width: naturalWidth,
+            clamped: naturalHeight * renderedWidth / naturalWidth > 300,
+          });
         }}
       />
     </div>

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { attachmentContentUrl, resolvePersistedAttachmentUrl } from "../api";
 import {
   TASK_PRIORITIES,
@@ -83,11 +83,37 @@ function firstTaskImage(task: Task) {
 }
 
 function TaskCardMedia({ src }: { src: string }) {
+  const mediaRef = useRef<HTMLDivElement>(null);
+  const imageSizeRef = useRef<{ naturalWidth: number; naturalHeight: number } | null>(null);
   const [presentation, setPresentation] = useState<{ width: number; clamped: boolean } | null>(null);
   const clamped = presentation?.clamped ?? false;
+  const updatePresentation = useCallback(() => {
+    const media = mediaRef.current;
+    const imageSize = imageSizeRef.current;
+    if (!media || !imageSize) return;
+    const renderedWidth = Math.min(imageSize.naturalWidth, media.clientWidth);
+    const nextPresentation = {
+      width: imageSize.naturalWidth,
+      clamped: imageSize.naturalHeight * renderedWidth / imageSize.naturalWidth > 300,
+    };
+    setPresentation((current) => (
+      current?.width === nextPresentation.width && current.clamped === nextPresentation.clamped
+        ? current
+        : nextPresentation
+    ));
+  }, []);
+
+  useEffect(() => {
+    const media = mediaRef.current;
+    if (!media) return;
+    const observer = new ResizeObserver(updatePresentation);
+    observer.observe(media);
+    return () => observer.disconnect();
+  }, [updatePresentation]);
 
   return (
     <div
+      ref={mediaRef}
       className={`task-card-media${clamped ? " is-clamped" : ""}`}
       style={presentation ? { width: presentation.width } : undefined}
     >
@@ -96,13 +122,11 @@ function TaskCardMedia({ src }: { src: string }) {
         alt=""
         loading="lazy"
         onLoad={(event) => {
-          const { naturalWidth, naturalHeight } = event.currentTarget;
-          const availableWidth = event.currentTarget.parentElement?.clientWidth ?? naturalWidth;
-          const renderedWidth = Math.min(naturalWidth, availableWidth);
-          setPresentation({
-            width: naturalWidth,
-            clamped: naturalHeight * renderedWidth / naturalWidth > 300,
-          });
+          imageSizeRef.current = {
+            naturalWidth: event.currentTarget.naturalWidth,
+            naturalHeight: event.currentTarget.naturalHeight,
+          };
+          updatePresentation();
         }}
       />
     </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9052,7 +9052,7 @@ kbd {
   left: -20px;
   width: 16px;
   height: 16px;
-  background: center / 16px 16px no-repeat url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAOdEVYdFNvZnR3YXJlAEZpZ21hnrGWYwAAAG5JREFUeAHdk8EJwCAMRU1XcP+jDuFKmhlSk5PamBK8lD4Q+WAefEWgTjjgCod8UICIobW2za8CppQyDa15ghT6YUopUa1VzSOqwCMxLxEAZO2yWSHnLLuWzQqeYQbEMsDPxsQY1fyouQq8/OAv3E4DGh/Tdlf8AAAAAElFTkSuQmCC");
+  background: center / 16px 16px no-repeat url("./assets/figma-taskboard/column-flow-arrow.svg");
   content: "";
   pointer-events: none;
 }
@@ -9230,6 +9230,7 @@ kbd {
 .task-card-media {
   display: block;
   width: 100%;
+  max-width: 100%;
   padding: 0;
   overflow: hidden;
   border: 1px solid rgba(0, 0, 0, .05);
@@ -9247,7 +9248,7 @@ kbd {
 }
 
 .task-card-media.is-clamped {
-  aspect-ratio: 3 / 4;
+  height: 300px;
 }
 
 .task-card-media.is-clamped img {


### PR DESCRIPTION
## 变更

- 将议题看板列间的 16×16 PNG data URI 替换为专用 SVG，只修改该箭头资源。
- 任务卡片小图按原始宽度显示，同时不超过卡片宽度。
- 图片按实际展示尺寸判断；高度超过 300px 时限制为 300px，并使用 `object-fit: cover`。

## 原因

列间箭头使用低分辨率位图，在高像素密度屏幕上发糊。任务卡片此前强制图片宽度为 100%，会放大小图；高图使用旧的 3:4 比例规则，不符合新的 300px 高度要求。

## 验证

- `npm run build:web`
- 独立本地看板：54×64 小图媒体宽度为 54px，未触发裁切。
- 独立本地看板：200×500 高图媒体高度为 300px，触发 `is-clamped`，`object-fit` 为 `cover`。
- 列间伪元素加载 16×16 SVG。
- 已合入 `origin/main` 的 `4f66efc`，并只重验以上路径。

关联任务：`1655E73440AB-71`、`1655E73440AB-72`。