### PR TITLE
LOCAL-153 调整暗色 Dashboard“其他”标签条颜色

### DIFF
--- a/web/src/components/DashboardView.css
+++ b/web/src/components/DashboardView.css
@@ -1,5 +1,6 @@
 .dashboard-view.dashboard-view {
   --dashboard-summary-text: #502bf5;
+  --dashboard-other-label-color: #e2e2e2;
   --dashboard-contribution-1: #f9e1d7;
   --dashboard-contribution-2: #f6c5b1;
   --dashboard-contribution-3: #f8aa89;
@@ -11,6 +12,7 @@
 
 :root[data-theme="dark"] .dashboard-view.dashboard-view {
   --dashboard-summary-text: color-mix(in srgb, var(--accent) 55%, var(--text-primary));
+  --dashboard-other-label-color: rgba(255, 255, 255, .2);
   --dashboard-contribution-1: color-mix(in srgb, #e98155 22%, var(--surface-muted));
   --dashboard-contribution-2: color-mix(in srgb, #e98155 42%, var(--surface-muted));
   --dashboard-contribution-3: color-mix(in srgb, #e98155 68%, var(--surface-muted));

--- a/web/src/components/DashboardView.tsx
+++ b/web/src/components/DashboardView.tsx
@@ -340,7 +340,7 @@ export function DashboardView({
     : labelCounts
   ).map((item, index) => ({
     ...item,
-    color: item.label === "__other__" ? "#e2e2e2" : LABEL_COLORS[index % LABEL_COLORS.length],
+    color: item.label === "__other__" ? "var(--dashboard-other-label-color)" : LABEL_COLORS[index % LABEL_COLORS.length],
   }));
   const maximumVisibleLabelCount = Math.max(1, ...visibleLabelCounts.map((item) => item.count));
 


### PR DESCRIPTION
关联看板议题：LOCAL-153

## 改动

- 为 Dashboard 标签分布的“其他”聚合条增加组件颜色变量。
- 浅色模式保留 `#e2e2e2`。
- 暗色模式将该变量设为 `rgba(255, 255, 255, 0.2)`。

## 原因与影响

原实现把“其他”条固定为浅色值 `#e2e2e2`，暗色背景下过亮。本改动只调整该聚合条的暗色计算颜色；其他标签颜色、浅色模式、布局、数据、图表逻辑和 i18n 不变。

## 直接验证

- Playwright 计算样式：light “其他”=`rgb(226, 226, 226)`。
- Playwright 计算样式：dark “其他”=`rgba(255, 255, 255, 0.2)`。
- 普通标签在 light/dark 均为 `rgb(94, 106, 210)`。
- `npm run build:web` 通过。
- `git diff --check` 通过。