### PR TITLE
fix: restore expanded search background

### DIFF
--- a/test/input-focus-chrome.test.mjs
+++ b/test/input-focus-chrome.test.mjs
@@ -37,13 +37,18 @@ test("editable controls suppress native focus outlines without disabling non-tex
 test("editable-control wrappers do not add focus chrome", () => {
   for (const selector of [
     ".project-card:focus-within",
-    ".search-field:focus-within",
     ".detail-property-row:focus-within",
     ".workflow-node-search:focus-within",
     ".comment-composer:focus-within",
   ]) {
     assertNoFocusChrome(globalStyles, selector);
   }
+
+  assert.doesNotMatch(
+    blocksForSelector(globalStyles, ".search-field:focus-within").join(";"),
+    /(?:^|;)\s*(?:border(?:-color)?|box-shadow|outline)\s*:/,
+    ".search-field:focus-within must not alter border, shadow or outline",
+  );
 
   assert.equal(blocksForSelector(globalStyles, ".workflow-tab.is-renaming input:focus").length, 0);
   assert.equal(blocksForSelector(globalStyles, ".workflow-config-section input:focus").length, 0);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1044,6 +1044,7 @@ kbd {
 .search-field:focus-within,
 .search-field.has-value {
   width: min(148px, 21vw);
+  background: var(--surface-hover);
 }
 
 .search-field input {


### PR DESCRIPTION
## 变更

- 在搜索框 `:focus-within` 和 `.has-value` 展开状态使用 `var(--surface-hover)` 背景。
- 保持纯 hover 状态透明，不恢复 `.search-field:hover`。
- 同步现有焦点样式契约：搜索框允许需求明确的背景，但仍禁止新增边框、阴影和 outline。

## 原因

PR #62 删除纯 hover 背景后，展开状态仍只设置宽度，背景此前间接依赖鼠标悬停。键盘聚焦或有输入且失焦时因此没有背景。

## 用户影响

搜索框展开或输入时恢复清晰背景；鼠标只悬停时仍无背景。

## 直接验证

- 静止：透明背景，28px。
- 纯 hover：透明背景，28px。
- focus：`rgb(246, 246, 247)`，176px。
- 有输入且失焦：`rgb(246, 246, 247)`，176px。
- 相关焦点样式测试：3/3 通过。
- `git diff --check` 通过。

关联：1655E73440AB-79。