### PR TITLE
移除搜索框 hover 效果

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1021,7 +1021,6 @@ kbd {
   background: transparent;
 }
 
-.search-field:hover,
 .task-filter-trigger:hover,
 .other-tasks-trigger:hover {
   background: var(--surface-hover);


### PR DESCRIPTION
## 修改

- 从工具栏共享 hover 选择器中移除 `.search-field:hover`
- 保留筛选按钮和其他任务按钮的 hover 样式

## 原因

搜索框与筛选、其他任务按钮共用 hover 规则，导致搜索框在未聚焦、未输入时也显示背景强调。

## 影响

搜索框仅在聚焦或有输入时展开；单独 hover 不再显示背景。筛选按钮 hover 不变。

## 直接验证

在本地 Taskboard 的议题看板工具栏中用 Playwright 检查计算样式：

- 搜索框静止：透明背景，28px
- 搜索框 hover：透明背景，28px
- 搜索框聚焦：输入可见，宽度展开到 176px
- 搜索框有输入且失焦：保留展开状态
- 筛选按钮 hover：背景仍为 `rgb(246, 246, 247)`

未增加自动化测试；按项目规则只验证本次直接操作路径。