### PR TITLE
修复搜索框清除按钮间距与图标

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2433,18 +2433,23 @@ export function App() {
             )}
           </div>
           {(boardView === "issues" || boardView === "list" || boardView === "gantt") && <div className="toolbar-tools">
-            <label className={`search-field${search ? " has-value" : ""}`} title="搜索议题 (/)" >
+            <div className={`search-field${search ? " has-value" : ""}`} title="搜索议题 (/)" >
               <TaskboardIcon className="search-icon" name="search" />
-              <span className="sr-only">搜索议题</span>
               <input
                 id="task-search"
                 type="search"
+                aria-label="搜索议题"
                 value={search}
                 onChange={(event) => setSearch(event.target.value)}
                 placeholder="搜索议题…"
               />
               {!search && <kbd>/</kbd>}
-            </label>
+              {search && (
+                <button className="search-clear" type="button" aria-label="清除搜索" onClick={() => setSearch("")}>
+                  <LinearIcon name="close" />
+                </button>
+              )}
+            </div>
             {boardView === "gantt" && (
               <div className="gantt-toolbar-controls">
                 <label className="gantt-hide-completed">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2445,7 +2445,15 @@ export function App() {
               />
               {!search && <kbd>/</kbd>}
               {search && (
-                <button className="search-clear" type="button" aria-label="清除搜索" onClick={() => setSearch("")}>
+                <button
+                  className="search-clear"
+                  type="button"
+                  aria-label="清除搜索"
+                  onClick={() => {
+                    setSearch("");
+                    document.getElementById("task-search")?.focus();
+                  }}
+                >
                   <LinearIcon name="close" />
                 </button>
               )}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1069,6 +1069,31 @@ kbd {
   color: var(--text-tertiary);
 }
 
+.search-field input::-webkit-search-cancel-button {
+  appearance: none;
+}
+
+.search-clear {
+  position: absolute;
+  top: 50%;
+  right: 6px;
+  display: grid;
+  place-items: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  transform: translateY(-50%);
+  border: 0;
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+}
+
+.search-clear svg {
+  width: 10px;
+  height: 10px;
+}
+
 .search-icon,
 .filter-icon {
   position: absolute;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1120,6 +1120,7 @@ kbd {
   background: var(--surface-muted);
   color: var(--text-tertiary);
   font-size: 8px;
+  pointer-events: none;
 }
 
 .search-field:not(:focus-within):not(.has-value) kbd {


### PR DESCRIPTION
## 变更

- 用项目现有的 `LinearIcon close` 内联 SVG 替换浏览器原生搜索取消图标。
- 将清除按钮固定在搜索框右侧 6px，并保留原有输入过滤与清空行为。

## 根因

搜索框使用 `input type="search"` 的 Chromium 原生取消控件。输入框的 26px 右内边距也作用于该控件，使图标离搜索框右边过远，且图标外观不由项目控制。

## 用户影响

输入搜索词后，清除按钮使用稳定的项目 SVG，并贴近搜索框右边；点击后清空关键词并恢复完整结果。

## 验证

- 隔离 Web 页面：2 项输入“2 额”后仅显示 1 项；出现 `svg[data-linear-icon="close"]`，按钮右边距 6.5px；点击后输入清空并恢复 2 项。
- `npm run typecheck`
- `npm run build:web`

Task: 1655E73440AB-77