### PR TITLE
release: v0.2.3

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -293,9 +293,9 @@ jobs:
             --target "$GITHUB_SHA" \
             --draft \
             --title "Codex Taskboard $RELEASE_TAG" \
-            --notes "Codex Taskboard 将任务看板直接集成到 Codex，支持任务创建、状态管理、会话关联、Worktree 开发协作和进度追踪。
+            --notes "Codex Taskboard 是本地优先的项目协作面板，可通过 macOS App 将任务管理直接集成到 Codex，也可通过 Web UI、taskctl CLI 和 Skill 管理任务、评论、附件、对话与 Worktree。
 
-          本版本优化了任务搜索、Dashboard 展示、详情页浏览位置与链接复制，并改善了 Codex 内置浏览器登录状态和 macOS 状态栏图标。" \
+          v0.2.3 提供中文和英文界面，并完善任务详情、Dashboard、List、Gantt、Workflow、自动化设置和 AI Chat；taskctl 也支持为任务和评论上传附件。" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.dmg" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" \

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -295,7 +295,7 @@ jobs:
             --title "Codex Taskboard $RELEASE_TAG" \
             --notes "Codex Taskboard 是本地优先的项目协作面板，可通过 macOS App 将任务管理直接集成到 Codex，也可通过 Web UI、taskctl CLI 和 Skill 管理任务、评论、附件、对话与 Worktree。
 
-          v0.2.3 提供中文和英文界面，并完善任务详情、Dashboard、List、Gantt、Workflow、自动化设置和 AI Chat；taskctl 也支持为任务和评论上传附件。" \
+          v0.2.3 提供中文和英文界面，并完善任务详情、Dashboard、List、Gantt、自动化设置和 AI Chat；taskctl 也支持为任务和评论上传附件。" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.dmg" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" \

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ npm start
 - 创建 `macos-release` environment，配置必需审核人，并启用“禁止发起人自行审核”。
 - 启用 immutable releases。promotion 在发布前检查此设置，并在发布后校验 Release API 的 `immutable: true` 和每个资产的 SHA-256。
 
-### 发布 `v0.2.2`
+### 发布 `v0.2.3`
 
 1. 在 PR 中把 `package.json`、`package-lock.json`、`src-tauri/Cargo.toml`、`src-tauri/Cargo.lock` 和 `src-tauri/tauri.conf.json` 的版本同步为目标版本。
 2. 合并已审核的 PR。
@@ -148,8 +148,8 @@ npm start
 4. 在已合并提交上创建并推送标签：
 
    ```bash
-   git tag -a v0.2.2 -m "Codex Taskboard 0.2.2"
-   git push origin v0.2.2
+   git tag -a v0.2.3 -m "Codex Taskboard 0.2.3"
+   git push origin v0.2.3
    ```
 
 5. 等待构建 job 创建 Draft Release。不要在 GitHub Release 页面直接发布。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-taskboard",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-taskboard",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@lobehub/icons-static-svg": "^1.94.0",
         "@xyflow/react": "^12.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-taskboard",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "codex-taskboard-launcher"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "libc",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-taskboard-launcher"
-version = "0.2.2"
+version = "0.2.3"
 description = "Codex Taskboard macOS launcher"
 edition = "2021"
 rust-version = "1.88"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex Taskboard",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "identifier": "com.chuspeeism.codex-taskboard",
   "app": {
     "windows": []


### PR DESCRIPTION
## What changed

- Synchronize the app, npm, Cargo, and Tauri versions at `0.2.3`.
- Update the documented release tag to `v0.2.3`.
- Replace the GitHub Release text with a product-only feature introduction.

## Why

This prepares the reviewed changes already merged into `main` for the next signed and notarized macOS release.

## Impact

This PR changes release metadata only. It does not change product implementation or add compatibility layers.

## Validation

- All six version sources resolve to `0.2.3`.
- `node --test test/launcher-release.test.mjs`: 3/3 passed.
- Release workflow YAML parsed successfully.
- `git diff --check` passed.

Taskboard: `LOCAL-158`
Exact head: `3ff0615d7cac9a849b19ccfdb10f3d5d36452f82`
