### PR TITLE
feat(taskctl): 支持任务与评论的附件上传

### DIFF
--- a/cli/taskctl.mjs
+++ b/cli/taskctl.mjs
@@ -79,6 +79,7 @@ const COMMAND_OPTIONS = new Map([
   ["comment update", new Set(["body", "thread-id", "if-version", "json"])],
   ["comment delete", new Set(["thread-id", "if-version", "json"])],
   ["attachment download", new Set(["output", "json"])],
+  ["attachment upload", new Set(["file", "task", "comment", "content-type", "json"])],
   ["context current", new Set(["cwd", "json"])],
 ]);
 
@@ -182,7 +183,7 @@ async function execute(parsed, overrides) {
   const allowedOptions = COMMAND_OPTIONS.get(command);
   if (!allowedOptions) {
     throw usageError(
-      "Expected one of: project list/create/map, cloud login/status/logout, issue list/get/create/update/move/archive/restore/relation, comment list/add/update/delete, attachment download, context current",
+      "Expected one of: project list/create/map, cloud login/status/logout, issue list/get/create/update/move/archive/restore/relation, comment list/add/update/delete, attachment download/upload, context current",
     );
   }
   validateOptions(parsed.options, allowedOptions);
@@ -291,6 +292,9 @@ async function execute(parsed, overrides) {
     case "attachment download":
       expectOperandCount(parsed, 1);
       return downloadAttachment(api, parsed.operands[0], parsed.options, overrides);
+    case "attachment upload":
+      expectOperandCount(parsed, 0);
+      return uploadAttachment(api, parsed.options, overrides);
     case "context current":
       expectOperandCount(parsed, 0);
       return currentContext(api, parsed.options, overrides);
@@ -383,6 +387,44 @@ function createApiClient(overrides, { baseUrl: explicitBaseUrl } = {}) {
         size: Number(response.headers.get("content-length")) || bytes.byteLength,
       };
     },
+    async upload(pathname, { body, contentType, filename }) {
+      let response;
+      try {
+        response = await fetchImplementation(resolveApiUrl(baseUrl, pathname), {
+          method: "POST",
+          headers: {
+            accept: "application/json",
+            "content-type": contentType,
+            "x-taskboard-client": "taskctl",
+            "x-taskboard-filename": encodeURIComponent(filename),
+          },
+          body,
+        });
+      } catch (error) {
+        throw new TaskctlError(`Cannot reach taskboard service at ${baseUrl}`, {
+          code: "SERVICE_UNAVAILABLE",
+          exitCode: 3,
+          details: error instanceof Error ? error.message : String(error),
+        });
+      }
+
+      const payload = await readResponse(response);
+      if (!response.ok) {
+        const apiError = extractApiError(payload, response.status);
+        throw new TaskctlError(apiError.message, {
+          code: apiError.code,
+          exitCode: response.status === 409 ? 5 : 4,
+          details: apiError.details,
+        });
+      }
+      if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+        throw new TaskctlError("Taskboard service returned an invalid JSON response", {
+          code: "INVALID_RESPONSE",
+          exitCode: 4,
+        });
+      }
+      return payload;
+    },
   };
 }
 
@@ -405,6 +447,86 @@ async function downloadAttachment(api, attachmentId, options, overrides) {
     contentType: downloaded.contentType,
     size: downloaded.size,
   };
+}
+
+async function uploadAttachment(api, options, overrides) {
+  const taskId = options.task;
+  const commentId = options.comment;
+  if (Boolean(taskId) === Boolean(commentId)) {
+    throw usageError("attachment upload requires exactly one of --task or --comment");
+  }
+
+  const filePath = resolveInputPath(requiredOption(options, "file"), overrides);
+  const read = overrides.readFile ?? readFile;
+  let bytes;
+  try {
+    bytes = await read(filePath);
+  } catch (error) {
+    throw new TaskctlError(`Cannot read attachment file: ${filePath}`, {
+      code: "FILE_READ_FAILED",
+      exitCode: 2,
+      details: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  const filename = path.basename(filePath);
+  if (!filename || filename === "." || filename === "..") {
+    throw usageError("Attachment --file must include a valid filename");
+  }
+
+  const contentType = options["content-type"]
+    ? String(options["content-type"]).trim().toLowerCase()
+    : guessContentType(filename);
+  if (!contentType) {
+    throw usageError("--content-type cannot be empty");
+  }
+
+  const body = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  const pathname = taskId
+    ? `${taskPath(taskId)}/attachments`
+    : `${commentPath(commentId)}/attachments`;
+  const payload = await api.upload(pathname, {
+    body,
+    contentType,
+    filename,
+  });
+
+  return {
+    attachment: payload.attachment ?? null,
+    file: filePath,
+    target: taskId
+      ? { type: "task", id: taskId }
+      : { type: "comment", id: commentId },
+  };
+}
+
+function guessContentType(filename) {
+  switch (path.extname(filename).toLowerCase()) {
+    case ".png":
+      return "image/png";
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    case ".gif":
+      return "image/gif";
+    case ".webp":
+      return "image/webp";
+    case ".svg":
+      return "image/svg+xml";
+    case ".md":
+      return "text/markdown";
+    case ".txt":
+      return "text/plain";
+    case ".json":
+      return "application/json";
+    case ".pdf":
+      return "application/pdf";
+    case ".html":
+    case ".htm":
+      return "text/html";
+    default:
+      return "application/octet-stream";
+  }
 }
 
 async function cloudLogin(api, rawUrl, actorName, overrides) {

--- a/skills/manage-taskboard/references/cli.md
+++ b/skills/manage-taskboard/references/cli.md
@@ -139,7 +139,7 @@ taskctl comment delete COMMENT_ID --if-version N [--thread-id ID] [--json]
 
 Each comment JSON object independently records the most recent conversation that created or changed that comment as `threadId`. Comment operations never change the parent issue's `threadId`.
 
-## Download inline images
+## Attachments
 
 Issue descriptions and comments may contain inline images at exact positions in their Markdown:
 
@@ -147,7 +147,21 @@ Issue descriptions and comments may contain inline images at exact positions in 
 ![alt text](api/attachments/ATTACHMENT_ID/content)
 ```
 
-Download an inline image to an explicit local path before inspecting it:
+Upload a local file to a task or a comment. Provide exactly one of `--task` or `--comment`:
+
+```bash
+taskctl attachment upload --task TASK_ID --file PATH [--content-type TYPE] [--json]
+taskctl attachment upload --comment COMMENT_ID --file PATH [--content-type TYPE] [--json]
+```
+
+The command sends the file bytes to:
+
+- `POST /api/tasks/:id/attachments`, or
+- `POST /api/comments/:id/attachments`
+
+with the same headers as the web UI (`Content-Type`, `X-Taskboard-Filename`). If `--content-type` is omitted, the CLI guesses from the file extension and falls back to `application/octet-stream`.
+
+Download an attachment to an explicit local path:
 
 ```bash
 taskctl attachment download ATTACHMENT_ID --output PATH [--json]

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -515,3 +515,77 @@ test("usage errors are stable and never call the service", async () => {
   assert.equal(result.stderr.error.code, "USAGE_ERROR");
   assert.match(result.stderr.error.message, /--title/);
 });
+
+test("attachment upload posts file bytes to a task with filename headers", async () => {
+  const calls = [];
+  const fileBytes = Buffer.from("hello attachment", "utf8");
+  const result = await run(
+    ["attachment", "upload", "--task", "TASK-1", "--file", "notes.md", "--json"],
+    async (url, init) => {
+      calls.push({ url: url.toString(), init });
+      return response({
+        attachment: {
+          id: "att-1",
+          taskId: "TASK-1",
+          filename: "notes.md",
+          contentType: "text/markdown",
+          size: fileBytes.byteLength,
+        },
+      }, 201);
+    },
+    {
+      readFile: async () => fileBytes,
+    },
+  );
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(result.stdout.attachment.id, "att-1");
+  assert.equal(result.stdout.target.type, "task");
+  assert.equal(result.stdout.target.id, "TASK-1");
+  assert.equal(calls[0].url, "http://127.0.0.1:47823/api/tasks/TASK-1/attachments");
+  assert.equal(calls[0].init.method, "POST");
+  assert.equal(calls[0].init.headers["content-type"], "text/markdown");
+  assert.equal(calls[0].init.headers["x-taskboard-filename"], encodeURIComponent("notes.md"));
+  assert.equal(calls[0].init.headers["x-taskboard-client"], "taskctl");
+  assert.deepEqual(Buffer.from(calls[0].init.body), fileBytes);
+});
+
+test("attachment upload requires exactly one target and can target comments", async () => {
+  const missing = await run(
+    ["attachment", "upload", "--file", "a.txt"],
+    async () => assert.fail("fetch should not be called"),
+    { readFile: async () => Buffer.from("x") },
+  );
+  assert.equal(missing.exitCode, 2);
+  assert.match(missing.stderr.error.message, /exactly one of --task or --comment/);
+
+  const both = await run(
+    ["attachment", "upload", "--task", "T1", "--comment", "C1", "--file", "a.txt"],
+    async () => assert.fail("fetch should not be called"),
+    { readFile: async () => Buffer.from("x") },
+  );
+  assert.equal(both.exitCode, 2);
+  assert.match(both.stderr.error.message, /exactly one of --task or --comment/);
+
+  let commentUrl;
+  const commentResult = await run(
+    ["attachment", "upload", "--comment", "COMMENT-1", "--file", "shot.png", "--content-type", "image/png"],
+    async (url, init) => {
+      commentUrl = url.toString();
+      assert.equal(init.headers["content-type"], "image/png");
+      return response({
+        attachment: {
+          id: "att-2",
+          commentId: "COMMENT-1",
+          filename: "shot.png",
+          contentType: "image/png",
+          size: 1,
+        },
+      }, 201);
+    },
+    { readFile: async () => Buffer.from([1]) },
+  );
+  assert.equal(commentResult.exitCode, 0);
+  assert.equal(commentUrl, "http://127.0.0.1:47823/api/comments/COMMENT-1/attachments");
+  assert.equal(commentResult.stdout.target.type, "comment");
+});


### PR DESCRIPTION
## 摘要

`taskctl` 目前支持下载附件（`attachment download`），但不支持上传。
网页端已经可以把文件挂到任务或评论上，服务端也已提供对应的 POST 接口。
本 PR 补齐 **CLI 命令** 与 **manage-taskboard skill 文档**，让代理/脚本能用 `taskctl` 按与网页相同的协议上传本地文件。

Closes #70

## 变更文件

| 文件                                          | 变更说明                                                                                                                                                                                                 |
| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `cli/taskctl.mjs`                           | 实现`attachment upload`：读本地文件 → `POST` 到已有上传接口；支持 `--task` / `--comment` / `--file` / `--content-type`；补 `api.upload`；更新 usage 列表为 `attachment download/upload` |
| `skills/manage-taskboard/references/cli.md` | 将「仅下载」改为完整**Attachments** 小节：补充 `attachment upload` 用法、请求路径与 header 约定                                                                                                  |
| `test/cli.test.mjs`                         | 新增 2 个 CLI 单测：任务上传 header/body、评论上传与「task/comment 二选一」校验                                                                                                                          |

**未改**：`server/`、`web/`、`cloud/`、数据库 schema（上传路由本就存在）。

## CLI 用法（`cli/taskctl.mjs`）

```bash
taskctl attachment upload --task TASK_ID --file PATH [--content-type TYPE] [--json]
taskctl attachment upload --comment COMMENT_ID --file PATH [--content-type TYPE] [--json]
```

规则：

- `--task` 与 `--comment` 必须且只能二选一
- 请求与网页端一致：
  - `POST /api/tasks/:id/attachments`
  - `POST /api/comments/:id/attachments`
  - body：文件原始字节
  - headers：`Content-Type`、`X-Taskboard-Filename`（URL 编码）、`x-taskboard-client: taskctl`
- 未传 `--content-type` 时按扩展名推断，默认 `application/octet-stream`

下载仍为：

```bash
taskctl attachment download ATTACHMENT_ID --output PATH [--json]
```

## Skill 文档（`skills/manage-taskboard/references/cli.md`）

- 原章节名侧重「下载内联图片」，未列出 upload
- 现改为 **Attachments** 一节，写明：
  - upload 两种目标（task / comment）
  - 与 web UI 相同的 POST 路径与 header
  - download 用法保留

代理按 skill 执行时，应使用 `taskctl attachment upload`，而不是直接调 HTTP 或写绝对路径代替附件。

## 测试

`test/cli.test.mjs` 新增：

1. `attachment upload posts file bytes to a task with filename headers`
2. `attachment upload requires exactly one target and can target comments`

建议本地执行：

```bash
node --test --test-name-pattern "attachment upload" test/cli.test.mjs
```

## 测试计划

- [X] 上述 2 条新增单测通过
- [X] 完整 `test/cli.test.mjs`：新增用例通过；Windows 上另有 3 条路径相关既有失败，与本改动无关
- [X] 本地服务实测：创建任务 → `attachment upload` → `attachment download` → SHA-256 一致
