### PR TITLE
feat: default task automation to Luna

### DIFF
--- a/shared/taskboard-automation-options.mjs
+++ b/shared/taskboard-automation-options.mjs
@@ -14,7 +14,7 @@ export const AUTOMATION_MODELS = [
   {
     label: "5.6 Luna",
     slug: "gpt-5.6-luna",
-    defaultEffort: "medium",
+    defaultEffort: "max",
     efforts: ["low", "medium", "high", "xhigh", "max"],
   },
   {

--- a/shared/taskboard-automation.mjs
+++ b/shared/taskboard-automation.mjs
@@ -64,12 +64,14 @@ export function buildTaskboardAutomationPrompt(request) {
   return [
     `[$manage-taskboard](${request.skillPath}) e-taskboard 每 ${request.intervalMinutes} 分钟检查任务面板中的「${request.projectName}」项目（项目 ID：${request.taskboardProjectId}，项目目录：${request.workspacePath}）。`,
     `本轮所有 taskctl 操作都使用完整命令前缀 ${taskctlCommand}，不要使用 PATH 中的 taskctl。`,
+    `本次扫描和领取后的主执行使用项目自动化明确选择的 ${request.model} / ${request.reasoningEffort}；未显式覆盖时系统默认 gpt-5.6-luna / max。`,
     `开始时先运行 ${taskctlCommand} issue list --project ${request.taskboardProjectId} --status todo --json。若没有 todo，使用 Codex automation_update 将名为「${automationName}」的当前自动化设为 PAUSED，保留其他字段，然后结束；不要创建或打开新的任务会话。`,
     "每次仅处理一个 todo：选定后先用 issue get 读取最新议题内容，并用 comment list 读取全部评论。根据描述和最新评论判断是否允许开始；若其中写明等待、暂不执行或当前不应开始，立即跳过并报告，不改状态。评论也包含已完成后被打回的返工要求。",
     "确认允许开始后，必须在读取代码、下载附件、分析或实施前，使用刚读取的 version 将仍可认领的 todo 移到 in_progress；写入成功前不得继续。不得认领已被其他会话绑定或其他 Agent 领取的议题。",
     "若因 version 陈旧发生版本冲突，重新运行 issue get 和 comment list；仅当仍为可认领 todo、未绑定其他会话、未归档且描述和最新评论未变化时，用最新 version 重试一次。若已被认领、状态或要求已变、已归档、服务或永久 API 错误，或重试仍失败，立即跳过该议题、退出并报告；不得抢占或循环重试。",
     "若首次 issue get 返回 threadId，议题已绑定原会话：不要在当前自动化会话认领；使用 Codex send_message_to_thread 向原会话发送继续处理指令，由原会话按上述协议判断和认领，然后结束当前自动化会话。若没有 threadId，则在当前自动化会话处理。",
     "若议题已绑定 branch 或 worktree，必须在该议题绑定的开发上下文执行，避免并行 Agent 修改同一工作目录。",
+    `若需要 subagent，且运行时已加载 luna_worker，则默认使用 luna_worker；未加载时由当前 ${request.model} / ${request.reasoningEffort} 主执行继续处理，不得擅自替换模型或 Agent。只有议题描述、最新评论或项目设置明确指定其他模型或 Agent 时才覆盖。`,
     "执行完成并验证后，先用 comment add 记录关键改动、验证结果、执行结果和剩余风险，再使用最新 version 将议题移动到 in_review；不要直接标记为 done。",
     `本次处理或交接后，再次运行 ${taskctlCommand} issue list --project ${request.taskboardProjectId} --status todo --json。若没有 todo，使用 Codex automation_update 将名为「${automationName}」的当前自动化设为 PAUSED，保留其他字段，避免后续创建空会话。`,
   ].join("\n");

--- a/test/project-automation-settings.test.mjs
+++ b/test/project-automation-settings.test.mjs
@@ -27,7 +27,10 @@ test("project automation state is device-local and scoped by taskboard project",
   assert.match(appSource, /automationId\?: string/);
   assert.match(appSource, /codexProjectId: string/);
   assert.match(appSource, /type AutomationIntervalMinutes = 5 \| 10 \| 15 \| 30 \| 60/);
-  assert.match(appSource, /DEFAULT_AUTOMATION_OPTIONS[\s\S]*?model: "gpt-5\.5"[\s\S]*?reasoningEffort: "high"/);
+  assert.match(appSource, /DEFAULT_AUTOMATION_OPTIONS[\s\S]*?model: "gpt-5\.6-luna"[\s\S]*?reasoningEffort: "max"/);
+  assert.match(appSource, /candidate\.model \?\? "gpt-5\.6-luna"/);
+  assert.match(appSource, /candidate\.reasoningEffort \?\? "max"/);
+  assert.match(menuSource, /DEFAULT_OPTIONS[\s\S]*?model: "gpt-5\.6-luna"[\s\S]*?reasoningEffort: "max"/);
   assert.match(appSource, /taskboardStorage\.getItem\(PROJECT_AUTOMATIONS_KEY\)/);
   assert.match(appSource, /taskboardStorage\.setItem\(PROJECT_AUTOMATIONS_KEY, JSON\.stringify\(next\)\)/);
   assert.match(appSource, /projectAutomations\[selectedProjectId\]/);

--- a/test/taskboard-automation.test.mjs
+++ b/test/taskboard-automation.test.mjs
@@ -28,8 +28,8 @@ const baseRequest = {
   enabledByUser: true,
   quotaAware: false,
   intervalMinutes: 5,
-  model: "gpt-5.5",
-  reasoningEffort: "high",
+  model: "gpt-5.6-luna",
+  reasoningEffort: "max",
 };
 
 test("the automation model catalog matches Codex and normalizes unsupported efforts", () => {
@@ -49,7 +49,7 @@ test("the automation model catalog matches Codex and normalizes unsupported effo
     {
       label: "5.6 Luna",
       slug: "gpt-5.6-luna",
-      defaultEffort: "medium",
+      defaultEffort: "max",
       efforts: ["low", "medium", "high", "xhigh", "max"],
     },
     {
@@ -85,7 +85,7 @@ test("the automation model catalog matches Codex and normalizes unsupported effo
   assert.deepEqual(withAutomationModel(current, "gpt-5.6-luna"), {
     ...current,
     model: "gpt-5.6-luna",
-    reasoningEffort: "medium",
+    reasoningEffort: "max",
   });
 });
 
@@ -185,6 +185,11 @@ test("the stable name and generated prompt are project-scoped and encode the cla
   assert.match(prompt, /关键改动、验证结果、执行结果和剩余风险/);
   assert.match(prompt, /in_review/);
   assert.match(prompt, /已绑定.*branch.*worktree/);
+  assert.match(prompt, /扫描和领取后的主执行.*gpt-5\.6-luna \/ max/);
+  assert.match(prompt, /默认 gpt-5\.6-luna \/ max/);
+  assert.match(prompt, /subagent.*已加载 luna_worker.*默认使用 luna_worker/);
+  assert.match(prompt, /未加载时由当前 gpt-5\.6-luna \/ max 主执行继续处理/);
+  assert.match(prompt, /明确指定其他模型或 Agent.*覆盖/);
 });
 
 test("the generated cron spec uses the selected whitelisted local Codex options", () => {
@@ -195,8 +200,8 @@ test("the generated cron spec uses the selected whitelisted local Codex options"
     projectId: "codex-project-123",
     executionEnvironment: "local",
     localEnvironmentConfigPath: null,
-    model: "gpt-5.5",
-    reasoningEffort: "high",
+    model: "gpt-5.6-luna",
+    reasoningEffort: "max",
     rrule: "RRULE:FREQ=MINUTELY;INTERVAL=5",
   });
   assert.deepEqual(buildTaskboardAutomationSpec({
@@ -206,7 +211,12 @@ test("the generated cron spec uses the selected whitelisted local Codex options"
     reasoningEffort: "medium",
   }), {
     ...buildTaskboardAutomationSpec(baseRequest),
-    prompt: buildTaskboardAutomationPrompt({ ...baseRequest, intervalMinutes: 30 }),
+    prompt: buildTaskboardAutomationPrompt({
+      ...baseRequest,
+      intervalMinutes: 30,
+      model: "gpt-5.4",
+      reasoningEffort: "medium",
+    }),
     model: "gpt-5.4",
     reasoningEffort: "medium",
     rrule: "RRULE:FREQ=MINUTELY;INTERVAL=30",
@@ -446,8 +456,8 @@ test("pause never creates and list returns only sanitized matching project autom
     items: [{
       id: "matching",
       status: "ACTIVE",
-      model: "gpt-5.5",
-      reasoningEffort: "high",
+      model: "gpt-5.6-luna",
+      reasoningEffort: "max",
       rrule: "RRULE:FREQ=MINUTELY;INTERVAL=5",
     }],
   });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -269,8 +269,8 @@ const DEFAULT_AUTOMATION_OPTIONS = {
   enabledByUser: false,
   quotaAware: false,
   intervalMinutes: 5,
-  model: "gpt-5.5",
-  reasoningEffort: "high",
+  model: "gpt-5.6-luna",
+  reasoningEffort: "max",
 } as const;
 
 function readIssueActivityKeys(storageKey: string): Record<string, string> {
@@ -352,8 +352,8 @@ function readProjectAutomations(): ProjectAutomations {
     for (const [projectId, record] of Object.entries(value)) {
       if (!record || typeof record !== "object" || Array.isArray(record)) continue;
       const candidate = record as Partial<ProjectAutomationRecord>;
-      const model = candidate.model ?? "gpt-5.5";
-      const reasoningEffort = candidate.reasoningEffort ?? "high";
+      const model = candidate.model ?? "gpt-5.6-luna";
+      const reasoningEffort = candidate.reasoningEffort ?? "max";
       const enabledByUser = candidate.enabledByUser ?? candidate.status === "ACTIVE";
       const quotaAware = candidate.quotaAware ?? false;
       if (

--- a/web/src/components/ProjectAutomationMenu.tsx
+++ b/web/src/components/ProjectAutomationMenu.tsx
@@ -45,8 +45,8 @@ const DEFAULT_OPTIONS: AutomationOptions = {
   enabledByUser: false,
   quotaAware: false,
   intervalMinutes: 5,
-  model: "gpt-5.5",
-  reasoningEffort: "high",
+  model: "gpt-5.6-luna",
+  reasoningEffort: "max",
 };
 
 const EFFORT_LABELS: Record<AutomationReasoningEffort, readonly [string, string]> = {


### PR DESCRIPTION
## Summary

- default new project automations and legacy records without explicit model settings to gpt-5.6-luna with max reasoning
- make Luna use max reasoning when selected from the automation model catalog
- instruct automation runs to preserve explicit model or agent overrides and prefer luna_worker when it is available
- keep execution on the currently selected model when luna_worker is not installed, so the public workflow has no hidden custom-agent dependency

Existing records with explicit model and reasoning settings remain unchanged.

## Validation

- npm test: 411 passed
- npm run typecheck
- npm run build:web