### PR TITLE
Localize Dashboard, List, and Gantt views

### DIFF
--- a/web/src/components/DashboardView.tsx
+++ b/web/src/components/DashboardView.tsx
@@ -5,6 +5,7 @@ import dueDoneIcon from "../assets/figma-taskboard/dashboard-due-done.svg";
 import dueEditIcon from "../assets/figma-taskboard/dashboard-due-edit.svg";
 import processingAnimation from "../assets/figma-taskboard/loading-16.svg";
 import { getProjectSummary } from "../api";
+import { taskPriorityLabel, taskStatusLabel, useTaskboardI18n } from "../i18n";
 import { labelPresentation } from "../labels";
 import type {
   TaskCardPresentation,
@@ -27,16 +28,7 @@ interface DashboardViewProps {
   onOpenConversation: (conversation: TaskConversationItem) => void;
 }
 
-const PRIORITY_DETAILS = [
-  { priority: "urgent", label: "紧急" },
-  { priority: "high", label: "高" },
-  { priority: "medium", label: "中" },
-  { priority: "low", label: "低" },
-  { priority: "none", label: "无优先级" },
-] satisfies Array<{
-  priority: Task["priority"];
-  label: string;
-}>;
+const PRIORITIES = ["urgent", "high", "medium", "low", "none"] satisfies Task["priority"][];
 
 const LABEL_COLORS = [
   "#5e6ad2",
@@ -69,10 +61,10 @@ interface ProgressForecast {
   conservativeAt: number;
 }
 
-function chartDate(value: number, referenceValue?: number) {
+function chartDate(value: number, locale: string, referenceValue?: number) {
   const includeYear = referenceValue !== undefined
     && new Date(value).getFullYear() !== new Date(referenceValue).getFullYear();
-  return new Intl.DateTimeFormat("zh-CN", {
+  return new Intl.DateTimeFormat(locale, {
     year: includeYear ? "numeric" : undefined,
     month: "short",
     day: "numeric",
@@ -165,9 +157,9 @@ function dayValue(value: string) {
   return new Date(`${value}T00:00:00`).getTime();
 }
 
-function shortDate(value: string) {
-  const [, month, day] = value.split("-").map(Number);
-  return `${month}月${day}日`;
+function shortDate(value: string, locale: string) {
+  return new Intl.DateTimeFormat(locale, { month: "short", day: "numeric" })
+    .format(new Date(`${value}T12:00:00`));
 }
 
 export function DashboardView({
@@ -181,6 +173,7 @@ export function DashboardView({
   onOpenTask,
   onOpenConversation,
 }: DashboardViewProps) {
+  const { language, locale, text } = useTaskboardI18n();
   const [projectSummary, setProjectSummary] = useState<ProjectSummary | null>(null);
   const [summaryLoadFailed, setSummaryLoadFailed] = useState(false);
   const [displayedSummary, setDisplayedSummary] = useState("");
@@ -304,9 +297,10 @@ export function DashboardView({
     .sort((left, right) => right.count - left.count);
   const completedTotal = Math.max(1, completedTasks.length);
 
-  const priorityCounts = PRIORITY_DETAILS.map((detail) => ({
-    ...detail,
-    count: tasks.filter((task) => task.priority === detail.priority).length,
+  const priorityCounts = PRIORITIES.map((priority) => ({
+    priority,
+    label: taskPriorityLabel(language, priority),
+    count: tasks.filter((task) => task.priority === priority).length,
   }));
 
   const labelCountMap = new Map<string, number>();
@@ -316,10 +310,15 @@ export function DashboardView({
     }
   }
   const labelCounts = [...labelCountMap.entries()]
-    .map(([label, count]) => ({ label, count, presentation: labelPresentation(label) }))
+    .map(([label, count]) => ({
+      label,
+      count,
+      sortName: labelPresentation(label).name,
+      presentation: labelPresentation(label, language),
+    }))
     .sort((left, right) => (
       right.count - left.count
-      || left.presentation.name.localeCompare(right.presentation.name)
+      || left.sortName.localeCompare(right.sortName)
     ));
   const totalLabelAssignments = Math.max(
     1,
@@ -333,7 +332,7 @@ export function DashboardView({
           count: labelCounts.slice(11).reduce((total, item) => total + item.count, 0),
           presentation: {
             ...labelPresentation("其他"),
-            name: `其他（${labelCounts.length - 11}个）`,
+            name: text(`其他（${labelCounts.length - 11}个）`, `Other (${labelCounts.length - 11})`),
           },
         },
       ]
@@ -365,12 +364,18 @@ export function DashboardView({
     })
   ));
   const contributionMaximum = Math.max(1, ...contributionWeeks.flat().map((day) => day.count));
+  const monthFormatter = new Intl.DateTimeFormat(locale, { month: "short" });
+  const contributionDateFormatter = new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
   const monthMarkers = contributionWeeks.flatMap((week, weekIndex) => {
     const firstDay = week.find((day) => day.date.getDate() === 1);
-    return firstDay ? [{ weekIndex, label: `${firstDay.date.getMonth() + 1}月` }] : [];
+    return firstDay ? [{ weekIndex, label: monthFormatter.format(firstDay.date) }] : [];
   });
   if (monthMarkers[0]?.weekIndex !== 0) {
-    monthMarkers.unshift({ weekIndex: 0, label: `${contributionStart.getMonth() + 1}月` });
+    monthMarkers.unshift({ weekIndex: 0, label: monthFormatter.format(contributionStart) });
   }
 
   const attentionItems = activeTasks
@@ -385,23 +390,23 @@ export function DashboardView({
 
   const metrics = [
     {
-      label: "处理中",
+      label: taskStatusLabel(language, "in_progress"),
       value: tasks.filter((task) => task.status === "in_progress").length,
       tone: "progress",
     },
     {
-      label: "等你确认",
+      label: taskStatusLabel(language, "in_review"),
       value: tasks.filter((task) => task.status === "in_review").length,
       tone: "review",
     },
     {
-      label: "遇到阻碍",
+      label: taskStatusLabel(language, "blocked"),
       value: tasks.filter((task) => task.status === "blocked").length,
       tone: "blocked",
     },
-    { label: "已逾期", value: overdueTasks.length, tone: "overdue" },
+    { label: text("已逾期", "Overdue"), value: overdueTasks.length, tone: "overdue" },
     {
-      label: "待立项",
+      label: taskStatusLabel(language, "backlog"),
       value: tasks.filter((task) => task.status === "backlog").length,
       tone: "backlog",
     },
@@ -409,11 +414,22 @@ export function DashboardView({
 
   const summaryBody = projectSummary?.summary
     ?? (summaryLoadFailed || projectSummary?.error
-      ? "Codex 暂时无法生成项目总结。"
-      : "Codex 正在整理当前项目的进展、风险和下一步重点…");
+      ? text("Codex 暂时无法生成项目总结。", "Codex cannot generate the project summary now.")
+      : text(
+          "Codex 正在整理当前项目的进展、风险和下一步重点…",
+          "Codex is reviewing the project's progress, risks, and next steps…",
+        ));
   const hour = new Date().getHours();
-  const greeting = hour < 12 ? "上午好" : hour < 18 ? "下午好" : "晚上好";
-  const summary = `${greeting}，${currentUser.name}，今天是${today.getMonth() + 1}月${today.getDate()}日，${summaryBody}`;
+  const greeting = hour < 12
+    ? text("上午好", "Good morning")
+    : hour < 18
+      ? text("下午好", "Good afternoon")
+      : text("晚上好", "Good evening");
+  const summaryDate = new Intl.DateTimeFormat(locale, { month: "long", day: "numeric" }).format(today);
+  const summary = text(
+    `${greeting}，${currentUser.name}，今天是${summaryDate}，${summaryBody}`,
+    `${greeting}, ${currentUser.name}. Today is ${summaryDate}. ${summaryBody}`,
+  );
   const summaryReady = projectSummary !== null || summaryLoadFailed;
 
   useEffect(() => {
@@ -464,18 +480,21 @@ export function DashboardView({
       <div className="dashboard-content">
         <div className="dashboard-overview">
           <header className="dashboard-heading">
-            <h1>项目完成度</h1>
+            <h1>{text("项目完成度", "Project completion")}</h1>
             <div className="dashboard-hero-value">
               <strong>{completionRate}%</strong>
-              <span>{completedTasks.length} 个已完成 · {activeTasks.length} 个尚未结束</span>
+              <span>{text(
+                `${completedTasks.length} 个已完成 · ${activeTasks.length} 个尚未结束`,
+                `${completedTasks.length} completed · ${activeTasks.length} remaining`,
+              )}</span>
             </div>
           </header>
 
-          <section className="dashboard-codex-summary" aria-label="Codex 项目总结">
+          <section className="dashboard-codex-summary" aria-label={text("Codex 项目总结", "Codex project summary")}>
             <div className="dashboard-summary-bubble">
               <p
                 className={summaryTyping ? "is-typing" : undefined}
-                aria-label={summaryReady ? summary : "Codex 正在整理项目总结"}
+                aria-label={summaryReady ? summary : text("Codex 正在整理项目总结", "Codex is preparing the project summary")}
               >{displayedSummary}</p>
             </div>
             <img className="dashboard-codex-mark" src="codex-agent-logo.png" alt="" aria-hidden="true" />
@@ -501,12 +520,12 @@ export function DashboardView({
         </div>
 
         <div className="dashboard-analysis-heading">
-          <h2>项目分析</h2>
+          <h2>{text("项目分析", "Project analysis")}</h2>
         </div>
 
         <div className="dashboard-grid">
           <section className="dashboard-panel dashboard-primary-panel dashboard-priority-panel">
-            <header><span>优先级</span></header>
+            <header><span>{text("优先级", "Priority")}</span></header>
             <div className="dashboard-priority-list">
               {priorityCounts.map((item) => (
                 <div className={`dashboard-priority-row priority-${item.priority}`} key={item.priority}>
@@ -524,7 +543,7 @@ export function DashboardView({
           </section>
 
           <section className="dashboard-panel dashboard-primary-panel dashboard-attention-panel">
-            <header><span>需要关注（未读、阻塞）</span></header>
+            <header><span>{text("需要关注（未读、阻塞）", "Needs attention (unread, blocked)")}</span></header>
             <div className="dashboard-task-list">
               {attentionItems.length ? attentionItems.map((task) => (
                 <button
@@ -538,13 +557,13 @@ export function DashboardView({
                   <small>ID: {task.identifier}</small>
                 </button>
               )) : (
-                <div className="dashboard-empty">当前没有需要关注的议题</div>
+                <div className="dashboard-empty">{text("当前没有需要关注的议题", "No issues need attention")}</div>
               )}
             </div>
           </section>
 
           <section className="dashboard-panel dashboard-primary-panel dashboard-running-panel">
-            <header><span>运行中对话</span></header>
+            <header><span>{text("运行中对话", "Active conversations")}</span></header>
             <div className="dashboard-task-list">
               {runningTasks.length ? runningTasks.map((task) => (
                 <article className="dashboard-running-card" key={task.id}>
@@ -559,7 +578,7 @@ export function DashboardView({
                   <div className="dashboard-running-footer">
                     <span className="task-processing is-running">
                       <img className="task-processing-glyph" src={processingAnimation} alt="" aria-hidden="true" />
-                      <span className="task-processing-label">正在处理…</span>
+                      <span className="task-processing-label">{text("正在处理…", "Processing…")}</span>
                     </span>
                     <TaskConversationMenu
                       conversations={presentations[task.id].conversations}
@@ -568,13 +587,13 @@ export function DashboardView({
                   </div>
                 </article>
               )) : (
-                <div className="dashboard-empty">当前没有运行中的对话</div>
+                <div className="dashboard-empty">{text("当前没有运行中的对话", "No active conversations")}</div>
               )}
             </div>
           </section>
 
           <section className="dashboard-panel dashboard-secondary-panel dashboard-role-panel">
-            <header><span>角色贡献</span><b>{roleContributions.length}</b></header>
+            <header><span>{text("角色贡献", "Role contributions")}</span><b>{roleContributions.length}</b></header>
             {roleContributions.length ? (
               <div className="dashboard-role-body">
                 <div className="dashboard-role-stack" aria-hidden="true">
@@ -592,7 +611,10 @@ export function DashboardView({
                       <ActorAvatar actor={item.actor} />
                       <span className="dashboard-role-copy">
                         <strong>{item.actor.name}</strong>
-                        <small>{item.count} 个已完成议题</small>
+                        <small>{text(
+                          `${item.count} 个已完成议题`,
+                          `${item.count} completed ${item.count === 1 ? "issue" : "issues"}`,
+                        )}</small>
                       </span>
                       <span className={`dashboard-role-share tone-${index % 5}`}>
                         {Math.round((item.count / completedTotal) * 100)}%
@@ -602,12 +624,12 @@ export function DashboardView({
                 </div>
               </div>
             ) : (
-              <div className="dashboard-empty">当前没有角色数据</div>
+              <div className="dashboard-empty">{text("当前没有角色数据", "No role data")}</div>
             )}
           </section>
 
           <section className="dashboard-panel dashboard-secondary-panel dashboard-contribution-panel">
-            <header><span>贡献图</span></header>
+            <header><span>{text("贡献图", "Contribution chart")}</span></header>
             <div className="dashboard-contribution-body">
               <div className="dashboard-contribution-chart">
                 <div className="dashboard-contribution-months" aria-hidden="true">
@@ -622,11 +644,11 @@ export function DashboardView({
                 </div>
                 <div className="dashboard-contribution-main">
                   <div className="dashboard-contribution-weekdays" aria-hidden="true">
-                    <span style={{ gridRow: 2 }}>一</span>
-                    <span style={{ gridRow: 4 }}>三</span>
-                    <span style={{ gridRow: 6 }}>五</span>
+                    <span style={{ gridRow: 2 }}>{text("一", "M")}</span>
+                    <span style={{ gridRow: 4 }}>{text("三", "W")}</span>
+                    <span style={{ gridRow: 6 }}>{text("五", "F")}</span>
                   </div>
-                  <div className="dashboard-contribution-grid" aria-label="过去一年议题贡献图">
+                  <div className="dashboard-contribution-grid" aria-label={text("过去一年议题贡献图", "Issue contributions over the past year")}>
                     {contributionWeeks.flat().map((day) => {
                       const level = day.count === 0
                         ? 0
@@ -634,26 +656,29 @@ export function DashboardView({
                       return (
                         <span
                           className={`dashboard-contribution-cell level-${level}${day.future ? " is-future" : ""}`}
-                          title={day.future ? undefined : `${day.key} · ${day.count} 个议题更新`}
+                          title={day.future ? undefined : text(
+                            `${contributionDateFormatter.format(day.date)} · ${day.count} 个议题更新`,
+                            `${contributionDateFormatter.format(day.date)} · ${day.count} issue ${day.count === 1 ? "update" : "updates"}`,
+                          )}
                           key={day.key}
                         />
                       );
                     })}
                   </div>
                 </div>
-                <div className="dashboard-contribution-legend" aria-label="贡献强度图例">
-                  <span>少</span>
+                <div className="dashboard-contribution-legend" aria-label={text("贡献强度图例", "Contribution intensity legend")}>
+                  <span>{text("少", "Less")}</span>
                   {[0, 1, 2, 3, 4].map((level) => (
                     <i className={`dashboard-contribution-cell level-${level}`} key={level} />
                   ))}
-                  <span>多</span>
+                  <span>{text("多", "More")}</span>
                 </div>
               </div>
             </div>
           </section>
 
           <section className="dashboard-panel dashboard-tertiary-panel dashboard-upcoming-panel">
-            <header><span>即将到期</span></header>
+            <header><span>{text("即将到期", "Due soon")}</span></header>
             <div className="dashboard-task-list">
               {upcomingTasks.length ? upcomingTasks.map((task) => (
                 <button
@@ -668,16 +693,16 @@ export function DashboardView({
                     aria-hidden="true"
                   />
                   <strong>{task.title}</strong>
-                  <time>ID: {task.identifier} | {shortDate(task.dueDate!)}</time>
+                  <time>ID: {task.identifier} | {shortDate(task.dueDate!, locale)}</time>
                 </button>
               )) : (
-                <div className="dashboard-empty">近期没有到期议题</div>
+                <div className="dashboard-empty">{text("近期没有到期议题", "No issues are due soon")}</div>
               )}
             </div>
           </section>
 
           <section className="dashboard-panel dashboard-tertiary-panel dashboard-label-panel">
-            <header><span>标签分布 {Math.min(12, labelCounts.length)}</span></header>
+            <header><span>{text("标签分布", "Label distribution")} {Math.min(12, labelCounts.length)}</span></header>
             {visibleLabelCounts.length ? (
               <div className="dashboard-label-chart">
                 {visibleLabelCounts.map((item) => (
@@ -695,19 +720,19 @@ export function DashboardView({
                 ))}
               </div>
             ) : (
-              <div className="dashboard-empty">当前没有标签数据</div>
+              <div className="dashboard-empty">{text("当前没有标签数据", "No label data")}</div>
             )}
           </section>
 
           <section className="dashboard-panel dashboard-tertiary-panel dashboard-progress-panel">
           <header className="dashboard-progress-header">
             <div className="dashboard-progress-title">
-              <span>优先级</span>
+              <span>{text("优先级", "Priority")}</span>
             </div>
             <div className="dashboard-progress-legend">
-              <span className="tone-scope"><i />范围 <strong>{progressData.scope}</strong></span>
-              <span className="tone-started"><i />已开始 <strong>{progressData.started}</strong></span>
-              <span className="tone-completed"><i />已完成 <strong>{progressData.completed}</strong></span>
+              <span className="tone-scope"><i />{text("范围", "Scope")} <strong>{progressData.scope}</strong></span>
+              <span className="tone-started"><i />{text("已开始", "Started")} <strong>{progressData.started}</strong></span>
+              <span className="tone-completed"><i />{text("已完成", "Completed")} <strong>{progressData.completed}</strong></span>
             </div>
           </header>
           <div className="dashboard-progress-body">
@@ -715,7 +740,10 @@ export function DashboardView({
               className="dashboard-progress-chart"
               viewBox="0 0 426 272"
               role="img"
-              aria-label={`项目累计进度：范围 ${progressData.scope}，已开始 ${progressData.started}，已完成 ${progressData.completed}`}
+              aria-label={text(
+                `项目累计进度：范围 ${progressData.scope}，已开始 ${progressData.started}，已完成 ${progressData.completed}`,
+                `Cumulative project progress: scope ${progressData.scope}, started ${progressData.started}, completed ${progressData.completed}`,
+              )}
             >
               <defs>
                 <linearGradient id="dashboard-progress-area" x1="0" y1="0" x2="0" y2="1">
@@ -801,11 +829,11 @@ export function DashboardView({
                   >
                     <rect width="162" height="80" rx="9" />
                     <text className="dashboard-progress-tooltip-date" x="12" y="20">
-                      {chartDate(hoveredProgressPoint.timestamp)}
+                      {chartDate(hoveredProgressPoint.timestamp, locale)}
                     </text>
-                    <text x="12" y="40">范围 {hoveredProgressPoint.scope}</text>
-                    <text x="12" y="58">已开始 {Math.max(0, hoveredProgressPoint.started - hoveredProgressPoint.completed)}</text>
-                    <text x="88" y="58">已完成 {hoveredProgressPoint.completed}</text>
+                    <text x="12" y="40">{text("范围", "Scope")} {hoveredProgressPoint.scope}</text>
+                    <text x="12" y="58">{text("已开始", "Started")} {Math.max(0, hoveredProgressPoint.started - hoveredProgressPoint.completed)}</text>
+                    <text x="88" y="58">{text("已完成", "Completed")} {hoveredProgressPoint.completed}</text>
                     <text className="dashboard-progress-tooltip-delta" x="88" y="40">
                       Δ {hoveredProgressPoint.scope - (progressChart.points[Math.max(0, progressHoverIndex! - 1)]?.scope ?? hoveredProgressPoint.scope)}
                     </text>
@@ -825,7 +853,10 @@ export function DashboardView({
                     fill="transparent"
                     role="button"
                     tabIndex={0}
-                    aria-label={`${chartDate(point.timestamp)}：范围 ${point.scope}，已开始 ${Math.max(0, point.started - point.completed)}，已完成 ${point.completed}`}
+                    aria-label={text(
+                      `${chartDate(point.timestamp, locale)}：范围 ${point.scope}，已开始 ${Math.max(0, point.started - point.completed)}，已完成 ${point.completed}`,
+                      `${chartDate(point.timestamp, locale)}: scope ${point.scope}, started ${Math.max(0, point.started - point.completed)}, completed ${point.completed}`,
+                    )}
                     onMouseEnter={() => setProgressHoverIndex(index)}
                     onMouseLeave={() => setProgressHoverIndex(null)}
                     onFocus={() => setProgressHoverIndex(index)}
@@ -840,13 +871,13 @@ export function DashboardView({
               })}
 
               <text className="dashboard-progress-axis-label" x={progressChart.left} y="260">
-                {chartDate(progressChart.points[0].timestamp)}
+                {chartDate(progressChart.points[0].timestamp, locale)}
               </text>
               <text className="dashboard-progress-axis-label is-current" x={progressChart.currentX} y="260" textAnchor="middle">
-                {chartDate(todayValue)}
+                {chartDate(todayValue, locale)}
               </text>
               <text className="dashboard-progress-axis-label" x={progressChart.right} y="260" textAnchor="end">
-                {chartDate(rangeEndValue, todayValue)}
+                {chartDate(rangeEndValue, locale, todayValue)}
               </text>
             </svg>
           </div>

--- a/web/src/components/GanttView.tsx
+++ b/web/src/components/GanttView.tsx
@@ -3,6 +3,7 @@ import { Gantt, type GanttStatic, type Task as GanttTask } from "dhtmlx-gantt";
 import "dhtmlx-gantt/codebase/dhtmlxgantt.css";
 import type { Task, TaskDraft } from "../types";
 import type { TaskCardPresentation } from "../taskConversations";
+import { useTaskboardI18n } from "../i18n";
 import { LinearIcon } from "./LinearIcon";
 import { taskboardIconSource } from "./TaskboardIcon";
 
@@ -10,7 +11,8 @@ type GanttZoom = "day" | "week" | "month";
 
 interface GanttGroupDefinition {
   id: string;
-  label: string;
+  chineseLabel: string;
+  englishLabel: string;
   statuses: Task["status"][];
   defaultOpen: boolean;
 }
@@ -41,12 +43,12 @@ interface GanttViewProps {
 let pendingDetailViewport: { projectId: string; x: number; y: number } | null = null;
 
 const GANTT_GROUPS: GanttGroupDefinition[] = [
-  { id: "in-progress", label: "处理中", statuses: ["in_progress"], defaultOpen: true },
-  { id: "in-review", label: "等你确认", statuses: ["in_review"], defaultOpen: true },
-  { id: "blocked", label: "遇到阻碍", statuses: ["blocked"], defaultOpen: true },
-  { id: "todo", label: "待处理", statuses: ["backlog", "todo"], defaultOpen: true },
-  { id: "done", label: "已完成", statuses: ["done"], defaultOpen: false },
-  { id: "canceled", label: "已取消", statuses: ["canceled"], defaultOpen: false },
+  { id: "in-progress", chineseLabel: "处理中", englishLabel: "In progress", statuses: ["in_progress"], defaultOpen: true },
+  { id: "in-review", chineseLabel: "等你确认", englishLabel: "In review", statuses: ["in_review"], defaultOpen: true },
+  { id: "blocked", chineseLabel: "遇到阻碍", englishLabel: "Blocked", statuses: ["blocked"], defaultOpen: true },
+  { id: "todo", chineseLabel: "待处理", englishLabel: "To do", statuses: ["backlog", "todo"], defaultOpen: true },
+  { id: "done", chineseLabel: "已完成", englishLabel: "Completed", statuses: ["done"], defaultOpen: false },
+  { id: "canceled", chineseLabel: "已取消", englishLabel: "Canceled", statuses: ["canceled"], defaultOpen: false },
 ];
 
 function localDate(value: string) {
@@ -64,6 +66,14 @@ function dateValue(value: Date) {
   const month = String(value.getMonth() + 1).padStart(2, "0");
   const day = String(value.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
+}
+
+function ganttDate(value: Date, locale: string, includeYear = false) {
+  return new Intl.DateTimeFormat(locale, {
+    year: includeYear ? "numeric" : undefined,
+    month: "short",
+    day: "numeric",
+  }).format(value);
 }
 
 function taskProgress(task: Task, presentation: TaskCardPresentation | undefined) {
@@ -96,6 +106,8 @@ function dateCellClass(date: Date) {
 }
 
 export function GanttView({ tasks, presentations, hasActiveFilters, zoom, hideCompleted, todayRequest, onOpenTask, onUpdate }: GanttViewProps) {
+  const { language, locale, text } = useTaskboardI18n();
+  const i18nRef = useRef({ language, locale, text });
   const containerRef = useRef<HTMLDivElement>(null);
   const ganttRef = useRef<GanttStatic | null>(null);
   const [gridCollapsed, setGridCollapsed] = useState(false);
@@ -110,12 +122,12 @@ export function GanttView({ tasks, presentations, hasActiveFilters, zoom, hideCo
   tasksRef.current = tasks;
   onOpenTaskRef.current = onOpenTask;
   onUpdateRef.current = onUpdate;
+  i18nRef.current = { language, locale, text };
 
   const visibleTasks = useMemo(
     () => hideCompleted ? tasks.filter((task) => task.status !== "done" && task.status !== "canceled") : tasks,
     [hideCompleted, tasks],
   );
-
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -140,7 +152,7 @@ export function GanttView({ tasks, presentations, hasActiveFilters, zoom, hideCo
     instance.config.columns = [
       {
         name: "text",
-        label: "议题",
+        label: i18nRef.current.text("议题", "Issue"),
         tree: true,
         width: "*",
         min_width: 190,
@@ -149,7 +161,7 @@ export function GanttView({ tasks, presentations, hasActiveFilters, zoom, hideCo
           if (task.taskboardGroup) {
             return `<div class="gantt-grid-group"><strong>${escapeHtml(task.taskboardTitle)}</strong><span>${task.taskboardCount}</span></div>`;
           }
-          return `<div class="gantt-grid-issue"><strong>${escapeHtml(task.taskboardTitle)}</strong>${task.taskboardUnread ? '<i class="task-unread-dot" aria-label="有未读更新"></i>' : ""}</div>`;
+          return `<div class="gantt-grid-issue"><strong>${escapeHtml(task.taskboardTitle)}</strong>${task.taskboardUnread ? `<i class="task-unread-dot" aria-label="${escapeHtml(i18nRef.current.text("有未读更新", "Unread updates"))}"></i>` : ""}</div>`;
         },
       },
     ];
@@ -170,8 +182,8 @@ export function GanttView({ tasks, presentations, hasActiveFilters, zoom, hideCo
       if (task.taskboardGroup) return "";
       const displayEnd = addDays(end, -1);
       const dateLabel = start.getFullYear() === displayEnd.getFullYear()
-        ? `${start.getMonth() + 1}月${start.getDate()}日 — ${displayEnd.getMonth() + 1}月${displayEnd.getDate()}日`
-        : `${start.getFullYear()}年${start.getMonth() + 1}月${start.getDate()}日 — ${displayEnd.getFullYear()}年${displayEnd.getMonth() + 1}月${displayEnd.getDate()}日`;
+        ? `${ganttDate(start, i18nRef.current.locale)} — ${ganttDate(displayEnd, i18nRef.current.locale)}`
+        : `${ganttDate(start, i18nRef.current.locale, true)} — ${ganttDate(displayEnd, i18nRef.current.locale, true)}`;
       const avatar = task.taskboardAssigneeType === "agent"
         ? `<img src="codex-agent-logo.png" alt="">`
         : task.taskboardAssigneeAvatarUrl
@@ -188,8 +200,13 @@ export function GanttView({ tasks, presentations, hasActiveFilters, zoom, hideCo
     instance.templates.task_row_class = (_start, _end, item) => rowClass(item);
     instance.templates.scale_cell_class = dateCellClass;
     instance.templates.timeline_cell_class = (_item, date) => dateCellClass(date);
-    const monthFormat = (date: Date) => `${date.getFullYear()}年${date.getMonth() + 1}月`;
-    const dayFormat = (date: Date) => `<span class="gantt-scale-date"><span class="gantt-scale-weekday">${["S", "M", "T", "W", "T", "F", "S"][date.getDay()]}</span><span class="gantt-scale-day">${date.getDate()}</span></span>`;
+    const monthFormat = (date: Date) => new Intl.DateTimeFormat(i18nRef.current.locale, { year: "numeric", month: "long" }).format(date);
+    const dayFormat = (date: Date) => {
+      const weekdayLabels = i18nRef.current.language === "zh"
+        ? ["日", "一", "二", "三", "四", "五", "六"]
+        : ["S", "M", "T", "W", "T", "F", "S"];
+      return `<span class="gantt-scale-date"><span class="gantt-scale-weekday">${weekdayLabels[date.getDay()]}</span><span class="gantt-scale-day">${date.getDate()}</span></span>`;
+    };
     instance.ext.zoom.init({
       levels: [
         {
@@ -215,8 +232,8 @@ export function GanttView({ tasks, presentations, hasActiveFilters, zoom, hideCo
           scale_height: 66,
           min_column_width: 82,
           scales: [
-            { unit: "year", step: 1, format: "%Y年" },
-            { unit: "month", step: 1, format: (date: Date) => `${date.getMonth() + 1}月` },
+            { unit: "year", step: 1, format: (date: Date) => new Intl.DateTimeFormat(i18nRef.current.locale, { year: "numeric" }).format(date) },
+            { unit: "month", step: 1, format: (date: Date) => new Intl.DateTimeFormat(i18nRef.current.locale, { month: "short" }).format(date) },
           ],
         },
       ],
@@ -320,26 +337,65 @@ export function GanttView({ tasks, presentations, hasActiveFilters, zoom, hideCo
   useEffect(() => {
     const instance = ganttRef.current;
     if (!instance) return;
-    const data: TaskboardGanttTask[] = [];
+    const scroll = instance.getScrollState();
+    const showGrid = instance.config.show_grid;
+    const gridWidth = instance.config.grid_width;
+    const issueColumn = instance.config.columns.find((column) => column.name === "text");
+    if (issueColumn) issueColumn.label = i18nRef.current.text("议题", "Issue");
 
     for (const group of GANTT_GROUPS) {
+      const id = `gantt-group-${group.id}`;
+      if (!instance.isTaskExists(id)) continue;
+      const task = instance.getTask(id) as TaskboardGanttTask & { $open?: boolean };
+      const open = task.$open;
+      const label = i18nRef.current.text(group.chineseLabel, group.englishLabel);
+      task.text = label;
+      task.taskboardTitle = label;
+      task.$open = open;
+    }
+
+    instance.config.show_grid = showGrid;
+    instance.config.grid_width = gridWidth;
+    instance.refreshData();
+    instance.render();
+    instance.config.show_grid = showGrid;
+    instance.config.grid_width = gridWidth;
+    instance.scrollTo(scroll.x, scroll.y);
+  }, [language, locale, text]);
+
+  useEffect(() => {
+    const instance = ganttRef.current;
+    if (!instance) return;
+    const data: TaskboardGanttTask[] = [];
+    const groupOpenState = new Map<string, boolean>();
+
+    for (const group of GANTT_GROUPS) {
+      const groupId = `gantt-group-${group.id}`;
+      if (!instance.isTaskExists(groupId)) continue;
+      const existingGroup = instance.getTask(groupId) as TaskboardGanttTask & { $open?: boolean };
+      groupOpenState.set(groupId, Boolean(existingGroup.$open));
+    }
+
+    for (const group of GANTT_GROUPS) {
+      const groupId = `gantt-group-${group.id}`;
+      const groupLabel = i18nRef.current.text(group.chineseLabel, group.englishLabel);
       const groupTasks = visibleTasks
         .filter((task) => group.statuses.includes(task.status))
         .sort((left, right) => Number(Boolean(right.startDate && right.dueDate)) - Number(Boolean(left.startDate && left.dueDate)));
       if (!groupTasks.length) continue;
       const progress = groupTasks.reduce((sum, task) => sum + taskProgress(task, presentations[task.id]), 0) / groupTasks.length;
       data.push({
-        id: `gantt-group-${group.id}`,
-        text: group.label,
+        id: groupId,
+        text: groupLabel,
         type: "project",
-        open: group.defaultOpen,
+        open: groupOpenState.get(groupId) ?? group.defaultOpen,
         readonly: true,
         row_height: 46,
         bar_height: 4,
         unscheduled: true,
         progress,
         taskboardStatus: group.statuses[0],
-        taskboardTitle: group.label,
+        taskboardTitle: groupLabel,
         taskboardUnread: groupTasks.some((task) => presentations[task.id]?.unread),
         taskboardAssigneeType: null,
         taskboardAssigneeName: "",
@@ -354,7 +410,7 @@ export function GanttView({ tasks, presentations, hasActiveFilters, zoom, hideCo
         const itemProgress = taskProgress(task, presentations[task.id]);
         data.push({
           id: task.id,
-          parent: `gantt-group-${group.id}`,
+          parent: groupId,
           text: task.title,
           row_height: 58,
           bar_height: 44,
@@ -440,23 +496,32 @@ export function GanttView({ tasks, presentations, hasActiveFilters, zoom, hideCo
       <div className="gantt-canvas-shell">
         <div className="gantt-canvas" ref={containerRef} />
         {todayMarkerLeft !== null && (
-          <div className="gantt-today-marker" style={{ left: todayMarkerLeft }} aria-label="今天">
-            <span>Today</span>
+          <div className="gantt-today-marker" style={{ left: todayMarkerLeft }} aria-label={text("今天", "Today")}>
+            <span>{text("今天", "Today")}</span>
           </div>
         )}
         <button
           type="button"
           className={`gantt-grid-toggle${gridCollapsed ? " is-collapsed" : ""}`}
           style={{ left: gridCollapsed ? 14 : gridWidth }}
-          aria-label={gridCollapsed ? "展开标题区域" : "收起标题区域"}
+          aria-label={gridCollapsed
+            ? text("展开标题区域", "Expand title area")
+            : text("收起标题区域", "Collapse title area")}
           aria-expanded={!gridCollapsed}
-          title={gridCollapsed ? "展开标题区域" : "收起标题区域"}
+          title={gridCollapsed
+            ? text("展开标题区域", "Expand title area")
+            : text("收起标题区域", "Collapse title area")}
           onClick={toggleGrid}
         >
           <LinearIcon name={gridCollapsed ? "chevronRight" : "chevronLeft"} />
         </button>
         {!visibleTasks.length && (
-          <div className="gantt-empty-overlay"><LinearIcon name="calendar" /><span>{hasActiveFilters || hideCompleted ? "当前条件下没有议题" : "创建议题后，可在这里安排时间线"}</span></div>
+          <div className="gantt-empty-overlay">
+            <LinearIcon name="calendar" />
+            <span>{hasActiveFilters || hideCompleted
+              ? text("当前条件下没有议题", "No issues match the current conditions")
+              : text("创建议题后，可在这里安排时间线", "Create an issue to schedule it on the timeline")}</span>
+          </div>
         )}
       </div>
     </div>

--- a/web/src/components/IssueListView.tsx
+++ b/web/src/components/IssueListView.tsx
@@ -1,22 +1,15 @@
 import { useState, type KeyboardEvent, type MouseEvent, type RefObject } from "react";
 import { assigneeTargetForActor } from "../actors";
+import { taskPriorityLabel, taskStatusLabel, useTaskboardI18n } from "../i18n";
 import { labelPresentation } from "../labels";
 import type { TaskCardPresentation } from "../taskConversations";
-import { TASK_PRIORITIES, TASK_STATUSES, type ActorIdentity, type Task, type TaskDraft, type TaskPriority, type TaskStatus } from "../types";
+import { TASK_PRIORITIES, TASK_STATUSES, type ActorIdentity, type Task, type TaskDraft, type TaskStatus } from "../types";
 import { ActorAvatar } from "./ActorAvatar";
-import { STATUS_DETAILS, StatusIcon } from "./BoardColumn";
+import { StatusIcon } from "./BoardColumn";
 import { LinearIcon, LinearPriorityIcon } from "./LinearIcon";
 import { TaskConversationMenu } from "./TaskConversationMenu";
 import { TaskPropertyPicker } from "./TaskPropertyPicker";
 import { TaskboardIcon } from "./TaskboardIcon";
-
-const PRIORITY_LABELS: Record<TaskPriority, string> = {
-  none: "无优先级",
-  urgent: "紧急",
-  high: "高",
-  medium: "中",
-  low: "低",
-};
 
 const COLLAPSED_BY_DEFAULT = new Set<TaskStatus>(["backlog", "done", "canceled"]);
 
@@ -31,12 +24,12 @@ interface IssueListViewProps {
   onUpdate: (task: Task, changes: Partial<TaskDraft>) => Promise<Task>;
 }
 
-function createdDate(value: string) {
-  return new Intl.DateTimeFormat("zh-CN", { month: "short", day: "numeric" }).format(new Date(value));
+function createdDate(value: string, locale: string) {
+  return new Intl.DateTimeFormat(locale, { month: "short", day: "numeric" }).format(new Date(value));
 }
 
-function calendarDate(value: string) {
-  return new Intl.DateTimeFormat("zh-CN", { month: "numeric", day: "numeric" })
+function calendarDate(value: string, locale: string) {
+  return new Intl.DateTimeFormat(locale, { month: "numeric", day: "numeric" })
     .format(new Date(`${value}T12:00:00`));
 }
 
@@ -50,6 +43,7 @@ export function IssueListView({
   onOpenConversation,
   onUpdate,
 }: IssueListViewProps) {
+  const { language, locale, text } = useTaskboardI18n();
   const [collapsed, setCollapsed] = useState(() => new Set(COLLAPSED_BY_DEFAULT));
   const [priorityMenuTaskId, setPriorityMenuTaskId] = useState<string | null>(null);
 
@@ -72,12 +66,13 @@ export function IssueListView({
         {TASK_STATUSES.map((status) => {
           const statusTasks = tasks.filter((task) => task.status === status);
           const isCollapsed = collapsed.has(status);
+          const statusLabel = taskStatusLabel(language, status);
           return (
             <section className={`issue-list-group status-${status}`} key={status}>
               <button className="issue-list-group-header" type="button" onClick={() => toggleStatus(status)} aria-expanded={!isCollapsed}>
                 <LinearIcon name={isCollapsed ? "chevronRight" : "chevronDown"} />
                 <span className="issue-list-status-icon"><StatusIcon status={status} /></span>
-                <strong>{STATUS_DETAILS[status].label}</strong>
+                <strong>{statusLabel}</strong>
                 <span>{statusTasks.length}</span>
               </button>
               {!isCollapsed && (
@@ -98,29 +93,29 @@ export function IssueListView({
                         <span className="issue-list-title-cell">
                           <small>{task.identifier}</small>
                           <strong>{task.title}</strong>
-                          {presentations[task.id]?.unread && <span className="task-unread-dot" aria-label="有未读更新" />}
+                          {presentations[task.id]?.unread && <span className="task-unread-dot" aria-label={text("有未读更新", "Unread updates")} />}
                         </span>
-                        <span className="issue-list-metadata" aria-label="议题属性">
+                        <span className="issue-list-metadata" aria-label={text("议题属性", "Issue properties")}>
                           <span className="issue-list-priority-control" onClick={stopRow} onKeyDown={stopRow}>
                             <TaskPropertyPicker
                               value={task.priority}
                               options={TASK_PRIORITIES.map((priority) => ({
                                 value: priority,
-                                label: PRIORITY_LABELS[priority],
+                                label: taskPriorityLabel(language, priority),
                                 icon: <LinearPriorityIcon priority={priority} />,
                                 className: `priority-${priority}`,
                               }))}
                               open={priorityMenuTaskId === task.id}
                               className="issue-list-property-picker"
                               triggerClassName={`issue-list-priority priority-${task.priority}`}
-                              ariaLabel={`${task.identifier} 优先级`}
+                              ariaLabel={text(`${task.identifier} 优先级`, `${task.identifier} priority`)}
                               onOpenChange={(open) => setPriorityMenuTaskId(open ? task.id : null)}
                               onChange={(priority) => void onUpdate(task, { priority }).catch(() => {})}
                             />
                           </span>
                           <span className="issue-list-labels">
                             {task.labels.slice(0, 2).map((label) => {
-                              const presentation = labelPresentation(label);
+                              const presentation = labelPresentation(label, language);
                               return (
                                 <i className={presentation.tone ? `tone-${presentation.tone}` : ""} key={label}>
                                   {presentation.tone && <span aria-hidden="true" />}
@@ -133,10 +128,10 @@ export function IssueListView({
                           {task.dueDate && (
                             <label className="issue-list-date" onClick={stopRow}>
                               <TaskboardIcon name="calendar" />
-                              <span>{calendarDate(task.dueDate)}</span>
+                              <span>{calendarDate(task.dueDate, locale)}</span>
                               <input
                                 type="date"
-                                aria-label={`${task.identifier} 截止日期`}
+                                aria-label={text(`${task.identifier} 截止日期`, `${task.identifier} due date`)}
                                 value={task.dueDate}
                                 onChange={(event) => void onUpdate(task, {
                                   dueDate: event.target.value || null,
@@ -152,7 +147,7 @@ export function IssueListView({
                           <label className="issue-list-assignee" title={task.assignee.name} onClick={stopRow}>
                             <ActorAvatar actor={task.assignee} />
                             <select
-                              aria-label={`${task.identifier} 负责人`}
+                              aria-label={text(`${task.identifier} 负责人`, `${task.identifier} assignee`)}
                               value={assigneeTarget}
                               onChange={(event) => void onUpdate(task, { assigneeTarget: event.target.value as "current-user" | "codex-agent" }).catch(() => {})}
                             >
@@ -161,13 +156,23 @@ export function IssueListView({
                             </select>
                           </label>
                         </span>
-                        <time dateTime={task.createdAt} title={`创建于 ${new Date(task.createdAt).toLocaleString("zh-CN")}`}>
-                          {createdDate(task.createdAt)}
+                        <time
+                          dateTime={task.createdAt}
+                          title={text(
+                            `创建于 ${new Date(task.createdAt).toLocaleString(locale)}`,
+                            `Created ${new Date(task.createdAt).toLocaleString(locale)}`,
+                          )}
+                        >
+                          {createdDate(task.createdAt, locale)}
                         </time>
                       </div>
                     );
                   }) : (
-                    <div className="issue-list-empty">{hasActiveFilters ? "当前筛选下没有匹配议题" : `没有${STATUS_DETAILS[status].label}议题`}</div>
+                    <div className="issue-list-empty">
+                      {hasActiveFilters
+                        ? text("当前筛选下没有匹配议题", "No issues match the current filters")
+                        : text(`没有${statusLabel}议题`, `No ${statusLabel.toLowerCase()} issues`)}
+                    </div>
                   )}
                 </div>
               )}


### PR DESCRIPTION
## Summary

- Localize Dashboard, List, and Gantt page content with the existing taskboard i18n context.
- Localize page dates, status and priority labels, empty states, controls, and accessibility text.
- Keep project names, issue content, comments, custom labels, and people names unchanged.
- Preserve the existing Gantt instance, grid state, scroll position, and manual group open state during language and data synchronization.

## Review fixes

- Pass the current language to built-in label presentation while keeping Dashboard label sorting stable.
- Handle English singular/plural counts and format contribution tooltip dates with the active locale.
- Keep Gantt initialization independent from language changes and refresh localized templates on the same instance.
- Snapshot existing `GANTT_GROUPS` node `$open` values before `clearAll/parse`; reuse them for the same group IDs and use `defaultOpen` only for new groups.

## Validation

- Direct browser verification: `zh-CN` shows Chinese; `en-US` shows English; `fr-FR` falls back to English.
- Real Provider `zh → en → fr` verification with two forced `filteredTasks` data synchronizations:
  - Same Gantt root and resize watcher.
  - Grid state and vertical scroll preserved; horizontal anchor stayed within existing rounding behavior.
  - A manually closed group remained closed after `clearAll/parse`.
  - Task bar date geometry stayed unchanged and no task write request occurred.
  - Browser runtime errors: 0.
- `npm run typecheck`: passed.
- `npm run build`: passed.
- `git diff --check`: passed.
- Exact-head CI for `3ff9e7a0e411df9f445e24dd7ada553d29bc729c`: push run `31472657893` and pull-request run `31472661940` both passed `check` and `macOS launcher`.
- The initial CI retries exposed only the existing `inject-fullheight-regression` timing race. The same focused local test produced two passes and one timing failure; no injection-path files are in this PR, and the final exact-head runs are green.

## History and scope

PR #82 is merged, so this PR targets `main` at `736c4dc8c293e1044d8ea1b3d2d6f3fbc91ce4ba`.

- Parent head `a8cd6ef7f7405787f99bea61f9889434cf2cf3b7` and `origin/main` had the same tree: `85f43a1374138103a912d801a5ab0dfece9a697b`.
- The branch was rebuilt from `origin/main` with `--force-with-lease` pinned to old remote head `b0202446b10adcbeb62aa6d9d7d7855aa7006eb2`.
- The tree before and after the history-only rebuild is identical: `670b0eddb0e1dce4bdad556e1513a3e52edf88ea`.
- The PR now contains one commit and only:
  - `web/src/components/DashboardView.tsx`
  - `web/src/components/IssueListView.tsx`
  - `web/src/components/GanttView.tsx`

Final head: `3ff9e7a0e411df9f445e24dd7ada553d29bc729c`
