### PR TITLE
Fix launcher token URL normalization

### DIFF
--- a/server/app.mjs
+++ b/server/app.mjs
@@ -1632,6 +1632,11 @@ export function createTaskboardServer(options = {}) {
     try {
       const incomingUrl = new URL(request.url, "http://127.0.0.1");
       if (resolved.instanceToken && incomingUrl.pathname !== "/health") {
+        if (incomingUrl.pathname === routePrefix) {
+          response.writeHead(301, { location: `${incomingUrl.pathname}/${incomingUrl.search}` });
+          response.end();
+          return;
+        }
         if (
           incomingUrl.pathname !== routePrefix
           && !incomingUrl.pathname.startsWith(`${routePrefix}/`)


### PR DESCRIPTION
## What changed

- Redirect the exact launcher instance-token route from `/token` to `/token/`.
- Preserve the original query string in the redirect.

## Why

`launcher-runtime.json` exposes the token URL without a trailing slash. The server returned `index.html` directly for that URL, so the browser resolved Vite's relative CSS, JavaScript, and favicon paths from `/` instead of `/token/`. Those requests were rejected by the token route and the page stayed blank.

The server route is the normalization boundary. Fixing it also covers direct visits to the valid token URL without changing the runtime URL producer.

## User impact

Opening the URL from `launcher-runtime.json` now redirects to the directory-form URL and renders Taskboard normally.

## Verification

- Built the current web bundle with `npm run build:web`.
- Started an isolated `127.0.0.1` server with a temporary data directory and instance token.
- Before the fix, `/token?probe=before` returned `200` without a redirect; CSS, JavaScript, and favicon resolved outside the token prefix and returned JSON `404` responses.
- After the fix, `/token?probe=after` returns `301 Location: /token/?probe=after`; the redirected HTML and its CSS, JavaScript, favicon, and API requests return `200` with correct content types.
- Playwright confirmed the original no-slash URL finishes at `/token/?probe=browser-after`, shows the Taskboard UI, and has no console errors.

Closes #54