### PR TITLE
feat: 完善 Launcher 状态栏菜单和更新进度

### DIFF
--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -1569,6 +1569,23 @@ async function main() {
   let codexProcess = null;
   let cdpRuntime = null;
   const injectedTargets = new Map();
+  let openPending = false;
+  const requestTaskboardOpen = () => {
+    const connection = injectedTargets.values().next().value;
+    if (!connection) {
+      openPending = true;
+      return;
+    }
+    openPending = false;
+    connection.send("Runtime.evaluate", {
+      expression: "window.__codexTaskboardInjection__?.open()",
+      returnByValue: true,
+    }).catch((error) => {
+      openPending = true;
+      console.error(`Waiting to open Taskboard: ${error.message}`);
+    });
+  };
+  if (options.watch) process.on("SIGUSR2", requestTaskboardOpen);
   let stopping = false;
   let wakeStop;
   const stopRequested = new Promise((resolve) => {
@@ -1683,7 +1700,8 @@ async function main() {
     if (firstResults.length > 0) {
       console.log(JSON.stringify({ injected: firstResults }, null, 2));
     }
-    let openPending = options.open && firstResults.length === 0;
+    if (firstResults.length === 0 && options.open) openPending = true;
+    else if (openPending) requestTaskboardOpen();
     let idleAfterNormalExit = false;
 
     if (!options.watch) {
@@ -1801,6 +1819,7 @@ async function main() {
     if (options.watch) {
       process.removeListener("SIGINT", requestStop);
       process.removeListener("SIGTERM", requestStop);
+      process.removeListener("SIGUSR2", requestTaskboardOpen);
       await cleanup();
     }
   }

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -1569,23 +1569,43 @@ async function main() {
   let codexProcess = null;
   let cdpRuntime = null;
   const injectedTargets = new Map();
-  let openPending = false;
-  const requestTaskboardOpen = () => {
-    const connection = injectedTargets.values().next().value;
-    if (!connection) {
-      openPending = true;
-      return;
-    }
-    openPending = false;
-    connection.send("Runtime.evaluate", {
-      expression: "window.__codexTaskboardInjection__?.open()",
-      returnByValue: true,
-    }).catch((error) => {
-      openPending = true;
-      console.error(`Waiting to open Taskboard: ${error.message}`);
-    });
+  let openRequestGeneration = options.open ? 1 : 0;
+  let openedRequestGeneration = 0;
+  const hasOpenPending = () => openedRequestGeneration < openRequestGeneration;
+  const queueTaskboardOpen = () => {
+    openRequestGeneration += 1;
+    console.log(JSON.stringify({ openTaskboardSignalQueued: true }));
   };
-  if (options.watch) process.on("SIGUSR2", requestTaskboardOpen);
+  const requestTaskboardOpen = async () => {
+    const generation = openRequestGeneration;
+    if (generation <= openedRequestGeneration) return true;
+    const connection = injectedTargets.values().next().value;
+    if (!connection) return false;
+    try {
+      const evaluation = await connection.send("Runtime.evaluate", {
+        expression: `(() => {
+          const taskboard = window.__codexTaskboardInjection__;
+          if (typeof taskboard?.open !== "function") return false;
+          taskboard.open();
+          return true;
+        })()`,
+        returnByValue: true,
+      });
+      if (evaluation.result.value !== true) {
+        throw new Error("Taskboard injection is not ready");
+      }
+      await connection.send("Page.bringToFront");
+      openedRequestGeneration = Math.max(openedRequestGeneration, generation);
+      return true;
+    } catch (error) {
+      console.error(`Waiting to open Taskboard: ${error.message}`);
+      return false;
+    }
+  };
+  if (options.watch) {
+    process.on("SIGUSR2", queueTaskboardOpen);
+    console.log(JSON.stringify({ openTaskboardSignalReady: true }));
+  }
   let stopping = false;
   let wakeStop;
   const stopRequested = new Promise((resolve) => {
@@ -1680,12 +1700,14 @@ async function main() {
 
     const { source, sourceHash } = await currentInjectionSource();
     let firstResults = [];
+    const firstOpenGeneration = openRequestGeneration;
+    const shouldOpenFirstTarget = firstOpenGeneration > openedRequestGeneration;
     try {
       firstResults = await injectAll(
         cdpRuntime,
         source,
         sourceHash,
-        options.open,
+        shouldOpenFirstTarget,
         options.screenshot,
         injectedTargets,
         options.watch,
@@ -1698,10 +1720,14 @@ async function main() {
       console.error(`Waiting for Codex renderer: ${error.message}`);
     }
     if (firstResults.length > 0) {
+      if (shouldOpenFirstTarget) {
+        openedRequestGeneration = Math.max(openedRequestGeneration, firstOpenGeneration);
+      }
       console.log(JSON.stringify({ injected: firstResults }, null, 2));
     }
-    if (firstResults.length === 0 && options.open) openPending = true;
-    else if (openPending) requestTaskboardOpen();
+    if (hasOpenPending() && injectedTargets.size > 0) {
+      await requestTaskboardOpen();
+    }
     let idleAfterNormalExit = false;
 
     if (!options.watch) {
@@ -1729,13 +1755,24 @@ async function main() {
           await connection.hostBridge?.publishHeartbeat();
         } catch (_) {}
       }
-      if (idleAfterNormalExit) continue;
+      if (idleAfterNormalExit) {
+        if (!hasOpenPending()) continue;
+        try {
+          const launched = await launchCodexWithPipe(options.appPath);
+          codexProcess = launched.child;
+          cdpRuntime = pipeCdpRuntime(launched.browser);
+          idleAfterNormalExit = false;
+        } catch (restartError) {
+          console.error(`Waiting to restart Codex: ${restartError.message}`);
+          continue;
+        }
+      }
       try {
         const results = await injectAll(
           cdpRuntime,
           source,
           sourceHash,
-          openPending,
+          false,
           null,
           injectedTargets,
           true,
@@ -1744,8 +1781,10 @@ async function main() {
           options.startupToken,
         );
         if (results.length > 0) {
-          openPending = false;
           console.log(JSON.stringify({ injected: results }, null, 2));
+        }
+        if (hasOpenPending() && injectedTargets.size > 0) {
+          await requestTaskboardOpen();
         }
       } catch (error) {
         if (stopping) break;
@@ -1787,9 +1826,11 @@ async function main() {
           });
           injectedTargets.clear();
           cdpRuntime?.close();
+          cdpRuntime = null;
           const exitCode = codexProcess.exitCode;
           codexProcess = null;
           if (exitCode === 0) {
+            idleAfterNormalExit = true;
             console.error(
               "Waiting for Codex after normal exit; open Codex Taskboard again to restart it.",
             );
@@ -1806,7 +1847,7 @@ async function main() {
               await waitUntilReachable(cdpVersionUrl, 30_000);
               cdpRuntime = tcpCdpRuntime(options.port);
             }
-            openPending = options.open;
+            if (options.open) openRequestGeneration += 1;
           } catch (restartError) {
             console.error(`Waiting to restart Codex: ${restartError.message}`);
           }
@@ -1819,7 +1860,7 @@ async function main() {
     if (options.watch) {
       process.removeListener("SIGINT", requestStop);
       process.removeListener("SIGTERM", requestStop);
-      process.removeListener("SIGUSR2", requestTaskboardOpen);
+      process.removeListener("SIGUSR2", queueTaskboardOpen);
       await cleanup();
     }
   }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -86,6 +86,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +350,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-dialog",
  "tauri-plugin-updater",
  "uuid",
@@ -584,11 +596,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -599,7 +631,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -726,7 +758,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.4+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2448,6 +2480,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -3285,7 +3328,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -3335,7 +3378,7 @@ checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -3406,6 +3449,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "tauri-plugin-dialog"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3454,7 +3511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http",
@@ -3925,7 +3982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "045979e3f037cd18ad1cb2a419dfda133c5c29c9f3453370079f2255d46c257e"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -4765,6 +4822,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -4795,7 +4861,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,6 +13,7 @@ libc = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2.11.5", features = ["tray-icon"] }
+tauri-plugin-autostart = "2.5.1"
 tauri-plugin-dialog = "2.7.2"
 tauri-plugin-updater = "2.10.1"
 uuid = { version = "1", features = ["v4"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -16,10 +16,11 @@ use std::{
     time::{Duration, Instant},
 };
 use tauri::{
-    menu::{Menu, MenuItem},
+    menu::{CheckMenuItem, Menu, MenuItem},
     tray::TrayIconBuilder,
     ActivationPolicy, AppHandle, Emitter, Manager,
 };
+use tauri_plugin_autostart::{MacosLauncher, ManagerExt};
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 use tauri_plugin_updater::{Update, UpdaterExt};
 use uuid::Uuid;
@@ -51,6 +52,7 @@ struct LauncherPidRecord {
 struct LauncherState {
     child: Mutex<Option<u32>>,
     snapshot: Mutex<LauncherSnapshot>,
+    status_menu: Mutex<Option<MenuItem<tauri::Wry>>>,
     intentional_stop: AtomicBool,
     update_flow_in_progress: AtomicBool,
     update_in_progress: AtomicBool,
@@ -81,6 +83,7 @@ impl LauncherState {
                 app_path: None,
                 child_pid: None,
             }),
+            status_menu: Mutex::new(None),
             intentional_stop: AtomicBool::new(false),
             update_flow_in_progress: AtomicBool::new(false),
             update_in_progress: AtomicBool::new(false),
@@ -151,6 +154,14 @@ fn update_snapshot(
         update(&mut snapshot);
         snapshot.clone()
     };
+    if let Some(status_menu) = state.status_menu.lock().unwrap().as_ref() {
+        let status = match snapshot.phase.as_str() {
+            "running" => "运行状态：正常",
+            "error" => "运行状态：异常",
+            _ => "运行状态：启动中",
+        };
+        let _ = status_menu.set_text(status);
+    }
     let _ = app.emit("launcher-status", snapshot.clone());
     snapshot
 }
@@ -509,6 +520,30 @@ fn restart_launcher(
     result
 }
 
+fn open_taskboard(state: &LauncherState) -> Result<(), String> {
+    let pid = state
+        .child
+        .lock()
+        .unwrap()
+        .ok_or_else(|| "任务面板服务尚未启动".to_string())?;
+    if unsafe { libc::kill(pid as i32, libc::SIGUSR2) } != 0 {
+        return Err(std::io::Error::last_os_error().to_string());
+    }
+    let app_path = state
+        .snapshot
+        .lock()
+        .unwrap()
+        .app_path
+        .clone()
+        .ok_or_else(|| "无法定位 Codex App".to_string())?;
+    StdCommand::new("/usr/bin/open")
+        .arg("-a")
+        .arg(app_path)
+        .spawn()
+        .map_err(|error| error.to_string())?;
+    Ok(())
+}
+
 async fn check_for_startup_update(
     app: &AppHandle,
     state: &Arc<LauncherState>,
@@ -547,39 +582,46 @@ async fn install_update(
     app: &AppHandle,
     state: &Arc<LauncherState>,
     update: Update,
+    check_update: &MenuItem<tauri::Wry>,
 ) -> Result<(), String> {
     let update_version = update.version.clone();
-    update_snapshot(app, state, |snapshot| {
-        snapshot.update_message = format!("正在下载版本 {update_version}…");
+    state.update_in_progress.store(true, Ordering::SeqCst);
+    let snapshot = update_snapshot(app, state, |snapshot| {
+        snapshot.update_message = format!("正在下载 {update_version}…");
         snapshot.update_available = false;
     });
+    check_update.set_text(&snapshot.update_message).unwrap();
     let progress_app = app.clone();
     let progress_state = Arc::clone(state);
     let progress_version = update_version.clone();
+    let progress_menu = check_update.clone();
     let finish_app = app.clone();
     let finish_state = Arc::clone(state);
+    let finish_menu = check_update.clone();
     let mut downloaded = 0_u64;
     let bytes = match update
         .download(
             move |chunk_length, content_length| {
                 downloaded = downloaded.saturating_add(chunk_length as u64);
-                update_snapshot(&progress_app, &progress_state, |snapshot| {
+                let snapshot = update_snapshot(&progress_app, &progress_state, |snapshot| {
                     snapshot.update_message = match content_length.filter(|total| *total > 0) {
                         Some(total) => format!(
-                            "正在下载版本 {progress_version}：{}%",
+                            "正在下载 {progress_version} · {}%",
                             downloaded
                                 .saturating_mul(100)
                                 .saturating_div(total)
                                 .min(100)
                         ),
-                        None => format!("正在下载版本 {progress_version}…"),
+                        None => format!("正在下载 {progress_version}…"),
                     };
                 });
+                progress_menu.set_text(&snapshot.update_message).unwrap();
             },
             move || {
-                update_snapshot(&finish_app, &finish_state, |snapshot| {
-                    snapshot.update_message = "下载完成，正在验证更新签名…".into();
+                let snapshot = update_snapshot(&finish_app, &finish_state, |snapshot| {
+                    snapshot.update_message = "正在验证更新…".into();
                 });
+                finish_menu.set_text(&snapshot.update_message).unwrap();
             },
         )
         .await
@@ -587,23 +629,25 @@ async fn install_update(
         Ok(bytes) => bytes,
         Err(error) => {
             append_log(state, &format!("Update download failed: {error}"));
-            update_snapshot(app, state, |snapshot| {
+            state.update_in_progress.store(false, Ordering::SeqCst);
+            let snapshot = update_snapshot(app, state, |snapshot| {
                 snapshot.update_message = format!("更新下载或签名验证失败：{error}");
                 snapshot.update_available = true;
             });
+            check_update.set_text(&snapshot.update_message).unwrap();
             return Err(error.to_string());
         }
     };
 
-    update_snapshot(app, state, |snapshot| {
-        snapshot.update_message = "更新签名验证通过，正在安装…".into();
+    let snapshot = update_snapshot(app, state, |snapshot| {
+        snapshot.update_message = "正在安装更新…".into();
     });
+    check_update.set_text(&snapshot.update_message).unwrap();
     {
         let _lifecycle = state.lifecycle.lock().unwrap();
         if state.intentional_stop.load(Ordering::SeqCst) {
             return Err("App exit is in progress".into());
         }
-        state.update_in_progress.store(true, Ordering::SeqCst);
         stop_managed_child_locked(app, state);
     }
     if let Err(error) = update.install(&bytes) {
@@ -626,7 +670,7 @@ async fn install_update(
                 "Taskboard restarted after update installation failure",
             );
         }
-        update_snapshot(app, state, |snapshot| {
+        let snapshot = update_snapshot(app, state, |snapshot| {
             snapshot.update_message = format!("更新安装失败：{error}");
             snapshot.update_available = true;
             if let Some(restart_error) = &restart_error {
@@ -634,6 +678,7 @@ async fn install_update(
                 snapshot.message = format!("任务面板恢复失败：{restart_error}");
             }
         });
+        check_update.set_text(&snapshot.update_message).unwrap();
         return Err(error.to_string());
     }
 
@@ -641,21 +686,30 @@ async fn install_update(
         state,
         &format!("Installed update {update_version}; restarting"),
     );
-    update_snapshot(app, state, |snapshot| {
-        snapshot.update_message = format!("版本 {update_version} 已安装，正在重启…");
+    let snapshot = update_snapshot(app, state, |snapshot| {
+        snapshot.update_message = "正在重启…".into();
     });
+    check_update.set_text(&snapshot.update_message).unwrap();
     app.restart()
 }
 
-fn finish_update_flow(state: &LauncherState, check_update: &MenuItem<tauri::Wry>) {
+fn finish_update_flow(
+    state: &LauncherState,
+    check_update: &MenuItem<tauri::Wry>,
+    quit: &MenuItem<tauri::Wry>,
+) {
     state.update_flow_in_progress.store(false, Ordering::SeqCst);
+    state.update_in_progress.store(false, Ordering::SeqCst);
+    check_update.set_text("检查更新").unwrap();
     check_update.set_enabled(true).unwrap();
+    quit.set_enabled(true).unwrap();
 }
 
 async fn offer_update(
     app: &AppHandle,
     state: &Arc<LauncherState>,
     check_update: &MenuItem<tauri::Wry>,
+    quit: &MenuItem<tauri::Wry>,
     show_current_version: bool,
 ) {
     if state
@@ -677,7 +731,7 @@ async fn offer_update(
                     &format!("无法检查更新。请稍后重试。\n\n{error}"),
                 );
             }
-            finish_update_flow(state, check_update);
+            finish_update_flow(state, check_update, quit);
             return;
         }
     };
@@ -689,7 +743,7 @@ async fn offer_update(
                 .buttons(MessageDialogButtons::Ok)
                 .blocking_show();
         }
-        finish_update_flow(state, check_update);
+        finish_update_flow(state, check_update, quit);
         return;
     };
 
@@ -708,11 +762,12 @@ async fn offer_update(
         .blocking_show();
     if !install_now {
         append_log(state, &format!("Update {version} deferred by user"));
-        finish_update_flow(state, check_update);
+        finish_update_flow(state, check_update, quit);
         return;
     }
     append_log(state, &format!("Update {version} accepted by user"));
-    if let Err(error) = install_update(app, state, update).await {
+    quit.set_enabled(false).unwrap();
+    if let Err(error) = install_update(app, state, update, check_update).await {
         append_log(state, &format!("Update installation failed: {error}"));
         let service_recovered = state.snapshot.lock().unwrap().child_pid.is_some();
         let service_message = if service_recovered {
@@ -725,13 +780,17 @@ async fn offer_update(
             "Codex Taskboard 更新失败",
             &format!("更新未完成。{service_message}\n\n请稍后重试。详情见启动日志。\n\n{error}"),
         );
-        finish_update_flow(state, check_update);
+        finish_update_flow(state, check_update, quit);
     }
 }
 
 fn main() {
     let app = tauri::Builder::default()
         .enable_macos_default_menu(false)
+        .plugin(tauri_plugin_autostart::init(
+            MacosLauncher::LaunchAgent,
+            None,
+        ))
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {
@@ -759,18 +818,56 @@ fn main() {
             let state = Arc::new(LauncherState::new(
                 data_directory,
                 log_directory,
-                version,
+                version.clone(),
                 instance_lock,
             ));
             app.manage(state.clone());
 
+            let app_info = MenuItem::with_id(
+                app,
+                "app-info",
+                format!("{} - {version}", app.package_info().name),
+                false,
+                None::<&str>,
+            )?;
+            let launcher_status = MenuItem::with_id(
+                app,
+                "launcher-status",
+                "运行状态：启动中",
+                false,
+                None::<&str>,
+            )?;
+            *state.status_menu.lock().unwrap() = Some(launcher_status.clone());
+            let open_taskboard_item =
+                MenuItem::with_id(app, "open-taskboard", "打开任务面板", true, None::<&str>)?;
             let check_update =
                 MenuItem::with_id(app, "check-update", "检查更新", false, None::<&str>)?;
             let restart_codex =
-                MenuItem::with_id(app, "restart-codex", "重新启动 Codex", true, None::<&str>)?;
+                MenuItem::with_id(app, "restart-codex", "重新打开 Codex", true, None::<&str>)?;
+            let autostart = CheckMenuItem::with_id(
+                app,
+                "autostart",
+                "开机自启动",
+                true,
+                app.autolaunch().is_enabled()?,
+                None::<&str>,
+            )?;
             let quit = MenuItem::with_id(app, "quit", "退出", true, None::<&str>)?;
-            let tray_menu = Menu::with_items(app, &[&check_update, &restart_codex, &quit])?;
+            let tray_menu = Menu::with_items(
+                app,
+                &[
+                    &app_info,
+                    &launcher_status,
+                    &open_taskboard_item,
+                    &restart_codex,
+                    &check_update,
+                    &autostart,
+                    &quit,
+                ],
+            )?;
             let check_update_menu = check_update.clone();
+            let quit_menu = quit.clone();
+            let autostart_menu = autostart.clone();
             TrayIconBuilder::new()
                 .icon(tauri::include_image!("icons/tray-codex.png"))
                 .icon_as_template(true)
@@ -784,8 +881,26 @@ fn main() {
                         let state = Arc::clone(state.inner());
                         let app = app.clone();
                         let check_update = check_update_menu.clone();
+                        let quit = quit_menu.clone();
                         tauri::async_runtime::spawn(async move {
-                            offer_update(&app, &state, &check_update, true).await;
+                            offer_update(&app, &state, &check_update, &quit, true).await;
+                        });
+                    }
+                    "open-taskboard" => {
+                        let Some(state) = app.try_state::<Arc<LauncherState>>() else {
+                            return;
+                        };
+                        let state = Arc::clone(state.inner());
+                        let app = app.clone();
+                        tauri::async_runtime::spawn_blocking(move || {
+                            if let Err(error) = open_taskboard(&state) {
+                                append_log(&state, &format!("Launcher menu open failed: {error}"));
+                                show_error_dialog(
+                                    &app,
+                                    "Codex Taskboard 打开失败",
+                                    &format!("{error}\n\n请确认 Codex 正在运行。"),
+                                );
+                            }
                         });
                     }
                     "restart-codex" => {
@@ -808,6 +923,24 @@ fn main() {
                             }
                         });
                     }
+                    "autostart" => {
+                        let manager = app.autolaunch();
+                        let result = manager.is_enabled().and_then(|enabled| {
+                            if enabled {
+                                manager.disable().map(|_| false)
+                            } else {
+                                manager.enable().map(|_| true)
+                            }
+                        });
+                        match result {
+                            Ok(enabled) => autostart_menu.set_checked(enabled).unwrap(),
+                            Err(error) => show_error_dialog(
+                                app,
+                                "Codex Taskboard 自启动设置失败",
+                                &error.to_string(),
+                            ),
+                        }
+                    }
                     "quit" => {
                         let Some(state) = app.try_state::<Arc<LauncherState>>() else {
                             return;
@@ -827,18 +960,21 @@ fn main() {
             let periodic_update_app = app.handle().clone();
             let periodic_update_state = Arc::clone(&state);
             let periodic_check_update = check_update.clone();
+            let periodic_quit = quit.clone();
             thread::spawn(move || loop {
                 thread::sleep(UPDATE_CHECK_INTERVAL);
                 let app_handle = periodic_update_app.clone();
                 let state = Arc::clone(&periodic_update_state);
                 let check_update = periodic_check_update.clone();
+                let quit = periodic_quit.clone();
                 tauri::async_runtime::spawn(async move {
-                    offer_update(&app_handle, &state, &check_update, false).await;
+                    offer_update(&app_handle, &state, &check_update, &quit, false).await;
                 });
             });
 
             let app_handle = app.handle().clone();
             let startup_check_update = check_update.clone();
+            let startup_quit = quit.clone();
             tauri::async_runtime::spawn(async move {
                 if let Err(error) = start_launcher(&app_handle, &state) {
                     append_log(&state, &format!("Launcher startup failed: {error}"));
@@ -854,7 +990,14 @@ fn main() {
                         ),
                     );
                 }
-                offer_update(&app_handle, &state, &startup_check_update, false).await;
+                offer_update(
+                    &app_handle,
+                    &state,
+                    &startup_check_update,
+                    &startup_quit,
+                    false,
+                )
+                .await;
             });
             Ok(())
         })

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -554,7 +554,7 @@ fn start_launcher_locked(
             return;
         }
         thread::sleep(Duration::from_secs(2));
-        let recovery_result = {
+        let (recovery_result, recovery_generation) = {
             let _lifecycle = event_state.lifecycle.lock().unwrap();
             if event_state.generation.load(Ordering::SeqCst) != recovery_token
                 || event_state.intentional_stop.load(Ordering::SeqCst)
@@ -562,13 +562,20 @@ fn start_launcher_locked(
             {
                 return;
             }
-            start_launcher_locked(&event_app, &event_state)
+            let result = start_launcher_locked(&event_app, &event_state);
+            let generation = event_state.generation.load(Ordering::SeqCst);
+            (result, generation)
         };
         if let Err(error) = recovery_result {
             append_log(&event_state, &format!("Launcher recovery failed: {error}"));
             update_snapshot(&event_app, &event_state, |snapshot| {
-                snapshot.phase = "error".into();
-                snapshot.message = error.clone();
+                if event_state.generation.load(Ordering::SeqCst) == recovery_generation
+                    && snapshot.child_pid.is_none()
+                {
+                    snapshot.phase = "error".into();
+                    snapshot.message = error.clone();
+                    snapshot.open_signal_pid = None;
+                }
             });
             show_error_dialog(
                 &event_app,
@@ -594,7 +601,7 @@ fn restart_launcher(
     app: &AppHandle,
     state: &Arc<LauncherState>,
 ) -> Result<LauncherSnapshot, String> {
-    let result = {
+    let (result, result_generation) = {
         let _lifecycle = state.lifecycle.lock().unwrap();
         if state.intentional_stop.load(Ordering::SeqCst) {
             return Ok(state.snapshot.lock().unwrap().clone());
@@ -608,15 +615,19 @@ fn restart_launcher(
         if result.is_err() {
             state.intentional_stop.store(false, Ordering::SeqCst);
         }
-        result
+        let generation = state.generation.load(Ordering::SeqCst);
+        (result, generation)
     };
     if let Err(error) = &result {
         let error = error.clone();
         update_snapshot(app, state, |snapshot| {
-            snapshot.phase = "error".into();
-            snapshot.message = format!("任务面板启动失败：{error}");
-            snapshot.child_pid = None;
-            snapshot.open_signal_pid = None;
+            if state.generation.load(Ordering::SeqCst) == result_generation
+                && snapshot.child_pid.is_none()
+            {
+                snapshot.phase = "error".into();
+                snapshot.message = format!("任务面板启动失败：{error}");
+                snapshot.open_signal_pid = None;
+            }
         });
     }
     result

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -39,6 +39,8 @@ struct LauncherSnapshot {
     version: String,
     app_path: Option<String>,
     child_pid: Option<u32>,
+    open_signal_pid: Option<u32>,
+    open_request_pending: bool,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -82,6 +84,8 @@ impl LauncherState {
                 version,
                 app_path: None,
                 child_pid: None,
+                open_signal_pid: None,
+                open_request_pending: false,
             }),
             status_menu: Mutex::new(None),
             intentional_stop: AtomicBool::new(false),
@@ -154,13 +158,17 @@ fn update_snapshot(
         update(&mut snapshot);
         snapshot.clone()
     };
-    if let Some(status_menu) = state.status_menu.lock().unwrap().as_ref() {
+    let status_menu = state.status_menu.lock().unwrap().clone();
+    if let Some(status_menu) = status_menu {
         let status = match snapshot.phase.as_str() {
             "running" => "运行状态：正常",
             "error" => "运行状态：异常",
             _ => "运行状态：启动中",
-        };
-        let _ = status_menu.set_text(status);
+        }
+        .to_string();
+        let _ = app.run_on_main_thread(move || {
+            let _ = status_menu.set_text(status);
+        });
     }
     let _ = app.emit("launcher-status", snapshot.clone());
     snapshot
@@ -206,6 +214,21 @@ fn send_process_group_signal(pid: u32, signal: i32) {
 
 fn process_group_is_running(pid: u32) -> bool {
     unsafe { libc::kill(-(pid as i32), 0) == 0 }
+}
+
+fn signal_pending_taskboard_open(state: &LauncherState) -> Result<(), String> {
+    let mut snapshot = state.snapshot.lock().unwrap();
+    if !snapshot.open_request_pending {
+        return Ok(());
+    }
+    let Some(pid) = snapshot.open_signal_pid else {
+        return Ok(());
+    };
+    if unsafe { libc::kill(pid as i32, libc::SIGUSR2) } != 0 {
+        snapshot.open_signal_pid = None;
+        return Err(std::io::Error::last_os_error().to_string());
+    }
+    Ok(())
 }
 
 fn wait_for_process_group_exit(pid: u32, timeout: Duration) -> bool {
@@ -286,6 +309,7 @@ fn stop_managed_child_locked(app: &AppHandle, state: &Arc<LauncherState>) {
         snapshot.phase = "stopped".into();
         snapshot.message = "任务面板已停止。".into();
         snapshot.child_pid = None;
+        snapshot.open_signal_pid = None;
     });
 }
 
@@ -299,6 +323,8 @@ fn watch_launcher_output<R: std::io::Read + Send + 'static>(
     is_stderr: bool,
     app: AppHandle,
     state: Arc<LauncherState>,
+    pid: u32,
+    generation: u64,
 ) {
     thread::spawn(move || {
         for line in BufReader::new(reader).lines().map_while(Result::ok) {
@@ -313,6 +339,26 @@ fn watch_launcher_output<R: std::io::Read + Send + 'static>(
                     snapshot.phase = "starting".into();
                     snapshot.message = "任务面板服务已启动，正在注入 Codex…".into();
                 });
+            } else if !is_stderr && line.contains("\"openTaskboardSignalReady\":true") {
+                if state.generation.load(Ordering::SeqCst) == generation {
+                    let snapshot = update_snapshot(&app, &state, |snapshot| {
+                        if state.generation.load(Ordering::SeqCst) == generation {
+                            snapshot.open_signal_pid = Some(pid);
+                        }
+                    });
+                    if snapshot.open_signal_pid == Some(pid) {
+                        if let Err(error) = signal_pending_taskboard_open(&state) {
+                            append_log(&state, &format!("Taskboard open signal failed: {error}"));
+                        }
+                    }
+                }
+            } else if !is_stderr && line.contains("\"openTaskboardSignalQueued\":true") {
+                let mut snapshot = state.snapshot.lock().unwrap();
+                if state.generation.load(Ordering::SeqCst) == generation
+                    && snapshot.open_signal_pid == Some(pid)
+                {
+                    snapshot.open_request_pending = false;
+                }
             } else if !is_stderr && line.contains("\"injected\"") {
                 update_snapshot(&app, &state, |snapshot| {
                     snapshot.phase = "running".into();
@@ -353,6 +399,7 @@ fn start_launcher_locked(
         snapshot.phase = "starting".into();
         snapshot.message = "正在启动任务面板服务…".into();
         snapshot.app_path = Some(codex_app.display().to_string());
+        snapshot.open_signal_pid = None;
     });
 
     let path_value = format!(
@@ -427,10 +474,10 @@ fn start_launcher_locked(
         ),
     );
     if let Some(stdout) = stdout {
-        watch_launcher_output(stdout, false, app.clone(), state.clone());
+        watch_launcher_output(stdout, false, app.clone(), state.clone(), pid, generation);
     }
     if let Some(stderr) = stderr {
-        watch_launcher_output(stderr, true, app.clone(), state.clone());
+        watch_launcher_output(stderr, true, app.clone(), state.clone(), pid, generation);
     }
 
     let event_app = app.clone();
@@ -455,6 +502,7 @@ fn start_launcher_locked(
         let intentional = event_state.intentional_stop.load(Ordering::SeqCst);
         update_snapshot(&event_app, &event_state, |snapshot| {
             snapshot.child_pid = None;
+            snapshot.open_signal_pid = None;
             if !intentional {
                 snapshot.phase = "error".into();
                 snapshot.message = "任务面板进程已退出，正在恢复…".into();
@@ -521,27 +569,8 @@ fn restart_launcher(
 }
 
 fn open_taskboard(state: &LauncherState) -> Result<(), String> {
-    let pid = state
-        .child
-        .lock()
-        .unwrap()
-        .ok_or_else(|| "任务面板服务尚未启动".to_string())?;
-    if unsafe { libc::kill(pid as i32, libc::SIGUSR2) } != 0 {
-        return Err(std::io::Error::last_os_error().to_string());
-    }
-    let app_path = state
-        .snapshot
-        .lock()
-        .unwrap()
-        .app_path
-        .clone()
-        .ok_or_else(|| "无法定位 Codex App".to_string())?;
-    StdCommand::new("/usr/bin/open")
-        .arg("-a")
-        .arg(app_path)
-        .spawn()
-        .map_err(|error| error.to_string())?;
-    Ok(())
+    state.snapshot.lock().unwrap().open_request_pending = true;
+    signal_pending_taskboard_open(state)
 }
 
 async fn check_for_startup_update(
@@ -698,11 +727,11 @@ fn finish_update_flow(
     check_update: &MenuItem<tauri::Wry>,
     quit: &MenuItem<tauri::Wry>,
 ) {
-    state.update_flow_in_progress.store(false, Ordering::SeqCst);
     state.update_in_progress.store(false, Ordering::SeqCst);
     check_update.set_text("检查更新").unwrap();
     check_update.set_enabled(true).unwrap();
     quit.set_enabled(true).unwrap();
+    state.update_flow_in_progress.store(false, Ordering::SeqCst);
 }
 
 async fn offer_update(
@@ -844,12 +873,13 @@ fn main() {
                 MenuItem::with_id(app, "check-update", "检查更新", false, None::<&str>)?;
             let restart_codex =
                 MenuItem::with_id(app, "restart-codex", "重新打开 Codex", true, None::<&str>)?;
+            let autostart_enabled = app.autolaunch().is_enabled()?;
             let autostart = CheckMenuItem::with_id(
                 app,
                 "autostart",
                 "开机自启动",
                 true,
-                app.autolaunch().is_enabled()?,
+                autostart_enabled,
                 None::<&str>,
             )?;
             let quit = MenuItem::with_id(app, "quit", "退出", true, None::<&str>)?;
@@ -868,6 +898,7 @@ fn main() {
             let check_update_menu = check_update.clone();
             let quit_menu = quit.clone();
             let autostart_menu = autostart.clone();
+            let autostart_confirmed = Arc::new(AtomicBool::new(autostart_enabled));
             TrayIconBuilder::new()
                 .icon(tauri::include_image!("icons/tray-codex.png"))
                 .icon_as_template(true)
@@ -925,20 +956,35 @@ fn main() {
                     }
                     "autostart" => {
                         let manager = app.autolaunch();
-                        let result = manager.is_enabled().and_then(|enabled| {
-                            if enabled {
-                                manager.disable().map(|_| false)
-                            } else {
-                                manager.enable().map(|_| true)
+                        let previous = autostart_confirmed.load(Ordering::SeqCst);
+                        let mut confirmed_before = previous;
+                        let operation_error = match manager.is_enabled() {
+                            Ok(enabled) => {
+                                confirmed_before = enabled;
+                                autostart_confirmed.store(enabled, Ordering::SeqCst);
+                                let result = if enabled {
+                                    manager.disable()
+                                } else {
+                                    manager.enable()
+                                };
+                                result.err().map(|error| error.to_string())
                             }
-                        });
-                        match result {
-                            Ok(enabled) => autostart_menu.set_checked(enabled).unwrap(),
-                            Err(error) => show_error_dialog(
-                                app,
-                                "Codex Taskboard 自启动设置失败",
-                                &error.to_string(),
-                            ),
+                            Err(error) => Some(error.to_string()),
+                        };
+                        let sync_error = match manager.is_enabled() {
+                            Ok(enabled) => {
+                                autostart_confirmed.store(enabled, Ordering::SeqCst);
+                                autostart_menu.set_checked(enabled).unwrap();
+                                None
+                            }
+                            Err(error) => {
+                                autostart_menu.set_checked(confirmed_before).unwrap();
+                                autostart_confirmed.store(confirmed_before, Ordering::SeqCst);
+                                Some(error.to_string())
+                            }
+                        };
+                        if let Some(error) = operation_error.or(sync_error) {
+                            show_error_dialog(app, "Codex Taskboard 自启动设置失败", &error);
                         }
                     }
                     "quit" => {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -160,13 +160,16 @@ fn update_snapshot(
     };
     let status_menu = state.status_menu.lock().unwrap().clone();
     if let Some(status_menu) = status_menu {
-        let status = match snapshot.phase.as_str() {
-            "running" => "运行状态：正常",
-            "error" => "运行状态：异常",
-            _ => "运行状态：启动中",
-        }
-        .to_string();
+        let status_state = Arc::clone(state);
         let _ = app.run_on_main_thread(move || {
+            let status = {
+                let snapshot = status_state.snapshot.lock().unwrap();
+                match snapshot.phase.as_str() {
+                    "running" => "运行状态：正常",
+                    "error" => "运行状态：异常",
+                    _ => "运行状态：启动中",
+                }
+            };
             let _ = status_menu.set_text(status);
         });
     }
@@ -331,38 +334,51 @@ fn watch_launcher_output<R: std::io::Read + Send + 'static>(
             append_log(&state, &line);
             if is_stderr && line.contains("Waiting for Codex") {
                 update_snapshot(&app, &state, |snapshot| {
-                    snapshot.phase = "starting".into();
-                    snapshot.message = "正在等待 Codex 窗口…".into();
+                    if state.generation.load(Ordering::SeqCst) == generation
+                        && snapshot.child_pid == Some(pid)
+                    {
+                        snapshot.phase = "starting".into();
+                        snapshot.message = "正在等待 Codex 窗口…".into();
+                    }
                 });
             } else if !is_stderr && line.contains("Codex Taskboard listening") {
                 update_snapshot(&app, &state, |snapshot| {
-                    snapshot.phase = "starting".into();
-                    snapshot.message = "任务面板服务已启动，正在注入 Codex…".into();
+                    if state.generation.load(Ordering::SeqCst) == generation
+                        && snapshot.child_pid == Some(pid)
+                    {
+                        snapshot.phase = "starting".into();
+                        snapshot.message = "任务面板服务已启动，正在注入 Codex…".into();
+                    }
                 });
             } else if !is_stderr && line.contains("\"openTaskboardSignalReady\":true") {
-                if state.generation.load(Ordering::SeqCst) == generation {
-                    let snapshot = update_snapshot(&app, &state, |snapshot| {
-                        if state.generation.load(Ordering::SeqCst) == generation {
-                            snapshot.open_signal_pid = Some(pid);
-                        }
-                    });
-                    if snapshot.open_signal_pid == Some(pid) {
-                        if let Err(error) = signal_pending_taskboard_open(&state) {
-                            append_log(&state, &format!("Taskboard open signal failed: {error}"));
-                        }
+                let snapshot = update_snapshot(&app, &state, |snapshot| {
+                    if state.generation.load(Ordering::SeqCst) == generation
+                        && snapshot.child_pid == Some(pid)
+                    {
+                        snapshot.open_signal_pid = Some(pid);
+                    }
+                });
+                if snapshot.child_pid == Some(pid) && snapshot.open_signal_pid == Some(pid) {
+                    if let Err(error) = signal_pending_taskboard_open(&state) {
+                        append_log(&state, &format!("Taskboard open signal failed: {error}"));
                     }
                 }
             } else if !is_stderr && line.contains("\"openTaskboardSignalQueued\":true") {
                 let mut snapshot = state.snapshot.lock().unwrap();
                 if state.generation.load(Ordering::SeqCst) == generation
+                    && snapshot.child_pid == Some(pid)
                     && snapshot.open_signal_pid == Some(pid)
                 {
                     snapshot.open_request_pending = false;
                 }
             } else if !is_stderr && line.contains("\"injected\"") {
                 update_snapshot(&app, &state, |snapshot| {
-                    snapshot.phase = "running".into();
-                    snapshot.message = "任务面板已在 Codex 客户端中打开。".into();
+                    if state.generation.load(Ordering::SeqCst) == generation
+                        && snapshot.child_pid == Some(pid)
+                    {
+                        snapshot.phase = "running".into();
+                        snapshot.message = "任务面板已在 Codex 客户端中打开。".into();
+                    }
                 });
             }
         }
@@ -484,37 +500,63 @@ fn start_launcher_locked(
     let event_state = state.clone();
     thread::spawn(move || {
         let status = child.wait();
+        let recovery_token = {
+            let mut current_child = event_state.child.lock().unwrap();
+            if *current_child != Some(pid) {
+                None
+            } else {
+                let recovery_token = generation + 1;
+                if event_state
+                    .generation
+                    .compare_exchange(
+                        generation,
+                        recovery_token,
+                        Ordering::SeqCst,
+                        Ordering::SeqCst,
+                    )
+                    .is_ok()
+                {
+                    *current_child = None;
+                    Some(recovery_token)
+                } else {
+                    None
+                }
+            }
+        };
+        let Some(recovery_token) = recovery_token else {
+            append_log(
+                &event_state,
+                &format!("Launcher child {pid} exited: {status:?}"),
+            );
+            terminate_process_group(pid);
+            return;
+        };
+        let intentional = event_state.intentional_stop.load(Ordering::SeqCst);
+        update_snapshot(&event_app, &event_state, |snapshot| {
+            if event_state.generation.load(Ordering::SeqCst) == recovery_token
+                && snapshot.child_pid == Some(pid)
+            {
+                snapshot.child_pid = None;
+                snapshot.open_signal_pid = None;
+                if !intentional {
+                    snapshot.phase = "error".into();
+                    snapshot.message = "任务面板进程已退出，正在恢复…".into();
+                }
+            }
+        });
         append_log(
             &event_state,
             &format!("Launcher child {pid} exited: {status:?}"),
         );
         terminate_process_group(pid);
-        if event_state.generation.load(Ordering::SeqCst) != generation {
-            return;
-        }
-        let mut current_child = event_state.child.lock().unwrap();
-        if *current_child != Some(pid) {
-            return;
-        }
-        *current_child = None;
-        drop(current_child);
         clear_pid_record(&event_state, pid);
-        let intentional = event_state.intentional_stop.load(Ordering::SeqCst);
-        update_snapshot(&event_app, &event_state, |snapshot| {
-            snapshot.child_pid = None;
-            snapshot.open_signal_pid = None;
-            if !intentional {
-                snapshot.phase = "error".into();
-                snapshot.message = "任务面板进程已退出，正在恢复…".into();
-            }
-        });
         if intentional {
             return;
         }
         thread::sleep(Duration::from_secs(2));
         let recovery_result = {
             let _lifecycle = event_state.lifecycle.lock().unwrap();
-            if event_state.generation.load(Ordering::SeqCst) != generation
+            if event_state.generation.load(Ordering::SeqCst) != recovery_token
                 || event_state.intentional_stop.load(Ordering::SeqCst)
                 || event_state.update_in_progress.load(Ordering::SeqCst)
             {
@@ -552,18 +594,30 @@ fn restart_launcher(
     app: &AppHandle,
     state: &Arc<LauncherState>,
 ) -> Result<LauncherSnapshot, String> {
-    let _lifecycle = state.lifecycle.lock().unwrap();
-    if state.intentional_stop.load(Ordering::SeqCst) {
-        return Ok(state.snapshot.lock().unwrap().clone());
-    }
-    if state.update_in_progress.load(Ordering::SeqCst) {
-        append_log(state, "Launcher reopen ignored during update installation");
-        return Ok(state.snapshot.lock().unwrap().clone());
-    }
-    stop_managed_child_locked(app, state);
-    let result = start_launcher_locked(app, state);
-    if result.is_err() {
-        state.intentional_stop.store(false, Ordering::SeqCst);
+    let result = {
+        let _lifecycle = state.lifecycle.lock().unwrap();
+        if state.intentional_stop.load(Ordering::SeqCst) {
+            return Ok(state.snapshot.lock().unwrap().clone());
+        }
+        if state.update_in_progress.load(Ordering::SeqCst) {
+            append_log(state, "Launcher reopen ignored during update installation");
+            return Ok(state.snapshot.lock().unwrap().clone());
+        }
+        stop_managed_child_locked(app, state);
+        let result = start_launcher_locked(app, state);
+        if result.is_err() {
+            state.intentional_stop.store(false, Ordering::SeqCst);
+        }
+        result
+    };
+    if let Err(error) = &result {
+        let error = error.clone();
+        update_snapshot(app, state, |snapshot| {
+            snapshot.phase = "error".into();
+            snapshot.message = format!("任务面板启动失败：{error}");
+            snapshot.child_pid = None;
+            snapshot.open_signal_pid = None;
+        });
     }
     result
 }
@@ -749,10 +803,15 @@ async fn offer_update(
         return;
     }
     check_update.set_enabled(false).unwrap();
+    check_update.set_text("正在检查更新…").unwrap();
     let update = match check_for_startup_update(app, state).await {
         Ok(update) => update,
         Err(error) => {
             append_log(state, &format!("Update check failed: {error}"));
+            update_snapshot(app, state, |snapshot| {
+                snapshot.update_message = format!("更新检查失败：{error}");
+                snapshot.update_available = false;
+            });
             if show_current_version {
                 show_error_dialog(
                     app,


### PR DESCRIPTION
## 改动

- 按要求重排 Launcher 状态栏菜单，显示 App 名称、当前版本和实时运行状态。
- 增加“打开任务面板”命令，复用常驻 injector 的 CDP 连接调用现有任务面板 `open()`。
- 增加真实的“开机自启动”勾选项，使用 Tauri 官方 autostart 插件读取和切换登录项。
- 将 `LauncherSnapshot.update_message` 显示在禁用的更新菜单项中，覆盖下载版本与百分比、验证、安装和重启阶段。
- 用户确认更新后禁用“检查更新”和“退出”；失败时沿用现有错误弹窗并恢复菜单。

## Pro 审核返工

- 菜单状态更新只在锁内克隆菜单句柄，再用 `run_on_main_thread` 异步改文字，消除 lifecycle 锁与主线程菜单调用的反向等待。
- 打开请求、ready PID 和 child generation 使用同一快照锁。Node 注册 SIGUSR2 handler 后才发 ready；收到信号后发 queued ack。Rust 只在 PID 和 generation 仍匹配时清 pending。
- injector 用递增 generation 记录打开请求。首次注入只消费捕获的 generation；常驻循环只在 `Runtime.evaluate` 和 `Page.bringToFront` 都成功后消费请求。临时 evaluate 失败会在下一轮重试。
- Codex 正常退出后，pending 请求只通过 `launchCodexWithPipe` 重建受管实例。菜单链不再调用 `open -a`，不会启动非 pipe 实例。
- `finish_update_flow` 先恢复共享状态和菜单，最后才释放 `update_flow_in_progress` 所有权。
- 自启动操作后总是重新读取真实状态并同步勾选；最终读取失败时恢复操作前确认值，再显示原有错误弹窗。

## 已修复的确定交错

1. 旧实现可能在 `swap(false)` 后遇到 ready，再把 pending 写回 true，导致永久丢唤醒。现在 pending 在 queued ack 前保持为 true。
2. 旧 child 的迟到 ready 可能把新 child 误标为 ready。现在 watcher 固定绑定 PID 和 generation。
3. 已有 target 时，新 target 的注入结果可能误清尚未执行的打开请求。现在常驻注入结果不再推进打开 generation。
4. `open -a` 在 evaluate 后目标退出时可能启动非 pipe Codex。该启动路径已移除。

## 直接验证

- 预排队打开请求后启动：日志顺序为 ready → queued；injector PID 79069 保持存活。
- 首次注入期间强制一次 evaluate 失败：请求未丢；下一轮成功消费 generation 2。
- 受管 Codex 正常退出后，injector PID 79069 保持存活；再次发请求后启动新 Codex PID 79752，父进程仍为 79069，启动参数含 `--remote-debugging-pipe`。
- 重启后的首次注入未误消费请求；随后 `Runtime.evaluate` 与 `Page.bringToFront` 成功后消费 generation 3。
- 所有临时诊断改动已恢复。最终源码和 App 产物不含诊断标记。
- Rust 1.88 `cargo check` 通过。
- `cargo fmt -- --check` 通过。
- `node --check scripts/codex-injector.mjs` 通过。
- `npm run app:prepare -- --target x86_64-apple-darwin` 通过。
- 未签名 x86_64 debug App 构建通过；产物仍为 0.2.3 且 `LSUIElement=true`。
- 按项目规则未新增测试。

## 基线同步

- 已 fetch 并 rebase 到 `origin/main@5de72b9aa8b1e7ea10ca00e597fac0f1c60cd104`。
- rebase 后基线 head：`91a292eb9f8a1f04c7b1b99be486db63c8587a67`。
- `range-diff`：
  - `5688deb = 5c5de6e feat: complete launcher status menu`
  - `0034041 = 91a292e fix: close launcher menu review races`
- 两条功能提交均为 `=`。rebase 无冲突，提交内容未变化。
- 已用精确旧 head 的 `--force-with-lease` 更新同一 PR 分支。

## 第二轮 Pro 复审返工

- 状态菜单 closure 在主线程执行时重新读取当前 `state.snapshot.phase`，不再使用派发前的旧文字。
- Waiting、listening、injected、ready、queued 五个 watcher 分支都在 snapshot 锁内同时校验 watcher generation 和 child PID。
- child wait 确认当前 PID 后立即用 `compare_exchange` 失效旧 generation，并保存 recovery token；两秒恢复只接受该 token。
- 更新检查 CAS 成功后立即显示禁用的“正在检查更新…”；检查异常写入终态 `update_message`，再由原 finish 路径恢复菜单。
- restart 的 start 失败时，先释放 lifecycle，再提交 `phase=error` 和启动错误。
- 本轮只改 `src-tauri/src/main.rs`。未改 Node，未新增测试、状态机或双故障处理。
- 新 head：`4a27e5594aac0b05817c74679965118faef83b37`。
- 确定性交错验证结果：延迟 running closure 最终为“运行状态：异常”；五类旧 watcher 行均被拒绝；死 PID 信号数为 0；recovery generation 进入 running；更新失败保留终态并恢复菜单；restart 终态为 error。
- Rust 1.88 `cargo check`、`cargo fmt -- --check`、`git diff --check`、Node syntax check 和未签名 x86_64 debug App 构建均通过。

## 第三轮 Pro 复审返工

- restart 在 lifecycle 内记录 start 返回后的 generation；锁外仅在 generation 未变且 `snapshot.child_pid.is_none()` 时提交错误。
- 自动 recovery 使用同一所有权条件。
- 迟到失败不再清除 `child_pid`；只在仍拥有失败 generation 时清 `open_signal_pid`。
- 新成功启动超越旧失败时，旧失败不修改 snapshot；独立失败仍写入 error。
- 本轮只改 `src-tauri/src/main.rs`：21 additions、10 deletions。
- exact head：`7ad945f2a4c4e148736baff31cb477c21c49f278`。
- 确定性交错结果：迟到 restart 失败保留 child 502/running；迟到 recovery 失败保留 child 602/running；两种独立失败均进入 error。
- Rust 1.88 `cargo check`、`cargo fmt -- --check`、`git diff --check` 和未签名 x86_64 debug App 构建通过。

## CI

- exact head `4a27e5594aac0b05817c74679965118faef83b37` 的 GitHub Actions [run #356](https://github.com/chuspeeism/dashi-taskboard/actions/runs/31522307444) 完成并通过。
- `check`：success。首次尝试的唯一失败是已知 iframe 握手波动；原生重跑成功，未改代码或测试。
- `macOS launcher`：success；universal App bundle、打包 taskctl、继承监听器和无密钥更新预检均通过。

## 影响

- 保持状态栏 App 形态。
- 不增加主窗口或 Dock 图标。
- 不增加新的更新流程。
- 不修改应用版本号。

## 已知限制

- LSUIElement 状态栏菜单无法由当前 UI 自动化工具定位。本轮用真实进程、信号、CDP 和日志验证打开链；菜单视觉点击由根会话继续复核。
- 自启动勾选失败恢复和更新流程所有权顺序完成源码路径核对与编译验证；本轮未改系统登录项，也未连接真实更新服务器。