### PR TITLE
LOCAL-156: localize root app errors

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -41,6 +41,7 @@ import {
   removeTaskRelation,
   resolveTaskboardUrl,
   restoreTask as restoreTaskRequest,
+  setApiText,
   setCurrentUserActor,
   uploadAttachment,
   updateTask as updateTaskRequest,
@@ -430,12 +431,6 @@ function workspaceName(path?: string): string | null {
   return parts.at(-1) ?? path;
 }
 
-function errorMessage(error: unknown): string {
-  if (error instanceof ApiError) return error.message;
-  if (error instanceof Error) return error.message;
-  return "Something went wrong while loading your issues.";
-}
-
 function isAutomationHostItem(value: unknown): value is AutomationHostItem {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const item = value as Partial<AutomationHostItem>;
@@ -699,6 +694,15 @@ export function App() {
   const revisionPollingInterval = getRevisionPollingInterval(taskboardMetadata);
   const textRef = useRef(text);
   textRef.current = text;
+  setApiText(text);
+  function errorMessage(error: unknown): string {
+    if (error instanceof ApiError) return error.message;
+    if (error instanceof Error) return error.message;
+    return textRef.current(
+      "加载议题时出现问题。",
+      "Something went wrong while loading your issues.",
+    );
+  }
   const pendingAutomationRequestsRef = useRef(new Map<string, PendingAutomationRequest>());
   const automationRequestInFlightRef = useRef<"list" | "save" | null>(null);
   const loadedAutomationProjectIdsRef = useRef(new Set<string>());
@@ -1966,7 +1970,10 @@ export function App() {
         candidate.id === previous.id ? previous : candidate,
       )));
       setActionError(error instanceof ApiError && error.code === "VERSION_CONFLICT"
-        ? "That issue changed elsewhere. The board has been refreshed."
+        ? text(
+          "该议题已在其他位置更新，看板已重新同步。",
+          "This issue changed elsewhere. The board has been synced.",
+        )
         : errorMessage(error));
       if (selectedProjectId) void refreshTasks(selectedProjectId, { quiet: true });
     } finally {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1970,7 +1970,7 @@ export function App() {
         candidate.id === previous.id ? previous : candidate,
       )));
       setActionError(error instanceof ApiError && error.code === "VERSION_CONFLICT"
-        ? text(
+        ? textRef.current(
           "该议题已在其他位置更新，看板已重新同步。",
           "This issue changed elsewhere. The board has been synced.",
         )

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -30,9 +30,14 @@ const DEFAULT_USER_ACTOR: ActorIdentity = {
 };
 
 let currentUserActor = DEFAULT_USER_ACTOR;
+let apiText = (_chinese: string, english: string) => english;
 
 export function setCurrentUserActor(actor?: ActorIdentity) {
   currentUserActor = actor?.type === "user" ? actor : DEFAULT_USER_ACTOR;
+}
+
+export function setApiText(text: typeof apiText) {
+  apiText = text;
 }
 
 interface ApiErrorBody {
@@ -49,7 +54,7 @@ export class ApiError extends Error {
   readonly details?: unknown;
 
   constructor(status: number, body: ApiErrorBody) {
-    super(body.error?.message ?? `Request failed (${status})`);
+    super(body.error?.message ?? apiText(`请求失败（${status}）`, `Request failed (${status})`));
     this.name = "ApiError";
     this.status = status;
     this.code = body.error?.code ?? "REQUEST_FAILED";
@@ -81,7 +86,10 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     throw new ApiError(0, {
       error: {
         code: "SERVICE_UNAVAILABLE",
-        message: "无法连接本地 Taskboard 服务，请重新通过 Taskboard 启动 Codex。",
+        message: apiText(
+          "无法连接本地 Taskboard 服务，请重新通过 Taskboard 启动 Codex。",
+          "Could not connect to the local Taskboard service. Start Codex from Taskboard again.",
+        ),
       },
     });
   }


### PR DESCRIPTION
## Summary

- Localize the remaining fixed root-app fallback and move-conflict messages in web/src/App.tsx.
- Localize the shared API request fallback and local service outage message in web/src/api.ts.
- Keep server and API Error.message values, issue titles, project names, identifiers, protocol fields, and saved actor values unchanged.

## Direct verification

- npm run typecheck
- npm run build:web
- node --test test/board-interactions.test.mjs test/project-home.test.mjs test/ai-chat-api.test.mjs: 30 passed
- git diff --check
- Real isolated root-app paths with lang=zh-CN and lang=en-US: create, move, update, undo, archive, restore, permanent delete, project create, and project delete
- Real disconnected local API submission in both languages
- Simulated real 409 move response through the root UI in both languages
- Generic 503 fallback changed by language; dynamic SERVER_ERROR_原样-ß stayed unchanged