### PR TITLE
Fix issue Markdown image editing and soft line breaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,9 @@
         "react-dom": "^19.2.7",
         "react-markdown": "^10.1.0",
         "remark-breaks": "^4.0.0",
-        "remark-gfm": "^4.0.1"
+        "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "unified": "^11.0.5"
       },
       "bin": {
         "taskctl": "cli/taskctl.mjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@lobehub/icons-static-svg": "^1.94.0",
         "@xyflow/react": "^12.11.2",
         "dhtmlx-gantt": "^10.0.0",
+        "mdast-util-definitions": "^6.0.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-markdown": "^10.1.0",
@@ -3186,6 +3187,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-definitions": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
+      "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdast-util-find-and-replace": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-markdown": "^10.1.0",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1"
       },
       "bin": {
@@ -3386,6 +3387,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -4208,6 +4223,21 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-markdown": "^10.1.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@lobehub/icons-static-svg": "^1.94.0",
     "@xyflow/react": "^12.11.2",
     "dhtmlx-gantt": "^10.0.0",
+    "mdast-util-definitions": "^6.0.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-markdown": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "react-dom": "^19.2.7",
     "react-markdown": "^10.1.0",
     "remark-breaks": "^4.0.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "unified": "^11.0.5"
   },
   "devDependencies": {
     "@tauri-apps/cli": "2.11.4",

--- a/test/issue-detail-markdown.test.mjs
+++ b/test/issue-detail-markdown.test.mjs
@@ -25,7 +25,7 @@ test("issue detail renders descriptions and comments with GFM markdown", () => {
   assert.match(detailSource, /import remarkGfm from "remark-gfm";/);
   assert.match(
     detailSource,
-    /<ReactMarkdown[\s\S]*remarkPlugins=\{\[remarkGfm\]\}[\s\S]*>\s*\{value\}\s*<\/ReactMarkdown>/,
+    /<ReactMarkdown[\s\S]*remarkPlugins=\{\[remarkGfm, remarkBreaks\]\}[\s\S]*>\s*\{value\}\s*<\/ReactMarkdown>/,
   );
   assert.match(
     detailSource,

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -8,7 +8,7 @@ import {
   type KeyboardEventHandler,
 } from "react";
 import type { Attachment } from "../types";
-import { attachmentContentUrl } from "../api";
+import { attachmentContentUrl, resolvePersistedAttachmentUrl } from "../api";
 import { useTaskboardI18n } from "../i18n";
 import { clipboardImages, fileKey, MAX_ATTACHMENT_SIZE } from "./PendingAttachments";
 import { LinearIcon } from "./LinearIcon";
@@ -26,7 +26,15 @@ interface InlineImageSegment {
   file: File;
 }
 
-export type InlineMediaSegment = InlineTextSegment | InlineImageSegment;
+interface PersistedImageSegment {
+  id: string;
+  type: "persisted-image";
+  markdown: string;
+  alt: string;
+  url: string;
+}
+
+export type InlineMediaSegment = InlineTextSegment | InlineImageSegment | PersistedImageSegment;
 export type PendingInlineImage = InlineImageSegment;
 type InlineMediaError = string | readonly [string, string];
 
@@ -68,7 +76,25 @@ function imageSegment(file: File): InlineImageSegment {
 }
 
 export function createInlineMediaSegments(text = ""): InlineMediaSegment[] {
-  return [textSegment(text)];
+  const segments: InlineMediaSegment[] = [];
+  const imagePattern = /!\[((?:\\.|[^\]\\])*)\]\((?:<([^>]+)>|([^\s)]+))(?:\s+["'][^)]*["'])?\)/g;
+  let offset = 0;
+
+  for (const match of text.matchAll(imagePattern)) {
+    const index = match.index;
+    if (index > offset) segments.push(textSegment(text.slice(offset, index)));
+    segments.push({
+      id: segmentId("image"),
+      type: "persisted-image",
+      markdown: match[0],
+      alt: match[1].replace(/\\([\\\[\]])/g, "$1"),
+      url: match[2] ?? match[3],
+    });
+    offset = index + match[0].length;
+  }
+
+  if (offset < text.length) segments.push(textSegment(text.slice(offset)));
+  return normalizeSegments(segments);
 }
 
 export function inlineMediaImages(segments: InlineMediaSegment[]): PendingInlineImage[] {
@@ -76,13 +102,19 @@ export function inlineMediaImages(segments: InlineMediaSegment[]): PendingInline
 }
 
 export function inlineMediaText(segments: InlineMediaSegment[]): string {
-  return segments.flatMap((segment) => segment.type === "text" ? [segment.text] : []).join("");
+  return segments.map((segment) => {
+    if (segment.type === "text") return segment.text;
+    if (segment.type === "persisted-image") return segment.markdown;
+    return "";
+  }).join("");
 }
 
 export function serializeInlineMedia(segments: InlineMediaSegment[]): string {
-  return segments.map((segment) => (
-    segment.type === "text" ? segment.text : `\n\n${segment.token}\n\n`
-  )).join("");
+  return segments.map((segment) => {
+    if (segment.type === "text") return segment.text;
+    if (segment.type === "persisted-image") return segment.markdown;
+    return `\n\n${segment.token}\n\n`;
+  }).join("");
 }
 
 export function resolveInlineMediaMarkdown(
@@ -151,6 +183,32 @@ function PendingImageBlock({
         type="button"
         disabled={disabled}
         aria-label={text(`移除 ${segment.file.name}`, `Remove ${segment.file.name}`)}
+        onClick={onRemove}
+      >
+        <LinearIcon name="close" />
+      </button>
+    </figure>
+  );
+}
+
+function PersistedImageBlock({
+  segment,
+  disabled,
+  onRemove,
+}: {
+  segment: PersistedImageSegment;
+  disabled: boolean;
+  onRemove: () => void;
+}) {
+  const { text } = useTaskboardI18n();
+
+  return (
+    <figure className="inline-media-image">
+      <img src={resolvePersistedAttachmentUrl(segment.url)} alt={segment.alt} />
+      <button
+        type="button"
+        disabled={disabled}
+        aria-label={text(`移除 ${segment.alt || "图片"}`, `Remove ${segment.alt || "image"}`)}
         onClick={onRemove}
       >
         <LinearIcon name="close" />
@@ -292,8 +350,15 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
               onPaste={(event) => pasteImages(event, segment)}
               onKeyDown={onKeyDown}
             />
-          ) : (
+          ) : segment.type === "pending-image" ? (
             <PendingImageBlock
+              key={segment.id}
+              segment={segment}
+              disabled={disabled}
+              onRemove={() => removeImage(segment.id)}
+            />
+          ) : (
+            <PersistedImageBlock
               key={segment.id}
               segment={segment}
               disabled={disabled}

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -7,6 +7,9 @@ import {
   type ClipboardEvent,
   type KeyboardEventHandler,
 } from "react";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
 import type { Attachment } from "../types";
 import { attachmentContentUrl, resolvePersistedAttachmentUrl } from "../api";
 import { useTaskboardI18n } from "../i18n";
@@ -34,6 +37,17 @@ interface PersistedImageSegment {
   url: string;
 }
 
+interface MarkdownAstNode {
+  type: string;
+  position: {
+    start: { offset: number };
+    end: { offset: number };
+  };
+  children?: MarkdownAstNode[];
+  alt?: string | null;
+  url?: string;
+}
+
 export type InlineMediaSegment = InlineTextSegment | InlineImageSegment | PersistedImageSegment;
 export type PendingInlineImage = InlineImageSegment;
 type InlineMediaError = string | readonly [string, string];
@@ -55,6 +69,7 @@ interface InlineMediaComposerProps {
 }
 
 let segmentSequence = 0;
+const inlineMediaMarkdownParser = unified().use(remarkParse).use(remarkGfm);
 
 function segmentId(prefix: string): string {
   segmentSequence += 1;
@@ -77,20 +92,35 @@ function imageSegment(file: File): InlineImageSegment {
 
 export function createInlineMediaSegments(text = ""): InlineMediaSegment[] {
   const segments: InlineMediaSegment[] = [];
-  const imagePattern = /!\[((?:\\.|[^\]\\])*)\]\((?:<([^>]+)>|([^\s)]+))(?:\s+["'][^)]*["'])?\)/g;
+  const images: Array<{ start: number; end: number; alt: string; url: string }> = [];
+  const nodes = [inlineMediaMarkdownParser.parse(text) as MarkdownAstNode];
+
+  while (nodes.length > 0) {
+    const node = nodes.pop()!;
+    if (node.type === "image") {
+      images.push({
+        start: node.position.start.offset,
+        end: node.position.end.offset,
+        alt: node.alt ?? "",
+        url: node.url!,
+      });
+    }
+    if (node.children) nodes.push(...node.children);
+  }
+
+  images.sort((a, b) => a.start - b.start);
   let offset = 0;
 
-  for (const match of text.matchAll(imagePattern)) {
-    const index = match.index;
-    if (index > offset) segments.push(textSegment(text.slice(offset, index)));
+  for (const image of images) {
+    if (image.start > offset) segments.push(textSegment(text.slice(offset, image.start)));
     segments.push({
       id: segmentId("image"),
       type: "persisted-image",
-      markdown: match[0],
-      alt: match[1].replace(/\\([\\\[\]])/g, "$1"),
-      url: match[2] ?? match[3],
+      markdown: text.slice(image.start, image.end),
+      alt: image.alt,
+      url: image.url,
     });
-    offset = index + match[0].length;
+    offset = image.end;
   }
 
   if (offset < text.length) segments.push(textSegment(text.slice(offset)));

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -7,6 +7,7 @@ import {
   type ClipboardEvent,
   type KeyboardEventHandler,
 } from "react";
+import { definitions } from "mdast-util-definitions";
 import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import { unified } from "unified";
@@ -45,6 +46,7 @@ interface MarkdownAstNode {
   };
   children?: MarkdownAstNode[];
   alt?: string | null;
+  identifier?: string;
   url?: string;
 }
 
@@ -93,7 +95,9 @@ function imageSegment(file: File): InlineImageSegment {
 export function createInlineMediaSegments(text = ""): InlineMediaSegment[] {
   const segments: InlineMediaSegment[] = [];
   const images: Array<{ start: number; end: number; alt: string; url: string }> = [];
-  const nodes = [inlineMediaMarkdownParser.parse(text) as MarkdownAstNode];
+  const root = inlineMediaMarkdownParser.parse(text);
+  const getDefinition = definitions(root);
+  const nodes = [root as MarkdownAstNode];
 
   while (nodes.length > 0) {
     const node = nodes.pop()!;
@@ -104,6 +108,17 @@ export function createInlineMediaSegments(text = ""): InlineMediaSegment[] {
         alt: node.alt ?? "",
         url: node.url!,
       });
+    }
+    if (node.type === "imageReference") {
+      const definition = getDefinition(node.identifier);
+      if (definition) {
+        images.push({
+          start: node.position.start.offset,
+          end: node.position.end.offset,
+          alt: node.alt ?? "",
+          url: definition.url,
+        });
+      }
     }
     if (node.children) nodes.push(...node.children);
   }

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type KeyboardEvent, type MouseEvent } from "react";
 import ReactMarkdown from "react-markdown";
 import { defaultUrlTransform } from "react-markdown";
+import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { taskboardStorage } from "../storage";
 import {
@@ -297,7 +298,7 @@ function DescriptionDocument({ value }: { value: string }) {
   return (
     <div className="issue-description-document">
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={[remarkGfm, remarkBreaks]}
         urlTransform={(url) => defaultUrlTransform(resolvePersistedAttachmentUrl(url))}
         components={{
           a: ({ node: _node, ...props }) => <a {...props} target="_blank" rel="noreferrer" />,


### PR DESCRIPTION
## 改动

- 已保存的 Markdown 图片在 `InlineMediaComposer` 内显示为图片段。图片前后仍是可编辑文本段。
- `createInlineMediaSegments` 使用 `unified + remark-parse + remark-gfm` 解析原文；收集 AST 的真实 `image`，并用 `mdast-util-definitions` 收集可解析的 `imageReference`。
- 使用 `node.position.start.offset` 和 `node.position.end.offset` 切分原始 source。`persisted-image.markdown` 保留原始 slice；alt 和 URL 使用 AST 值。
- 保存、删除、pending 图片上传、附件 token 替换和议题/评论 PATCH 路径不变。
- 共享 `DescriptionDocument` 继续使用 `[remarkGfm, remarkBreaks]`。单回车显示为换行，双回车仍是段落。

## Pro 审核阻塞项根治

- 删除了 Markdown 图片正则 scanner。编辑态不再把转义图片、行内代码或 fenced code 中的图片源码误切为可删除图片。
- 平衡括号 URL 会被完整识别；括号形式 title 会按 Markdown parser 语义识别。
- 未删除的图片 Markdown 逐字写回。删除真实图片时只移除该 AST 节点的原始 source slice。
- 完整、折叠和快捷图片引用仅在 definition 可解析时显示为图片段。图片引用的原始 slice 单独保存；definition、共享链接和未解析引用继续留在文本段。
- 非阻塞建议 `PersistedImageBlock` 使用 `defaultUrlTransform` 不影响当前附件和 HTTP/HTTPS 路径，本轮按最小实现规则未处理。

## 直接验证

- LOCAL-160 两张真实附件在阅读态和编辑态均显示；周边文字可编辑；原图片 Markdown 保存后原样保留。
- 转义图片、行内代码和 fenced code 中的图片源码留在 textarea。
- `https://example.com/assets/a_(b).png` 被完整识别。
- 括号 title 图片被识别。删除后，前后正文顺序正确，保存只移除该图片 slice。
- 完整 `![full][asset]`、折叠 `![asset][]`、快捷 `![asset]` 均显示为图片；definition 位于引用之后仍可解析。
- 两张图片和链接共享 definition 时，删除一张只移除对应引用 slice；另一张、链接和 definition 保持。未定义引用保持源码文本。
- LOCAL-160 临时样例已删除，原描述已逐字恢复到 version 20；原来的两张真实附件在恢复后的编辑态仍显示为图片。
- LOCAL-161 共享评论阅读链：单回车 DOM 为 `第一行<br>\n第二行`；双回车生成独立段落；粗体、链接、列表、任务列表和表格正常。临时评论已删除。
- 本轮没有新增测试；此前同步的聚焦 Markdown 测试为 3/3 通过。
- `npm run typecheck` 通过。
- `npm run build:web` 通过。
- `git diff --check` 通过。

## 提交与基线

- head：`21e6d88be4e10205276f33828591d5b4d3769d4c`
- base：最新 `origin/main` 的 `5de72b9aa8b1e7ea10ca00e597fac0f1c60cd104`
- 本地复核入口：`http://127.0.0.1:5174/?project=1655e734-40ab-4f63-8b45-ca8a8fa930de&issue=LOCAL-160`

## CI 同步

- 既有源码契约正则已从 `[remarkGfm]` 同步为 `[remarkGfm, remarkBreaks]`。
- 没有新增测试用例、断言、护栏、兼容层或无关改动。

## 最新 CI 状态

- 新 head 的两套 `check` 均已通过；两个 `macOS launcher` 仍在运行。
