### PR TITLE
Fix embedded attachment downloads

### DIFF
--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -157,6 +157,9 @@ function fileSize(value: number): string {
 
 async function downloadAttachmentFile(attachment: Attachment) {
   const response = await fetch(resolveTaskboardUrl(attachmentDownloadUrl(attachment)));
+  if (!response.ok) {
+    throw new ApiError(response.status, await response.json().catch(() => ({})));
+  }
   const url = URL.createObjectURL(await response.blob());
   const link = document.createElement("a");
   link.href = url;

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent, type MouseEvent } from "react";
 import ReactMarkdown from "react-markdown";
 import { defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -13,6 +13,7 @@ import {
   listComments,
   listTaskActivities,
   markdownIncludesAttachment,
+  resolveTaskboardUrl,
   resolvePersistedAttachmentUrl,
   uploadAttachment,
   uploadCommentAttachment,
@@ -152,6 +153,18 @@ function fileSize(value: number): string {
   if (value < 1024) return `${value} B`;
   if (value < 1024 * 1024) return `${(value / 1024).toFixed(value < 10 * 1024 ? 1 : 0)} KB`;
   return `${(value / (1024 * 1024)).toFixed(value < 10 * 1024 * 1024 ? 1 : 0)} MB`;
+}
+
+async function downloadAttachmentFile(attachment: Attachment) {
+  const response = await fetch(resolveTaskboardUrl(attachmentDownloadUrl(attachment)));
+  const url = URL.createObjectURL(await response.blob());
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = attachment.filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
 }
 
 function contextValue(context: DevelopmentContext | null): string {
@@ -763,6 +776,14 @@ export function TaskDetail({
     }
   }
 
+  function handleAttachmentDownload(event: MouseEvent<HTMLAnchorElement>, attachment: Attachment) {
+    event.preventDefault();
+    setAttachmentsError(null);
+    void downloadAttachmentFile(attachment).catch((error) => {
+      setAttachmentsError(messageFor(error));
+    });
+  }
+
   const developmentOptions = [...developmentScan.contexts];
   if (
     currentTask.developmentContext
@@ -941,6 +962,7 @@ export function TaskDetail({
                         href={attachmentDownloadUrl(attachment)}
                         download={attachment.filename}
                         title={text(`下载 ${attachment.filename}`, `Download ${attachment.filename}`)}
+                        onClick={(event) => handleAttachmentDownload(event, attachment)}
                       >
                         <span className="attachment-file-icon" aria-hidden="true">
                           <LinearIcon name="file" />
@@ -956,6 +978,7 @@ export function TaskDetail({
                           download={attachment.filename}
                           aria-label={text(`下载 ${attachment.filename}`, `Download ${attachment.filename}`)}
                           title={text("下载附件", "Download attachment")}
+                          onClick={(event) => handleAttachmentDownload(event, attachment)}
                         >
                           <LinearIcon name="openExternal" />
                         </a>
@@ -1223,6 +1246,7 @@ export function TaskDetail({
                                   href={attachmentDownloadUrl(attachment)}
                                   download={attachment.filename}
                                   title={text(`下载 ${attachment.filename}`, `Download ${attachment.filename}`)}
+                                  onClick={(event) => handleAttachmentDownload(event, attachment)}
                                 >
                                   <span className="attachment-file-icon" aria-hidden="true">
                                     <LinearIcon name="file" />


### PR DESCRIPTION
## 改动

- 在议题附件入口阻止 sandbox iframe 的默认导航。
- 通过现有附件下载 API 获取 Blob，并在当前文档触发下载。
- 同时覆盖议题附件主入口、下载图标和评论附件入口。
- 下载响应为非 2xx 时，在 Blob 转换前解析错误体并抛出现有 ApiError。
- 错误体不是 JSON 时按现有 request() 语义收敛为 {}，由 ApiError 显示状态码消息。

## 根因

注入式 Taskboard 运行在 opaque sandbox iframe。附件链接虽然带有 download 属性，但 Chromium 会把本机下载 URL 当成 iframe 导航。iframe 的 load 事件随后把 frameReady 重置为 false，并显示“正在启动任务面板…”。

返工前，新的 fetch 下载路径没有检查 response.ok。404/500 会被转换为 Blob，并按原附件名保存；现有 attachmentsError/messageFor 不会执行。

## 直接验证

- npm run typecheck
- npm run build:web
- 在官方 ChatGPT.app 的真实 CDP 注入实例中打开 LOCAL-160，并用真实鼠标事件点击 image.png。
- 成功路径下载 185,919 字节，文件名为 image.png；Taskboard 子 iframe 导航事件为 0，host 保持面板可见。
- 在同一真实点击请求上返回非 JSON 500：页面显示“请求失败（500）”；Browser 下载事件为 0，下载目录前后不变，iframe 导航事件为 0。
- 点击“返回议题看板”成功，面板可继续使用。

## 基线同步

- 两个功能 commit 已机械 rebase 到 origin/main 5b6ad074f6202579016e63fd8748e4a2249c2ad5。
- range-diff 对两个 commit 都为 =，功能补丁未变。
- rebase 后再次通过 npm run typecheck 和 npm run build:web。

## 交付范围

- exact head：e25260e9c4d12d5deddaa7e911e4d867696f863a
- 本次返工只修改 web/src/components/TaskDetail.tsx 的 downloadAttachmentFile()。
- 未添加测试、状态机、兼容层、兜底或无关重构。