### PR TITLE
修复自动化下拉框被后台轮询收回

### DIFF
--- a/test/project-automation-settings.test.mjs
+++ b/test/project-automation-settings.test.mjs
@@ -36,7 +36,7 @@ test("project automation state is device-local and scoped by taskboard project",
 test("automation requests use the exact Codex host message contract", () => {
   assert.match(appSource, /type: "taskboard:automation-request"/);
   assert.match(appSource, /operation: "ensure-active" \| "pause" \| "list"/);
-  assert.match(appSource, /taskboardProjectId: selectedProjectId/);
+  assert.match(appSource, /context: AutomationRequestContext[\s\S]*?taskboardProjectId: context\.taskboardProjectId/);
   assert.match(appSource, /codexProjectId/);
   assert.match(appSource, /projectName: selectedProject\.name/);
   assert.match(appSource, /workspacePath/);
@@ -111,7 +111,7 @@ test("unavailable automation state has one notice, clears stale errors, and cann
   );
   assert.match(
     reconcileSource,
-    /automationProjectContext\.unavailableReason[\s\S]*?\) \{\s*setAutomationError\(null\);\s*return;/,
+    /if \(!automationRequestContext\) \{\s*setAutomationError\(null\);\s*return;/,
   );
   assert.doesNotMatch(reconcileSource, /setAutomationError\(automationProjectContext\.unavailableReason/);
 });
@@ -149,18 +149,18 @@ test("opening settings and changing projects reconcile with the host list", () =
     appSource.indexOf("const reconcileProjectAutomation"),
     appSource.indexOf("const saveProjectAutomation"),
   );
-  const saveSource = appSource.slice(
-    appSource.indexOf("const saveProjectAutomation"),
-    appSource.indexOf("function openTaskDetail"),
+  const drainSource = appSource.slice(
+    appSource.indexOf("const drainQueuedAutomationSaves"),
+    appSource.indexOf("const reconcileProjectAutomation"),
   );
   assert.match(
     reconcileSource,
-    /sendAutomationRequest\(\s*"list",\s*options,\s*stored\?\.automationId,\s*\)/,
+    /sendAutomationRequest\(\s*"list",\s*options,\s*automationRequestContext,\s*stored\?\.automationId,\s*\)/,
   );
   assert.doesNotMatch(reconcileSource, /"apply-policy"/);
   assert.match(
-    saveSource,
-    /sendAutomationRequest\("apply-policy", options, stored\?\.automationId\)/,
+    drainSource,
+    /sendAutomationRequest\(\s*"apply-policy",\s*queuedSave\.options,\s*queuedSave\.context,\s*previousRecord\?\.automationId,\s*\)/,
   );
   assert.match(appSource, /const policy = isAutomationHostPolicy\(response\.policy\) \? response\.policy : null/);
   assert.match(appSource, /const item = \(isAutomationHostItem\(response\.item\) \? response\.item : undefined\)\s*\?\? items\.find\(\(candidate\) => candidate\.id === policy\.automationId\)/);
@@ -171,5 +171,5 @@ test("opening settings and changing projects reconcile with the host list", () =
   assert.match(appSource, /enabledByUser: policy\.enabledByUser/);
   assert.match(appSource, /quotaAware: policy\.quotaAware/);
   assert.match(appSource, /automationId: undefined,[\s\S]*?status: "PAUSED"/);
-  assert.match(appSource, /writeProjectAutomation\(selectedProjectId, previousRecord\)/);
+  assert.match(drainSource, /writeProjectAutomation\(queuedSave\.projectId, previousRecord\)/);
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -191,6 +191,11 @@ interface ProjectAutomationRecord {
   reasoningEffort: AutomationReasoningEffort;
 }
 
+type ProjectAutomationOptions = Pick<
+  ProjectAutomationRecord,
+  "enabledByUser" | "quotaAware" | "intervalMinutes" | "model" | "reasoningEffort"
+>;
+
 type ProjectAutomations = Record<string, ProjectAutomationRecord>;
 
 interface AutomationHostItem {
@@ -663,8 +668,13 @@ export function App() {
 
   const revisionPollingInterval = getRevisionPollingInterval(taskboardMetadata);
   const pendingAutomationRequestsRef = useRef(new Map<string, PendingAutomationRequest>());
-  const automationRequestInFlightRef = useRef(false);
+  const automationRequestInFlightRef = useRef<"list" | "save" | null>(null);
   const loadedAutomationProjectIdsRef = useRef(new Set<string>());
+  const queuedAutomationSaveRef = useRef<{
+    projectId: string;
+    options: ProjectAutomationOptions;
+  } | null>(null);
+  const saveProjectAutomationRef = useRef<(options: ProjectAutomationOptions) => void>(() => {});
   const projectAutomationsRef = useRef(projectAutomations);
 
   const setAnnouncement = useCallback((message: string) => {
@@ -872,10 +882,7 @@ export function App() {
 
   const sendAutomationRequest = useCallback((
     operation: "ensure-active" | "pause" | "list" | "apply-policy",
-    options: Pick<
-      ProjectAutomationRecord,
-      "enabledByUser" | "quotaAware" | "intervalMinutes" | "model" | "reasoningEffort"
-    >,
+    options: ProjectAutomationOptions,
     automationId?: string,
   ) => {
     if (
@@ -929,7 +936,7 @@ export function App() {
     if (!selectedProjectId || !automationProjectContext.codexProjectId || automationRequestInFlightRef.current) return;
     const stored = projectAutomationsRef.current[selectedProjectId];
     const initialLoad = !loadedAutomationProjectIdsRef.current.has(selectedProjectId);
-    automationRequestInFlightRef.current = true;
+    automationRequestInFlightRef.current = "list";
     if (initialLoad) setAutomationPending(true);
     setAutomationError(null);
     try {
@@ -1002,9 +1009,14 @@ export function App() {
     } catch (error) {
       setAutomationError(error instanceof Error ? error.message : "无法读取自动化状态");
     } finally {
+      const queuedSave = queuedAutomationSaveRef.current;
+      if (queuedSave?.projectId === selectedProjectId) queuedAutomationSaveRef.current = null;
       loadedAutomationProjectIdsRef.current.add(selectedProjectId);
-      automationRequestInFlightRef.current = false;
+      automationRequestInFlightRef.current = null;
       if (initialLoad) setAutomationPending(false);
+      if (queuedSave?.projectId === selectedProjectId) {
+        saveProjectAutomationRef.current(queuedSave.options);
+      }
     }
   }, [
     automationProjectContext,
@@ -1013,22 +1025,20 @@ export function App() {
     writeProjectAutomation,
   ]);
 
-  const saveProjectAutomation = useCallback(async (options: {
-    enabledByUser: boolean;
-    quotaAware: boolean;
-    intervalMinutes: AutomationIntervalMinutes;
-    model: AutomationModel;
-    reasoningEffort: AutomationReasoningEffort;
-  }) => {
+  const saveProjectAutomation = useCallback(async (options: ProjectAutomationOptions) => {
     const stored = projectAutomations[selectedProjectId];
     if (
       !selectedProjectId
       || automationProjectContext.unavailableReason
       || !automationProjectContext.codexProjectId
-      || automationRequestInFlightRef.current
     ) return;
+    if (automationRequestInFlightRef.current === "list") {
+      queuedAutomationSaveRef.current = { projectId: selectedProjectId, options };
+      return;
+    }
+    if (automationRequestInFlightRef.current) return;
     const previousRecord = stored;
-    automationRequestInFlightRef.current = true;
+    automationRequestInFlightRef.current = "save";
     setAutomationPending(true);
     setAutomationError(null);
     try {
@@ -1049,7 +1059,7 @@ export function App() {
       writeProjectAutomation(selectedProjectId, previousRecord);
       setAutomationError(error instanceof Error ? error.message : "无法更新自动化");
     } finally {
-      automationRequestInFlightRef.current = false;
+      automationRequestInFlightRef.current = null;
       setAutomationPending(false);
     }
   }, [
@@ -1059,6 +1069,7 @@ export function App() {
     sendAutomationRequest,
     writeProjectAutomation,
   ]);
+  saveProjectAutomationRef.current = saveProjectAutomation;
 
   function openTaskDetail(task: Pick<Task, "identifier" | "projectId">) {
     const fullTask = tasksRef.current.find((candidate) => candidate.identifier === task.identifier);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -664,6 +664,7 @@ export function App() {
   const revisionPollingInterval = getRevisionPollingInterval(taskboardMetadata);
   const pendingAutomationRequestsRef = useRef(new Map<string, PendingAutomationRequest>());
   const automationRequestInFlightRef = useRef(false);
+  const loadedAutomationProjectIdsRef = useRef(new Set<string>());
   const projectAutomationsRef = useRef(projectAutomations);
 
   const setAnnouncement = useCallback((message: string) => {
@@ -927,8 +928,9 @@ export function App() {
     }
     if (!selectedProjectId || !automationProjectContext.codexProjectId || automationRequestInFlightRef.current) return;
     const stored = projectAutomationsRef.current[selectedProjectId];
+    const initialLoad = !loadedAutomationProjectIdsRef.current.has(selectedProjectId);
     automationRequestInFlightRef.current = true;
-    setAutomationPending(true);
+    if (initialLoad) setAutomationPending(true);
     setAutomationError(null);
     try {
       const options = stored ?? {
@@ -1000,8 +1002,9 @@ export function App() {
     } catch (error) {
       setAutomationError(error instanceof Error ? error.message : "无法读取自动化状态");
     } finally {
+      loadedAutomationProjectIdsRef.current.add(selectedProjectId);
       automationRequestInFlightRef.current = false;
-      setAutomationPending(false);
+      if (initialLoad) setAutomationPending(false);
     }
   }, [
     automationProjectContext,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -196,6 +196,20 @@ type ProjectAutomationOptions = Pick<
   "enabledByUser" | "quotaAware" | "intervalMinutes" | "model" | "reasoningEffort"
 >;
 
+interface AutomationRequestContext {
+  taskboardProjectId: string;
+  codexProjectId: string;
+  projectName: string;
+  workspacePath: string;
+  skillPath: string;
+}
+
+interface QueuedProjectAutomationSave {
+  projectId: string;
+  context: AutomationRequestContext;
+  options: ProjectAutomationOptions;
+}
+
 type ProjectAutomations = Record<string, ProjectAutomationRecord>;
 
 interface AutomationHostItem {
@@ -670,11 +684,7 @@ export function App() {
   const pendingAutomationRequestsRef = useRef(new Map<string, PendingAutomationRequest>());
   const automationRequestInFlightRef = useRef<"list" | "save" | null>(null);
   const loadedAutomationProjectIdsRef = useRef(new Set<string>());
-  const queuedAutomationSaveRef = useRef<{
-    projectId: string;
-    options: ProjectAutomationOptions;
-  } | null>(null);
-  const saveProjectAutomationRef = useRef<(options: ProjectAutomationOptions) => void>(() => {});
+  const queuedAutomationSavesRef = useRef(new Map<string, QueuedProjectAutomationSave>());
   const projectAutomationsRef = useRef(projectAutomations);
 
   const setAnnouncement = useCallback((message: string) => {
@@ -758,6 +768,21 @@ export function App() {
     manageTaskboardSkillPath,
     selectedProject,
   ]);
+  const automationRequestContext = useMemo<AutomationRequestContext | null>(() => {
+    if (
+      !selectedProject
+      || !automationProjectContext.codexProjectId
+      || !automationProjectContext.workspacePath
+      || !manageTaskboardSkillPath
+    ) return null;
+    return {
+      taskboardProjectId: selectedProject.id,
+      codexProjectId: automationProjectContext.codexProjectId,
+      projectName: selectedProject.name,
+      workspacePath: automationProjectContext.workspacePath,
+      skillPath: manageTaskboardSkillPath,
+    };
+  }, [automationProjectContext, manageTaskboardSkillPath, selectedProject]);
   const detailTask = detailTaskIdentifier
     ? tasks.find((task) => task.identifier === detailTaskIdentifier) ?? null
     : null;
@@ -883,17 +908,9 @@ export function App() {
   const sendAutomationRequest = useCallback((
     operation: "ensure-active" | "pause" | "list" | "apply-policy",
     options: ProjectAutomationOptions,
+    context: AutomationRequestContext,
     automationId?: string,
   ) => {
-    if (
-      !selectedProject
-      || !automationProjectContext.codexProjectId
-      || !automationProjectContext.workspacePath
-    ) {
-      return Promise.reject(new Error(
-        automationProjectContext.unavailableReason ?? "无法读取项目自动化信息",
-      ));
-    }
     const requestId = window.crypto.randomUUID();
     const response = new Promise<AutomationHostResponse>((resolve, reject) => {
       const timeoutId = window.setTimeout(() => {
@@ -907,11 +924,11 @@ export function App() {
       payload: {
         requestId,
         operation,
-        taskboardProjectId: selectedProjectId,
-        codexProjectId: automationProjectContext.codexProjectId,
-        projectName: selectedProject.name,
-        workspacePath: automationProjectContext.workspacePath,
-        skillPath: manageTaskboardSkillPath,
+        taskboardProjectId: context.taskboardProjectId,
+        codexProjectId: context.codexProjectId,
+        projectName: context.projectName,
+        workspacePath: context.workspacePath,
+        skillPath: context.skillPath,
         ...(automationId ? { automationId } : {}),
         enabledByUser: options.enabledByUser,
         quotaAware: options.quotaAware,
@@ -921,21 +938,60 @@ export function App() {
       },
     });
     return response;
-  }, [
-    automationProjectContext,
-    manageTaskboardSkillPath,
-    selectedProject,
-    selectedProjectId,
-  ]);
+  }, []);
+
+  const drainQueuedAutomationSaves = useCallback(async (preferredProjectId?: string) => {
+    if (automationRequestInFlightRef.current) return;
+    let nextProjectId = preferredProjectId;
+    while (queuedAutomationSavesRef.current.size > 0) {
+      const queuedSave = (
+        nextProjectId ? queuedAutomationSavesRef.current.get(nextProjectId) : undefined
+      ) ?? queuedAutomationSavesRef.current.values().next().value;
+      nextProjectId = undefined;
+      if (!queuedSave) return;
+      queuedAutomationSavesRef.current.delete(queuedSave.projectId);
+      const previousRecord = projectAutomationsRef.current[queuedSave.projectId];
+      automationRequestInFlightRef.current = "save";
+      setAutomationPending(true);
+      setAutomationError(null);
+      try {
+        const response = await sendAutomationRequest(
+          "apply-policy",
+          queuedSave.options,
+          queuedSave.context,
+          previousRecord?.automationId,
+        );
+        const item = isAutomationHostItem(response.item) ? response.item : undefined;
+        writeProjectAutomation(queuedSave.projectId, {
+          automationId: item?.id,
+          codexProjectId: queuedSave.context.codexProjectId,
+          status: item?.status ?? "PAUSED",
+          enabledByUser: queuedSave.options.enabledByUser,
+          quotaAware: queuedSave.options.quotaAware,
+          ...(response.quota ? { quota: response.quota } : {}),
+          intervalMinutes: queuedSave.options.intervalMinutes,
+          model: queuedSave.options.model,
+          reasoningEffort: queuedSave.options.reasoningEffort,
+        });
+      } catch (error) {
+        writeProjectAutomation(queuedSave.projectId, previousRecord);
+        setAutomationError(error instanceof Error ? error.message : "无法更新自动化");
+      } finally {
+        automationRequestInFlightRef.current = null;
+        setAutomationPending(false);
+      }
+    }
+  }, [sendAutomationRequest, writeProjectAutomation]);
 
   const reconcileProjectAutomation = useCallback(async () => {
-    if (automationProjectContext.unavailableReason) {
+    if (!automationRequestContext) {
       setAutomationError(null);
       return;
     }
-    if (!selectedProjectId || !automationProjectContext.codexProjectId || automationRequestInFlightRef.current) return;
-    const stored = projectAutomationsRef.current[selectedProjectId];
-    const initialLoad = !loadedAutomationProjectIdsRef.current.has(selectedProjectId);
+    if (automationRequestInFlightRef.current) return;
+    const projectId = automationRequestContext.taskboardProjectId;
+    const stored = projectAutomationsRef.current[projectId];
+    const initialLoad = !loadedAutomationProjectIdsRef.current.has(projectId);
     automationRequestInFlightRef.current = "list";
     if (initialLoad) setAutomationPending(true);
     setAutomationError(null);
@@ -947,6 +1003,7 @@ export function App() {
       const response = await sendAutomationRequest(
         "list",
         options,
+        automationRequestContext,
         stored?.automationId,
       );
       const items = Array.isArray(response.items)
@@ -958,9 +1015,9 @@ export function App() {
         const item = (isAutomationHostItem(response.item) ? response.item : undefined)
           ?? items.find((candidate) => candidate.id === policy.automationId)
           ?? (items.length === 1 ? items[0] : undefined);
-        writeProjectAutomation(selectedProjectId, {
+        writeProjectAutomation(projectId, {
           automationId: item?.id ?? policy.automationId,
-          codexProjectId: automationProjectContext.codexProjectId,
+          codexProjectId: automationRequestContext.codexProjectId,
           status: item?.status ?? "PAUSED",
           enabledByUser: policy.enabledByUser,
           quotaAware: policy.quotaAware,
@@ -976,7 +1033,7 @@ export function App() {
         ?? (items.length === 1 ? items[0] : undefined);
       if (!item) {
         if (stored) {
-          writeProjectAutomation(selectedProjectId, {
+          writeProjectAutomation(projectId, {
             ...stored,
             automationId: undefined,
             status: "PAUSED",
@@ -989,9 +1046,9 @@ export function App() {
       }
       const intervalMinutes = intervalMinutesFromRrule(item.rrule);
       if (!intervalMinutes) return;
-      writeProjectAutomation(selectedProjectId, {
+      writeProjectAutomation(projectId, {
         automationId: item.id,
-        codexProjectId: automationProjectContext.codexProjectId,
+        codexProjectId: automationRequestContext.codexProjectId,
         status: item.status,
         enabledByUser: policy?.enabledByUser ?? stored.enabledByUser,
         quotaAware: policy?.quotaAware ?? stored.quotaAware,
@@ -1009,67 +1066,33 @@ export function App() {
     } catch (error) {
       setAutomationError(error instanceof Error ? error.message : "无法读取自动化状态");
     } finally {
-      const queuedSave = queuedAutomationSaveRef.current;
-      if (queuedSave?.projectId === selectedProjectId) queuedAutomationSaveRef.current = null;
-      loadedAutomationProjectIdsRef.current.add(selectedProjectId);
+      loadedAutomationProjectIdsRef.current.add(projectId);
       automationRequestInFlightRef.current = null;
       if (initialLoad) setAutomationPending(false);
-      if (queuedSave?.projectId === selectedProjectId) {
-        saveProjectAutomationRef.current(queuedSave.options);
-      }
+      void drainQueuedAutomationSaves(projectId);
     }
   }, [
-    automationProjectContext,
-    selectedProjectId,
+    automationRequestContext,
+    drainQueuedAutomationSaves,
     sendAutomationRequest,
     writeProjectAutomation,
   ]);
 
-  const saveProjectAutomation = useCallback(async (options: ProjectAutomationOptions) => {
-    const stored = projectAutomations[selectedProjectId];
-    if (
-      !selectedProjectId
-      || automationProjectContext.unavailableReason
-      || !automationProjectContext.codexProjectId
-    ) return;
-    if (automationRequestInFlightRef.current === "list") {
-      queuedAutomationSaveRef.current = { projectId: selectedProjectId, options };
-      return;
-    }
-    if (automationRequestInFlightRef.current) return;
-    const previousRecord = stored;
-    automationRequestInFlightRef.current = "save";
-    setAutomationPending(true);
-    setAutomationError(null);
-    try {
-      const response = await sendAutomationRequest("apply-policy", options, stored?.automationId);
-      const item = isAutomationHostItem(response.item) ? response.item : undefined;
-      writeProjectAutomation(selectedProjectId, {
-        automationId: item?.id,
-        codexProjectId: automationProjectContext.codexProjectId,
-        status: item?.status ?? "PAUSED",
-        enabledByUser: options.enabledByUser,
-        quotaAware: options.quotaAware,
-        ...(response.quota ? { quota: response.quota } : {}),
-        intervalMinutes: options.intervalMinutes,
-        model: options.model,
-        reasoningEffort: options.reasoningEffort,
-      });
-    } catch (error) {
-      writeProjectAutomation(selectedProjectId, previousRecord);
-      setAutomationError(error instanceof Error ? error.message : "无法更新自动化");
-    } finally {
-      automationRequestInFlightRef.current = null;
-      setAutomationPending(false);
+  const saveProjectAutomation = useCallback((options: ProjectAutomationOptions) => {
+    if (!automationRequestContext) return;
+    const queuedSave = {
+      projectId: automationRequestContext.taskboardProjectId,
+      context: automationRequestContext,
+      options,
+    };
+    queuedAutomationSavesRef.current.set(queuedSave.projectId, queuedSave);
+    if (!automationRequestInFlightRef.current) {
+      void drainQueuedAutomationSaves(queuedSave.projectId);
     }
   }, [
-    automationProjectContext,
-    projectAutomations,
-    selectedProjectId,
-    sendAutomationRequest,
-    writeProjectAutomation,
+    automationRequestContext,
+    drainQueuedAutomationSaves,
   ]);
-  saveProjectAutomationRef.current = saveProjectAutomation;
 
   function openTaskDetail(task: Pick<Task, "identifier" | "projectId">) {
     const fullTask = tasksRef.current.find((candidate) => candidate.identifier === task.identifier);


### PR DESCRIPTION
## 改动

- 记录每个项目在当前页面是否已经完成首次自动化状态读取。
- 首次读取仍使用 `automationPending`；后续背景 `list` 刷新不再禁用设置控件。
- 背景 `list` 与用户 `apply-policy` 共用串行请求通道，但保存队列按项目 ID 保存最新完整选项。
- 每个排队项固定原项目 ID、Codex 项目 ID、项目名、工作区路径和 Skill 路径。
- 当前 `list` 先处理响应，再按项目依次发送排队保存；旧响应不会在保存后覆盖新值。
- 无背景读取时，普通保存立即进入原有 pending 并发送。
- 同步现有源码契约断言，使 CI 检查显式上下文、按项目 drain 和原项目回滚路径。

## 根因

Codex 注入脚本每秒发送 host context。App 收到新对象后重新读取自动化状态。最初的实现让背景读取设置全局 pending，所以原生 `select` 每秒短暂变为 `disabled`，系统下拉层自动关闭。

上一轮修复让已加载项目的背景读取不再设置 pending，并在 list 期间排队最新修改。但单槽队列及保存回调依赖当前渲染项目。用户修改 A 后切到 B，A 的 list 完成时可能通过 B 的当前上下文保存，或被 B 的修改覆盖。

本次返工把队列改为按项目 ID 保存，并把原请求上下文放入队列项。保存执行不再读取当前选择项目。

## 用户影响

- 模型、推理强度和间隔下拉框在背景轮询期间保持可用和焦点。
- A、B 在同一读取期间产生的最新修改会分别写入正确项目。
- 同项目连续修改只保存最新完整选项。
- 首次读取仍保持禁用，正常保存仍立即发送。
- host context 轮询和 host API 协议未改。

## 验证

- Vite 生产构建通过：`node_modules/.bin/vite build --config web/vite.config.ts --configLoader runner`
- 聚焦源码契约测试通过：`node --test test/project-automation-settings.test.mjs`，11/11。
- A 的背景 list 延迟，修改 A 后切到 B：list 完成后 `apply-policy.taskboardProjectId` 明确为 A，B 保持原值。
- A 的背景 list 延迟，修改 A 后切到 B 并修改 B：请求顺序为 A apply、B apply；A 最终为 `gpt-5.6-terra / ultra / 30 分钟`，B 最终为 `gpt-5.4 / xhigh / 15 分钟`。
- 同项目连续修改只发送最新完整选项；旧 A list 响应未覆盖保存结果。
- 背景 list 期间 select 保持 enabled 且模型 select 保持焦点。
- A、B 首次读取期间 select 均为 disabled。
- 每次 apply 期间 `aria-busy=true` 且 select 为 disabled。
- 无 list 时把 B 改为 60 分钟，apply 立即发送；最终界面和模拟服务端均为 60 分钟。

Closes #67