### PR TITLE
release: show macOS DMG first

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -261,14 +261,16 @@ jobs:
           RELEASE_ASSETS="$RUNNER_TEMP/release-assets"
           MANIFEST_ROOT="$RUNNER_TEMP/release-manifest"
           mkdir -p "$RELEASE_ASSETS" "$MANIFEST_ROOT"
-          cp "$BUNDLE_ROOT/dmg/Codex.Taskboard_${PACKAGE_VERSION}_universal.dmg" "$RELEASE_ASSETS/"
+          cp \
+            "$BUNDLE_ROOT/dmg/Codex.Taskboard_${PACKAGE_VERSION}_universal.dmg" \
+            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg"
           cp "$BUNDLE_ROOT/release/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" "$RELEASE_ASSETS/"
           cp "$BUNDLE_ROOT/release/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" "$RELEASE_ASSETS/"
           cp "$BUNDLE_ROOT/release/latest.json" "$RELEASE_ASSETS/"
           (
             cd "$RELEASE_ASSETS"
             shasum -a 256 \
-              "Codex.Taskboard_${PACKAGE_VERSION}_universal.dmg" \
+              "Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg" \
               "Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" \
               "Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" \
               "latest.json" > "$MANIFEST_ROOT/release-assets.sha256"
@@ -296,7 +298,7 @@ jobs:
             --notes "Codex Taskboard 是本地优先的项目协作面板，可通过 macOS App 将任务管理直接集成到 Codex，也可通过 Web UI、taskctl CLI 和 Skill 管理任务、评论、附件、对话与 Worktree。
 
           v0.2.3 提供中文和英文界面，并完善任务详情、Dashboard、List、Gantt、自动化设置和 AI Chat；taskctl 也支持为任务和评论上传附件。" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.dmg" \
+            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" \
             "$RELEASE_ASSETS/latest.json"
@@ -467,7 +469,7 @@ jobs:
             -C "$UPDATER_ROOT"
           npm run app:verify-release -- \
             "$UPDATER_ROOT/Codex Taskboard.app" \
-            "$DRAFT_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.dmg" \
+            "$DRAFT_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg" \
             "$DRAFT_ASSETS" \
             "$RELEASE_TAG"
 


### PR DESCRIPTION
## 目标

让 GitHub Release 的 macOS DMG 安装包显示在资产列表第一位。

## 实现

GitHub Release 页面按资产文件名显示；gh release create 会并发上传，参数顺序不能保证页面顺序。本 PR 只把最终上传资产命名为 Codex.Taskboard_<version>_macOS-universal.dmg，并同步 SHA 清单与发布验证路径。

构建产物、签名、公证、stapling、updater 资产和应用版本号均未改变。下一正式发布仍按看板要求使用 v1.0.1。

## 验证

- 发布 workflow YAML 可解析
- 所有 DMG 发布资产引用使用同一新名称
- 内部构建与签名路径保持原名
- 未创建 tag，未触发真实发布