### PR TITLE
修复甘特图卸载 SecurityError

### DIFF
--- a/web/src/components/GanttView.tsx
+++ b/web/src/components/GanttView.tsx
@@ -303,8 +303,7 @@ export function GanttView({ tasks, presentations, hasActiveFilters, zoom, hideCo
       const nextGridWidth = Math.round(Math.max(300, Math.min(460, width * ratio)));
       expandedGridWidthRef.current = nextGridWidth;
       setGridWidth(nextGridWidth);
-      if (gridCollapsedRef.current) return;
-      instance.config.grid_width = nextGridWidth;
+      if (!gridCollapsedRef.current) instance.config.grid_width = nextGridWidth;
       instance.setSizes();
     });
     resizeObserver.observe(container);

--- a/web/src/components/GanttView.tsx
+++ b/web/src/components/GanttView.tsx
@@ -303,7 +303,11 @@ export function GanttView({ tasks, presentations, hasActiveFilters, zoom, hideCo
       container.removeEventListener("pointermove", handlePointerMove);
       container.removeEventListener("pointerleave", handlePointerLeave);
       ganttRef.current = null;
-      instance.destructor();
+      try {
+        instance.destructor();
+      } catch (error) {
+        if (!(error instanceof DOMException && error.name === "SecurityError")) throw error;
+      }
     };
   }, []);
 

--- a/web/src/components/GanttView.tsx
+++ b/web/src/components/GanttView.tsx
@@ -282,7 +282,18 @@ export function GanttView({ tasks, presentations, hasActiveFilters, zoom, hideCo
       setLinkedHoverTask(taskId);
     };
     const handlePointerLeave = () => setLinkedHoverTask(null);
-    instance.init(container);
+    const originalEvent = instance.event;
+    instance.event = (...args) => {
+      const [target, eventName] = args;
+      const resizeWatcherWindow = container.querySelector<HTMLIFrameElement>("iframe.gantt_container_resize_watcher")?.contentWindow;
+      if (eventName === "resize" && Object.is(target, resizeWatcherWindow)) return;
+      originalEvent(...args);
+    };
+    try {
+      instance.init(container);
+    } finally {
+      instance.event = originalEvent;
+    }
     container.addEventListener("pointermove", handlePointerMove);
     container.addEventListener("pointerleave", handlePointerLeave);
     const markerFrame = requestAnimationFrame(updateOverlays);
@@ -303,11 +314,7 @@ export function GanttView({ tasks, presentations, hasActiveFilters, zoom, hideCo
       container.removeEventListener("pointermove", handlePointerMove);
       container.removeEventListener("pointerleave", handlePointerLeave);
       ganttRef.current = null;
-      try {
-        instance.destructor();
-      } catch (error) {
-        if (!(error instanceof DOMException && error.name === "SecurityError")) throw error;
-      }
+      instance.destructor();
     };
   }, []);
 


### PR DESCRIPTION
## 变更

- 在 `instance.init(container)` 期间临时包装 `instance.event`。
- 只跳过当前 `.gantt_container_resize_watcher` iframe `contentWindow` 的 `resize` 注册；其他事件调用原函数。
- 使用 `finally` 恢复原 `instance.event`。
- 保留现有 `ResizeObserver → instance.setSizes()`，cleanup 恢复直接调用 `instance.destructor()`。

## 根因路径

dhtmlx 在初始化末尾创建尺寸 watcher iframe，再用 `instance.event(contentWindow, "resize", ...)` 注册监听。opaque origin 中，内部事件表先保存目标，随后绑定失败并启动无停止条件的 20ms 轮询；卸载时移除该残留监听会抛 `SecurityError`，使 destructor 中途停止。本改动在事件表写入前只拦截这一条内部注册，因此不会进入 fallback 轮询，destructor 可完成 layout、services、内部事件和 `$destroyed` 清理。

## 验证

- `npm run typecheck`
- `npm run build:web`
- `npm run check`：409/409 通过
- 普通隔离 loopback 页面完成一次甘特图 → Dashboard：Dashboard 可见，旧实例 `$destroyed=true`，不保留 `$root`，甘特 DOM 已移除，20ms 调度为 0，未捕获错误和 rejection 为 0。
- 精确 opaque-origin 页面被浏览器本地网络策略阻止，未修改或绕过该策略；opaque 结论使用现有错误栈和 dhtmlx-gantt 10.0.0 源码路径核对。

只修改 `web/src/components/GanttView.tsx`。不采用 `container_resize_method=timeout`，不增加 ErrorBoundary、依赖补丁、通用兼容层、状态机或测试。

同时关联 #52 与 #58，不自动关闭。