### PR TITLE
修复自动认领调用错误 taskctl

### DIFF
--- a/shared/taskboard-automation.mjs
+++ b/shared/taskboard-automation.mjs
@@ -60,16 +60,31 @@ export function buildTaskboardAutomationName(request) {
 
 export function buildTaskboardAutomationPrompt(request) {
   const automationName = buildTaskboardAutomationName(request);
+  const taskctlCommand = buildTaskctlCommand(request);
   return [
     `[$manage-taskboard](${request.skillPath}) e-taskboard 每 ${request.intervalMinutes} 分钟检查任务面板中的「${request.projectName}」项目（项目 ID：${request.taskboardProjectId}，项目目录：${request.workspacePath}）。`,
-    `开始时先运行 taskctl issue list --project ${request.taskboardProjectId} --status todo --json。若没有 todo，使用 Codex automation_update 将名为「${automationName}」的当前自动化设为 PAUSED，保留其他字段，然后结束；不要创建或打开新的任务会话。`,
+    `本轮所有 taskctl 操作都使用完整命令前缀 ${taskctlCommand}，不要使用 PATH 中的 taskctl。`,
+    `开始时先运行 ${taskctlCommand} issue list --project ${request.taskboardProjectId} --status todo --json。若没有 todo，使用 Codex automation_update 将名为「${automationName}」的当前自动化设为 PAUSED，保留其他字段，然后结束；不要创建或打开新的任务会话。`,
     "每次仅处理一个 todo：选定后用 issue get 读取最新议题内容，并用 comment list 读取全部评论，确认是否包含已完成后被打回的返工要求。",
     "认领时使用最新 version 将议题移动到 in_progress；若发生版本冲突或最新状态已变化，立即跳过，避免多个 Agent 抢同一任务。",
     "若 issue get 返回 threadId，认领时将 --thread-id 设为该值以保留绑定，再使用 Codex send_message_to_thread 向原会话发送继续处理此议题的指令；当前自动化会话不要重复处理。若没有 threadId，则在当前自动化会话处理。",
     "若议题已绑定 branch 或 worktree，必须在该议题绑定的开发上下文执行，避免并行 Agent 修改同一工作目录。",
     "执行完成并验证后，先用 comment add 记录关键改动、验证结果、执行结果和剩余风险，再使用最新 version 将议题移动到 in_review；不要直接标记为 done。",
-    `本次处理或交接后，再次运行 taskctl issue list --project ${request.taskboardProjectId} --status todo --json。若没有 todo，使用 Codex automation_update 将名为「${automationName}」的当前自动化设为 PAUSED，保留其他字段，避免后续创建空会话。`,
+    `本次处理或交接后，再次运行 ${taskctlCommand} issue list --project ${request.taskboardProjectId} --status todo --json。若没有 todo，使用 Codex automation_update 将名为「${automationName}」的当前自动化设为 PAUSED，保留其他字段，避免后续创建空会话。`,
   ].join("\n");
+}
+
+function buildTaskctlCommand(request) {
+  const cliPath = path.resolve(path.dirname(request.skillPath), "../..", "cli/taskctl.mjs");
+  const command = `${shellQuote(process.execPath)} ${shellQuote(cliPath)}`;
+  const runtimeFilePath = process.env.CODEX_TASKBOARD_RUNTIME_FILE;
+  return runtimeFilePath
+    ? `CODEX_TASKBOARD_RUNTIME_FILE=${shellQuote(runtimeFilePath)} ${command}`
+    : command;
+}
+
+function shellQuote(value) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 export function buildTaskboardAutomationSpec(request) {


### PR DESCRIPTION
## 变更

- 自动认领提示使用当前应用包的 Node 和 CLI，不再依赖会话的 `PATH` 顺序。
- 提示传入 Launcher 的运行时描述文件，以连接随机端口和 token URL。
- 提示要求本轮所有 `taskctl` 操作复用同一完整命令前缀。

## 根因

Codex 会话把旧的全局 `taskctl` 排在应用包 wrapper 前。旧 CLI 不读取 Launcher 运行时描述文件，只访问默认端口 47823。因此自动化可创建，但执行首条待办查询时失败。

## 验证

- 在 `origin/main` 上复现原命令：退出码 3，`SERVICE_UNAVAILABLE`，目标是默认端口 47823。
- 使用修改后的真实提示命令、包内 Node、包内 CLI 和隔离 Launcher 描述文件：退出码 0，`schemaVersion=2`，成功读取待办。
- 甘特图症状独立验证：Chromium 开发页、Chromium 生产页和 WebKit 生产页各完成 30 组“甘特图 → 看板/列表/Dashboard”快速回切。页面错误和未处理拒绝均为 0。本 PR 不修改甘特图代码。

关联 #52
