### PR TITLE
feat(taskctl): support uploading task/comment attachments

### DIFF
--- a/cli/taskctl.mjs
+++ b/cli/taskctl.mjs
@@ -79,6 +79,7 @@ const COMMAND_OPTIONS = new Map([
   ["comment update", new Set(["body", "thread-id", "if-version", "json"])],
   ["comment delete", new Set(["thread-id", "if-version", "json"])],
   ["attachment download", new Set(["output", "json"])],
+  ["attachment upload", new Set(["file", "task", "comment", "content-type", "json"])],
   ["context current", new Set(["cwd", "json"])],
 ]);
 
@@ -182,7 +183,7 @@ async function execute(parsed, overrides) {
   const allowedOptions = COMMAND_OPTIONS.get(command);
   if (!allowedOptions) {
     throw usageError(
-      "Expected one of: project list/create/map, cloud login/status/logout, issue list/get/create/update/move/archive/restore/relation, comment list/add/update/delete, attachment download, context current",
+      "Expected one of: project list/create/map, cloud login/status/logout, issue list/get/create/update/move/archive/restore/relation, comment list/add/update/delete, attachment download/upload, context current",
     );
   }
   validateOptions(parsed.options, allowedOptions);
@@ -291,6 +292,9 @@ async function execute(parsed, overrides) {
     case "attachment download":
       expectOperandCount(parsed, 1);
       return downloadAttachment(api, parsed.operands[0], parsed.options, overrides);
+    case "attachment upload":
+      expectOperandCount(parsed, 0);
+      return uploadAttachment(api, parsed.options, overrides);
     case "context current":
       expectOperandCount(parsed, 0);
       return currentContext(api, parsed.options, overrides);
@@ -383,6 +387,44 @@ function createApiClient(overrides, { baseUrl: explicitBaseUrl } = {}) {
         size: Number(response.headers.get("content-length")) || bytes.byteLength,
       };
     },
+    async upload(pathname, { body, contentType, filename }) {
+      let response;
+      try {
+        response = await fetchImplementation(resolveApiUrl(baseUrl, pathname), {
+          method: "POST",
+          headers: {
+            accept: "application/json",
+            "content-type": contentType,
+            "x-taskboard-client": "taskctl",
+            "x-taskboard-filename": encodeURIComponent(filename),
+          },
+          body,
+        });
+      } catch (error) {
+        throw new TaskctlError(`Cannot reach taskboard service at ${baseUrl}`, {
+          code: "SERVICE_UNAVAILABLE",
+          exitCode: 3,
+          details: error instanceof Error ? error.message : String(error),
+        });
+      }
+
+      const payload = await readResponse(response);
+      if (!response.ok) {
+        const apiError = extractApiError(payload, response.status);
+        throw new TaskctlError(apiError.message, {
+          code: apiError.code,
+          exitCode: response.status === 409 ? 5 : 4,
+          details: apiError.details,
+        });
+      }
+      if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+        throw new TaskctlError("Taskboard service returned an invalid JSON response", {
+          code: "INVALID_RESPONSE",
+          exitCode: 4,
+        });
+      }
+      return payload;
+    },
   };
 }
 
@@ -405,6 +447,88 @@ async function downloadAttachment(api, attachmentId, options, overrides) {
     contentType: downloaded.contentType,
     size: downloaded.size,
   };
+}
+
+async function uploadAttachment(api, options, overrides) {
+  const taskId = options.task;
+  const commentId = options.comment;
+  if (Boolean(taskId) === Boolean(commentId)) {
+    throw usageError("attachment upload requires exactly one of --task or --comment");
+  }
+
+  const filePath = resolveInputPath(requiredOption(options, "file"), overrides);
+  const read = overrides.readFile ?? readFile;
+  let bytes;
+  try {
+    bytes = await read(filePath);
+  } catch (error) {
+    throw new TaskctlError(`Cannot read attachment file: ${filePath}`, {
+      code: "FILE_READ_FAILED",
+      exitCode: 2,
+      details: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  const filename = path.basename(filePath);
+  if (!filename || filename === "." || filename === "..") {
+    throw usageError("Attachment --file must include a valid filename");
+  }
+
+  const contentType = options["content-type"]
+    ? String(options["content-type"]).trim().toLowerCase()
+    : guessContentType(filename);
+
+  if (!contentType) {
+    throw usageError("--content-type cannot be empty");
+  }
+
+  const body = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  const pathname = taskId
+    ? `${taskPath(taskId)}/attachments`
+    : `${commentPath(commentId)}/attachments`;
+  const payload = await api.upload(pathname, {
+    body,
+    contentType,
+    filename,
+  });
+
+  return {
+    attachment: payload.attachment ?? null,
+    file: filePath,
+    target: taskId
+      ? { type: "task", id: taskId }
+      : { type: "comment", id: commentId },
+  };
+}
+
+function guessContentType(filename) {
+  const extension = path.extname(filename).toLowerCase();
+  switch (extension) {
+    case ".png":
+      return "image/png";
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    case ".gif":
+      return "image/gif";
+    case ".webp":
+      return "image/webp";
+    case ".svg":
+      return "image/svg+xml";
+    case ".md":
+      return "text/markdown";
+    case ".txt":
+      return "text/plain";
+    case ".json":
+      return "application/json";
+    case ".pdf":
+      return "application/pdf";
+    case ".html":
+    case ".htm":
+      return "text/html";
+    default:
+      return "application/octet-stream";
+  }
 }
 
 async function cloudLogin(api, rawUrl, actorName, overrides) {

--- a/skills/manage-taskboard/references/cli.md
+++ b/skills/manage-taskboard/references/cli.md
@@ -139,7 +139,7 @@ taskctl comment delete COMMENT_ID --if-version N [--thread-id ID] [--json]
 
 Each comment JSON object independently records the most recent conversation that created or changed that comment as `threadId`. Comment operations never change the parent issue's `threadId`.
 
-## Download inline images
+## Attachments
 
 Issue descriptions and comments may contain inline images at exact positions in their Markdown:
 
@@ -147,7 +147,16 @@ Issue descriptions and comments may contain inline images at exact positions in 
 ![alt text](api/attachments/ATTACHMENT_ID/content)
 ```
 
-Download an inline image to an explicit local path before inspecting it:
+Upload a local file onto a task or comment. Provide exactly one of `--task` or `--comment`:
+
+```bash
+taskctl attachment upload --task TASK_ID --file PATH [--content-type TYPE] [--json]
+taskctl attachment upload --comment COMMENT_ID --file PATH [--content-type TYPE] [--json]
+```
+
+The upload posts file bytes with `X-Taskboard-Filename` and `Content-Type`. When `--content-type` is omitted, `taskctl` guesses from the extension and falls back to `application/octet-stream`.
+
+Download an attachment to an explicit local path:
 
 ```bash
 taskctl attachment download ATTACHMENT_ID --output PATH [--json]

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -515,3 +515,77 @@ test("usage errors are stable and never call the service", async () => {
   assert.equal(result.stderr.error.code, "USAGE_ERROR");
   assert.match(result.stderr.error.message, /--title/);
 });
+
+test("attachment upload posts file bytes to a task with filename headers", async () => {
+  const calls = [];
+  const fileBytes = Buffer.from("hello attachment", "utf8");
+  const result = await run(
+    ["attachment", "upload", "--task", "TASK-1", "--file", "notes.md", "--json"],
+    async (url, init) => {
+      calls.push({ url: url.toString(), init });
+      return response({
+        attachment: {
+          id: "att-1",
+          taskId: "TASK-1",
+          filename: "notes.md",
+          contentType: "text/markdown",
+          size: fileBytes.byteLength,
+        },
+      }, 201);
+    },
+    {
+      readFile: async () => fileBytes,
+    },
+  );
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.stdout.attachment.id, "att-1");
+  assert.equal(result.stdout.target.type, "task");
+  assert.equal(result.stdout.target.id, "TASK-1");
+  assert.equal(calls[0].url, "http://127.0.0.1:47823/api/tasks/TASK-1/attachments");
+  assert.equal(calls[0].init.method, "POST");
+  assert.equal(calls[0].init.headers["content-type"], "text/markdown");
+  assert.equal(calls[0].init.headers["x-taskboard-filename"], encodeURIComponent("notes.md"));
+  assert.equal(calls[0].init.headers["x-taskboard-client"], "taskctl");
+  assert.deepEqual(Buffer.from(calls[0].init.body), fileBytes);
+});
+
+test("attachment upload requires exactly one target and can target comments", async () => {
+  const missing = await run(
+    ["attachment", "upload", "--file", "a.txt"],
+    async () => assert.fail("fetch should not be called"),
+    { readFile: async () => Buffer.from("x") },
+  );
+  assert.equal(missing.exitCode, 2);
+  assert.match(missing.stderr.error.message, /exactly one of --task or --comment/);
+
+  const both = await run(
+    ["attachment", "upload", "--task", "T1", "--comment", "C1", "--file", "a.txt"],
+    async () => assert.fail("fetch should not be called"),
+    { readFile: async () => Buffer.from("x") },
+  );
+  assert.equal(both.exitCode, 2);
+  assert.match(both.stderr.error.message, /exactly one of --task or --comment/);
+
+  let commentUrl;
+  const commentResult = await run(
+    ["attachment", "upload", "--comment", "COMMENT-1", "--file", "shot.png", "--content-type", "image/png"],
+    async (url, init) => {
+      commentUrl = url.toString();
+      assert.equal(init.headers["content-type"], "image/png");
+      return response({
+        attachment: {
+          id: "att-2",
+          commentId: "COMMENT-1",
+          filename: "shot.png",
+          contentType: "image/png",
+          size: 1,
+        },
+      }, 201);
+    },
+    { readFile: async () => Buffer.from([1]) },
+  );
+  assert.equal(commentResult.exitCode, 0);
+  assert.equal(commentUrl, "http://127.0.0.1:47823/api/comments/COMMENT-1/attachments");
+  assert.equal(commentResult.stdout.target.type, "comment");
+});


### PR DESCRIPTION
## Summary
Adds `taskctl attachment upload` so agents can attach local files to tasks or comments through the existing companion API.

Closes #70

## Changes
- `cli/taskctl.mjs`: `attachment upload --task|--comment --file [--content-type]`
- Posts raw bytes with `X-Taskboard-Filename` + `Content-Type` (same contract as the web UI)
- Docs: `skills/manage-taskboard/references/cli.md`
- Tests: CLI unit coverage for task/comment targets and validation

## Non-goals
No server/API changes — upload routes already exist for tasks and comments.

## Test plan
- [x] `node --test test/cli.test.mjs` (new attachment tests pass; 3 pre-existing Windows path assertion failures unrelated)
- [ ] Manual: `taskctl attachment upload --task <id> --file ./notes.md` against a running companion
- [ ] Manual: download the returned attachment id and verify bytes