### PR TITLE
LOCAL-169: 等待 hostile iframe 最终撤销状态

### DIFF
--- a/test/inject-fullheight-regression.test.mjs
+++ b/test/inject-fullheight-regression.test.mjs
@@ -191,10 +191,16 @@ function fixtureHtml(origin) {
 
         for (let attempt = 0; attempt < 500; attempt += 1) {
           const frame = document.getElementById("codex-taskboard-frame");
-          if (frame && window.__externalOpenUrl && window.__hostileNavigationLoaded) break;
+          const status = document.getElementById("codex-taskboard-status");
+          if (
+            frame
+            && window.__externalOpenUrl
+            && window.__hostileNavigationLoaded
+            && frame.hidden
+            && status?.hidden === false
+          ) break;
           await new Promise((resolve) => setTimeout(resolve, 20));
         }
-        await new Promise((resolve) => setTimeout(resolve, 250));
 
         const page = document.getElementById("codex-taskboard-page");
         const frame = document.getElementById("codex-taskboard-frame");

--- a/test/inject-fullheight-regression.test.mjs
+++ b/test/inject-fullheight-regression.test.mjs
@@ -25,7 +25,7 @@ const embeddedHostSource = await readFile(
   new URL("../web/src/embeddedHost.mjs", import.meta.url),
   "utf8",
 );
-const embeddedHostDataUrl = `data:text/javascript;base64,${Buffer.from(embeddedHostSource).toString("base64")}`;
+const embeddedHostClassicSource = embeddedHostSource.replaceAll("export ", "");
 
 async function chromeExecutable() {
   const candidates = [
@@ -125,22 +125,22 @@ function fixtureHtml(origin) {
           const request = event.data.payload;
           if (request.action === "load-frame") {
             const frame = document.querySelector('iframe[name="' + request.frameName + '"]');
-            const moduleUrl = ${JSON.stringify(embeddedHostDataUrl)};
             frame.srcdoc = '<a id="external-link" href="https://example.com/review" target="_blank">Review</a>'
-              + '<script type="module">import * as host from ' + JSON.stringify(moduleUrl) + ';'
-              + 'globalThis.__CODEX_TASKBOARD_FRAME_CAPABILITY__='
+              + '<script>'
+              + ${JSON.stringify(embeddedHostClassicSource)}
+              + '\\nglobalThis.__CODEX_TASKBOARD_FRAME_CAPABILITY__='
               + JSON.stringify(request.frameCapability)
-              + ';host.installEmbeddedExternalLinkHandler();'
+              + ';installEmbeddedExternalLinkHandler();'
               + 'let activated=false,acknowledgedChallenge="";window.addEventListener("message",function(event){'
               + 'if(event.data?.type!=="taskboard:frame-challenge")return;'
               + 'const challenge=event.data.payload?.challenge;if(!challenge||challenge===acknowledgedChallenge)return;'
-              + 'acknowledgedChallenge=challenge;host.setEmbeddedFrameChallenge(challenge);'
-              + 'host.postEmbeddedHostMessage({type:"taskboard:ready"});'
+              + 'acknowledgedChallenge=challenge;setEmbeddedFrameChallenge(challenge);'
+              + 'postEmbeddedHostMessage({type:"taskboard:ready"});'
               + 'if(activated)return;activated=true;'
               + 'parent.postMessage({type:"taskboard:ready"},"*");'
               + 'parent.postMessage({type:"taskboard:open-thread",payload:{threadId:"forged"}},"*");'
               + 'document.getElementById("external-link").click();'
-              + '});host.postEmbeddedHostMessage({type:"taskboard:frame-awaiting-challenge"});<\\/script>';
+              + '});postEmbeddedHostMessage({type:"taskboard:frame-awaiting-challenge"});<\\/script>';
           }
           if (request.action === "open-external") {
             window.__externalOpenUrl = request.url;
@@ -149,6 +149,7 @@ function fixtureHtml(origin) {
             window.__statusHiddenBeforeNavigation = document.getElementById("codex-taskboard-status")?.hidden === true;
             frame?.addEventListener("load", () => {
               window.__hostileNavigationLoaded = true;
+              window.__resolveHostileNavigationLoaded();
             }, { once: true });
             frame.removeAttribute("srcdoc");
             frame.src = ${JSON.stringify(`${origin}/attacker`)};
@@ -187,20 +188,11 @@ function fixtureHtml(origin) {
         const entry = document.getElementById("codex-taskboard-entry");
         const panel = document.querySelector("[data-browser-sidebar-webview]");
         const panelVisibleBefore = getComputedStyle(panel).visibility !== "hidden";
+        const hostileNavigationLoaded = new Promise((resolve) => {
+          window.__resolveHostileNavigationLoaded = resolve;
+        });
         entry?.click();
-
-        for (let attempt = 0; attempt < 500; attempt += 1) {
-          const frame = document.getElementById("codex-taskboard-frame");
-          const status = document.getElementById("codex-taskboard-status");
-          if (
-            frame
-            && window.__externalOpenUrl
-            && window.__hostileNavigationLoaded
-            && frame.hidden
-            && status?.hidden === false
-          ) break;
-          await new Promise((resolve) => setTimeout(resolve, 20));
-        }
+        await hostileNavigationLoaded;
 
         const page = document.getElementById("codex-taskboard-page");
         const frame = document.getElementById("codex-taskboard-frame");


### PR DESCRIPTION
## 变更

- 现有 iframe 回归 fixture 不再用 20 ms 轮询和固定 250 ms 等待。
- 测试通过事件 Promise 等待攻击页实际 load，再读取原有最终断言。
- fixture 将 embeddedHost.mjs 的三个导出函数作为同一同步脚本执行，去掉 data URL 动态 module 调度竞态。

## 原因

push runner 先后暴露两种时序误判：攻击页 load 后过早快照，以及轮询耗尽 Chrome virtual-time budget、iframe 握手尚未完成。最终方案直接移除这两个竞态来源。

## 影响

只修改 test/inject-fullheight-regression.test.mjs。产品代码、测试数量、断言范围和发布逻辑不变。

## 验证

- 目标测试在最终方案下连续 3 次通过
- git diff --check 通过
- 等待 exact-head GitHub Actions