### PR TITLE
修复 Dashboard 运行中对话判定与卡片显示

### DIFF
--- a/server/app.mjs
+++ b/server/app.mjs
@@ -1572,13 +1572,16 @@ export function createTaskboardServer(options = {}) {
       } catch {}
     }
 
-    const turnStates = new Map();
+    let runningTurnId = null;
     for (const record of records) {
       const payload = record?.payload;
       if (record?.type !== "event_msg" || typeof payload?.turn_id !== "string") continue;
-      if (payload.type === "task_started") turnStates.set(payload.turn_id, true);
-      if (payload.type === "task_complete" || payload.type === "turn_aborted") {
-        turnStates.set(payload.turn_id, false);
+      if (payload.type === "task_started") runningTurnId = payload.turn_id;
+      if (
+        (payload.type === "task_complete" || payload.type === "turn_aborted")
+        && payload.turn_id === runningTurnId
+      ) {
+        runningTurnId = null;
       }
     }
 
@@ -1616,7 +1619,7 @@ export function createTaskboardServer(options = {}) {
     const state = {
       completed: progress?.completed ?? null,
       total: progress?.total ?? null,
-      running: [...turnStates.values()].some(Boolean),
+      running: runningTurnId !== null,
     };
     codexSessionStateCache.set(sessionPath, {
       size: sessionStat.size,

--- a/web/src/components/DashboardView.css
+++ b/web/src/components/DashboardView.css
@@ -703,7 +703,8 @@
   flex-direction: column;
   justify-content: space-between;
   width: 100%;
-  min-height: 80px;
+  min-width: 0;
+  max-width: 100%;
   gap: 10px;
   padding: 16px;
   border: .5px solid var(--border);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9494,11 +9494,11 @@ kbd {
 .task-processing.is-running .task-processing-label {
   background: linear-gradient(
     90deg,
-    rgba(0, 0, 0, 0.36) 0%,
-    rgba(0, 0, 0, 0.36) 35%,
-    rgba(0, 0, 0, 0.7) 50%,
-    rgba(0, 0, 0, 0.36) 65%,
-    rgba(0, 0, 0, 0.36) 100%
+    var(--text-tertiary) 0%,
+    var(--text-tertiary) 35%,
+    var(--text-primary) 50%,
+    var(--text-tertiary) 65%,
+    var(--text-tertiary) 100%
   );
   background-position: 100% 0;
   background-size: 220% 100%;
@@ -9566,11 +9566,11 @@ kbd {
 .task-processing-row.is-running .task-processing-label {
   background: linear-gradient(
     90deg,
-    rgba(0, 0, 0, .36) 0%,
-    rgba(0, 0, 0, .36) 35%,
-    rgba(0, 0, 0, .7) 50%,
-    rgba(0, 0, 0, .36) 65%,
-    rgba(0, 0, 0, .36) 100%
+    var(--text-tertiary) 0%,
+    var(--text-tertiary) 35%,
+    var(--text-primary) 50%,
+    var(--text-tertiary) 65%,
+    var(--text-tertiary) 100%
   );
   background-position: 100% 0;
   background-size: 220% 100%;

--- a/web/src/taskConversations.ts
+++ b/web/src/taskConversations.ts
@@ -143,7 +143,8 @@ export function taskCardPresentation(
     conversations,
     unread,
     processing: {
-      running: Boolean(running) || taskNativeSession?.running === true,
+      running: task.status === "in_progress"
+        && (Boolean(running) || taskNativeSession?.running === true),
       completed: latestTodo?.completed ?? null,
       total: latestTodo?.total ?? null,
       startedAt: runningAi?.currentRun?.startedAt ?? null,


### PR DESCRIPTION
## 变更

- 让 Dashboard 的“运行中对话”只显示处于处理中且真实运行的议题。
- Codex 会话运行态只按最新一轮生命周期计算，旧的未闭合 turn 不再造成永久运行。
- 限制运行卡片宽度在面板内，并让高度由内容决定。
- “正在处理…”渐变改用主题文字色，暗色主题保持可读，动画参数不变。

## 根因

多个历史议题可共享同一个 Codex thread。前端把同一份 thread 运行状态应用到所有议题，又没有统一限制议题状态；服务端还对所有历史 turn 使用任一为 true 的判定。旧 turn 缺少终止事件时，已暂停或已完成议题会继续显示为运行中。

## 影响

修复 todo 1655E73440AB-80、1655E73440AB-81、1655E73440AB-82。Dashboard 现在与看板卡片的真实运行态一致，卡片不再横向溢出，暗色主题下的运行文字可读。

## 直接验证

- `npm run typecheck`
- `npm run build:web`
- 真实暂停会话 API：修复前 `running:true`，修复后 `running:false`；当前活动会话仍为 `running:true`
- 浏览器对照：Dashboard 运行 ID 与看板 `.is-running-card` ID 完全一致；暂停的 1655E73440AB-79 被排除
- 卡片边界：面板右边界 1180px，卡片右边界 1165.5px；列表无横向滚动
- 暗色渐变：`#85858b → #eeeeef → #85858b`，动画仍为 `task-processing-sheen 1.9s`

按项目规则未新增测试文件。