### PR TITLE
release: v0.2.2

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -3,7 +3,7 @@ name: Release macOS
 on:
   push:
     tags:
-      - "app-v*"
+      - "v*"
 
 permissions:
   contents: write
@@ -69,7 +69,7 @@ jobs:
             echo "package.json、Cargo.toml 和 tauri.conf.json 的版本必须一致。" >&2
             exit 1
           fi
-          if [[ "$RELEASE_TAG" != "app-v$PACKAGE_VERSION" ]]; then
+          if [[ "$RELEASE_TAG" != "v$PACKAGE_VERSION" ]]; then
             echo "发布标签必须与应用版本一致。" >&2
             exit 1
           fi
@@ -110,7 +110,7 @@ jobs:
             return 0;
           };
           for (const tag of fs.readFileSync(process.env.RELEASE_TAGS, "utf8").split(/\r?\n/)) {
-            const match = /^app-v(\d+(?:\.\d+)*)$/.exec(tag);
+            const match = /^(?:app-)?v(\d+(?:\.\d+)*)$/.exec(tag);
             if (match && compare(match[1].split(".").map(Number), current) >= 0) {
               console.error(`已有相同或更高版本的 Release：${tag}`);
               process.exit(1);
@@ -293,7 +293,9 @@ jobs:
             --target "$GITHUB_SHA" \
             --draft \
             --title "Codex Taskboard $RELEASE_TAG" \
-            --notes "macOS universal 安装包。此 Release 等待受保护的 promotion job 完成远程复验后发布。" \
+            --notes "Codex Taskboard 将任务看板直接集成到 Codex，支持任务创建、状态管理、会话关联、Worktree 开发协作和进度追踪。
+
+          本版本优化了任务搜索、Dashboard 展示、详情页浏览位置与链接复制，并改善了 Codex 内置浏览器登录状态和 macOS 状态栏图标。" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.dmg" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" \
@@ -334,7 +336,7 @@ jobs:
           set -euo pipefail
           API_VERSION_HEADER="X-GitHub-Api-Version: 2026-03-10"
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
-          if [[ "$(git rev-parse HEAD)" != "$GITHUB_SHA" || "$RELEASE_TAG" != "app-v$PACKAGE_VERSION" ]]; then
+          if [[ "$(git rev-parse HEAD)" != "$GITHUB_SHA" || "$RELEASE_TAG" != "v$PACKAGE_VERSION" ]]; then
             echo "promotion checkout、标签和应用版本不一致。" >&2
             exit 1
           fi
@@ -372,8 +374,8 @@ jobs:
                 .conditions.ref_name.include[]?;
                 . == $tag_ref or
                 (
-                  . == "refs/tags/app-v*" and
-                  ($tag_ref | test("^refs/tags/app-v[^/]*$"))
+                  . == "refs/tags/v*" and
+                  ($tag_ref | test("^refs/tags/v[^/]*$"))
                 )
               ) and
               ((.conditions.ref_name.exclude | type) == "array") and

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ npm start
 
 ### 发布 `v0.2.2`
 
-1. 在 PR 中把 `package.json`、`package-lock.json`、`src-tauri/Cargo.toml` 和 `src-tauri/tauri.conf.json` 的版本同步为目标版本。
+1. 在 PR 中把 `package.json`、`package-lock.json`、`src-tauri/Cargo.toml`、`src-tauri/Cargo.lock` 和 `src-tauri/tauri.conf.json` 的版本同步为目标版本。
 2. 合并已审核的 PR。
 3. 确认所有 GitHub Secrets 和上述仓库发布设置已配置。
 4. 在已合并提交上创建并推送标签：

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ npm start
 
 ## 发布 macOS App
 
-`.github/workflows/check.yml` 在 PR 中使用 macOS runner 准备内置 Node，并构建真实的 unsigned universal App bundle。`.github/workflows/release-macos.yml` 只接受 `app-v*` 标签推送。构建 job 验证标签提交属于 `main`，并确认 `package.json`、`Cargo.toml` 和 `tauri.conf.json` 的版本一致，然后使用 Node.js 22、Rust 1.88 和两个 macOS Rust target 构建 universal 包并创建 GitHub Draft Release。它同时保存 4 个上传资产的可信 SHA-256 manifest。独立的 `macos-release` promotion job 从 Draft 重新下载全部资产，对比 manifest，并重新执行签名、公证、Team ID、Updater 公钥、`latest.json` 和 App/DMG/updater 内容一致性验证。验证通过后，该 job 发布 Release，并确认 Release 已不可变且最终资产摘要未变化。所有第三方 Action 都锁定到完整提交 SHA。
+`.github/workflows/check.yml` 在 PR 中使用 macOS runner 准备内置 Node，并构建真实的 unsigned universal App bundle。`.github/workflows/release-macos.yml` 只接受 `v*` 标签推送。构建 job 验证标签提交属于 `main`，并确认 `package.json`、`Cargo.toml` 和 `tauri.conf.json` 的版本一致，然后使用 Node.js 22、Rust 1.88 和两个 macOS Rust target 构建 universal 包并创建 GitHub Draft Release。它同时保存 4 个上传资产的可信 SHA-256 manifest。独立的 `macos-release` promotion job 从 Draft 重新下载全部资产，对比 manifest，并重新执行签名、公证、Team ID、Updater 公钥、`latest.json` 和 App/DMG/updater 内容一致性验证。验证通过后，该 job 发布 Release，并确认 Release 已不可变且最终资产摘要未变化。所有第三方 Action 都锁定到完整提交 SHA。
 
 内置 Node 版本固定为 `22.23.2`。arm64 与 x64 安装包的 SHA-256 已写入 `scripts/prepare-tauri-app.mjs`，构建不会信任与安装包同源、临时下载的校验清单。
 
@@ -136,20 +136,20 @@ npm start
 
 发布前还必须完成以下仓库设置：
 
-- 启用覆盖当前 `app-v*` 标签的 active tag ruleset。`exclude` 必须为空，`bypass_actors` 必须为空，并启用禁止更新和禁止删除规则。
+- 启用覆盖当前 `v*` 标签的 active tag ruleset。`exclude` 必须为空，`bypass_actors` 必须为空，并启用禁止更新和禁止删除规则。
 - 创建 `macos-release` environment，配置必需审核人，并启用“禁止发起人自行审核”。
 - 启用 immutable releases。promotion 在发布前检查此设置，并在发布后校验 Release API 的 `immutable: true` 和每个资产的 SHA-256。
 
-### 发布 `app-v0.2.0`
+### 发布 `v0.2.2`
 
-1. 在 PR 中把 `package.json`、`package-lock.json`、`src-tauri/Cargo.toml` 和 `src-tauri/tauri.conf.json` 的版本同步为 `0.2.0`。
+1. 在 PR 中把 `package.json`、`package-lock.json`、`src-tauri/Cargo.toml` 和 `src-tauri/tauri.conf.json` 的版本同步为目标版本。
 2. 合并已审核的 PR。
 3. 确认所有 GitHub Secrets 和上述仓库发布设置已配置。
 4. 在已合并提交上创建并推送标签：
 
    ```bash
-   git tag -a app-v0.2.0 -m "Codex Taskboard 0.2.0"
-   git push origin app-v0.2.0
+   git tag -a v0.2.2 -m "Codex Taskboard 0.2.2"
+   git push origin v0.2.2
    ```
 
 5. 等待构建 job 创建 Draft Release。不要在 GitHub Release 页面直接发布。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-taskboard",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-taskboard",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@lobehub/icons-static-svg": "^1.94.0",
         "@xyflow/react": "^12.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-taskboard",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/create-macos-updater.mjs
+++ b/scripts/create-macos-updater.mjs
@@ -16,7 +16,7 @@ if (!appPath || !outputDirectory || !releaseTag) {
 }
 
 const packageJson = JSON.parse(await readFile(path.join(projectRoot, "package.json"), "utf8"));
-if (releaseTag !== `app-v${packageJson.version}`) {
+if (releaseTag !== `v${packageJson.version}`) {
   throw new Error("Release tag does not match package.json version");
 }
 

--- a/scripts/verify-macos-release.mjs
+++ b/scripts/verify-macos-release.mjs
@@ -36,7 +36,7 @@ const releasePolicy = JSON.parse(await readFile(
   path.join(projectRoot, "src-tauri", "release.json"),
   "utf8",
 ));
-if (releaseTag !== `app-v${packageJson.version}`) {
+if (releaseTag !== `v${packageJson.version}`) {
   throw new Error("Release tag does not match package.json version");
 }
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "codex-taskboard-launcher"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "libc",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-taskboard-launcher"
-version = "0.2.1"
+version = "0.2.2"
 description = "Codex Taskboard macOS launcher"
 edition = "2021"
 rust-version = "1.88"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex Taskboard",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "com.chuspeeism.codex-taskboard",
   "app": {
     "windows": []


### PR DESCRIPTION
将应用版本更新到 0.2.2，将发布 Tag 缩短为 v0.2.2，并把 GitHub Release 正文改为纯产品功能介绍。