### PR TITLE
Fix detail return position and copied links

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -118,6 +118,9 @@ import { createRevisionPoller, getRevisionPollingInterval } from "./revisionPoll
 type ConnectionState = "connecting" | "live" | "reconnecting";
 type Theme = "light" | "dark";
 type BoardView = "dashboard" | "issues" | "list" | "gantt" | "workflow";
+type DetailSourceScroll =
+  | { projectId: string; view: "issues"; status: TaskStatus; scrollTop: number }
+  | { projectId: string; view: "list"; scrollTop: number };
 type GanttZoom = "day" | "week" | "month";
 const SHOW_WORKFLOW_BOARD_ENTRY = false;
 const GANTT_ZOOM_OPTIONS: GanttZoom[] = ["day", "week", "month"];
@@ -653,7 +656,8 @@ export function App() {
   const undoInFlightRef = useRef(false);
   const dragRegionRef = useRef<HTMLDivElement>(null);
   const issueListRef = useRef<HTMLDivElement>(null);
-  const pendingIssueListScrollRef = useRef<{ projectId: string; scrollTop: number } | null>(null);
+  const boardColumnScrollRefs = useRef<Partial<Record<TaskStatus, HTMLDivElement | null>>>({});
+  const pendingDetailSourceScrollRef = useRef<DetailSourceScroll | null>(null);
   const selectedProjectIdRef = useRef(selectedProjectId);
   selectedProjectIdRef.current = selectedProjectId;
 
@@ -1056,11 +1060,22 @@ export function App() {
   function openTaskDetail(task: Pick<Task, "identifier" | "projectId">) {
     const fullTask = tasksRef.current.find((candidate) => candidate.identifier === task.identifier);
     if (fullTask) markTaskRead(fullTask);
-    if (issueListRef.current) {
-      pendingIssueListScrollRef.current = {
+    if (boardView === "list" && issueListRef.current) {
+      pendingDetailSourceScrollRef.current = {
         projectId: selectedProjectId,
+        view: "list",
         scrollTop: issueListRef.current.scrollTop,
       };
+    } else if (boardView === "issues" && fullTask) {
+      const scrollContainer = boardColumnScrollRefs.current[fullTask.status];
+      if (scrollContainer) {
+        pendingDetailSourceScrollRef.current = {
+          projectId: selectedProjectId,
+          view: "issues",
+          status: fullTask.status,
+          scrollTop: scrollContainer.scrollTop,
+        };
+      }
     }
     closeContextMenu();
     setProjectMenuOpen(false);
@@ -1086,15 +1101,18 @@ export function App() {
 
   useLayoutEffect(() => {
     if (detailTaskIdentifier) return;
-    const pendingScroll = pendingIssueListScrollRef.current;
+    const pendingScroll = pendingDetailSourceScrollRef.current;
     if (!pendingScroll) return;
-    if (boardView !== "list" || pendingScroll.projectId !== selectedProjectId) {
-      pendingIssueListScrollRef.current = null;
+    if (pendingScroll.view !== boardView || pendingScroll.projectId !== selectedProjectId) {
+      pendingDetailSourceScrollRef.current = null;
       return;
     }
-    if (!issueListRef.current) return;
-    issueListRef.current.scrollTop = pendingScroll.scrollTop;
-    pendingIssueListScrollRef.current = null;
+    const scrollContainer = pendingScroll.view === "list"
+      ? issueListRef.current
+      : boardColumnScrollRefs.current[pendingScroll.status];
+    if (!scrollContainer) return;
+    scrollContainer.scrollTop = pendingScroll.scrollTop;
+    pendingDetailSourceScrollRef.current = null;
   }, [boardView, detailTaskIdentifier, selectedProjectId]);
 
   useEffect(() => {
@@ -1102,11 +1120,27 @@ export function App() {
       const url = new URL(window.location.href);
       const routeProjectId = url.searchParams.get("project") ?? GLOBAL_PROJECT_ID;
       const routeIssueIdentifier = readIssueIdentifier(url.search);
-      if (routeIssueIdentifier && issueListRef.current) {
-        pendingIssueListScrollRef.current = {
+      if (routeIssueIdentifier && boardView === "list" && issueListRef.current) {
+        pendingDetailSourceScrollRef.current = {
           projectId: selectedProjectId,
+          view: "list",
           scrollTop: issueListRef.current.scrollTop,
         };
+      } else if (routeIssueIdentifier && boardView === "issues") {
+        const routeTask = tasksRef.current.find(
+          (task) => task.identifier === routeIssueIdentifier,
+        );
+        const scrollContainer = routeTask
+          ? boardColumnScrollRefs.current[routeTask.status]
+          : null;
+        if (routeTask && scrollContainer) {
+          pendingDetailSourceScrollRef.current = {
+            projectId: selectedProjectId,
+            view: "issues",
+            status: routeTask.status,
+            scrollTop: scrollContainer.scrollTop,
+          };
+        }
       }
       setDetailTaskIdentifier(routeIssueIdentifier);
       if (routeProjectId === selectedProjectId) return;
@@ -1116,7 +1150,7 @@ export function App() {
 
     window.addEventListener("popstate", syncRouteFromLocation);
     return () => window.removeEventListener("popstate", syncRouteFromLocation);
-  }, [selectedProjectId]);
+  }, [boardView, selectedProjectId]);
 
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
@@ -2626,6 +2660,9 @@ export function App() {
                     {mainStatuses.map((status) => (
                       <BoardColumn
                         key={status}
+                        scrollRef={(element) => {
+                          boardColumnScrollRefs.current[status] = element;
+                        }}
                         status={status}
                         tasks={tasksByStatus[status]}
                         presentations={taskPresentations}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1110,9 +1110,9 @@ export function App() {
     const scrollContainer = pendingScroll.view === "list"
       ? issueListRef.current
       : boardColumnScrollRefs.current[pendingScroll.status];
+    pendingDetailSourceScrollRef.current = null;
     if (!scrollContainer) return;
     scrollContainer.scrollTop = pendingScroll.scrollTop;
-    pendingDetailSourceScrollRef.current = null;
   }, [boardView, detailTaskIdentifier, selectedProjectId]);
 
   useEffect(() => {

--- a/web/src/components/BoardColumn.tsx
+++ b/web/src/components/BoardColumn.tsx
@@ -62,6 +62,7 @@ function ColumnStatusIcon({ status }: { status: TaskStatus }) {
 }
 
 interface BoardColumnProps {
+  scrollRef: (element: HTMLDivElement | null) => void;
   status: TaskStatus;
   tasks: Task[];
   presentations: Record<string, TaskCardPresentation>;
@@ -88,6 +89,7 @@ interface BoardColumnProps {
 }
 
 export function BoardColumn({
+  scrollRef,
   status,
   tasks,
   presentations,
@@ -193,7 +195,7 @@ export function BoardColumn({
         </div>
       </header>
 
-      <div className="column-list">
+      <div className="column-list" ref={scrollRef}>
         {tasks.map((task) => {
           const dragShift = getTaskDragShift(task);
           return (

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -1187,7 +1187,7 @@ export function TaskDetail({
                 type="button"
                 onClick={() => onCopy(
                   buildIssueUrl(
-                    window.location.href,
+                    document.baseURI,
                     currentTask.projectId,
                     currentTask.identifier,
                   ).href,


### PR DESCRIPTION
## 改动

- 在默认议题看板进入详情前，保存任务所在 `.column-list` 的滚动位置，并在返回后恢复。
- 保留显式列表视图已有的滚动恢复路径，并让浏览器历史导航使用同一来源快照。
- 复制详情链接时使用 `document.baseURI`，生成普通浏览器可打开的 HTTP URL，并保留 `project` 和 `issue`。

## 根因

- 1655E73440AB-24：旧实现只保存 `IssueListView` 的 ref。默认看板实际由每个 `.column-list` 独立纵向滚动，详情条件渲染卸载看板后，该位置丢失。
- 1655E73440AB-67：Codex 注入文档的 `window.location.href` 是 `about:blank`。注入器提供的 `document.baseURI` 才是带实例入口的 HTTP URL。

## 直接验证

- 修复前：默认看板 `scrollTop 600 → 详情 → 返回 → 0`。
- 修复后：默认看板 `scrollTop 600 → 详情 → 返回 → 600`。
- 复制结果：`http://127.0.0.1:47824/?host=codex&project=local&issue=LOCAL-10`；新浏览器标签直接打开并显示 `LOCAL-10 议题详情`。
- `npm run typecheck`
- `npm run build:web`

未新增测试。