### PR TITLE
LOCAL-136 调整 dark mode 甘特图配色

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -11577,8 +11577,8 @@ kbd {
   padding: 0;
 }
 
-:root[data-theme="dark"] .gantt_scale_line:first-child {
-  border-bottom-color: rgba(255, 255, 255, .1) !important;
+:where(:root[data-theme="dark"]) .gantt_task_scale .gantt_scale_line + .gantt_scale_line {
+  border-top-color: rgba(255, 255, 255, .1) !important;
 }
 
 .gantt_row,
@@ -11586,13 +11586,13 @@ kbd {
   border-top: 0 !important;
   border-bottom: 0 !important;
 }
-:root[data-theme="dark"] .gantt_grid,
-:root[data-theme="dark"] .gantt_grid_data,
-:root[data-theme="dark"] .gantt_task,
-:root[data-theme="dark"] .gantt_data_area,
-:root[data-theme="dark"] .gantt_task_bg,
-:root[data-theme="dark"] .gantt_row:not(.is-group),
-:root[data-theme="dark"] .gantt_task_row:not(.is-group) { background: var(--bg) !important; }
+:where(:root[data-theme="dark"]) .gantt_grid,
+:where(:root[data-theme="dark"]) .gantt_grid_data,
+:where(:root[data-theme="dark"]) .gantt_task,
+:where(:root[data-theme="dark"]) .gantt_data_area,
+:where(:root[data-theme="dark"]) .gantt_task_bg,
+:where(:root[data-theme="dark"]) .gantt_row:not(.is-group),
+:where(:root[data-theme="dark"]) .gantt_task_row:not(.is-group) { background: var(--bg) !important; }
 .gantt_row:not(.is-group):hover,
 .gantt_task_row:not(.is-group):hover,
 .gantt_row:not(.is-group).is-linked-hover,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -11577,11 +11577,22 @@ kbd {
   padding: 0;
 }
 
+:root[data-theme="dark"] .gantt_scale_line:first-child {
+  border-bottom-color: rgba(255, 255, 255, .1) !important;
+}
+
 .gantt_row,
 .gantt_task_row {
   border-top: 0 !important;
   border-bottom: 0 !important;
 }
+:root[data-theme="dark"] .gantt_grid,
+:root[data-theme="dark"] .gantt_grid_data,
+:root[data-theme="dark"] .gantt_task,
+:root[data-theme="dark"] .gantt_data_area,
+:root[data-theme="dark"] .gantt_task_bg,
+:root[data-theme="dark"] .gantt_row:not(.is-group),
+:root[data-theme="dark"] .gantt_task_row:not(.is-group) { background: var(--bg) !important; }
 .gantt_row:not(.is-group):hover,
 .gantt_task_row:not(.is-group):hover,
 .gantt_row:not(.is-group).is-linked-hover,


### PR DESCRIPTION
## 改动

- 让 dark mode 甘特图左侧非分组内容使用应用背景色 `var(--bg)`。
- 让时间区和周中列使用相同的应用背景色。
- 保留分组标题区域原有颜色。
- 把顶部月份行分割线调整为 10% 白色。

## 原因

甘特图内容区原来统一使用 `var(--surface)`，与其他视图的背景板不一致。DHTMLX 的月份行分割线在暗色模式下也过亮。

## 影响

仅影响 dark mode 甘特图颜色。布局、滚动、任务数据和交互不变。

## 验证

- `npm run build:web`
- 独立 Playwright 预览：应用背景 `#171719`；左侧内容和时间区均为 `rgb(23, 23, 25)`；分组标题为 `rgb(34, 34, 37)`；月份分割线为 `rgba(255, 255, 255, 0.1)`。