### PR TITLE
Launcher 运行期间每 24 小时检查更新

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -25,6 +25,7 @@ use tauri_plugin_updater::{Update, UpdaterExt};
 use uuid::Uuid;
 
 const STOP_TIMEOUT: Duration = Duration::from_secs(5);
+const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 const TASKBOARD_LISTEN_FD: i32 = 5;
 
 #[derive(Clone, Serialize)]
@@ -664,6 +665,7 @@ async fn offer_update(
     {
         return;
     }
+    check_update.set_enabled(false).unwrap();
     let update = match check_for_startup_update(app, state).await {
         Ok(update) => update,
         Err(error) => {
@@ -779,7 +781,6 @@ fn main() {
                         let Some(state) = app.try_state::<Arc<LauncherState>>() else {
                             return;
                         };
-                        check_update_menu.set_enabled(false).unwrap();
                         let state = Arc::clone(state.inner());
                         let app = app.clone();
                         let check_update = check_update_menu.clone();
@@ -822,6 +823,19 @@ fn main() {
                     _ => {}
                 })
                 .build(app)?;
+
+            let periodic_update_app = app.handle().clone();
+            let periodic_update_state = Arc::clone(&state);
+            let periodic_check_update = check_update.clone();
+            thread::spawn(move || loop {
+                thread::sleep(UPDATE_CHECK_INTERVAL);
+                let app_handle = periodic_update_app.clone();
+                let state = Arc::clone(&periodic_update_state);
+                let check_update = periodic_check_update.clone();
+                tauri::async_runtime::spawn(async move {
+                    offer_update(&app_handle, &state, &check_update, false).await;
+                });
+            });
 
             let app_handle = app.handle().clone();
             let startup_check_update = check_update.clone();


### PR DESCRIPTION
## E3 与真实路径

- Launcher 进程从 src-tauri/src/main.rs 的 main/setup 启动。
- 启动检查和状态栏手动检查都进入现有 offer_update。
- offer_update 用 update_flow_in_progress 的 CAS 保证单一 in-flight 流程，再调用 Tauri updater 的 check 请求 release endpoint。
- 无更新和自动检查失败只使用现有日志；发现更新继续显示现有“立即更新/稍后”确认弹窗。
- “重新启动 Codex”只调用 restart_launcher 重启受管子进程，不重新执行 setup。

## 24 小时决策

固定周期为 24 小时，从 Launcher 进程 setup 时开始计时。首次等待 24 小时，之后每 24 小时复用 offer_update(app, state, check_update, false)。不增加用户配置。

## 改动

- 增加固定的 24 小时 UPDATE_CHECK_INTERVAL。
- 在 setup 中只创建一个进程级定时线程。
- 定时检查复用现有静默自动检查和更新确认流程。
- 把检查菜单禁用移到 CAS 成功之后，让启动、定时和手动入口统一使用同一个互斥赢家。

## 直接验证

- cargo fmt --check：通过。
- Rust 1.88 cargo check：通过。
- 一次性测试构建把周期缩短为 1 秒，并使用本机可控 updater endpoint：周期成功触发后续检查。
- 首个请求延迟 3 秒期间，mock 记录 maxActive=1；启动、定时竞争时只执行一个 updater 请求。
- mock 无更新时只记录 No update is available；受控 500 时只记录 Update check failed。
- mock 返回 9.9.9 时真实进入现有 Showing update prompt for 9.9.9 路径；没有新增静默安装分支。
- restart_launcher 只停止和启动受管子进程；timer 的唯一创建点仍在进程 setup，因此受管 Codex 重启不会重置或叠加 timer。
- git diff --check：通过。

## 范围

只改 src-tauri/src/main.rs。没有新增配置界面、抽象、状态机、兼容层、护栏或测试。

关联：LOCAL-154
