### PR TITLE
release: prepare v1.0.1

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -295,9 +295,9 @@ jobs:
             --target "$GITHUB_SHA" \
             --draft \
             --title "Codex Taskboard $RELEASE_TAG" \
-            --notes "Codex Taskboard 是本地优先的项目协作面板，可通过 macOS App 将任务管理直接集成到 Codex，也可通过 Web UI、taskctl CLI 和 Skill 管理任务、评论、附件、对话与 Worktree。
+            --notes "Codex Taskboard 是本地优先的任务面板，与 Codex 深度集成。它也提供 Web UI、taskctl CLI 和 Skill，用于管理任务、评论、附件、对话与 Worktree。
 
-          v0.2.3 提供中文和英文界面，并完善任务详情、Dashboard、List、Gantt、自动化设置和 AI Chat；taskctl 也支持为任务和评论上传附件。" \
+          产品支持中文和英文界面，并提供 Dashboard、List、Gantt、自动化和 AI Chat，帮助你在同一工作区查看进度、组织工作并协同执行。" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-taskboard",
-  "version": "0.2.3",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-taskboard",
-      "version": "0.2.3",
+      "version": "1.0.1",
       "dependencies": {
         "@lobehub/icons-static-svg": "^1.94.0",
         "@xyflow/react": "^12.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-taskboard",
-  "version": "0.2.3",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "codex-taskboard-launcher"
-version = "0.2.3"
+version = "1.0.1"
 dependencies = [
  "libc",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-taskboard-launcher"
-version = "0.2.3"
+version = "1.0.1"
 description = "Codex Taskboard macOS launcher"
 edition = "2021"
 rust-version = "1.88"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex Taskboard",
-  "version": "0.2.3",
+  "version": "1.0.1",
   "identifier": "com.chuspeeism.codex-taskboard",
   "app": {
     "windows": []


### PR DESCRIPTION
## 改动

- 将 npm、Cargo 和 Tauri 版本统一更新为 1.0.1。
- 将 GitHub Release 说明改为纯产品功能介绍。
- 保持 DMG 为 Release 资产第一项。
- 不改变签名、公证、stapling、updater、SHA、受保护审批和 immutable Release 流程。

## 直接验证

- 6 个版本字段均为 1.0.1。
- release-macos.yml YAML 解析通过。
- Release 说明不含旧版本号或开发流程说明。
- 资产顺序仍为 DMG、App 压缩包、签名、latest.json。
- git diff --check 通过。

## 审核决策

本 PR 只有机械版本同步和局部产品文案替换，不改变运行时或发布语义。按复杂度规则跳过网页 Pro 审核，以人工精确 diff 审核和 exact-head CI 为合并门槛。