### PR TITLE
Open embedded attachments and recover Taskboard safely

### DIFF
--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -937,6 +937,25 @@
     } catch (_) {}
   }
 
+  async function handleAttachmentOpen(payload) {
+    try {
+      await requestHost("open-attachment", {
+        attachmentId: payload?.attachmentId,
+        filename: payload?.filename,
+      });
+    } catch (_) {
+      postToFrame({
+        type: "taskboard:attachment-open-error",
+        payload: {
+          error: hostText(
+            "无法用系统默认应用打开附件，请重试。",
+            "Could not open the attachment in its default app. Try again.",
+          ),
+        },
+      });
+    }
+  }
+
   function challengeFrameDocument(event) {
     if (!frame || event.currentTarget !== frame) return;
     frameReady = false;
@@ -989,6 +1008,10 @@
     }
     if (message.type === "taskboard:open-external") {
       handleExternalOpen(message.payload);
+      return;
+    }
+    if (message.type === "taskboard:open-attachment") {
+      void handleAttachmentOpen(message.payload);
       return;
     }
     if (message.type === "taskboard:create-thread") void createThreadForTask(message.payload);

--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -1118,7 +1118,7 @@
     text.textContent = hostErrorText(loadError);
     const retry = document.createElement("button");
     retry.type = "button";
-    retry.textContent = hostText("重新启动", "Restart");
+    retry.textContent = hostText("重新加载面板", "Reload panel");
     retry.addEventListener("click", openTaskboard, { once: true });
     content.append(text, retry);
     status.replaceChildren(content);

--- a/scripts/codex-injector-runtime.mjs
+++ b/scripts/codex-injector-runtime.mjs
@@ -35,6 +35,17 @@ function parseHostRequest(payload, parseAutomationRequest) {
       }
     } catch {}
   }
+  if (
+    request.action === "open-attachment"
+    && typeof request.attachmentId === "string"
+    && /^[a-f0-9-]{36}$/i.test(request.attachmentId)
+    && typeof request.filename === "string"
+    && request.filename.length > 0
+    && request.filename.length <= 240
+    && request.filename !== "."
+    && request.filename !== ".."
+    && !/[\u0000-\u001f\u007f/\\]/.test(request.filename)
+  ) return { id, request, error: null };
   if (request.action === "automation") {
     const parsed = parseAutomationRequest(request);
     return parsed
@@ -85,6 +96,8 @@ export async function handleHostBindingPayload(params, handlers) {
       result = await handlers.loadFrame(parsed.request);
     } else if (parsed.request.action === "open-external") {
       result = await handlers.openExternal(parsed.request);
+    } else if (parsed.request.action === "open-attachment") {
+      result = await handlers.openAttachment(parsed.request);
     } else if (parsed.request.action === "automation") {
       result = await handlers.runAutomation(parsed.request, params.executionContextId);
     } else {

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -742,9 +742,9 @@ async function loadTaskboardFrameViaCdp(cdp, frameName, frameCapability) {
   throw new Error("Timed out waiting for the isolated Taskboard frame");
 }
 
-async function openExternalUrl(request) {
+async function openWithDefaultApplication(target) {
   await new Promise((resolve, reject) => {
-    const child = spawn("/usr/bin/open", [request.url], {
+    const child = spawn("/usr/bin/open", [target], {
       detached: true,
       env: withoutTaskboardLauncherEnvironment(process.env),
       stdio: "ignore",
@@ -755,6 +755,28 @@ async function openExternalUrl(request) {
       resolve();
     });
   });
+}
+
+async function openExternalUrl(request) {
+  await openWithDefaultApplication(request.url);
+  return { opened: true };
+}
+
+async function openAttachment(request) {
+  const response = await fetch(
+    `${taskboardBaseUrl}/api/attachments/${encodeURIComponent(request.attachmentId)}/download`,
+    { cache: "no-store" },
+  );
+  if (!response.ok) throw new Error(`Attachment download returned HTTP ${response.status}`);
+  const directory = path.join(
+    taskboardDataDirectory,
+    "opened-attachments",
+    request.attachmentId,
+  );
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  const attachmentPath = path.join(directory, request.filename);
+  await writeFile(attachmentPath, Buffer.from(await response.arrayBuffer()), { mode: 0o600 });
+  await openWithDefaultApplication(attachmentPath);
   return { opened: true };
 }
 
@@ -1194,6 +1216,7 @@ function installTaskboardHostBinding(cdp, supervisor, startupToken) {
         request.frameCapability,
       ),
       openExternal: openExternalUrl,
+      openAttachment,
       runAutomation: (request) => (
         (async () => {
           const rpc = (method, body) => requestCodexAutomationViaCdp(

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -764,10 +764,10 @@ async function openExternalUrl(request) {
 
 async function openAttachment(request) {
   const response = await fetch(
-    `${taskboardBaseUrl}/api/attachments/${encodeURIComponent(request.attachmentId)}/download`,
+    `${taskboardBaseUrl}/api/attachments/${encodeURIComponent(request.attachmentId)}/content`,
     { cache: "no-store" },
   );
-  if (!response.ok) throw new Error(`Attachment download returned HTTP ${response.status}`);
+  if (!response.ok) throw new Error(`Attachment content returned HTTP ${response.status}`);
   const directory = path.join(
     taskboardDataDirectory,
     "opened-attachments",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1126,11 +1126,12 @@ fn main() {
             let Some(state) = app_handle.try_state::<Arc<LauncherState>>() else {
                 return;
             };
-            if let Err(error) = restart_launcher(app_handle, &state) {
-                append_log(&state, &format!("Launcher reopen failed: {error}"));
+            let result = start_launcher(app_handle, &state).and_then(|_| open_taskboard(&state));
+            if let Err(error) = result {
+                append_log(&state, &format!("Launcher panel reopen failed: {error}"));
                 show_error_dialog(
                     app_handle,
-                    "Codex Taskboard 启动失败",
+                    "Codex Taskboard 打开失败",
                     &format!("{error}\n\n请确认官方 Codex/ChatGPT App 已安装。"),
                 );
             }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -130,11 +130,18 @@ type DetailSourceScroll =
   | { projectId: string; view: "list"; scrollTop: number };
 type GanttZoom = "day" | "week" | "month";
 type ActionError = string | readonly [string, string];
-type LoadError = {
-  source: "projects" | "tasks";
+type ProjectLoadError = {
+  source: "projects";
+  operation: "initial" | "refresh";
   requestId: number;
   message: string;
 };
+type TasksLoadError = {
+  source: "tasks";
+  requestId: number;
+  message: string;
+};
+type LoadError = ProjectLoadError | TasksLoadError;
 const SHOW_WORKFLOW_BOARD_ENTRY = false;
 const GANTT_ZOOM_OPTIONS: GanttZoom[] = ["day", "week", "month"];
 
@@ -629,7 +636,9 @@ export function App() {
   const [archivedTasks, setArchivedTasks] = useState<Task[]>([]);
   const [tasksLoading, setTasksLoading] = useState(false);
   const [hasLoadedTasks, setHasLoadedTasks] = useState(false);
-  const [loadError, setLoadError] = useState<LoadError | null>(null);
+  const [projectLoadError, setProjectLoadError] = useState<ProjectLoadError | null>(null);
+  const [tasksLoadError, setTasksLoadError] = useState<TasksLoadError | null>(null);
+  const loadError: LoadError | null = projectLoadError ?? tasksLoadError;
   const [actionError, setActionError] = useState<ActionError | null>(null);
   const actionErrorText = actionError === null
     ? null
@@ -1439,8 +1448,8 @@ export function App() {
 
   const loadProjectList = useCallback(async (signal?: AbortSignal) => {
     const requestId = ++projectsRequestRef.current;
-    setLoadError((current) => (
-      current?.source === "projects" ? { ...current, requestId } : current
+    setProjectLoadError((current) => (
+      current?.operation === "initial" ? { ...current, requestId } : current
     ));
     try {
       const [nextProjects, metadata, workspaces] = await Promise.all([
@@ -1477,12 +1486,17 @@ export function App() {
           ?? nextProjects[0]?.id
           ?? GLOBAL_PROJECT_ID;
       });
-      setLoadError((current) => (
-        current?.source === "projects" && current.requestId === requestId ? null : current
+      setProjectLoadError((current) => (
+        current?.operation === "initial" && current.requestId === requestId ? null : current
       ));
     } catch (error) {
       if ((error as Error).name !== "AbortError" && requestId === projectsRequestRef.current) {
-        setLoadError({ source: "projects", requestId, message: errorMessage(error) });
+        setProjectLoadError({
+          source: "projects",
+          operation: "initial",
+          requestId,
+          message: errorMessage(error),
+        });
       }
     }
   }, []);
@@ -1495,19 +1509,24 @@ export function App() {
 
   const refreshProjectList = useCallback(async () => {
     const requestId = ++projectsRequestRef.current;
-    setLoadError((current) => (
-      current?.source === "projects" ? { ...current, requestId } : current
+    setProjectLoadError((current) => (
+      current?.operation === "refresh" ? { ...current, requestId } : current
     ));
     try {
       const nextProjects = await listProjects();
       if (requestId !== projectsRequestRef.current) return;
       setProjects(nextProjects);
-      setLoadError((current) => (
-        current?.source === "projects" && current.requestId === requestId ? null : current
+      setProjectLoadError((current) => (
+        current?.operation === "refresh" && current.requestId === requestId ? null : current
       ));
     } catch (error) {
       if (requestId === projectsRequestRef.current) {
-        setLoadError({ source: "projects", requestId, message: errorMessage(error) });
+        setProjectLoadError({
+          source: "projects",
+          operation: "refresh",
+          requestId,
+          message: errorMessage(error),
+        });
       }
     }
   }, []);
@@ -1518,8 +1537,8 @@ export function App() {
   ) => {
     const requestId = ++tasksRequestRef.current;
     if (!options.quiet) setTasksLoading(true);
-    setLoadError((current) => (
-      current?.source === "tasks" ? { ...current, requestId } : current
+    setTasksLoadError((current) => (
+      current ? { ...current, requestId } : current
     ));
     try {
       const [nextTasks, nextArchivedTasks] = await Promise.all([
@@ -1530,12 +1549,12 @@ export function App() {
       setTasks(sortTasks(nextTasks));
       setArchivedTasks(sortTasks(nextArchivedTasks));
       setHasLoadedTasks(true);
-      setLoadError((current) => (
-        current?.source === "tasks" && current.requestId === requestId ? null : current
+      setTasksLoadError((current) => (
+        current?.requestId === requestId ? null : current
       ));
     } catch (error) {
       if ((error as Error).name !== "AbortError" && requestId === tasksRequestRef.current) {
-        setLoadError({ source: "tasks", requestId, message: errorMessage(error) });
+        setTasksLoadError({ source: "tasks", requestId, message: errorMessage(error) });
       }
     } finally {
       if (!options.quiet && requestId === tasksRequestRef.current) setTasksLoading(false);
@@ -2727,8 +2746,10 @@ export function App() {
               type="button"
               onClick={() => {
                 setActionError(null);
-                if (loadError?.source === "projects") void refreshProjectList();
-                else if (selectedProjectId) void refreshTasks(selectedProjectId);
+                if (loadError?.source === "projects") {
+                  if (loadError.operation === "initial") void loadProjectList();
+                  else void refreshProjectList();
+                } else if (selectedProjectId) void refreshTasks(selectedProjectId);
                 else void loadProjectList();
               }}
             >

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1481,6 +1481,7 @@ export function App() {
   const refreshProjectList = useCallback(async () => {
     try {
       setProjects(await listProjects());
+      setLoadError(null);
     } catch (error) {
       setLoadError(errorMessage(error));
     }
@@ -1502,6 +1503,7 @@ export function App() {
       setTasks(sortTasks(nextTasks));
       setArchivedTasks(sortTasks(nextArchivedTasks));
       setHasLoadedTasks(true);
+      setLoadError(null);
     } catch (error) {
       if ((error as Error).name !== "AbortError" && requestId === tasksRequestRef.current) {
         setLoadError(errorMessage(error));

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -130,6 +130,11 @@ type DetailSourceScroll =
   | { projectId: string; view: "list"; scrollTop: number };
 type GanttZoom = "day" | "week" | "month";
 type ActionError = string | readonly [string, string];
+type LoadError = {
+  source: "projects" | "tasks";
+  requestId: number;
+  message: string;
+};
 const SHOW_WORKFLOW_BOARD_ENTRY = false;
 const GANTT_ZOOM_OPTIONS: GanttZoom[] = ["day", "week", "month"];
 
@@ -624,7 +629,7 @@ export function App() {
   const [archivedTasks, setArchivedTasks] = useState<Task[]>([]);
   const [tasksLoading, setTasksLoading] = useState(false);
   const [hasLoadedTasks, setHasLoadedTasks] = useState(false);
-  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<LoadError | null>(null);
   const [actionError, setActionError] = useState<ActionError | null>(null);
   const actionErrorText = actionError === null
     ? null
@@ -679,6 +684,7 @@ export function App() {
   const [automationError, setAutomationError] = useState<string | null>(null);
   const [announcement, setAnnouncementValue] = useState("");
   const [undoNotice, setUndoNotice] = useState<UndoNotice | null>(null);
+  const projectsRequestRef = useRef(0);
   const tasksRequestRef = useRef(0);
   const tasksRef = useRef<Task[]>([]);
   const undoSequenceRef = useRef(0);
@@ -1432,13 +1438,17 @@ export function App() {
   }, [detailTaskId, embedded, embeddedFrameChallenge, selectedProjectId]);
 
   const loadProjectList = useCallback(async (signal?: AbortSignal) => {
-    setLoadError(null);
+    const requestId = ++projectsRequestRef.current;
+    setLoadError((current) => (
+      current?.source === "projects" ? { ...current, requestId } : current
+    ));
     try {
       const [nextProjects, metadata, workspaces] = await Promise.all([
         listProjects(signal),
         getTaskboardMetadata(signal),
         listDeviceWorkspaces(signal),
       ]);
+      if (requestId !== projectsRequestRef.current) return;
       setTaskboardMetadata((current) => (
         current
         && current.mode === metadata.mode
@@ -1467,8 +1477,13 @@ export function App() {
           ?? nextProjects[0]?.id
           ?? GLOBAL_PROJECT_ID;
       });
+      setLoadError((current) => (
+        current?.source === "projects" && current.requestId === requestId ? null : current
+      ));
     } catch (error) {
-      if ((error as Error).name !== "AbortError") setLoadError(errorMessage(error));
+      if ((error as Error).name !== "AbortError" && requestId === projectsRequestRef.current) {
+        setLoadError({ source: "projects", requestId, message: errorMessage(error) });
+      }
     }
   }, []);
 
@@ -1479,11 +1494,21 @@ export function App() {
   }, [loadProjectList]);
 
   const refreshProjectList = useCallback(async () => {
+    const requestId = ++projectsRequestRef.current;
+    setLoadError((current) => (
+      current?.source === "projects" ? { ...current, requestId } : current
+    ));
     try {
-      setProjects(await listProjects());
-      setLoadError(null);
+      const nextProjects = await listProjects();
+      if (requestId !== projectsRequestRef.current) return;
+      setProjects(nextProjects);
+      setLoadError((current) => (
+        current?.source === "projects" && current.requestId === requestId ? null : current
+      ));
     } catch (error) {
-      setLoadError(errorMessage(error));
+      if (requestId === projectsRequestRef.current) {
+        setLoadError({ source: "projects", requestId, message: errorMessage(error) });
+      }
     }
   }, []);
 
@@ -1493,7 +1518,9 @@ export function App() {
   ) => {
     const requestId = ++tasksRequestRef.current;
     if (!options.quiet) setTasksLoading(true);
-    setLoadError(null);
+    setLoadError((current) => (
+      current?.source === "tasks" ? { ...current, requestId } : current
+    ));
     try {
       const [nextTasks, nextArchivedTasks] = await Promise.all([
         listTasks(projectId, options.signal),
@@ -1503,10 +1530,12 @@ export function App() {
       setTasks(sortTasks(nextTasks));
       setArchivedTasks(sortTasks(nextArchivedTasks));
       setHasLoadedTasks(true);
-      setLoadError(null);
+      setLoadError((current) => (
+        current?.source === "tasks" && current.requestId === requestId ? null : current
+      ));
     } catch (error) {
       if ((error as Error).name !== "AbortError" && requestId === tasksRequestRef.current) {
-        setLoadError(errorMessage(error));
+        setLoadError({ source: "tasks", requestId, message: errorMessage(error) });
       }
     } finally {
       if (!options.quiet && requestId === tasksRequestRef.current) setTasksLoading(false);
@@ -2693,12 +2722,13 @@ export function App() {
         {(loadError || actionErrorText) && (
           <div className="error-banner" role="alert">
             <span className="error-mark" aria-hidden="true"><LinearIcon name="alert" /></span>
-            <div><strong>{text("任务面板需要处理", "Taskboard needs attention")}</strong><p>{actionErrorText ?? loadError}</p></div>
+            <div><strong>{text("任务面板需要处理", "Taskboard needs attention")}</strong><p>{actionErrorText ?? loadError?.message}</p></div>
             <button
               type="button"
               onClick={() => {
                 setActionError(null);
-                if (selectedProjectId) void refreshTasks(selectedProjectId);
+                if (loadError?.source === "projects") void refreshProjectList();
+                else if (selectedProjectId) void refreshTasks(selectedProjectId);
                 else void loadProjectList();
               }}
             >

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -78,20 +78,39 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     }
   }
 
+  const readRequest = method === "GET" || method === "HEAD";
   let response: Response;
-  try {
-    response = await fetch(resolveTaskboardUrl(path), { ...init, headers });
-  } catch (error) {
-    if (error instanceof Error && error.name === "AbortError") throw error;
-    throw new ApiError(0, {
-      error: {
-        code: "SERVICE_UNAVAILABLE",
-        message: apiText(
-          "无法连接本地 Taskboard 服务，请重新通过 Taskboard 启动 Codex。",
-          "Could not connect to the local Taskboard service. Start Codex from Taskboard again.",
-        ),
-      },
-    });
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      response = await fetch(resolveTaskboardUrl(path), { ...init, headers });
+      break;
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") throw error;
+      if (readRequest && attempt < 2) {
+        await new Promise((resolve) => setTimeout(resolve, 250 * (attempt + 1)));
+        continue;
+      }
+      const failure = error instanceof Error && error.name === "TimeoutError"
+        ? "timeout"
+        : error instanceof TypeError
+          ? "browser-network"
+          : "network";
+      throw new ApiError(0, {
+        error: {
+          code: readRequest ? "READ_FAILED" : "SERVICE_UNAVAILABLE",
+          message: readRequest
+            ? apiText(
+                "暂时无法读取 Taskboard 数据。面板会自动重试，请稍后再试。",
+                "Taskboard data is temporarily unavailable. The panel will retry automatically.",
+              )
+            : apiText(
+                "暂时无法连接 Taskboard 服务，请稍后重试。",
+                "The Taskboard service is temporarily unavailable. Try again later.",
+              ),
+          details: { method, failure },
+        },
+      });
+    }
   }
   let body: T & ApiErrorBody;
   try {

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -75,6 +75,7 @@ import {
 } from "./IssueRelations";
 import { TaskPropertyPicker } from "./TaskPropertyPicker";
 import { buildIssueUrl } from "../issueRoute";
+import { postEmbeddedHostMessage } from "../embeddedHost.mjs";
 import copyIdIcon from "../assets/figma-taskboard/copy-id.svg";
 import copyLinkIcon from "../assets/figma-taskboard/copy-link.svg";
 
@@ -157,6 +158,18 @@ function fileSize(value: number): string {
 }
 
 async function downloadAttachmentFile(attachment: Attachment) {
+  const host = new URL(document.baseURI).searchParams.get("host");
+  if (host === "codex" && window.parent !== window) {
+    postEmbeddedHostMessage({
+      type: "taskboard:open-attachment",
+      payload: {
+        attachmentId: attachment.id,
+        filename: attachment.filename,
+      },
+    });
+    return;
+  }
+
   const response = await fetch(resolveTaskboardUrl(attachmentDownloadUrl(attachment)));
   if (!response.ok) {
     throw new ApiError(response.status, await response.json().catch(() => ({})));
@@ -468,6 +481,18 @@ export function TaskDetail({
     );
     return () => controller.abort();
   }, [attachmentsRevision, task.id]);
+
+  useEffect(() => {
+    function receiveAttachmentOpenError(event: MessageEvent) {
+      if (event.source !== window.parent || !event.data || typeof event.data !== "object") return;
+      if (event.data.type !== "taskboard:attachment-open-error") return;
+      setAttachmentsError(typeof event.data.payload?.error === "string"
+        ? event.data.payload.error
+        : ["无法打开附件，请重试。", "Could not open the attachment. Try again."]);
+    }
+    window.addEventListener("message", receiveAttachmentOpenError);
+    return () => window.removeEventListener("message", receiveAttachmentOpenError);
+  }, []);
 
   useEffect(() => {
     const key = `taskboard.comment-draft.${task.id}`;


### PR DESCRIPTION
## Summary

- Open Taskboard attachments from the embedded Codex panel by downloading them through the authenticated host bridge and launching the local file with the macOS default application.
- Read attachment bytes from the existing `/api/attachments/:id/content` endpoint before writing the local file.
- Retry transient GET/HEAD network failures and keep diagnostic categories without exposing URLs or local paths.
- Keep project and task failures in two independent error slots. Retrying the visible failure then reveals any remaining failure. Initial project-load failures retry projects, metadata, and workspaces together; background project refresh failures retry only projects.
- Reopen the Taskboard panel without restarting the managed Codex process. The explicit tray action to reopen Codex remains unchanged.
- Rename the embedded recovery action to Reload panel so the label matches its safe behavior.

## Direct verification

- `npm run typecheck`
- `npm run app:prepare -- --target x86_64-apple-darwin`
- Rust 1.88 `cargo check` for `src-tauri`
- JavaScript syntax checks for the injection and host runtime files
- Packaged resource copy verification
- Current Launcher and Taskboard data: read the existing `LOCAL-160` `image.png` attachment from `/content`; received `image/png` and 185,919 bytes; wrote it to `opened-attachments/<attachment-id>/image.png` with mode `0600`; verified the file type and SHA-256; then invoked the production-equivalent `openWithDefaultApplication` path and confirmed `/usr/bin/open` spawned successfully.
- Controlled browser timing against the real React panel: projects and tasks both failed; retrying projects exposed the retained tasks failure; retrying tasks cleared the final banner. Each retry called only its own resource endpoints.
- Initial metadata failure and initial workspaces failure were each recovered with one retry that reloaded projects, metadata, and workspaces together.

No regression tests were added or run before user confirmation, per the repository workflow.

Reported by @maodun96 in #99 and #100.

Fixes #99
Fixes #100
