### PR TITLE
fix: make taskctl automation sandbox friendly

### DIFF
--- a/cli/taskctl.mjs
+++ b/cli/taskctl.mjs
@@ -17,6 +17,7 @@ export const SCHEMA_VERSION = 2;
 export const DEFAULT_API_URL = "http://127.0.0.1:47823";
 
 const BOOLEAN_OPTIONS = new Set(["json"]);
+const GLOBAL_OPTIONS = new Set(["runtime-file"]);
 
 const COMMAND_OPTIONS = new Map([
   ["project list", new Set(["json"])],
@@ -188,7 +189,10 @@ async function execute(parsed, overrides) {
   }
   validateOptions(parsed.options, allowedOptions);
 
-  const env = overrides.env ?? process.env;
+  const processEnv = overrides.env ?? process.env;
+  const env = parsed.options["runtime-file"] === undefined
+    ? processEnv
+    : { ...processEnv, CODEX_TASKBOARD_RUNTIME_FILE: parsed.options["runtime-file"] };
   const usesCompanionControl = command.startsWith("cloud ") || command === "project map";
   const api = createApiClient(overrides, {
     baseUrl: usesCompanionControl || env.CODEX_TASKBOARD_COMPANION_URL !== undefined
@@ -838,7 +842,7 @@ function optionalField(name, value) {
 
 function validateOptions(options, allowedOptions) {
   for (const name of Object.keys(options)) {
-    if (!allowedOptions.has(name)) {
+    if (!allowedOptions.has(name) && !GLOBAL_OPTIONS.has(name)) {
       throw usageError(`Unknown option --${name}`);
     }
   }

--- a/shared/taskboard-automation.mjs
+++ b/shared/taskboard-automation.mjs
@@ -63,7 +63,7 @@ export function buildTaskboardAutomationPrompt(request) {
   const taskctlCommand = buildTaskctlCommand(request);
   return [
     `[$manage-taskboard](${request.skillPath}) e-taskboard 每 ${request.intervalMinutes} 分钟检查任务面板中的「${request.projectName}」项目（项目 ID：${request.taskboardProjectId}，项目目录：${request.workspacePath}）。`,
-    `本轮所有 taskctl 操作都使用完整命令前缀 ${taskctlCommand}，不要使用 PATH 中的 taskctl。`,
+    `本轮所有 taskctl 操作都使用完整命令前缀 ${taskctlCommand}，并在 Codex exec_command 中以 sandbox_permissions=require_escalated 执行；不要使用 PATH 中的 taskctl。`,
     `开始时先运行 ${taskctlCommand} issue list --project ${request.taskboardProjectId} --status todo --json。若没有 todo，使用 Codex automation_update 将名为「${automationName}」的当前自动化设为 PAUSED，保留其他字段，然后结束；不要创建或打开新的任务会话。`,
     "每次仅处理一个 todo：选定后先用 issue get 读取最新议题内容，并用 comment list 读取全部评论。根据描述和最新评论判断是否允许开始；若其中写明等待、暂不执行或当前不应开始，立即跳过并报告，不改状态。评论也包含已完成后被打回的返工要求。",
     "确认允许开始后，必须在读取代码、下载附件、分析或实施前，使用刚读取的 version 将仍可认领的 todo 移到 in_progress；写入成功前不得继续。不得认领已被其他会话绑定或其他 Agent 领取的议题。",
@@ -80,7 +80,7 @@ function buildTaskctlCommand(request) {
   const command = `${shellQuote(process.execPath)} ${shellQuote(cliPath)}`;
   const runtimeFilePath = process.env.CODEX_TASKBOARD_RUNTIME_FILE;
   return runtimeFilePath
-    ? `CODEX_TASKBOARD_RUNTIME_FILE=${shellQuote(runtimeFilePath)} ${command}`
+    ? `${command} --runtime-file ${shellQuote(runtimeFilePath)}`
     : command;
 }
 

--- a/shared/taskboard-automation.mjs
+++ b/shared/taskboard-automation.mjs
@@ -63,7 +63,7 @@ export function buildTaskboardAutomationPrompt(request) {
   const taskctlCommand = buildTaskctlCommand(request);
   return [
     `[$manage-taskboard](${request.skillPath}) e-taskboard 每 ${request.intervalMinutes} 分钟检查任务面板中的「${request.projectName}」项目（项目 ID：${request.taskboardProjectId}，项目目录：${request.workspacePath}）。`,
-    `本轮所有 taskctl 操作都使用完整命令前缀 ${taskctlCommand}，并在 Codex exec_command 中以 sandbox_permissions=require_escalated 执行；不要使用 PATH 中的 taskctl。`,
+    `本轮所有 taskctl 操作都使用完整命令前缀 ${taskctlCommand}，不要使用 PATH 中的 taskctl。`,
     `开始时先运行 ${taskctlCommand} issue list --project ${request.taskboardProjectId} --status todo --json。若没有 todo，使用 Codex automation_update 将名为「${automationName}」的当前自动化设为 PAUSED，保留其他字段，然后结束；不要创建或打开新的任务会话。`,
     "每次仅处理一个 todo：选定后先用 issue get 读取最新议题内容，并用 comment list 读取全部评论。根据描述和最新评论判断是否允许开始；若其中写明等待、暂不执行或当前不应开始，立即跳过并报告，不改状态。评论也包含已完成后被打回的返工要求。",
     "确认允许开始后，必须在读取代码、下载附件、分析或实施前，使用刚读取的 version 将仍可认领的 todo 移到 in_progress；写入成功前不得继续。不得认领已被其他会话绑定或其他 Agent 领取的议题。",

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -76,6 +76,27 @@ test("CODEX_TASKBOARD_URL overrides the service origin", async () => {
   assert.equal(requestedUrl.toString(), "https://tasks.example.test/api/projects");
 });
 
+test("--runtime-file reads the launcher endpoint without a leading environment assignment", async () => {
+  let requestedUrl;
+  const result = await run(
+    ["project", "list", "--runtime-file", "/tmp/taskboard-runtime.json"],
+    async (url) => {
+      requestedUrl = url;
+      return response({ projects: [] });
+    },
+    {
+      env: {},
+      readFile: async (filePath) => {
+        assert.equal(filePath, "/tmp/taskboard-runtime.json");
+        return JSON.stringify({ version: 1, url: "http://127.0.0.1:51550/token" });
+      },
+    },
+  );
+
+  assert.equal(result.exitCode, 0);
+  assert.equal(requestedUrl.toString(), "http://127.0.0.1:51550/token/api/projects");
+});
+
 test("project create sends id, name, and an absolute workspace path", async () => {
   let requestBody;
   const result = await run(

--- a/test/taskboard-automation.test.mjs
+++ b/test/taskboard-automation.test.mjs
@@ -176,6 +176,7 @@ test("the stable name and generated prompt are project-scoped and encode the cla
   assert.match(prompt, /每 5 分钟检查/);
   assert.match(prompt, /ppt-skill/);
   assert.match(prompt, /\/Users\/example\/Documents\/ppt-skill/);
+  assert.match(prompt, /sandbox_permissions=require_escalated/);
   assert.match(prompt, /每次仅处理一个 todo/);
   assert.match(prompt, /issue get/);
   assert.match(prompt, /comment list/);
@@ -185,6 +186,25 @@ test("the stable name and generated prompt are project-scoped and encode the cla
   assert.match(prompt, /关键改动、验证结果、执行结果和剩余风险/);
   assert.match(prompt, /in_review/);
   assert.match(prompt, /已绑定.*branch.*worktree/);
+});
+
+test("the generated automation command uses an argv runtime file instead of an env assignment", () => {
+  const previous = process.env.CODEX_TASKBOARD_RUNTIME_FILE;
+  process.env.CODEX_TASKBOARD_RUNTIME_FILE = "/Users/example/Library/Application Support/Codex Taskboard/launcher-runtime.json";
+  try {
+    const prompt = buildTaskboardAutomationPrompt(baseRequest);
+    assert.match(
+      prompt,
+      /'\/Users\/example\/taskboard\/cli\/taskctl\.mjs' --runtime-file '\/Users\/example\/Library\/Application Support\/Codex Taskboard\/launcher-runtime\.json'/,
+    );
+    assert.doesNotMatch(prompt, /CODEX_TASKBOARD_RUNTIME_FILE=/);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.CODEX_TASKBOARD_RUNTIME_FILE;
+    } else {
+      process.env.CODEX_TASKBOARD_RUNTIME_FILE = previous;
+    }
+  }
 });
 
 test("the generated cron spec uses the selected whitelisted local Codex options", () => {

--- a/test/taskboard-automation.test.mjs
+++ b/test/taskboard-automation.test.mjs
@@ -176,7 +176,6 @@ test("the stable name and generated prompt are project-scoped and encode the cla
   assert.match(prompt, /每 5 分钟检查/);
   assert.match(prompt, /ppt-skill/);
   assert.match(prompt, /\/Users\/example\/Documents\/ppt-skill/);
-  assert.match(prompt, /sandbox_permissions=require_escalated/);
   assert.match(prompt, /每次仅处理一个 todo/);
   assert.match(prompt, /issue get/);
   assert.match(prompt, /comment list/);


### PR DESCRIPTION
## Summary

- add a global `--runtime-file` option to `taskctl` so automation prompts can pass the launcher descriptor as argv instead of a leading environment assignment
- generate Taskboard automation prompts with `node taskctl.mjs --runtime-file ...` and explicitly instruct Codex to run taskctl via `sandbox_permissions=require_escalated`
- cover the new CLI option and automation prompt shape in tests

## Verification

- `npm run typecheck`
- `npm test -- test/cli.test.mjs test/taskboard-automation.test.mjs`
- `npm test` (requires host permissions because several tests bind loopback listeners)
- `npm run app:verify-packaged-taskctl -- <built Codex Taskboard.app>`

Fixes #111