### PR TITLE
LOCAL-171: 为每个版本生成对应 Release 说明

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -295,9 +295,7 @@ jobs:
             --target "$GITHUB_SHA" \
             --draft \
             --title "Codex Taskboard $RELEASE_TAG" \
-            --notes "Codex Taskboard 是本地优先的任务面板，与 Codex 深度集成。它也提供 Web UI、taskctl CLI 和 Skill，用于管理任务、评论、附件、对话与 Worktree。
-
-          产品支持中文和英文界面，并提供 Dashboard、List、Gantt、自动化和 AI Chat，帮助你在同一工作区查看进度、组织工作并协同执行。" \
+            --generate-notes \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" \


### PR DESCRIPTION
## 改动

- 将 macOS Release 的固定产品介绍改为 GitHub 自动生成版本说明
- 保留既有 Release 标题、Draft 创建、资产上传和 promotion 流程

## 原因

原 workflow 通过 `--notes` 为每个版本写入相同正文。promotion 只将 Draft 改为公开，不会更新正文，所以用户看到的 Release 内容与该版本功能变化无关。

## 直接验证

- `git diff --check` 通过
- 使用 GitHub `releases/generate-notes` 只读接口分别生成 `v1.0.1 ← v0.2.3` 和 `v0.2.3 ← v0.2.2` 的说明
- 两个版本返回不同的 PR 功能清单和 Full Changelog 链接
- 未创建或发布 Release
