### PR TITLE
feat: localize automation and AI chat panels

### DIFF
--- a/test/ai-chat-ui.test.mjs
+++ b/test/ai-chat-ui.test.mjs
@@ -166,8 +166,8 @@ test("chat renders Markdown, public thinking steps and never renders host-only f
   assert.match(chatSource, /ReactMarkdown/);
   assert.match(chatSource, /remarkPlugins=\{\[remarkGfm\]\}/);
   assert.match(chatSource, /ai-chat-thinking-steps/);
-  assert.match(chatSource, /aria-label="停止生成"/);
-  assert.match(chatSource, /aria-label="发送消息"/);
+  assert.match(chatSource, /aria-label=\{text\("停止生成", "Stop generating"\)\}/);
+  assert.match(chatSource, /aria-label=\{text\("发送消息", "Send message"\)\}/);
   assert.doesNotMatch(chatSource, /origin\.workspacePath/);
   assert.doesNotMatch(chatSource, /codexThreadId/);
   assert.doesNotMatch(chatSource, /manageTaskboardSkillPath/);
@@ -230,7 +230,7 @@ test("SSE hints are coalesced and custom panel resize handles do not clip narrow
 
 test("history exposes deletion of local records without adding rename controls", () => {
   assert.match(chatSource, /deleteAiChatThread\(/);
-  assert.match(chatSource, /aria-label=\{`删除对话 \$\{thread\.title\}`\}/);
-  assert.match(chatSource, /window\.confirm\(`删除本地对话“\$\{thread\.title\}”\？`\)/);
+  assert.match(chatSource, /aria-label=\{text\(`删除对话 \$\{thread\.title\}`, `Delete chat \$\{thread\.title\}`\)\}/);
+  assert.match(chatSource, /window\.confirm\(text\(\s*`删除本地对话“\$\{thread\.title\}”？`,\s*`Delete local chat “\$\{thread\.title\}”\?`,\s*\)\)/);
   assert.doesNotMatch(chatSource, /重命名对话|renameAiChatThread/);
 });

--- a/test/project-automation-settings.test.mjs
+++ b/test/project-automation-settings.test.mjs
@@ -122,11 +122,11 @@ test("automation changes submit immediately with model-specific effort normaliza
   assert.match(menuSource, /const submitChange = \(next: AutomationOptions\) => \{[\s\S]*?setDraft\(next\);[\s\S]*?onChange\(next\);[\s\S]*?\}/);
   assert.match(menuSource, /submitChange\(withAutomationModel\(draft, event\.target\.value as AutomationModel\)\)/);
   assert.match(menuSource, /getAutomationModel\(draft\.model\)\.efforts\.map/);
-  assert.match(menuSource, /<option key=\{effort\} value=\{effort\}>\{EFFORT_LABELS\[effort\]\}<\/option>/);
-  assert.match(menuSource, /low: "轻度"/);
-  assert.match(menuSource, /xhigh: "极高 \(xhigh\)"/);
-  assert.match(menuSource, /max: "最高"/);
-  assert.match(menuSource, /ultra: "极高 \(ultra\)"/);
+  assert.match(menuSource, /<option key=\{effort\} value=\{effort\}>\{text\(\.\.\.EFFORT_LABELS\[effort\]\)\}<\/option>/);
+  assert.match(menuSource, /low: \["轻度", "Low"\]/);
+  assert.match(menuSource, /xhigh: \["极高 \(xhigh\)", "Extra high \(xhigh\)"\]/);
+  assert.match(menuSource, /max: \["最高", "Maximum"\]/);
+  assert.match(menuSource, /ultra: \["极高 \(ultra\)", "Ultra"\]/);
   assert.doesNotMatch(menuSource, />取消</);
   assert.doesNotMatch(menuSource, />保存</);
   assert.doesNotMatch(menuSource, /project-automation-actions/);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -750,12 +750,14 @@ export function App() {
   const selectedProjectAutomation = projectAutomations[selectedProjectId];
   const automationProjectContext = useMemo(() => {
     if (!embedded || window.parent === window) {
-      return { unavailableReason: "仅可在 Codex App 中使用" };
+      return { unavailableReason: text("仅可在 Codex App 中使用", "Available only in the Codex app") };
     }
     if (!isLocalTaskboardOrigin(new URL(document.baseURI).origin)) {
-      return { unavailableReason: "仅本地任务面板可用" };
+      return { unavailableReason: text("仅本地任务面板可用", "Available only on the local taskboard") };
     }
-    if (!selectedProject) return { unavailableReason: "请先选择项目" };
+    if (!selectedProject) {
+      return { unavailableReason: text("请先选择项目", "Select a project first") };
+    }
 
     const directCodexProject = hostContext?.projects?.some(
       (project) => project.id === selectedProject.id,
@@ -774,10 +776,16 @@ export function App() {
       )?.id;
 
     if (!workspacePath || !codexProjectId) {
-      return { unavailableReason: "请先在 Codex 中添加并映射该项目目录" };
+      return { unavailableReason: text(
+        "请先在 Codex 中添加并映射该项目目录",
+        "Add and map this project directory in Codex first",
+      ) };
     }
     if (!manageTaskboardSkillPath) {
-      return { unavailableReason: "任务面板还没有读取到 Skill 路径" };
+      return { unavailableReason: text(
+        "任务面板还没有读取到 Skill 路径",
+        "Taskboard has not received the Skill path",
+      ) };
     }
     return { workspacePath, codexProjectId, unavailableReason: null };
   }, [
@@ -786,6 +794,7 @@ export function App() {
     hostContext,
     manageTaskboardSkillPath,
     selectedProject,
+    text,
   ]);
   const automationRequestContext = useMemo<AutomationRequestContext | null>(() => {
     if (
@@ -936,7 +945,10 @@ export function App() {
     const response = new Promise<AutomationHostResponse>((resolve, reject) => {
       const timeoutId = window.setTimeout(() => {
         pendingAutomationRequestsRef.current.delete(requestId);
-        reject(new Error("Codex 自动化没有响应，请稍后重试"));
+        reject(new Error(text(
+          "Codex 自动化没有响应，请稍后重试",
+          "Codex automation did not respond. Try again later.",
+        )));
       }, 10_000);
       pendingAutomationRequestsRef.current.set(requestId, { resolve, reject, timeoutId });
     });
@@ -996,7 +1008,9 @@ export function App() {
         });
       } catch (error) {
         writeProjectAutomation(queuedSave.projectId, previousRecord);
-        setAutomationError(error instanceof Error ? error.message : "无法更新自动化");
+        setAutomationError(error instanceof Error
+          ? error.message
+          : textRef.current("无法更新自动化", "Could not update automation."));
       } finally {
         automationRequestInFlightRef.current = null;
         setAutomationPending(false);
@@ -1085,7 +1099,9 @@ export function App() {
         reasoningEffort: item.reasoningEffort,
       });
     } catch (error) {
-      setAutomationError(error instanceof Error ? error.message : "无法读取自动化状态");
+      setAutomationError(error instanceof Error
+        ? error.message
+        : text("无法读取自动化状态", "Could not read the automation status."));
     } finally {
       loadedAutomationProjectIdsRef.current.add(projectId);
       automationRequestInFlightRef.current = null;
@@ -1096,6 +1112,7 @@ export function App() {
     automationRequestContext,
     drainQueuedAutomationSaves,
     sendAutomationRequest,
+    text,
     writeProjectAutomation,
   ]);
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -945,7 +945,7 @@ export function App() {
     const response = new Promise<AutomationHostResponse>((resolve, reject) => {
       const timeoutId = window.setTimeout(() => {
         pendingAutomationRequestsRef.current.delete(requestId);
-        reject(new Error(text(
+        reject(new Error(textRef.current(
           "Codex 自动化没有响应，请稍后重试",
           "Codex automation did not respond. Try again later.",
         )));

--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -147,10 +147,10 @@ const COMPOSER_HTML_BLOCKS = new Set([
   "SECTION",
 ]);
 const COMPOSER_HTML_IGNORED = new Set(["SCRIPT", "STYLE", "SVG"]);
-const SANDBOX_LABELS: Record<AiChatSandbox, string> = {
-  "read-only": "请求批准",
-  "workspace-write": "替我审批",
-  "danger-full-access": "完全访问权限",
+const SANDBOX_LABELS: Record<AiChatSandbox, readonly [string, string]> = {
+  "read-only": ["请求批准", "Ask for approval"],
+  "workspace-write": ["替我审批", "Approve selected actions"],
+  "danger-full-access": ["完全访问权限", "Full access"],
 };
 
 function clampPanelGeometry(geometry: PanelGeometry): PanelGeometry {
@@ -184,10 +184,10 @@ function loadPanelGeometry(): PanelGeometry {
   }
 }
 
-const SANDBOX_DESCRIPTIONS: Record<AiChatSandbox, string> = {
-  "read-only": "编辑外部文件和使用互联网时始终询问",
-  "workspace-write": "仅对检测到的风险操作请求批准",
-  "danger-full-access": "不受限制地访问互联网和您电脑上的任何文件",
+const SANDBOX_DESCRIPTIONS: Record<AiChatSandbox, readonly [string, string]> = {
+  "read-only": ["编辑外部文件和使用互联网时始终询问", "Always ask before editing external files or using the internet"],
+  "workspace-write": ["仅对检测到的风险操作请求批准", "Ask only for operations that are detected as risky"],
+  "danger-full-access": ["不受限制地访问互联网和您电脑上的任何文件", "Access the internet and any file on your computer without restrictions"],
 };
 
 const SANDBOX_ICONS: Record<AiChatSandbox, "hand" | "terminal" | "shieldAlert"> = {
@@ -196,13 +196,13 @@ const SANDBOX_ICONS: Record<AiChatSandbox, "hand" | "terminal" | "shieldAlert"> 
   "danger-full-access": "shieldAlert",
 };
 
-const EFFORT_LABELS: Record<string, string> = {
-  low: "低",
-  medium: "中",
-  high: "高",
-  xhigh: "极高",
-  max: "最高",
-  ultra: "极高",
+const EFFORT_LABELS: Record<string, readonly [string, string]> = {
+  low: ["低", "Low"],
+  medium: ["中", "Medium"],
+  high: ["高", "High"],
+  xhigh: ["极高", "Extra high"],
+  max: ["最高", "Maximum"],
+  ultra: ["极高", "Ultra"],
 };
 
 function modelDisplayName(value: string): string {
@@ -562,21 +562,21 @@ function SkillReference({
   );
 }
 
-const ACTIVITY_LABELS: Record<string, string> = {
-  plan: "执行计划",
-  todo: "任务进度",
-  todo_list: "任务进度",
-  command: "运行命令",
-  command_execution: "运行命令",
-  file: "文件修改",
-  file_change: "文件修改",
-  mcp: "调用 MCP",
-  mcp_tool_call: "调用 MCP",
-  skill: "调用 Skill",
-  web: "搜索资料",
-  web_search: "搜索资料",
-  error: "执行失败",
-  "turn.failed": "执行失败",
+const ACTIVITY_LABELS: Record<string, readonly [string, string]> = {
+  plan: ["执行计划", "Plan"],
+  todo: ["任务进度", "Task progress"],
+  todo_list: ["任务进度", "Task progress"],
+  command: ["运行命令", "Run command"],
+  command_execution: ["运行命令", "Run command"],
+  file: ["文件修改", "File changes"],
+  file_change: ["文件修改", "File changes"],
+  mcp: ["调用 MCP", "Use MCP"],
+  mcp_tool_call: ["调用 MCP", "Use MCP"],
+  skill: ["调用 Skill", "Use Skill"],
+  web: ["搜索资料", "Search the web"],
+  web_search: ["搜索资料", "Search the web"],
+  error: ["执行失败", "Failed"],
+  "turn.failed": ["执行失败", "Failed"],
 };
 
 const ACTIVITY_ICONS: Record<string, LinearIconName> = {
@@ -596,8 +596,11 @@ const ACTIVITY_ICONS: Record<string, LinearIconName> = {
   "turn.failed": "alert",
 };
 
-function messageFor(error: unknown): string {
-  return error instanceof Error ? error.message : "AI 对话暂时不可用";
+const AI_CHAT_UNAVAILABLE_ERROR = Symbol("ai-chat-unavailable");
+type AiChatError = string | typeof AI_CHAT_UNAVAILABLE_ERROR;
+
+function messageFor(error: unknown): AiChatError {
+  return error instanceof Error ? error.message : AI_CHAT_UNAVAILABLE_ERROR;
 }
 
 function isAiChatSandbox(value: string): value is AiChatSandbox {
@@ -606,10 +609,10 @@ function isAiChatSandbox(value: string): value is AiChatSandbox {
     || value === "danger-full-access";
 }
 
-function dateLabel(value: string): string {
+function dateLabel(value: string, locale: string): string {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "";
-  return new Intl.DateTimeFormat("zh-CN", {
+  return new Intl.DateTimeFormat(locale, {
     month: "short",
     day: "numeric",
     hour: "2-digit",
@@ -636,18 +639,21 @@ function parsedTodoLines(value: unknown): string[] {
   }
 }
 
-function activityDetail(event: AiChatEvent): ThinkingActivityDetail | null {
+function activityDetail(
+  event: AiChatEvent,
+  text: (chinese: string, english: string) => string,
+): ThinkingActivityDetail | null {
   const files = event.data?.files;
   if (Array.isArray(files)) {
     const visibleFiles = files.filter((value): value is string => typeof value === "string");
     if (visibleFiles.length > 0) {
-      return { kind: "lines", summary: "查看文件", value: visibleFiles };
+      return { kind: "lines", summary: text("查看文件", "View files"), value: visibleFiles };
     }
   }
   if (event.type === "todo" || event.type === "todo_list") {
     const lines = parsedTodoLines(event.data?.detail);
     if (lines.length > 0) {
-      return { kind: "lines", summary: "查看任务", value: lines };
+      return { kind: "lines", summary: text("查看任务", "View tasks"), value: lines };
     }
   }
   for (const key of ["output", "command", "detail", "path"]) {
@@ -655,7 +661,7 @@ function activityDetail(event: AiChatEvent): ThinkingActivityDetail | null {
     if (typeof value === "string" && value.trim()) {
       return {
         kind: "pre",
-        summary: activityDetailSummary(event),
+        summary: activityDetailSummary(event, text),
         value,
       };
     }
@@ -663,13 +669,16 @@ function activityDetail(event: AiChatEvent): ThinkingActivityDetail | null {
   return null;
 }
 
-function activityDetailSummary(event: AiChatEvent): string {
-  if (typeof event.data?.output === "string" && event.data.output.trim()) return "查看输出";
-  if (typeof event.data?.command === "string" && event.data.command.trim()) return "查看命令";
-  if (typeof event.data?.detail === "string" && event.data.detail.trim()) return "查看详情";
-  if (typeof event.data?.path === "string" && event.data.path.trim()) return "查看路径";
-  if (Array.isArray(event.data?.files)) return "查看文件";
-  return "查看详情";
+function activityDetailSummary(
+  event: AiChatEvent,
+  text: (chinese: string, english: string) => string,
+): string {
+  if (typeof event.data?.output === "string" && event.data.output.trim()) return text("查看输出", "View output");
+  if (typeof event.data?.command === "string" && event.data.command.trim()) return text("查看命令", "View command");
+  if (typeof event.data?.detail === "string" && event.data.detail.trim()) return text("查看详情", "View details");
+  if (typeof event.data?.path === "string" && event.data.path.trim()) return text("查看路径", "View path");
+  if (Array.isArray(event.data?.files)) return text("查看文件", "View files");
+  return text("查看详情", "View details");
 }
 
 function MarkdownMessage({
@@ -745,6 +754,7 @@ function ThinkingSteps({
   events: AiChatEvent[];
   active: boolean;
 }) {
+  const { text } = useTaskboardI18n();
   const statuses = events.map(aiChatEventStatus);
   const status = statuses.includes("running")
     ? "running"
@@ -759,8 +769,10 @@ function ThinkingSteps({
   }, [active]);
 
   const statusLabel = status === "running"
-    ? "思考中"
-    : status === "failed" ? "思考中断" : "已思考";
+    ? text("思考中", "Thinking")
+    : status === "failed"
+      ? text("思考中断", "Thinking stopped")
+      : text("已思考", "Thought");
 
   return (
     <section className={`ai-chat-thinking-steps is-${status}`}>
@@ -782,13 +794,20 @@ function ThinkingSteps({
           <div className="ai-chat-thinking-list">
             {events.map((event, index) => {
               const eventStatus = aiChatEventStatus(event);
-              const detail = activityDetail(event);
+              const detail = activityDetail(event, text);
+              const activityLabel = ACTIVITY_LABELS[event.type];
               const content = detail?.kind === "lines"
                 && (event.type === "file" || event.type === "file_change")
-                ? `${detail.value.length} 个文件`
+                ? text(
+                  `${detail.value.length} 个文件`,
+                  `${detail.value.length} ${detail.value.length === 1 ? "file" : "files"}`,
+                )
                 : detail?.kind === "lines"
                   && (event.type === "todo" || event.type === "todo_list")
-                  ? `${detail.value.length} 项任务`
+                  ? text(
+                    `${detail.value.length} 项任务`,
+                    `${detail.value.length} ${detail.value.length === 1 ? "task" : "tasks"}`,
+                  )
                   : event.content.trim();
               return (
                 <div
@@ -810,7 +829,9 @@ function ThinkingSteps({
                     <div className="ai-chat-thinking-step-content">
                       <div className="ai-chat-thinking-step-heading">
                         <span className="ai-chat-thinking-step-label">
-                          {ACTIVITY_LABELS[event.type] ?? "执行活动"}
+                          {activityLabel
+                            ? text(...activityLabel)
+                            : text("执行活动", "Activity")}
                           {eventStatus === "running" && <span aria-hidden="true">…</span>}
                         </span>
                         {content && (
@@ -965,7 +986,7 @@ export function AiChat({
   onThreadsChange,
   openThreadRequest,
 }: AiChatProps) {
-  const { text } = useTaskboardI18n();
+  const { locale, text } = useTaskboardI18n();
   const [panelOpen, setPanelOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [menu, setMenu] = useState<MenuName>(null);
@@ -977,9 +998,9 @@ export function AiChat({
   const [draftOrigin, setDraftOrigin] = useState<DraftThreadOrigin | null>(null);
   const [catalog, setCatalog] = useState<AiChatCatalog | null>(null);
   const [catalogLoadedProjectId, setCatalogLoadedProjectId] = useState<string | null>(null);
-  const [catalogError, setCatalogError] = useState<string | null>(null);
+  const [catalogError, setCatalogError] = useState<AiChatError | null>(null);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<AiChatError | null>(null);
   const [draft, setDraft] = useState("");
   const [requestedComposerText, setRequestedComposerText] = useState<string | null>(null);
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
@@ -1387,6 +1408,7 @@ export function AiChat({
   const currentRun = snapshot?.thread.currentRun
     ?? snapshot?.runs.find((run) => run.status === "running")
     ?? null;
+  const visibleError = error ?? catalogError;
   const composerBlocked = Boolean(
     selectedThreadId && deletingThreadId === selectedThreadId,
   );
@@ -1541,7 +1563,10 @@ export function AiChat({
   function beginNewConversation() {
     const input = buildThreadCreateInput(projectId ?? "", issueId);
     if (!input) {
-      setError("请先进入一个已映射的项目，再新建对话");
+      setError(text(
+        "请先进入一个已映射的项目，再新建对话",
+        "Open a mapped project before you start a new chat.",
+      ));
       return;
     }
     if (!draftOrigin) draftReturnThreadIdRef.current = selectedThreadRef.current;
@@ -1563,7 +1588,10 @@ export function AiChat({
     );
     const input = buildThreadCreateInput(origin?.projectId ?? "", origin?.issueId ?? null);
     if (!input) {
-      setError("请先进入一个已映射的项目，再新建对话");
+      setError(text(
+        "请先进入一个已映射的项目，再新建对话",
+        "Open a mapped project before you start a new chat.",
+      ));
       return null;
     }
     const inheritedSettings = {
@@ -1612,7 +1640,10 @@ export function AiChat({
   }
 
   async function deleteThread(thread: AiChatThread) {
-    if (!window.confirm(`删除本地对话“${thread.title}”？`)) return;
+    if (!window.confirm(text(
+      `删除本地对话“${thread.title}”？`,
+      `Delete local chat “${thread.title}”?`,
+    ))) return;
     setDeletingThreadId(thread.id);
     try {
       await deleteAiChatThread(thread.id);
@@ -1912,7 +1943,10 @@ export function AiChat({
           const reader = new FileReader();
           reader.onload = () => {
             if (typeof reader.result !== "string") {
-              reject(new Error(`无法读取附件 ${file.name}`));
+              reject(new Error(text(
+                `无法读取附件 ${file.name}`,
+                `Could not read attachment ${file.name}.`,
+              )));
               return;
             }
             const separator = reader.result.indexOf(",");
@@ -1924,7 +1958,10 @@ export function AiChat({
               ...(file.type.startsWith("image/") ? { previewUrl: reader.result } : {}),
             });
           };
-          reader.onerror = () => reject(new Error(`无法读取附件 ${file.name}`));
+          reader.onerror = () => reject(new Error(text(
+            `无法读取附件 ${file.name}`,
+            `Could not read attachment ${file.name}.`,
+          )));
           reader.readAsDataURL(file);
         })
       )));
@@ -2127,8 +2164,8 @@ export function AiChat({
           ref={panelRef}
           className={`ai-chat-panel${panelResizeEdge ? ` is-resizing-${panelResizeEdge}` : ""}`}
           style={panelGeometry ?? undefined}
-          aria-label="Codex AI 对话"
-          data-screen-label="Codex AI 对话"
+          aria-label={text("Codex AI 对话", "Codex AI chat")}
+          data-screen-label={text("Codex AI 对话", "Codex AI chat")}
         >
           <div
             className="ai-chat-resize-handle is-top"
@@ -2147,22 +2184,27 @@ export function AiChat({
           />
           <header className="ai-chat-panel-header">
             <div className="ai-chat-panel-title">
-              <strong>{snapshot?.thread.title ?? "新对话"}</strong>
-              <span>{snapshot?.thread.origin.projectName ?? "选择对话或从当前项目新建"}</span>
+              <strong>{snapshot?.thread.title ?? text("新对话", "New chat")}</strong>
+              <span>{snapshot?.thread.origin.projectName ?? text(
+                "选择对话或从当前项目新建",
+                "Select a chat or start one in the current project",
+              )}</span>
             </div>
             <button
               type="button"
-              aria-label="对话历史"
+              aria-label={text("对话历史", "Chat history")}
               aria-pressed={historyOpen}
-              title="对话历史"
+              title={text("对话历史", "Chat history")}
               onClick={() => { setHistoryOpen((current) => !current); setMenu(null); }}
             >
               <LinearIcon name="conversation" />
             </button>
             <button
               type="button"
-              aria-label="新建对话"
-              title={projectId ? "新建对话" : "请先进入项目"}
+              aria-label={text("新建对话", "New chat")}
+              title={projectId
+                ? text("新建对话", "New chat")
+                : text("请先进入项目", "Open a project first")}
               disabled={!projectId || loading}
               onClick={beginNewConversation}
             >
@@ -2170,8 +2212,8 @@ export function AiChat({
             </button>
             <button
               type="button"
-              aria-label="关闭 AI 对话"
-              title="关闭"
+              aria-label={text("关闭 AI 对话", "Close AI chat")}
+              title={text("关闭", "Close")}
               onClick={() => {
                 restorePersistedConversationFromDraft();
                 setPanelOpen(false);
@@ -2182,9 +2224,9 @@ export function AiChat({
           </header>
 
           {historyOpen && (
-            <div className="ai-chat-history" aria-label="对话历史">
+            <div className="ai-chat-history" aria-label={text("对话历史", "Chat history")}>
               <div className="ai-chat-history-heading">
-                <strong>对话历史</strong>
+                <strong>{text("对话历史", "Chat history")}</strong>
                 <span>{threads.length}</span>
               </div>
               {threads.length > 0 ? threads.map((thread) => (
@@ -2205,14 +2247,14 @@ export function AiChat({
                     <span className={`ai-chat-thread-status is-${thread.status}`} aria-hidden="true" />
                     <span>
                       <strong>{thread.title}</strong>
-                      <small>{thread.origin.projectName} · {dateLabel(thread.updatedAt)}</small>
+                      <small>{thread.origin.projectName} · {dateLabel(thread.updatedAt, locale)}</small>
                     </span>
                   </button>
                   <button
                     className="ai-chat-history-delete"
                     type="button"
-                    aria-label={`删除对话 ${thread.title}`}
-                    title="删除本地记录"
+                    aria-label={text(`删除对话 ${thread.title}`, `Delete chat ${thread.title}`)}
+                    title={text("删除本地记录", "Delete local record")}
                     disabled={thread.status === "running" || deletingThreadId === thread.id}
                     onClick={() => void deleteThread(thread)}
                   >
@@ -2220,7 +2262,7 @@ export function AiChat({
                   </button>
                 </div>
               )) : (
-                <p>还没有本地对话</p>
+                <p>{text("还没有本地对话", "No local chats yet")}</p>
               )}
             </div>
           )}
@@ -2232,7 +2274,10 @@ export function AiChat({
             aria-live="polite"
           >
             {loading && !snapshot ? (
-              <div className="ai-chat-empty"><span className="ai-chat-spinner" />正在恢复对话…</div>
+              <div className="ai-chat-empty">
+                <span className="ai-chat-spinner" />
+                {text("正在恢复对话…", "Restoring chat…")}
+              </div>
             ) : snapshot ? (
               <>
                 <MessageTimeline
@@ -2243,7 +2288,7 @@ export function AiChat({
                 {snapshot.thread.status === "running" && (
                   <div className="ai-chat-running" role="status">
                     <span className="ai-chat-spinner" />
-                    Codex 正在处理
+                    {text("Codex 正在处理", "Codex is working")}
                   </div>
                 )}
                 {retryableUserEvent && (
@@ -2261,25 +2306,32 @@ export function AiChat({
                     }}
                   >
                     <LinearIcon name="recurrence" />
-                    重试上一条消息
+                    {text("重试上一条消息", "Retry the previous message")}
                   </button>
                 )}
               </>
             ) : (
               <div className="ai-chat-empty">
                 <LinearIcon name="conversation" />
-                <strong>{projectId ? "在当前项目中开始对话" : "打开一个历史对话"}</strong>
+                <strong>{projectId
+                  ? text("在当前项目中开始对话", "Start a chat in the current project")
+                  : text("打开一个历史对话", "Open a chat from history")}</strong>
                 <p>{projectId
-                  ? "Codex 会在新对话创建时记住当前项目。"
-                  : "进入项目后可以新建对话。"}</p>
+                  ? text(
+                    "Codex 会在新对话创建时记住当前项目。",
+                    "Codex will remember the current project when it creates the new chat.",
+                  )
+                  : text("进入项目后可以新建对话。", "Open a project to start a new chat.")}</p>
               </div>
             )}
           </div>
 
-          {(error || catalogError) && (
+          {visibleError && (
             <div className="ai-chat-error" role="alert">
               <LinearIcon name="alert" />
-              <span>{error ?? catalogError}</span>
+              <span>{visibleError === AI_CHAT_UNAVAILABLE_ERROR
+                ? text("AI 对话暂时不可用", "AI chat is temporarily unavailable.")
+                : visibleError}</span>
             </div>
           )}
 
@@ -2292,7 +2344,7 @@ export function AiChat({
           >
             {attachmentDragActive && (
               <div className="ai-chat-attachment-drop-hint" aria-hidden="true">
-                松开添加文件
+                {text("松开添加文件", "Drop files to add them")}
               </div>
             )}
             <div className="ai-chat-input-wrap">
@@ -2313,8 +2365,11 @@ export function AiChat({
                         )}
                       <button
                         type="button"
-                        aria-label={`移除附件 ${attachment.filename}`}
-                        title="移除附件"
+                        aria-label={text(
+                          `移除附件 ${attachment.filename}`,
+                          `Remove attachment ${attachment.filename}`,
+                        )}
+                        title={text("移除附件", "Remove attachment")}
                         onClick={() => {
                           setAttachments((current) => current.filter((item) => item.id !== attachment.id));
                         }}
@@ -2329,9 +2384,9 @@ export function AiChat({
                 ref={editorRef}
                 className="ai-chat-composer-editor"
                 contentEditable={!composerBlocked}
-                data-placeholder="询问 Codex"
+                data-placeholder={text("询问 Codex", "Ask Codex")}
                 role="textbox"
-                aria-label="发送给 Codex 的消息"
+                aria-label={text("发送给 Codex 的消息", "Message to Codex")}
                 aria-multiline="true"
                 suppressContentEditableWarning
                 onBeforeInput={(event) => rememberComposerBeforeInput(event.nativeEvent as InputEvent)}
@@ -2373,7 +2428,10 @@ export function AiChat({
                 return createPortal(
                   <button
                     type="button"
-                    aria-label={`移除 Skill ${skill ? skillDisplayName(skill) : token.id}`}
+                    aria-label={text(
+                      `移除 Skill ${skill ? skillDisplayName(skill) : token.id}`,
+                      `Remove Skill ${skill ? skillDisplayName(skill) : token.id}`,
+                    )}
                     onMouseDown={(event) => event.preventDefault()}
                     onClick={() => removeComposerSkillToken(token.element)}
                   >
@@ -2388,7 +2446,7 @@ export function AiChat({
                   ref={skillMenuRef}
                   className="ai-chat-skill-menu"
                   role="listbox"
-                  aria-label="可用 Skill"
+                  aria-label={text("可用 Skill", "Available Skills")}
                 >
                   {visibleSkills.map((skill, index) => (
                     <button
@@ -2425,8 +2483,8 @@ export function AiChat({
               <button
                 className="ai-chat-attachment-button"
                 type="button"
-                aria-label="添加附件"
-                title="添加附件"
+                aria-label={text("添加附件", "Add attachment")}
+                title={text("添加附件", "Add attachment")}
                 disabled={attachmentBlocked}
                 onClick={() => attachmentInputRef.current?.click()}
               >
@@ -2447,19 +2505,23 @@ export function AiChat({
                   onClick={() => setMenu((current) => current === "sandbox" ? null : "sandbox")}
                 >
                   <LinearIcon name={SANDBOX_ICONS[draftSandbox]} />
-                  {SANDBOX_LABELS[draftSandbox]}
+                  {text(...SANDBOX_LABELS[draftSandbox])}
                   <LinearIcon name="chevronDown" />
                 </button>
                 {menu === "sandbox" && (
-                  <div className="ai-chat-option-menu ai-chat-permission-menu" role="menu" aria-label="执行权限">
+                  <div
+                    className="ai-chat-option-menu ai-chat-permission-menu"
+                    role="menu"
+                    aria-label={text("执行权限", "Execution permissions")}
+                  >
                     <header>
-                      <span>应如何批准 Codex 操作？</span>
+                      <span>{text("应如何批准 Codex 操作？", "How should Codex operations be approved?")}</span>
                       <a
                         href="https://developers.openai.com/codex/security"
                         target="_blank"
                         rel="noreferrer"
                       >
-                        了解更多
+                        {text("了解更多", "Learn more")}
                       </a>
                     </header>
                     {availableSandboxes.map((sandbox) => (
@@ -2473,8 +2535,8 @@ export function AiChat({
                       >
                         <LinearIcon name={SANDBOX_ICONS[sandbox]} />
                         <span>
-                          <strong>{SANDBOX_LABELS[sandbox]}</strong>
-                          <small>{SANDBOX_DESCRIPTIONS[sandbox]}</small>
+                          <strong>{text(...SANDBOX_LABELS[sandbox])}</strong>
+                          <small>{text(...SANDBOX_DESCRIPTIONS[sandbox])}</small>
                         </span>
                         {sandbox === draftSandbox && <LinearIcon name="check" />}
                       </button>
@@ -2502,33 +2564,51 @@ export function AiChat({
                       : "model"
                   ))}
                 >
-                  <span>{modelDisplayName(selectedModel?.displayName ?? (draftModel || "模型"))}</span>
+                  <span>{modelDisplayName(
+                    selectedModel?.displayName ?? (draftModel || text("模型", "Model")),
+                  )}</span>
                   <span className="ai-chat-model-effort">
-                    {EFFORT_LABELS[draftEffort] ?? (draftEffort || "推理")}
+                    {EFFORT_LABELS[draftEffort]
+                      ? text(...EFFORT_LABELS[draftEffort])
+                      : draftEffort || text("推理", "Reasoning")}
                   </span>
                   <LinearIcon name="chevronDown" />
                 </button>
                 {menu === "model" && (
-                  <div className="ai-chat-option-menu ai-chat-config-menu" role="menu" aria-label="模型与推理强度">
+                  <div
+                    className="ai-chat-option-menu ai-chat-config-menu"
+                    role="menu"
+                    aria-label={text("模型与推理强度", "Model and reasoning effort")}
+                  >
                     <button type="button" onClick={() => setMenu("model-list")}>
-                      <span>模型</span>
+                      <span>{text("模型", "Model")}</span>
                       <strong>{modelDisplayName(selectedModel?.displayName ?? draftModel)}</strong>
                       <LinearIcon name="chevronRight" />
                     </button>
                     <button type="button" onClick={() => setMenu("effort-list")}>
-                      <span>推理强度</span>
-                      <strong>{EFFORT_LABELS[draftEffort] ?? draftEffort}</strong>
+                      <span>{text("推理强度", "Reasoning effort")}</span>
+                      <strong>{EFFORT_LABELS[draftEffort]
+                        ? text(...EFFORT_LABELS[draftEffort])
+                        : draftEffort}</strong>
                       <LinearIcon name="chevronRight" />
                     </button>
                   </div>
                 )}
                 {menu === "model-list" && (
-                  <div className="ai-chat-option-menu ai-chat-config-menu ai-chat-config-submenu ai-chat-model-list" role="menu" aria-label="选择模型">
+                  <div
+                    className="ai-chat-option-menu ai-chat-config-menu ai-chat-config-submenu ai-chat-model-list"
+                    role="menu"
+                    aria-label={text("选择模型", "Select model")}
+                  >
                     <header>
-                      <button type="button" aria-label="返回模型与推理强度" onClick={() => setMenu("model")}>
+                      <button
+                        type="button"
+                        aria-label={text("返回模型与推理强度", "Back to model and reasoning effort")}
+                        onClick={() => setMenu("model")}
+                      >
                         <LinearIcon name="chevronLeft" />
                       </button>
-                      <strong>模型</strong>
+                      <strong>{text("模型", "Model")}</strong>
                     </header>
                     {(activeCatalog?.models ?? []).map((model) => (
                       <button
@@ -2547,12 +2627,20 @@ export function AiChat({
                   </div>
                 )}
                 {menu === "effort-list" && selectedModel && (
-                  <div className="ai-chat-option-menu ai-chat-config-menu ai-chat-config-submenu" role="menu" aria-label="选择推理强度">
+                  <div
+                    className="ai-chat-option-menu ai-chat-config-menu ai-chat-config-submenu"
+                    role="menu"
+                    aria-label={text("选择推理强度", "Select reasoning effort")}
+                  >
                     <header>
-                      <button type="button" aria-label="返回模型与推理强度" onClick={() => setMenu("model")}>
+                      <button
+                        type="button"
+                        aria-label={text("返回模型与推理强度", "Back to model and reasoning effort")}
+                        onClick={() => setMenu("model")}
+                      >
                         <LinearIcon name="chevronLeft" />
                       </button>
-                      <strong>推理强度</strong>
+                      <strong>{text("推理强度", "Reasoning effort")}</strong>
                     </header>
                     {selectedModel.supportedReasoningEfforts.map((effort) => (
                       <button
@@ -2562,7 +2650,7 @@ export function AiChat({
                         key={effort}
                         onClick={() => void chooseEffort(effort)}
                       >
-                        <span>{EFFORT_LABELS[effort] ?? effort}</span>
+                        <span>{EFFORT_LABELS[effort] ? text(...EFFORT_LABELS[effort]) : effort}</span>
                         {effort === draftEffort && <LinearIcon name="check" />}
                       </button>
                     ))}
@@ -2574,8 +2662,8 @@ export function AiChat({
                 <button
                   className="ai-chat-send-button is-stop"
                   type="button"
-                  aria-label="停止生成"
-                  title="停止"
+                  aria-label={text("停止生成", "Stop generating")}
+                  title={text("停止", "Stop")}
                   onClick={() => void stopRun(currentRun)}
                 >
                   <span className="ai-chat-stop-mark" aria-hidden="true" />
@@ -2584,8 +2672,8 @@ export function AiChat({
                 <button
                   className="ai-chat-send-button"
                   type="button"
-                  aria-label="发送消息"
-                  title="发送"
+                  aria-label={text("发送消息", "Send message")}
+                  title={text("发送", "Send")}
                   disabled={
                     primaryAction === "disabled"
                     || loading
@@ -2603,10 +2691,15 @@ export function AiChat({
           {dangerConfirmOpen && (
             <div className="ai-chat-confirm-backdrop">
               <div className="ai-chat-confirm" role="alertdialog" aria-modal="true" aria-labelledby="ai-chat-confirm-title">
-                <strong id="ai-chat-confirm-title">允许完全访问？</strong>
-                <p>本次消息允许 Codex 访问工作区之外的文件和命令。确认只对本次发送生效。</p>
+                <strong id="ai-chat-confirm-title">{text("允许完全访问？", "Allow full access?")}</strong>
+                <p>{text(
+                  "本次消息允许 Codex 访问工作区之外的文件和命令。确认只对本次发送生效。",
+                  "This message lets Codex access files and commands outside the workspace. This approval applies only to this message.",
+                )}</p>
                 <div>
-                  <button type="button" onClick={() => setPendingDangerInput(null)}>取消</button>
+                  <button type="button" onClick={() => setPendingDangerInput(null)}>
+                    {text("取消", "Cancel")}
+                  </button>
                   <button
                     className="is-danger"
                     type="button"
@@ -2621,7 +2714,7 @@ export function AiChat({
                       );
                     }}
                   >
-                    允许并发送
+                    {text("允许并发送", "Allow and send")}
                   </button>
                 </div>
               </div>

--- a/web/src/components/ProjectAutomationMenu.tsx
+++ b/web/src/components/ProjectAutomationMenu.tsx
@@ -49,13 +49,13 @@ const DEFAULT_OPTIONS: AutomationOptions = {
   reasoningEffort: "high",
 };
 
-const EFFORT_LABELS: Record<AutomationReasoningEffort, string> = {
-  low: "轻度",
-  medium: "中",
-  high: "高",
-  xhigh: "极高 (xhigh)",
-  max: "最高",
-  ultra: "极高 (ultra)",
+const EFFORT_LABELS: Record<AutomationReasoningEffort, readonly [string, string]> = {
+  low: ["轻度", "Low"],
+  medium: ["中", "Medium"],
+  high: ["高", "High"],
+  xhigh: ["极高 (xhigh)", "Extra high (xhigh)"],
+  max: ["最高", "Maximum"],
+  ultra: ["极高 (ultra)", "Ultra"],
 };
 
 export function ProjectAutomationMenu({
@@ -66,7 +66,7 @@ export function ProjectAutomationMenu({
   onOpen,
   onChange,
 }: ProjectAutomationMenuProps) {
-  const { text } = useTaskboardI18n();
+  const { locale, text } = useTaskboardI18n();
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const wasPendingRef = useRef(pending);
@@ -76,16 +76,16 @@ export function ProjectAutomationMenu({
   const status = automation?.status ?? "PAUSED";
   const quota = automation?.quota;
   const stateLabel = !automation?.enabledByUser
-    ? "已暂停"
+    ? text("已暂停", "Paused")
     : automation.quotaAware && quota?.state === "blocked"
-      ? "额度暂停"
+      ? text("额度暂停", "Paused by quota")
       : automation.quotaAware && quota?.state === "unavailable"
-        ? "额度不可用"
+        ? text("额度不可用", "Quota unavailable")
         : automation.quotaAware && (!quota || quota.state === "unknown")
-          ? "额度未知"
+          ? text("额度未知", "Quota unknown")
           : status === "ACTIVE"
-            ? "运行中"
-            : "已暂停";
+            ? text("运行中", "Running")
+            : text("已暂停", "Paused");
   const disabled = pending || Boolean(unavailableReason);
 
   useEffect(() => {
@@ -150,17 +150,17 @@ export function ProjectAutomationMenu({
       ref={menuRef}
       className="project-automation-menu no-drag"
       role="dialog"
-      aria-label="自动认领待办设置"
+      aria-label={text("自动认领待办设置", "Auto-claim settings")}
       style={{ left: position.left, top: position.top, visibility: position.ready ? "visible" : "hidden" }}
     >
       <div className="project-automation-menu-heading">
-        <strong>自动认领待办</strong>
+        <strong>{text("自动认领待办", "Auto-claim tasks")}</strong>
         <span className={status === "ACTIVE" ? "is-active" : "is-paused"}>
           {stateLabel}
         </span>
       </div>
       <div className="project-automation-switch">
-        <span>自动认领开关</span>
+        <span>{text("自动认领开关", "Auto-claim")}</span>
         <button
           type="button"
           className={`board-setting-switch${draft.enabledByUser ? " is-on" : ""}`}
@@ -176,7 +176,7 @@ export function ProjectAutomationMenu({
         </button>
       </div>
       <div className="project-automation-switch">
-        <span>根据额度启用/关闭</span>
+        <span>{text("根据额度启用/关闭", "Use quota limits")}</span>
         <button
           type="button"
           className={`board-setting-switch${draft.quotaAware ? " is-on" : ""}`}
@@ -193,22 +193,31 @@ export function ProjectAutomationMenu({
       </div>
       {draft.quotaAware && (
         <div className={`project-automation-quota is-${quota?.state ?? "unknown"}`}>
-          {quota?.state === "available" && "当前额度可用"}
+          {quota?.state === "available" && text("当前额度可用", "Quota is available")}
           {quota?.state === "blocked" && (
             quota.resetsAt
-              ? `额度已用尽，预计 ${formatResetTime(quota.resetsAt)} 恢复`
-              : "额度已用尽，自动认领已暂停"
+              ? text(
+                `额度已用尽，预计 ${formatResetTime(quota.resetsAt, locale)} 恢复`,
+                `Quota is exhausted. Expected reset: ${formatResetTime(quota.resetsAt, locale)}.`,
+              )
+              : text("额度已用尽，自动认领已暂停", "Quota is exhausted. Auto-claim is paused.")
           )}
           {quota?.state === "unavailable" && (
             quota.reason === "api-key"
-              ? "API Key 模式不支持读取 Codex App 额度"
-              : "当前账户无法读取额度"
+              ? text(
+                "API Key 模式不支持读取 Codex App 额度",
+                "API key mode cannot read the Codex app quota.",
+              )
+              : text("当前账户无法读取额度", "This account cannot read quota information.")
           )}
-          {(!quota || quota.state === "unknown") && "额度状态未知，自动认领已暂停"}
+          {(!quota || quota.state === "unknown") && text(
+            "额度状态未知，自动认领已暂停",
+            "Quota status is unknown. Auto-claim is paused.",
+          )}
         </div>
       )}
       <label className="project-automation-field">
-        <span>间隔</span>
+        <span>{text("间隔", "Interval")}</span>
         <select
           value={draft.intervalMinutes}
           disabled={disabled}
@@ -217,11 +226,13 @@ export function ProjectAutomationMenu({
             intervalMinutes: Number(event.target.value) as IntervalMinutes,
           })}
         >
-          {[5, 10, 15, 30, 60].map((minutes) => <option key={minutes} value={minutes}>{minutes} 分钟</option>)}
+          {[5, 10, 15, 30, 60].map((minutes) => (
+            <option key={minutes} value={minutes}>{text(`${minutes} 分钟`, `${minutes} min`)}</option>
+          ))}
         </select>
       </label>
       <label className="project-automation-field">
-        <span>模型</span>
+        <span>{text("模型", "Model")}</span>
         <select
           value={draft.model}
           disabled={disabled}
@@ -233,7 +244,7 @@ export function ProjectAutomationMenu({
         </select>
       </label>
       <label className="project-automation-field">
-        <span>推理强度</span>
+        <span>{text("推理强度", "Reasoning effort")}</span>
         <select
           value={draft.reasoningEffort}
           disabled={disabled}
@@ -243,7 +254,7 @@ export function ProjectAutomationMenu({
           })}
         >
           {getAutomationModel(draft.model).efforts.map((effort) => (
-            <option key={effort} value={effort}>{EFFORT_LABELS[effort]}</option>
+            <option key={effort} value={effort}>{text(...EFFORT_LABELS[effort])}</option>
           ))}
         </select>
       </label>
@@ -286,8 +297,8 @@ export function ProjectAutomationMenu({
   );
 }
 
-function formatResetTime(value: number) {
-  return new Intl.DateTimeFormat("zh-CN", {
+function formatResetTime(value: number, locale: string) {
+  return new Intl.DateTimeFormat(locale, {
     month: "numeric",
     day: "numeric",
     hour: "2-digit",


### PR DESCRIPTION
## Summary

- Localize visible automation settings content, status, prompts, errors, and accessibility text.
- Localize the AI Chat panel, history, empty states, activity labels, permissions, model controls, confirmations, and local errors.
- Keep project names, user messages, Agent content, model names, Skill names, and dynamic payloads unchanged.

## Language behavior

- `zh` and `zh-*` use Chinese.
- All other languages use English.

## Validation

- Direct browser paths: `zh-CN`, `en-US`, and `fr-FR` for Automation settings and AI Chat.
- `fr-FR` permission and model/reasoning menus confirmed in English.
- `npm run typecheck`
- `npm run build`

## Scope

Targets `codex/local-140-bilingual-ui` while PR #82 is open, so this PR contains only the LOCAL-151 slice.