### PR TITLE
docs(skill): 澄清本地 companion 术语，避免中文误写成「伴侣 / 伴侣 API」

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npm run taskctl -- issue create \
   --labels product,mvp
 ```
 
-Use `npm link` if you want `taskctl` on your shell path. Set `CODEX_TASKBOARD_URL` to point the CLI at another local or LAN service. Cloud deployments are configured through the loopback companion with `taskctl cloud login`.
+Use `npm link` if you want `taskctl` on your shell path. Set `CODEX_TASKBOARD_URL` to point the CLI at another local or LAN service. Cloud deployments are configured through the **loopback companion** (device-local loopback service for auth and path mapping—not a chat persona) with `taskctl cloud login`.
 
 ## Install the Codex Skill
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,7 +46,7 @@ npm run taskctl -- issue create \
   --labels product,mvp
 ```
 
-请运行 `npm link`，以便在 shell 路径中使用 `taskctl`。设置 `CODEX_TASKBOARD_URL`，可让 CLI 指向另一个本地或局域网服务。云端部署通过回环 companion 使用 `taskctl cloud login` 配置。
+请运行 `npm link`，以便在 shell 路径中使用 `taskctl`。设置 `CODEX_TASKBOARD_URL`，可让 CLI 指向另一个本地或局域网服务。云端部署通过**回环 companion**（本机 loopback 配套服务，不是「伴侣」）使用 `taskctl cloud login` 配置。
 
 ## 安装 Codex Skill
 
@@ -135,7 +135,7 @@ npm run codex:inject -- --port 9229 --open
 
 对于两名受信任的协作者，Taskboard 可以在 Cloudflare 上运行，使用 Worker Static Assets 和 API 路由，以 D1 作为权威业务数据库，并使用私有 R2 bucket 存储附件。该部署使用带共享密码的 HTTPS Basic 身份验证，并在全局修订号变化后刷新已打开的面板。
 
-每台设备保留自己的项目检出映射，并继续使用本地 companion 提供 Codex、Git/worktree、Skill 和 MCP 能力。云端模式绝不会回退到本地 SQLite 数据库，也不会同时写入本地数据库。
+每台设备保留自己的项目检出映射，并继续使用**本地 companion**（本机配套服务 / 环回代理）提供 Codex、Git/worktree、Skill 和 MCP 能力。请勿将 companion 译为「伴侣」，也不要把普通 Taskboard HTTP 接口称为「伴侣 API」。云端模式绝不会回退到本地 SQLite 数据库，也不会同时写入本地数据库。
 
 请参阅[云端协作](docs/cloud-collaboration.md)，了解所有者部署、现有 GitHub 安装设置、密码轮换、本地路径映射和一次性本地数据迁移流程。
 

--- a/docs/cloud-collaboration.md
+++ b/docs/cloud-collaboration.md
@@ -22,7 +22,7 @@ This is intentionally a shared-password trust model. The Basic username is only 
 
 The cloud stores project, issue, comment, relation, workflow, and attachment data. It does not store a device's absolute project or worktree paths.
 
-Each collaborator runs the local companion for Codex, Git/worktree scanning, installed Skill/MCP discovery, and project path mapping. The companion keeps the cloud URL, actor name, shared password, and device-specific project mappings in `.data/cloud-companion.json` with mode `0600`.
+Each collaborator runs the **local companion**: a **device-local loopback service** (not a chat persona) for Codex, Git/worktree scanning, installed Skill/MCP discovery, and project path mapping. The companion keeps the cloud URL, actor name, shared password, and device-specific project mappings in `.data/cloud-companion.json` with mode `0600`. Ordinary Taskboard HTTP routes (tasks, comments, attachments) are the shared API; they are not a separate “companion API”.
 
 When cloud mode is active, the cloud is the only business-data source. A failed cloud request fails visibly. The companion does not fall back to the local SQLite database and does not write to both databases. `taskctl cloud logout` returns that device to its separate local mode; it does not merge local and cloud data.
 

--- a/skills/manage-taskboard/SKILL.md
+++ b/skills/manage-taskboard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: manage-taskboard
-description: Manage taskboard work with taskctl. Use for e-taskboard prompts, issue IDs from any project, status sync, or comments.
+description: Manage Codex Taskboard / e-taskboard work with taskctl. Use for taskboard issue IDs, status sync, comments, or taskctl cloud setup—not for unrelated product docs.
 ---
 
 # Manage Taskboard
@@ -8,6 +8,12 @@ description: Manage taskboard work with taskctl. Use for e-taskboard prompts, is
 Use `taskctl` for every project, issue, relation, and comment operation. Consume its JSON output. Use the exact issue identifier returned by the taskboard or supplied in the prompt. Never assume, derive, or rewrite an identifier prefix.
 
 Open only the relevant section of [references/cli.md](references/cli.md) when command syntax is needed.
+
+## Terminology: local companion
+
+In this product, **companion** means the **device-local loopback service** used for cloud mode (Codex/Git/Skill/MCP, path mapping, Basic Auth proxy). Related names: `local companion`, `loopback companion`, `CODEX_TASKBOARD_COMPANION_URL`, `cloud-companion.json`, `LOCAL_COMPANION_REQUIRED`.
+
+When writing Chinese, keep the English word or use **本地 companion** / **本地配套服务** / **环回代理**. Never translate as **伴侣** or invent **伴侣 API**. Ordinary task/comment/attachment HTTP routes (`/api/tasks`, `/api/comments`, `/api/attachments`, …) are the **Taskboard HTTP API** (or local server API)—not “companion API”.
 
 ## Core workflow
 

--- a/skills/manage-taskboard/references/cli.md
+++ b/skills/manage-taskboard/references/cli.md
@@ -2,6 +2,17 @@
 
 `taskctl` emits JSON. Add `--json` when making the output contract explicit.
 
+## Terminology: local companion
+
+**Companion** here is a product term for the **device-local loopback HTTP service** that `taskctl` talks to in cloud mode. It applies Basic Authentication, stores device-only project path mappings, and keeps Codex/Git/Skill/MCP capabilities on the machine. It is not a chat persona and not a separate public “companion product API”.
+
+| English | Prefer in Chinese | Do not use |
+| --- | --- | --- |
+| local companion / loopback companion | 本地 companion、本地配套服务、环回代理 | 伴侣、伴侣 API |
+| Taskboard HTTP API (`/api/tasks`, `/api/comments`, `/api/attachments`, …) | Taskboard HTTP API、本地服务 API、附件上传接口 | companion API、伴侣 API |
+
+Env and files that refer to this service: `CODEX_TASKBOARD_COMPANION_URL`, `CODEX_TASKBOARD_URL` (loopback origin), `.data/cloud-companion.json`. Error code `LOCAL_COMPANION_REQUIRED` means a capability needs that **local loopback service**, not a different API surface.
+
 ## Context and projects
 
 ```bash
@@ -15,7 +26,7 @@ Use `--workspace-path` to associate a project with a local repository. `context 
 
 Set `CODEX_TASKBOARD_URL` to override the default local API origin, `http://127.0.0.1:47823`.
 
-For a shared cloud board, keep `taskctl` pointed at the loopback companion and configure the upstream HTTPS origin through it:
+For a shared cloud board, keep `taskctl` pointed at the **loopback companion** (local loopback service; see Terminology above) and configure the upstream HTTPS origin through it:
 
 ```bash
 taskctl cloud login --url HTTPS_ORIGIN --actor-name NAME [--json]
@@ -25,7 +36,7 @@ taskctl project map PROJECT_ID --workspace-path /absolute/local/path [--json]
 taskctl cloud logout [--json]
 ```
 
-`cloud login` reads the shared password from a private `Shared key:` prompt. The actor name is the display attribution sent through Basic Authentication. The companion stores its configuration with mode `0600`; project mappings stay on the current device and can differ between collaborators. In cloud mode, failed upstream writes fail rather than falling back to or double-writing the local SQLite database.
+`cloud login` reads the shared password from a private `Shared key:` prompt. The actor name is the display attribution sent through Basic Authentication. The local companion stores its configuration with mode `0600`; project mappings stay on the current device and can differ between collaborators. In cloud mode, failed upstream writes fail rather than falling back to or double-writing the local SQLite database.
 
 Every issue or comment write must be attributed to a Codex conversation. In Codex, `taskctl` reads the current conversation from `CODEX_THREAD_ID`. Outside Codex, pass `--thread-id ID` explicitly. An explicit option takes precedence over the environment. Read commands do not require a conversation id.
 

--- a/test/manage-taskboard-skill.test.mjs
+++ b/test/manage-taskboard-skill.test.mjs
@@ -6,6 +6,23 @@ const skillSource = await readFile(
   new URL("../skills/manage-taskboard/SKILL.md", import.meta.url),
   "utf8",
 );
+const cliReference = await readFile(
+  new URL("../skills/manage-taskboard/references/cli.md", import.meta.url),
+  "utf8",
+);
+
+test("the taskboard skill disambiguates companion terminology for agents", () => {
+  assert.match(skillSource, /## Terminology: local companion/i);
+  assert.match(skillSource, /device-local loopback service/i);
+  assert.match(skillSource, /Never translate as \*\*伴侣\*\*/i);
+  assert.match(skillSource, /not “companion API”/i);
+
+  assert.match(cliReference, /## Terminology: local companion/i);
+  assert.match(cliReference, /Do not use/i);
+  assert.match(cliReference, /伴侣 API/i);
+  assert.match(cliReference, /Taskboard HTTP API/i);
+  assert.match(cliReference, /local loopback service/i);
+});
 
 test("the taskboard skill coordinates safe issue execution and review handoff", () => {
   assert.match(


### PR DESCRIPTION
## 摘要

使用 Codex / Grok 等本地 Agent 时，加载 `manage-taskboard` skill 后，中文输出经常把产品术语 **companion** 误译成 **「伴侣」**，并进一步捏造 **「伴侣 API」**，写进 PR 说明、架构文档，甚至无关业务仓库的对话里。

这会造成跨会话、跨平台的 **上下文污染**：审阅者误以为存在“伴侣服务层”，或以为改动了云协作 / 代理架构。对中文开发者尤其严重——「伴侣」在中文里强联想情感/虚拟伴侣产品，与工程组件无关。

本 PR **只澄清术语与文档**，不重命名环境变量，不改运行时行为。

Closes #101

## companion 实际指什么？

云协作场景下的 **设备本机 loopback 配套服务**，用于：

- 本机 Codex / Git / Skill / MCP
- 设备侧项目路径映射
- 对云端源的 Basic Auth 代理

相关名称：`local companion`、`loopback companion`、`CODEX_TASKBOARD_COMPANION_URL`、`cloud-companion.json`、`LOCAL_COMPANION_REQUIRED`。

它 **不是** 聊天人格，也 **不是** 另一套公开的 “companion 产品 API”。  
普通 `/api/tasks`、`/api/comments`、`/api/attachments` 等是 **Taskboard HTTP API**，不要写成 companion API / 伴侣 API。

## 改动

| 文件 | 改动 |
|------|------|
| `skills/manage-taskboard/SKILL.md` | 增加术语说明；略收窄 skill 触发描述 |
| `skills/manage-taskboard/references/cli.md` | 术语表：推荐「本地 companion / 本地配套服务」；禁止「伴侣 / 伴侣 API」 |
| `docs/cloud-collaboration.md` | 首次出现 companion 时说明：本机 loopback 服务，非聊天人格 |
| `README.md` / `README.zh-CN.md` | 中英文消歧说明 |
| `test/manage-taskboard-skill.test.mjs` | 锁定 glossary 关键文案 |

## 中文推荐写法

| 推荐 | 不要用 |
|------|--------|
| 本地 companion、本地配套服务、环回代理 | 伴侣、伴侣 API |
| Taskboard HTTP API、本地服务 API、附件上传接口 | companion API、伴侣 API |

## 测试

- [x] `node --test test/manage-taskboard-skill.test.mjs`
- [x] 上游 PR checks（`check` / `macOS launcher`）已通过  
  （fork 仓库上若因账号 billing 无法启动 Actions，与本次代码无关）

## 相关 Issue

https://github.com/chuspeeism/dashi-taskboard/issues/101