### PR TITLE
Fix new task editor title and keyboard behavior

### DIFF
--- a/web/src/components/TaskEditor.tsx
+++ b/web/src/components/TaskEditor.tsx
@@ -129,7 +129,7 @@ export function TaskEditor({
 }: TaskEditorProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const backdropPointerRef = useRef({ down: false, up: false });
-  const titleRef = useRef<HTMLInputElement>(null);
+  const titleRef = useRef<HTMLTextAreaElement>(null);
   const descriptionComposerRef = useRef<InlineMediaComposerHandle>(null);
   const createSubmitIntentRef = useRef(false);
   const attachmentInputRef = useRef<HTMLInputElement>(null);
@@ -174,6 +174,13 @@ export function TaskEditor({
       if (dialogRef.current?.open) dialogRef.current.close();
     };
   }, []);
+
+  useEffect(() => {
+    const titleElement = titleRef.current;
+    if (!titleElement) return;
+    titleElement.style.height = "0px";
+    titleElement.style.height = `${titleElement.scrollHeight}px`;
+  }, [title]);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -234,7 +241,6 @@ export function TaskEditor({
     }
     if (event.target === titleRef.current) {
       event.preventDefault();
-      descriptionComposerRef.current?.focus();
     }
   }
 
@@ -302,7 +308,7 @@ export function TaskEditor({
         if (backdropClick && !saving) cancelEditor();
       }}
     >
-      <form className="task-form" onSubmit={handleSubmit} onKeyDown={handleKeyDown}>
+      <form className={`task-form${task ? "" : " is-creating"}`} onSubmit={handleSubmit} onKeyDown={handleKeyDown}>
         <header className="dialog-header">
           <div className="dialog-context">
             <strong id="task-dialog-title">{task ? task.identifier : "新建议题"}</strong>
@@ -320,7 +326,7 @@ export function TaskEditor({
         <div className="form-body">
           <label className="composer-title">
             <span className="sr-only">标题</span>
-            <input ref={titleRef} value={title} onChange={(event) => setTitle(event.target.value)} placeholder="Issue title" maxLength={240} autoComplete="off" />
+            <textarea ref={titleRef} rows={1} value={title} onChange={(event) => setTitle(event.target.value.replace(/\n/g, ""))} placeholder="Issue title" maxLength={240} autoComplete="off" />
           </label>
           {task ? (
             <label className="composer-description">

--- a/web/src/components/TaskEditor.tsx
+++ b/web/src/components/TaskEditor.tsx
@@ -258,7 +258,7 @@ export function TaskEditor({
       event.currentTarget.requestSubmit();
       return;
     }
-    if (event.target !== titleRef.current || event.metaKey || event.ctrlKey) return;
+    if (event.target !== titleRef.current) return;
     event.preventDefault();
     if (task) event.currentTarget.requestSubmit();
   }

--- a/web/src/components/TaskEditor.tsx
+++ b/web/src/components/TaskEditor.tsx
@@ -178,8 +178,26 @@ export function TaskEditor({
   useEffect(() => {
     const titleElement = titleRef.current;
     if (!titleElement) return;
-    titleElement.style.height = "0px";
-    titleElement.style.height = `${titleElement.scrollHeight}px`;
+    const resizeTitle = () => {
+      titleElement.style.height = "0px";
+      titleElement.style.height = `${titleElement.scrollHeight}px`;
+    };
+    resizeTitle();
+
+    let titleWidth = titleElement.clientWidth;
+    let resizeFrame = 0;
+    const observer = new ResizeObserver(() => {
+      const nextWidth = titleElement.clientWidth;
+      if (nextWidth === titleWidth) return;
+      titleWidth = nextWidth;
+      cancelAnimationFrame(resizeFrame);
+      resizeFrame = requestAnimationFrame(resizeTitle);
+    });
+    observer.observe(titleElement);
+    return () => {
+      observer.disconnect();
+      cancelAnimationFrame(resizeFrame);
+    };
   }, [title]);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -232,16 +250,16 @@ export function TaskEditor({
   }
 
   function handleKeyDown(event: KeyboardEvent<HTMLFormElement>) {
-    if (task || event.key !== "Enter") return;
-    if (event.metaKey || event.ctrlKey) {
+    if (event.key !== "Enter") return;
+    if (!task && (event.metaKey || event.ctrlKey)) {
       event.preventDefault();
       createSubmitIntentRef.current = true;
       event.currentTarget.requestSubmit();
       return;
     }
-    if (event.target === titleRef.current) {
-      event.preventDefault();
-    }
+    if (event.target !== titleRef.current || event.metaKey || event.ctrlKey) return;
+    event.preventDefault();
+    if (task) event.currentTarget.requestSubmit();
   }
 
   function addAttachments(files: FileList | File[]) {

--- a/web/src/components/TaskEditor.tsx
+++ b/web/src/components/TaskEditor.tsx
@@ -250,6 +250,7 @@ export function TaskEditor({
   }
 
   function handleKeyDown(event: KeyboardEvent<HTMLFormElement>) {
+    if (event.nativeEvent.isComposing || event.keyCode === 229) return;
     if (event.key !== "Enter") return;
     if (!task && (event.metaKey || event.ctrlKey)) {
       event.preventDefault();

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6011,6 +6011,11 @@ kbd {
   max-height: inherit;
 }
 
+.task-form.is-creating {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
 .dialog-header,
 .dialog-footer {
   display: flex;
@@ -6088,7 +6093,7 @@ kbd {
   display: block;
 }
 
-.composer-title input,
+.composer-title textarea,
 .composer-description textarea {
   width: 100%;
   padding: 0;
@@ -6098,8 +6103,10 @@ kbd {
   color: var(--text-primary);
 }
 
-.composer-title input {
-  height: 34px;
+.composer-title textarea {
+  min-height: 34px;
+  overflow: hidden;
+  resize: none;
   font-size: 18px;
   font-weight: 600;
   line-height: 28.8px;
@@ -6131,7 +6138,7 @@ kbd {
   min-height: 100px;
 }
 
-.composer-title input::placeholder,
+.composer-title textarea::placeholder,
 .composer-description textarea::placeholder,
 .property-control input::placeholder,
 .codex-link-row input::placeholder {


### PR DESCRIPTION
## Summary

- Wrap long new-issue titles inside an auto-growing title field.
- Prevent dragging to select non-input UI text in the new-issue dialog.
- Keep focus in the title field when plain Enter is pressed.
- Preserve Cmd/Ctrl+Enter submission and the Create Issue button.

## Why

The title used a single-line input, so long text could not wrap. The create-form Enter handler also moved focus from the title to the description. The dialog did not explicitly set its non-input UI selection behavior.

## Validation

- `npm run typecheck`
- `npm run build:web -- --outDir /private/tmp/codex-taskboard-local-138-build`
- Direct isolated Chromium check: the long-title field grew to 86 px with matching client and scroll heights; plain Enter kept focus in the title without adding a newline; header, property, and create-button text computed to `user-select: none`.

Taskboard issues: LOCAL-138, LOCAL-144, LOCAL-146.