### PR TITLE
持久化项目标签并支持删除

### DIFF
--- a/cloud/migrations/0006_project_labels.sql
+++ b/cloud/migrations/0006_project_labels.sql
@@ -1,0 +1,31 @@
+ALTER TABLE projects
+ADD COLUMN labels TEXT NOT NULL DEFAULT '["缺陷","特性","for-claude","hold","改进","phase-1","phase-2","phase-3","phase-4","phase-5","phase-6"]';
+
+WITH catalog AS (
+  SELECT
+    projects.id AS project_id,
+    default_labels.value AS label,
+    0 AS source_order,
+    printf('%08d', default_labels.key) AS label_order
+  FROM projects, json_each('["缺陷","特性","for-claude","hold","改进","phase-1","phase-2","phase-3","phase-4","phase-5","phase-6"]') AS default_labels
+
+  UNION ALL
+
+  SELECT
+    tasks.project_id,
+    task_labels.value,
+    1,
+    tasks.created_at || ':' || tasks.id || ':' || printf('%08d', task_labels.key)
+  FROM tasks, json_each(tasks.labels) AS task_labels
+)
+UPDATE projects
+SET labels = (
+  SELECT json_group_array(label)
+  FROM (
+    SELECT label
+    FROM catalog
+    WHERE catalog.project_id = projects.id
+    GROUP BY label
+    ORDER BY MIN(source_order), MIN(label_order)
+  )
+);

--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -1272,46 +1272,52 @@ async function createProject(env, input) {
 }
 
 async function addProjectLabel(env, projectId, label) {
-  const project = await requireProject(env, projectId);
-  const labels = JSON.parse(project.labels);
-  if (!labels.includes(label)) {
-    await env.DB.prepare(`
-      UPDATE projects SET labels = ?, updated_at = ? WHERE id = ?
-    `).bind(JSON.stringify([...labels, label]), now(), projectId).run();
-  }
+  await requireProject(env, projectId);
+  await env.DB.prepare(`
+    UPDATE projects
+    SET labels = json_insert(labels, '$[#]', ?), updated_at = ?
+    WHERE id = ?
+      AND NOT EXISTS (
+        SELECT 1 FROM json_each(projects.labels) WHERE value = ?
+      )
+  `).bind(label, now(), projectId, label).run();
   return getProject(env, projectId);
 }
 
 async function deleteProjectLabel(env, projectId, label) {
-  const project = await requireProject(env, projectId);
+  await requireProject(env, projectId);
   const timestamp = now();
-  const labels = JSON.parse(project.labels);
-  const statements = [];
-  if (labels.includes(label)) {
-    statements.push(env.DB.prepare(`
-      UPDATE projects SET labels = ?, updated_at = ? WHERE id = ?
-    `).bind(
-      JSON.stringify(labels.filter((current) => current !== label)),
-      timestamp,
-      projectId,
-    ));
-  }
-  statements.push(env.DB.prepare(`
-    UPDATE tasks
-    SET
-      labels = (
-        SELECT COALESCE(json_group_array(value), '[]')
-        FROM json_each(tasks.labels)
-        WHERE value != ?
-      ),
-      version = version + 1,
-      updated_at = ?
-    WHERE project_id = ?
-      AND EXISTS (
-        SELECT 1 FROM json_each(tasks.labels) WHERE value = ?
-      )
-  `).bind(label, timestamp, projectId, label));
-  await env.DB.batch(statements);
+  await env.DB.batch([
+    env.DB.prepare(`
+      UPDATE projects
+      SET
+        labels = (
+          SELECT COALESCE(json_group_array(value), '[]')
+          FROM json_each(projects.labels)
+          WHERE value != ?
+        ),
+        updated_at = ?
+      WHERE id = ?
+        AND EXISTS (
+          SELECT 1 FROM json_each(projects.labels) WHERE value = ?
+        )
+    `).bind(label, timestamp, projectId, label),
+    env.DB.prepare(`
+      UPDATE tasks
+      SET
+        labels = (
+          SELECT COALESCE(json_group_array(value), '[]')
+          FROM json_each(tasks.labels)
+          WHERE value != ?
+        ),
+        version = version + 1,
+        updated_at = ?
+      WHERE project_id = ?
+        AND EXISTS (
+          SELECT 1 FROM json_each(tasks.labels) WHERE value = ?
+        )
+    `).bind(label, timestamp, projectId, label),
+  ]);
   return getProject(env, projectId);
 }
 
@@ -1389,7 +1395,6 @@ async function createTask(env, input, actor) {
   const project = await env.DB.prepare(`
     SELECT
       projects.id,
-      projects.labels,
       (
         SELECT tasks.identifier
         FROM tasks
@@ -1484,13 +1489,27 @@ async function createTask(env, input, actor) {
           FROM tasks
           WHERE id = ?
         ),
-        labels = ?,
+        labels = (
+          SELECT json_group_array(value)
+          FROM (
+            SELECT value
+            FROM (
+              SELECT value, 0 AS source_order, key AS label_order
+              FROM json_each(projects.labels)
+              UNION ALL
+              SELECT value, 1 AS source_order, key AS label_order
+              FROM json_each(?)
+            )
+            GROUP BY value
+            ORDER BY MIN(source_order), MIN(label_order)
+          )
+        ),
         updated_at = ?
       WHERE id = ?
     `).bind(
       suffixStart,
       id,
-      JSON.stringify([...new Set([...JSON.parse(project.labels), ...input.labels])]),
+      JSON.stringify(input.labels),
       timestamp,
       input.projectId,
     ),
@@ -1513,12 +1532,10 @@ async function updateTask(env, id, input, actor) {
     ? await requireProject(env, input.changes.projectId)
     : null;
   const projectChanged = Boolean(targetProject && targetProject.id !== currentTask.projectId);
-  const destinationProject = targetProject ?? await requireProject(env, currentTask.projectId);
-  const destinationProjectLabels = JSON.parse(destinationProject.labels);
+  const destinationProjectId = targetProject?.id ?? currentTask.projectId;
   const taskLabels = Object.hasOwn(input.changes, "labels")
     ? input.changes.labels
     : currentTask.labels;
-  const mergedProjectLabels = [...new Set([...destinationProjectLabels, ...taskLabels])];
   if (projectChanged) {
     const relation = await env.DB.prepare(`
       SELECT 1
@@ -1637,21 +1654,47 @@ async function updateTask(env, id, input, actor) {
       timestamp,
     ));
   }
-  if (mergedProjectLabels.length !== destinationProjectLabels.length) {
+  if (taskLabels.length > 0) {
     statements.push(env.DB.prepare(`
       UPDATE projects
-      SET labels = ?, updated_at = ?
+      SET
+        labels = (
+          SELECT json_group_array(value)
+          FROM (
+            SELECT value
+            FROM (
+              SELECT value, 0 AS source_order, key AS label_order
+              FROM json_each(projects.labels)
+              UNION ALL
+              SELECT value, 1 AS source_order, key AS label_order
+              FROM json_each(?)
+            )
+            GROUP BY value
+            ORDER BY MIN(source_order), MIN(label_order)
+          )
+        ),
+        updated_at = ?
       WHERE id = ?
         AND EXISTS (
           SELECT 1 FROM tasks WHERE id = ? AND version = ? AND updated_at = ?
         )
+        AND EXISTS (
+          SELECT 1
+          FROM json_each(?) AS task_labels
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM json_each(projects.labels) AS project_labels
+            WHERE project_labels.value = task_labels.value
+          )
+        )
     `).bind(
-      JSON.stringify(mergedProjectLabels),
+      JSON.stringify(taskLabels),
       timestamp,
-      destinationProject.id,
+      destinationProjectId,
       current.id,
       input.version + 1,
       timestamp,
+      JSON.stringify(taskLabels),
     ));
   }
   const results = await env.DB.batch(statements);

--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -1494,14 +1494,24 @@ async function createTask(env, input, actor) {
           FROM (
             SELECT value
             FROM (
-              SELECT value, 0 AS source_order, key AS label_order
-              FROM json_each(projects.labels)
-              UNION ALL
-              SELECT value, 1 AS source_order, key AS label_order
-              FROM json_each(?)
+              SELECT
+                value,
+                source_order,
+                label_order,
+                ROW_NUMBER() OVER (
+                  PARTITION BY value
+                  ORDER BY source_order, label_order
+                ) AS occurrence_rank
+              FROM (
+                SELECT value, 0 AS source_order, key AS label_order
+                FROM json_each(projects.labels)
+                UNION ALL
+                SELECT value, 1 AS source_order, key AS label_order
+                FROM json_each(?)
+              )
             )
-            GROUP BY value
-            ORDER BY MIN(source_order), MIN(label_order)
+            WHERE occurrence_rank = 1
+            ORDER BY source_order, label_order
           )
         ),
         updated_at = ?
@@ -1663,14 +1673,24 @@ async function updateTask(env, id, input, actor) {
           FROM (
             SELECT value
             FROM (
-              SELECT value, 0 AS source_order, key AS label_order
-              FROM json_each(projects.labels)
-              UNION ALL
-              SELECT value, 1 AS source_order, key AS label_order
-              FROM json_each(?)
+              SELECT
+                value,
+                source_order,
+                label_order,
+                ROW_NUMBER() OVER (
+                  PARTITION BY value
+                  ORDER BY source_order, label_order
+                ) AS occurrence_rank
+              FROM (
+                SELECT value, 0 AS source_order, key AS label_order
+                FROM json_each(projects.labels)
+                UNION ALL
+                SELECT value, 1 AS source_order, key AS label_order
+                FROM json_each(?)
+              )
             )
-            GROUP BY value
-            ORDER BY MIN(source_order), MIN(label_order)
+            WHERE occurrence_rank = 1
+            ORDER BY source_order, label_order
           )
         ),
         updated_at = ?

--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -1,7 +1,9 @@
 import { normalizeWorkflowSnapshot } from "../../shared/workflow-control-flow.mjs";
+import { DEFAULT_LABEL_NAMES } from "../../shared/domain.mjs";
 
 const JSON_BODY_LIMIT = 1024 * 1024;
 const ATTACHMENT_BODY_LIMIT = 25 * 1024 * 1024;
+const DEFAULT_PROJECT_LABELS_JSON = JSON.stringify(DEFAULT_LABEL_NAMES);
 const PROJECT_ID_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
 const TASK_STATUSES = [
   "backlog",
@@ -467,6 +469,7 @@ function projectFromRow(row) {
     id: row.id,
     name: row.name,
     workspacePath: null,
+    labels: JSON.parse(row.labels),
     issueCount: Number(row.issue_count ?? 0),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -919,6 +922,12 @@ function parseProjectCreate(body) {
   return { id, name };
 }
 
+function parseProjectLabel(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["label"]));
+  return stringField(body.label, "label", { required: true, maxLength: 64 });
+}
+
 function parseTaskCreate(body) {
   assertPlainObject(body);
   assertAllowedKeys(body, new Set([
@@ -1199,6 +1208,7 @@ async function listProjects(env) {
       projects.id,
       projects.name,
       projects.workspace_path,
+      projects.labels,
       projects.created_at,
       projects.updated_at,
       COUNT(tasks.id) AS issue_count
@@ -1210,6 +1220,7 @@ async function listProjects(env) {
       projects.id,
       projects.name,
       projects.workspace_path,
+      projects.labels,
       projects.created_at,
       projects.updated_at
     ORDER BY projects.created_at, projects.id
@@ -1223,6 +1234,7 @@ async function getProject(env, id) {
       projects.id,
       projects.name,
       projects.workspace_path,
+      projects.labels,
       projects.created_at,
       projects.updated_at,
       COUNT(tasks.id) AS issue_count
@@ -1235,6 +1247,7 @@ async function getProject(env, id) {
       projects.id,
       projects.name,
       projects.workspace_path,
+      projects.labels,
       projects.created_at,
       projects.updated_at
   `).bind(id).first();
@@ -1246,9 +1259,9 @@ async function createProject(env, input) {
   try {
     await env.DB.prepare(`
       INSERT INTO projects (
-        id, name, workspace_path, next_task_number, created_at, updated_at
-      ) VALUES (?, ?, NULL, 1, ?, ?)
-    `).bind(input.id, input.name, timestamp, timestamp).run();
+        id, name, workspace_path, labels, next_task_number, created_at, updated_at
+      ) VALUES (?, ?, NULL, ?, 1, ?, ?)
+    `).bind(input.id, input.name, DEFAULT_PROJECT_LABELS_JSON, timestamp, timestamp).run();
   } catch (error) {
     if (String(error.message).includes("UNIQUE constraint failed")) {
       throw new ApiError(409, "PROJECT_EXISTS", `Project '${input.id}' already exists`);
@@ -1256,6 +1269,50 @@ async function createProject(env, input) {
     throw error;
   }
   return getProject(env, input.id);
+}
+
+async function addProjectLabel(env, projectId, label) {
+  const project = await requireProject(env, projectId);
+  const labels = JSON.parse(project.labels);
+  if (!labels.includes(label)) {
+    await env.DB.prepare(`
+      UPDATE projects SET labels = ?, updated_at = ? WHERE id = ?
+    `).bind(JSON.stringify([...labels, label]), now(), projectId).run();
+  }
+  return getProject(env, projectId);
+}
+
+async function deleteProjectLabel(env, projectId, label) {
+  const project = await requireProject(env, projectId);
+  const timestamp = now();
+  const labels = JSON.parse(project.labels);
+  const statements = [];
+  if (labels.includes(label)) {
+    statements.push(env.DB.prepare(`
+      UPDATE projects SET labels = ?, updated_at = ? WHERE id = ?
+    `).bind(
+      JSON.stringify(labels.filter((current) => current !== label)),
+      timestamp,
+      projectId,
+    ));
+  }
+  statements.push(env.DB.prepare(`
+    UPDATE tasks
+    SET
+      labels = (
+        SELECT COALESCE(json_group_array(value), '[]')
+        FROM json_each(tasks.labels)
+        WHERE value != ?
+      ),
+      version = version + 1,
+      updated_at = ?
+    WHERE project_id = ?
+      AND EXISTS (
+        SELECT 1 FROM json_each(tasks.labels) WHERE value = ?
+      )
+  `).bind(label, timestamp, projectId, label));
+  await env.DB.batch(statements);
+  return getProject(env, projectId);
 }
 
 async function deleteProject(env, id) {
@@ -1332,6 +1389,7 @@ async function createTask(env, input, actor) {
   const project = await env.DB.prepare(`
     SELECT
       projects.id,
+      projects.labels,
       (
         SELECT tasks.identifier
         FROM tasks
@@ -1426,9 +1484,16 @@ async function createTask(env, input, actor) {
           FROM tasks
           WHERE id = ?
         ),
+        labels = ?,
         updated_at = ?
       WHERE id = ?
-    `).bind(suffixStart, id, timestamp, input.projectId),
+    `).bind(
+      suffixStart,
+      id,
+      JSON.stringify([...new Set([...JSON.parse(project.labels), ...input.labels])]),
+      timestamp,
+      input.projectId,
+    ),
   ]);
   if (!changed(results[0]) || !changed(results[1])) {
     throw new ApiError(
@@ -1448,6 +1513,12 @@ async function updateTask(env, id, input, actor) {
     ? await requireProject(env, input.changes.projectId)
     : null;
   const projectChanged = Boolean(targetProject && targetProject.id !== currentTask.projectId);
+  const destinationProject = targetProject ?? await requireProject(env, currentTask.projectId);
+  const destinationProjectLabels = JSON.parse(destinationProject.labels);
+  const taskLabels = Object.hasOwn(input.changes, "labels")
+    ? input.changes.labels
+    : currentTask.labels;
+  const mergedProjectLabels = [...new Set([...destinationProjectLabels, ...taskLabels])];
   if (projectChanged) {
     const relation = await env.DB.prepare(`
       SELECT 1
@@ -1561,6 +1632,23 @@ async function updateTask(env, id, input, actor) {
       timestamp,
       currentTask.projectId,
       targetProject.id,
+      current.id,
+      input.version + 1,
+      timestamp,
+    ));
+  }
+  if (mergedProjectLabels.length !== destinationProjectLabels.length) {
+    statements.push(env.DB.prepare(`
+      UPDATE projects
+      SET labels = ?, updated_at = ?
+      WHERE id = ?
+        AND EXISTS (
+          SELECT 1 FROM tasks WHERE id = ? AND version = ? AND updated_at = ?
+        )
+    `).bind(
+      JSON.stringify(mergedProjectLabels),
+      timestamp,
+      destinationProject.id,
       current.id,
       input.version + 1,
       timestamp,
@@ -2423,6 +2511,22 @@ async function routeApi(request, env, actor, url) {
     if (request.method !== "DELETE") methodNotAllowed(["DELETE"]);
     await deleteProject(env, projectId);
     return empty(204);
+  }
+
+  const projectLabelsMatch = pathname.match(/^\/api\/projects\/([^/]+)\/labels$/);
+  if (projectLabelsMatch) {
+    requireNoQuery(url, "Project label routes");
+    const projectId = validateProjectId(
+      decodePathPart(projectLabelsMatch[1], "Project id"),
+    );
+    if (request.method !== "POST" && request.method !== "DELETE") {
+      methodNotAllowed(["POST", "DELETE"]);
+    }
+    const label = parseProjectLabel(await readJson(request));
+    const project = request.method === "POST"
+      ? await addProjectLabel(env, projectId, label)
+      : await deleteProjectLabel(env, projectId, label);
+    return json(200, { project });
   }
 
   const workflowMatch = pathname.match(

--- a/scripts/migrate-to-cloud.mjs
+++ b/scripts/migrate-to-cloud.mjs
@@ -15,6 +15,8 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { DatabaseSync } from "node:sqlite";
 
+import { DEFAULT_LABEL_NAMES } from "../shared/domain.mjs";
+
 const SCHEMA_VERSION = 1;
 const WRANGLER_D1_STATEMENT_MAX_BYTES = 90_000;
 const TABLE_ORDER = [
@@ -79,6 +81,23 @@ function sanitizeWorkflowRow(row) {
     ...row,
     workspace: JSON.stringify(sanitizeWorkflowValue(workspace)),
   };
+}
+
+function projectRowsWithLabels(tables) {
+  const labelsByProject = new Map(tables.projects.map((project) => [
+    project.id,
+    project.labels == null ? [...DEFAULT_LABEL_NAMES] : JSON.parse(project.labels),
+  ]));
+  for (const task of tables.tasks) {
+    const labels = labelsByProject.get(task.project_id);
+    for (const label of JSON.parse(task.labels)) {
+      if (!labels.includes(label)) labels.push(label);
+    }
+  }
+  return tables.projects.map((project) => ({
+    ...project,
+    labels: JSON.stringify(labelsByProject.get(project.id)),
+  }));
 }
 
 function buildProjectCounts(tables) {
@@ -324,7 +343,7 @@ export async function createCloudMigrationBundle({
   attachmentsDirectory,
 }) {
   const tables = await readSnapshot(databasePath);
-  tables.projects = tables.projects.map((project) => ({
+  tables.projects = projectRowsWithLabels(tables).map((project) => ({
     ...project,
     workspace_path: null,
   }));
@@ -346,7 +365,9 @@ export async function createCloudMigrationBundle({
 }
 
 const CLOUD_COLUMNS = {
-  projects: ["id", "name", "workspace_path", "next_task_number", "created_at", "updated_at"],
+  projects: [
+    "id", "name", "workspace_path", "labels", "next_task_number", "created_at", "updated_at",
+  ],
   tasks: [
     "id", "identifier", "project_id", "title", "description", "status", "priority", "labels",
     "sort_order", "thread_id", "creator_type", "creator_id", "creator_name",
@@ -377,8 +398,9 @@ function cloudTaskRow(task) {
   };
 }
 
-function cloudRows(table, rows) {
-  return table === "tasks" ? rows.map(cloudTaskRow) : rows;
+function cloudRows(table, tables) {
+  if (table === "projects") return projectRowsWithLabels(tables);
+  return table === "tasks" ? tables.tasks.map(cloudTaskRow) : tables[table];
 }
 
 function insertTableSql(table) {
@@ -392,7 +414,7 @@ function insertTableSql(table) {
 export function createCloudD1ImportPlan(tables) {
   return TABLE_ORDER.map((table) => {
     const columns = CLOUD_COLUMNS[table];
-    const values = cloudRows(table, tables[table]).map((row) => (
+    const values = cloudRows(table, tables).map((row) => (
       Object.fromEntries(columns.map((column) => [column, row[column] ?? null]))
     ));
     return { table, sql: insertTableSql(table), json: JSON.stringify(values) };

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -491,6 +491,12 @@ function parseProjectCreate(body) {
   return { id, name, workspacePath };
 }
 
+function parseProjectLabel(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["label"]));
+  return stringField(body.label, "label", { required: true, maxLength: 64 });
+}
+
 function parseThreadId(value) {
   if (value === undefined) return undefined;
   return stringField(value, "threadId", { required: true, maxLength: 256 });
@@ -2059,6 +2065,29 @@ export function createTaskboardServer(options = {}) {
           return sendEmpty(response, 204);
         }
         return methodNotAllowed(response, ["DELETE"]);
+      }
+
+      const projectLabelsRoute = pathname.match(/^\/api\/projects\/([^/]+)\/labels$/);
+      if (projectLabelsRoute) {
+        if ([...url.searchParams.keys()].length > 0) {
+          throw new ApiError(400, "UNKNOWN_QUERY_PARAMETER", "Project label routes do not accept query parameters");
+        }
+        let projectId;
+        try {
+          projectId = decodeURIComponent(projectLabelsRoute[1]);
+        } catch {
+          throw new ApiError(400, "INVALID_PATH", "Project id contains invalid encoding");
+        }
+        validateProjectId(projectId);
+        if (request.method !== "POST" && request.method !== "DELETE") {
+          return methodNotAllowed(response, ["POST", "DELETE"]);
+        }
+        const label = parseProjectLabel(await readJson(request));
+        const project = request.method === "POST"
+          ? database.addProjectLabel(projectId, label)
+          : database.deleteProjectLabel(projectId, label);
+        events.emit("project.labels.updated", { project });
+        return sendJson(response, 200, { project });
       }
 
       const workflowWorkspaceRoute = pathname.match(/^\/api\/projects\/([^/]+)\/workflow-workspace$/);

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -1471,7 +1471,7 @@ export class TaskboardDatabase {
     this.#requireVersion(current, version);
     const activityChanges = taskFieldChanges(current, changes);
     const targetProject = Object.hasOwn(changes, "projectId")
-      ? this.database.prepare("SELECT id, name, workspace_path FROM projects WHERE id = ?").get(changes.projectId)
+      ? this.database.prepare("SELECT id, name, workspace_path, labels FROM projects WHERE id = ?").get(changes.projectId)
       : null;
     if (Object.hasOwn(changes, "projectId") && !targetProject) {
       throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${changes.projectId}' does not exist`);

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -3,6 +3,10 @@ import { mkdirSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
+import { DEFAULT_LABEL_NAMES } from "../shared/domain.mjs";
+
+const DEFAULT_PROJECT_LABELS_JSON = JSON.stringify(DEFAULT_LABEL_NAMES);
+
 export class ApiError extends Error {
   constructor(status, code, message, details) {
     super(message);
@@ -248,6 +252,7 @@ function projectFromRow(row) {
     id: row.id,
     name: row.name,
     workspacePath: row.workspace_path,
+    labels: JSON.parse(row.labels),
     issueCount: Number(row.issue_count ?? 0),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -341,6 +346,7 @@ export class TaskboardDatabase {
         id TEXT PRIMARY KEY,
         name TEXT NOT NULL,
         workspace_path TEXT,
+        labels TEXT NOT NULL DEFAULT '${DEFAULT_PROJECT_LABELS_JSON}',
         next_task_number INTEGER NOT NULL DEFAULT 1 CHECK (next_task_number > 0),
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL
@@ -581,6 +587,41 @@ export class TaskboardDatabase {
         throw error;
       }
     }
+    if (!projectColumns.some((column) => column.name === "labels")) {
+      this.database.exec("BEGIN IMMEDIATE");
+      try {
+        this.database.exec(`
+          ALTER TABLE projects
+          ADD COLUMN labels TEXT NOT NULL DEFAULT '${DEFAULT_PROJECT_LABELS_JSON}'
+        `);
+        const labelsByProject = new Map(
+          this.database.prepare("SELECT id FROM projects").all().map((project) => (
+            [project.id, [...DEFAULT_LABEL_NAMES]]
+          )),
+        );
+        for (const task of this.database.prepare(`
+          SELECT project_id, labels
+          FROM tasks
+          ORDER BY created_at, id
+        `).all()) {
+          const projectLabels = labelsByProject.get(task.project_id);
+          if (!projectLabels) continue;
+          for (const label of JSON.parse(task.labels)) {
+            if (!projectLabels.includes(label)) projectLabels.push(label);
+          }
+        }
+        const updateProjectLabels = this.database.prepare(`
+          UPDATE projects SET labels = ? WHERE id = ?
+        `);
+        for (const [projectId, labels] of labelsByProject) {
+          updateProjectLabels.run(JSON.stringify(labels), projectId);
+        }
+        this.database.exec("COMMIT");
+      } catch (error) {
+        this.database.exec("ROLLBACK");
+        throw error;
+      }
+    }
     this.database.exec(`
       CREATE INDEX IF NOT EXISTS tasks_project_status_sort
         ON tasks(project_id, archived_at, status, sort_order, created_at)
@@ -749,6 +790,7 @@ export class TaskboardDatabase {
         projects.id,
         projects.name,
         projects.workspace_path,
+        projects.labels,
         projects.created_at,
         projects.updated_at,
         COUNT(tasks.id) AS issue_count
@@ -760,6 +802,7 @@ export class TaskboardDatabase {
         projects.id,
         projects.name,
         projects.workspace_path,
+        projects.labels,
         projects.created_at,
         projects.updated_at
       ORDER BY projects.created_at, projects.id
@@ -770,9 +813,17 @@ export class TaskboardDatabase {
     const timestamp = now();
     try {
       this.database.prepare(`
-        INSERT INTO projects (id, name, workspace_path, next_task_number, created_at, updated_at)
-        VALUES (?, ?, ?, 1, ?, ?)
-      `).run(input.id, input.name, input.workspacePath, timestamp, timestamp);
+        INSERT INTO projects (
+          id, name, workspace_path, labels, next_task_number, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, 1, ?, ?)
+      `).run(
+        input.id,
+        input.name,
+        input.workspacePath,
+        DEFAULT_PROJECT_LABELS_JSON,
+        timestamp,
+        timestamp,
+      );
     } catch (error) {
       if (String(error.message).includes("UNIQUE constraint failed")) {
         throw new ApiError(409, "PROJECT_EXISTS", `Project '${input.id}' already exists`);
@@ -810,6 +861,7 @@ export class TaskboardDatabase {
         projects.id,
         projects.name,
         projects.workspace_path,
+        projects.labels,
         projects.created_at,
         projects.updated_at,
         COUNT(tasks.id) AS issue_count
@@ -822,10 +874,64 @@ export class TaskboardDatabase {
         projects.id,
         projects.name,
         projects.workspace_path,
+        projects.labels,
         projects.created_at,
         projects.updated_at
     `).get(id);
     return row ? projectFromRow(row) : null;
+  }
+
+  addProjectLabel(projectId, label) {
+    const project = this.database.prepare("SELECT labels FROM projects WHERE id = ?").get(projectId);
+    if (!project) {
+      throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${projectId}' does not exist`);
+    }
+    const labels = JSON.parse(project.labels);
+    if (!labels.includes(label)) {
+      this.database.prepare(`
+        UPDATE projects SET labels = ?, updated_at = ? WHERE id = ?
+      `).run(JSON.stringify([...labels, label]), now(), projectId);
+    }
+    return this.getProject(projectId);
+  }
+
+  deleteProjectLabel(projectId, label) {
+    this.database.exec("BEGIN IMMEDIATE");
+    try {
+      const project = this.database.prepare("SELECT labels FROM projects WHERE id = ?").get(projectId);
+      if (!project) {
+        throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${projectId}' does not exist`);
+      }
+      const timestamp = now();
+      const labels = JSON.parse(project.labels);
+      if (labels.includes(label)) {
+        this.database.prepare(`
+          UPDATE projects SET labels = ?, updated_at = ? WHERE id = ?
+        `).run(JSON.stringify(labels.filter((current) => current !== label)), timestamp, projectId);
+      }
+      const updateTask = this.database.prepare(`
+        UPDATE tasks
+        SET labels = ?, version = version + 1, updated_at = ?
+        WHERE id = ?
+      `);
+      for (const task of this.database.prepare(`
+        SELECT id, labels FROM tasks WHERE project_id = ?
+      `).all(projectId)) {
+        const taskLabels = JSON.parse(task.labels);
+        if (taskLabels.includes(label)) {
+          updateTask.run(
+            JSON.stringify(taskLabels.filter((current) => current !== label)),
+            timestamp,
+            task.id,
+          );
+        }
+      }
+      this.database.exec("COMMIT");
+    } catch (error) {
+      this.database.exec("ROLLBACK");
+      throw error;
+    }
+    return this.getProject(projectId);
   }
 
   getProjectSummary(projectId) {
@@ -1267,6 +1373,7 @@ export class TaskboardDatabase {
       const project = this.database.prepare(`
         SELECT
           projects.id,
+          projects.labels,
           projects.next_task_number,
           (
             SELECT tasks.identifier
@@ -1305,8 +1412,13 @@ export class TaskboardDatabase {
       }
 
       this.database.prepare(`
-        UPDATE projects SET next_task_number = ?, updated_at = ? WHERE id = ?
-      `).run(number + 1, timestamp, input.projectId);
+        UPDATE projects SET next_task_number = ?, labels = ?, updated_at = ? WHERE id = ?
+      `).run(
+        number + 1,
+        JSON.stringify([...new Set([...JSON.parse(project.labels), ...input.labels])]),
+        timestamp,
+        input.projectId,
+      );
       this.database.prepare(`
         INSERT INTO tasks (
           id, identifier, project_id, title, description, status, priority, labels,
@@ -1464,6 +1576,18 @@ export class TaskboardDatabase {
         this.database.prepare(`
           UPDATE projects SET updated_at = ? WHERE id IN (?, ?)
         `).run(timestamp, current.projectId, targetProject.id);
+      }
+      const destinationProjectId = projectChanged ? targetProject.id : current.projectId;
+      const destinationProject = this.database.prepare(`
+        SELECT labels FROM projects WHERE id = ?
+      `).get(destinationProjectId);
+      const taskLabels = Object.hasOwn(changes, "labels") ? changes.labels : current.labels;
+      const projectLabels = JSON.parse(destinationProject.labels);
+      const mergedLabels = [...new Set([...projectLabels, ...taskLabels])];
+      if (mergedLabels.length !== projectLabels.length) {
+        this.database.prepare(`
+          UPDATE projects SET labels = ?, updated_at = ? WHERE id = ?
+        `).run(JSON.stringify(mergedLabels), timestamp, destinationProjectId);
       }
       this.#recordTaskActivity(current.id, actor, activityChanges, timestamp);
       this.database.exec("COMMIT");

--- a/shared/domain.mjs
+++ b/shared/domain.mjs
@@ -10,6 +10,19 @@ export const TASK_STATUSES = [
 export const TASK_PRIORITIES = ["none", "urgent", "high", "medium", "low"];
 
 export const DEFAULT_PROJECT_ID = "local";
+export const DEFAULT_LABEL_NAMES = [
+  "缺陷",
+  "特性",
+  "for-claude",
+  "hold",
+  "改进",
+  "phase-1",
+  "phase-2",
+  "phase-3",
+  "phase-4",
+  "phase-5",
+  "phase-6",
+];
 
 export function isTaskStatus(value) {
   return TASK_STATUSES.includes(value);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,9 +22,11 @@ import {
   ApiError,
   addTaskRelation,
   archiveTask as archiveTaskRequest,
+  createProjectLabel as createProjectLabelRequest,
   createProject as createProjectRequest,
   createTask as createTaskRequest,
   deleteArchivedTask as deleteArchivedTaskRequest,
+  deleteProjectLabel as deleteProjectLabelRequest,
   deleteProject as deleteProjectRequest,
   getCodexThreadProgress,
   getHostRuntime,
@@ -84,7 +86,6 @@ import {
   MAIN_STATUSES,
   type OtherTaskTab,
 } from "./issueBoardStatuses";
-import { DEFAULT_LABELS } from "./labels";
 import {
   normalizeCodexThreadId,
   taskCardPresentation,
@@ -317,6 +318,7 @@ const EVENT_NAMES = [
   "attachment.created",
   "attachment.deleted",
   "project.created",
+  "project.labels.updated",
   "workflow.updated",
 ] as const;
 
@@ -521,16 +523,25 @@ function LocalRealtimeSync({
 
     const handleEvent = (event: Event) => {
       const message = event as MessageEvent<string>;
-      let payload: { projectId?: string; taskId?: string } = {};
+      let payload: { projectId?: string; taskId?: string; project?: Project } = {};
       try {
-        payload = JSON.parse(message.data) as { projectId?: string; taskId?: string };
+        payload = JSON.parse(message.data) as {
+          projectId?: string;
+          taskId?: string;
+          project?: Project;
+        };
       } catch {
         // A malformed event should not interrupt later updates.
       }
+      const eventProjectId = payload.projectId ?? payload.project?.id;
       const affectsSelectedProject = Boolean(selectedProjectId)
-        && (!payload.projectId || payload.projectId === selectedProjectId);
+        && (!eventProjectId || eventProjectId === selectedProjectId);
       if (event.type === "project.created") {
         scheduleRefresh({ projects: true });
+        return;
+      }
+      if (event.type === "project.labels.updated") {
+        scheduleRefresh({ projects: true, tasks: affectsSelectedProject });
         return;
       }
       if (event.type.startsWith("task.")) {
@@ -828,13 +839,7 @@ export function App() {
   const contextMenuTask = contextMenu
     ? tasks.find((task) => task.id === contextMenu.taskId) ?? null
     : null;
-  const availableLabels = useMemo(
-    () => [...new Set([
-      ...DEFAULT_LABELS.map((label) => label.name),
-      ...tasks.flatMap((task) => task.labels),
-    ])],
-    [tasks],
-  );
+  const availableLabels = selectedProject?.labels ?? [];
   const projectChoices = useMemo<ProjectChoice[]>(() => {
     const persistedById = new Map(projects.map((project) => [project.id, project]));
     const seen = new Set<string>();
@@ -2054,6 +2059,33 @@ export function App() {
     }
   }
 
+  async function persistProjectLabel(label: string) {
+    setActionError(null);
+    try {
+      const project = await createProjectLabelRequest(selectedProjectId, label);
+      setProjects((current) => current.map((candidate) => (
+        candidate.id === project.id ? project : candidate
+      )));
+    } catch (error) {
+      setActionError(errorMessage(error));
+      throw error;
+    }
+  }
+
+  async function removeProjectLabel(label: string) {
+    setActionError(null);
+    try {
+      const project = await deleteProjectLabelRequest(selectedProjectId, label);
+      setProjects((current) => current.map((candidate) => (
+        candidate.id === project.id ? project : candidate
+      )));
+      await refreshTasks(selectedProjectId, { quiet: true });
+    } catch (error) {
+      setActionError(errorMessage(error));
+      throw error;
+    }
+  }
+
   async function mutateTaskRelation(
     action: "add" | "remove",
     task: Task,
@@ -2716,6 +2748,8 @@ export function App() {
             developmentScanLoading={developmentScanLoading}
             commentsRevision={commentsRevision}
             attachmentsRevision={attachmentsRevision}
+            onCreateLabel={persistProjectLabel}
+            onDeleteLabel={removeProjectLabel}
             onUpdate={(current, changes) => updateTaskProperties(current, changes)}
             onOpenTask={openTaskDetail}
             onAddRelation={(current, type, relatedTaskId) => (
@@ -2826,6 +2860,7 @@ export function App() {
                         contextMenuTaskId={contextMenu?.taskId ?? null}
                         availableLabels={availableLabels}
                         currentUser={currentUser}
+                        onCreateLabel={persistProjectLabel}
                         onCreate={(initialStatus) => setEditor({ task: null, status: initialStatus })}
                         onEdit={openTaskDetail}
                         onUpdate={updateTaskProperties}
@@ -2857,6 +2892,7 @@ export function App() {
                     contextMenuTaskId={contextMenu?.taskId ?? null}
                     availableLabels={availableLabels}
                     currentUser={currentUser}
+                    onCreateLabel={persistProjectLabel}
                     restoringTaskId={restoringTaskId}
                     deletingTaskId={deletingArchivedTaskId}
                     onTabChange={setOtherTasksTab}
@@ -3087,6 +3123,7 @@ export function App() {
           currentUser={currentUser}
           developmentScan={developmentScan}
           developmentScanLoading={developmentScanLoading}
+          onCreateLabel={persistProjectLabel}
           onCancel={(draft) => {
             if (!editor.task) setNewTaskDraft(draft);
             setEditor(null);

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -334,6 +334,28 @@ export async function createProject(input: {
   return data.project;
 }
 
+export async function createProjectLabel(projectId: string, label: string): Promise<Project> {
+  const data = await request<{ project: Project }>(
+    `/api/projects/${encodeURIComponent(projectId)}/labels`,
+    {
+      method: "POST",
+      body: JSON.stringify({ label }),
+    },
+  );
+  return data.project;
+}
+
+export async function deleteProjectLabel(projectId: string, label: string): Promise<Project> {
+  const data = await request<{ project: Project }>(
+    `/api/projects/${encodeURIComponent(projectId)}/labels`,
+    {
+      method: "DELETE",
+      body: JSON.stringify({ label }),
+    },
+  );
+  return data.project;
+}
+
 export async function deleteProject(projectId: string): Promise<void> {
   await request(`/api/projects/${encodeURIComponent(projectId)}`, {
     method: "DELETE",

--- a/web/src/components/BoardColumn.tsx
+++ b/web/src/components/BoardColumn.tsx
@@ -77,6 +77,7 @@ interface BoardColumnProps {
   contextMenuTaskId: string | null;
   availableLabels: string[];
   currentUser: ActorIdentity;
+  onCreateLabel: (label: string) => Promise<void>;
   onCreate: (status: TaskStatus) => void;
   onEdit: (task: Task) => void;
   onUpdate: (task: Task, changes: Partial<TaskDraft>) => Promise<Task>;
@@ -104,6 +105,7 @@ export function BoardColumn({
   contextMenuTaskId,
   availableLabels,
   currentUser,
+  onCreateLabel,
   onCreate,
   onEdit,
   onUpdate,
@@ -214,6 +216,7 @@ export function BoardColumn({
               isContextMenuOpen={contextMenuTaskId === task.id}
               availableLabels={availableLabels}
               currentUser={currentUser}
+              onCreateLabel={onCreateLabel}
               onEdit={onEdit}
               onUpdate={onUpdate}
               onComplete={onComplete}

--- a/web/src/components/LabelPicker.tsx
+++ b/web/src/components/LabelPicker.tsx
@@ -16,6 +16,8 @@ interface LabelPickerProps {
   triggerContent?: ReactNode;
   onOpenChange: (open: boolean) => void;
   onChange: (labels: string[]) => void;
+  onCreateLabel: (label: string) => Promise<void>;
+  onDeleteLabel?: (label: string) => Promise<void>;
 }
 
 export function LabelPicker({
@@ -31,12 +33,15 @@ export function LabelPicker({
   triggerContent,
   onOpenChange,
   onChange,
+  onCreateLabel,
+  onDeleteLabel,
 }: LabelPickerProps) {
   const { language, text } = useTaskboardI18n();
   const resolvedPlaceholder = placeholder ?? text("标签", "Labels");
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const [search, setSearch] = useState("");
+  const [pendingLabel, setPendingLabel] = useState<string | null>(null);
   const normalizedSearch = search.trim();
   const filteredLabels = availableLabels.filter((label) => (
     !normalizedSearch
@@ -74,10 +79,36 @@ export function LabelPicker({
   }, [onOpenChange, open]);
 
   function toggleLabel(label: string) {
-    if (disabled) return;
+    if (disabled || pendingLabel) return;
     onChange(selectedLabels.includes(label)
       ? selectedLabels.filter((item) => item !== label)
       : [...selectedLabels, label]);
+  }
+
+  async function createLabel() {
+    const label = normalizedSearch;
+    setPendingLabel(label);
+    try {
+      await onCreateLabel(label);
+      onChange(selectedLabels.includes(label) ? selectedLabels : [...selectedLabels, label]);
+      setSearch("");
+    } catch {
+      // The caller reports API errors in the shared action banner.
+    } finally {
+      setPendingLabel(null);
+    }
+  }
+
+  async function deleteLabel(label: string) {
+    if (!onDeleteLabel) return;
+    setPendingLabel(label);
+    try {
+      await onDeleteLabel(label);
+    } catch {
+      // The caller reports API errors in the shared action banner.
+    } finally {
+      setPendingLabel(null);
+    }
   }
 
   return (
@@ -126,28 +157,38 @@ export function LabelPicker({
             {filteredLabels.map((label) => {
               const presentation = labelPresentation(label, language);
               return (
-                <button
-                  type="button"
-                  role="option"
-                  aria-selected={selectedLabels.includes(label)}
-                  disabled={disabled}
-                  key={label}
-                  onClick={() => toggleLabel(label)}
-                >
-                  <i style={{ background: presentation.tone ? presentation.color : "transparent" }} />
-                  <span>{presentation.name}</span>
-                  {selectedLabels.includes(label) && <b><LinearIcon name="check" /></b>}
-                </button>
+                <div className="label-option-row" role="presentation" key={label}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={selectedLabels.includes(label)}
+                    disabled={disabled || pendingLabel !== null}
+                    onClick={() => toggleLabel(label)}
+                  >
+                    <i style={{ background: presentation.tone ? presentation.color : "transparent" }} />
+                    <span>{presentation.name}</span>
+                    {selectedLabels.includes(label) && <b><LinearIcon name="check" /></b>}
+                  </button>
+                  {onDeleteLabel && (
+                    <button
+                      type="button"
+                      className="label-delete-button"
+                      disabled={disabled || pendingLabel !== null}
+                      aria-label={text(`删除标签 ${presentation.name}`, `Delete label ${presentation.name}`)}
+                      title={text("删除标签", "Delete label")}
+                      onClick={() => void deleteLabel(label)}
+                    >
+                      <LinearIcon name="trash" />
+                    </button>
+                  )}
+                </div>
               );
             })}
             {canCreateLabel && (
               <button
                 type="button"
-                disabled={disabled}
-                onClick={() => {
-                  toggleLabel(normalizedSearch);
-                  setSearch("");
-                }}
+                disabled={disabled || pendingLabel !== null}
+                onClick={() => void createLabel()}
               >
                 <i style={{
                   background: labelPresentation(normalizedSearch, language).tone

--- a/web/src/components/OtherTasksPanel.tsx
+++ b/web/src/components/OtherTasksPanel.tsx
@@ -90,6 +90,7 @@ interface OtherTasksPanelProps {
   contextMenuTaskId: string | null;
   availableLabels: string[];
   currentUser: ActorIdentity;
+  onCreateLabel: (label: string) => Promise<void>;
   restoringTaskId: string | null;
   deletingTaskId: string | null;
   onTabChange: (tab: OtherTaskTab) => void;
@@ -122,6 +123,7 @@ export function OtherTasksPanel({
   contextMenuTaskId,
   availableLabels,
   currentUser,
+  onCreateLabel,
   restoringTaskId,
   deletingTaskId,
   onTabChange,
@@ -280,6 +282,7 @@ export function OtherTasksPanel({
               isContextMenuOpen={contextMenuTaskId === task.id}
               availableLabels={availableLabels}
               currentUser={currentUser}
+              onCreateLabel={onCreateLabel}
               onEdit={onEdit}
               onUpdate={onUpdate}
               onContextMenu={onContextMenu}

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -36,6 +36,7 @@ interface TaskCardProps {
   isContextMenuOpen: boolean;
   availableLabels: string[];
   currentUser: ActorIdentity;
+  onCreateLabel: (label: string) => Promise<void>;
   onEdit: (task: Task) => void;
   onUpdate: (task: Task, changes: Partial<TaskDraft>) => Promise<Task>;
   onComplete?: (task: Task) => void;
@@ -349,6 +350,7 @@ export function TaskCard({
   isContextMenuOpen,
   availableLabels,
   currentUser,
+  onCreateLabel,
   onEdit,
   onUpdate,
   onComplete,
@@ -478,6 +480,7 @@ export function TaskCard({
               triggerContent={<TaskLabels task={task} />}
               onOpenChange={(open) => setPropertyMenu(open ? "labels" : null)}
               onChange={(labels) => updateProperty({ labels }, "labels")}
+              onCreateLabel={onCreateLabel}
             />
           )}
           <DueDateControl

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -89,6 +89,8 @@ interface TaskDetailProps {
   developmentScanLoading: boolean;
   commentsRevision: number;
   attachmentsRevision: number;
+  onCreateLabel: (label: string) => Promise<void>;
+  onDeleteLabel: (label: string) => Promise<void>;
   onUpdate: (task: Task, changes: Partial<TaskDraft>) => Promise<Task>;
   onOpenTask: (task: TaskRelationSummary) => void;
   onAddRelation: (
@@ -342,6 +344,8 @@ export function TaskDetail({
   developmentScanLoading,
   commentsRevision,
   attachmentsRevision,
+  onCreateLabel,
+  onDeleteLabel,
   onUpdate,
   onOpenTask,
   onAddRelation,
@@ -1485,6 +1489,8 @@ export function TaskDetail({
                 placeholder={text("添加标签…", "Add labels…")}
                 onOpenChange={(open) => setPropertyMenu(open ? "labels" : null)}
                 onChange={(nextLabels) => void saveTask({ labels: nextLabels }, "labels")}
+                onCreateLabel={onCreateLabel}
+                onDeleteLabel={onDeleteLabel}
               />
             </div>
             <label className="detail-property-row development-property">

--- a/web/src/components/TaskEditor.tsx
+++ b/web/src/components/TaskEditor.tsx
@@ -83,6 +83,7 @@ interface TaskEditorProps {
   currentUser: ActorIdentity;
   developmentScan: DevelopmentScan;
   developmentScanLoading: boolean;
+  onCreateLabel: (label: string) => Promise<void>;
   onCancel: (draft: NewTaskEditorDraft | null) => void;
   onSave: (
     draft: TaskDraft,
@@ -135,6 +136,7 @@ export function TaskEditor({
   currentUser,
   developmentScan,
   developmentScanLoading,
+  onCreateLabel,
   onCancel,
   onSave,
 }: TaskEditorProps) {
@@ -471,6 +473,7 @@ export function TaskEditor({
               showIcon
               onOpenChange={(open) => setMenu(open ? "labels" : null)}
               onChange={setSelectedLabels}
+              onCreateLabel={onCreateLabel}
             />
 
             <label className="property-control property-development" title={developmentScan.workspacePath ?? undefined}>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6619,6 +6619,29 @@ kbd {
   overflow: auto;
 }
 
+.label-option-row {
+  display: flex;
+  align-items: center;
+}
+
+.label-option-row > button[role="option"] {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.label-options .label-delete-button {
+  width: 32px;
+  flex: 0 0 32px;
+  justify-content: center;
+  padding: 0;
+  color: var(--text-tertiary);
+}
+
+.label-options .label-delete-button svg {
+  width: 14px;
+  height: 14px;
+}
+
 .label-options button,
 .more-popover button,
 .due-popover button {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -176,6 +176,7 @@ export interface Project {
   id: string;
   name: string;
   workspacePath: string | null;
+  labels: string[];
   issueCount: number;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## 变更

- 把项目标签目录持久化到本地 SQLite 和云端 D1。
- 创建标签时立即写入项目标签目录。
- 从现有标签管理入口删除默认标签或用户标签。
- 删除时同步清理活动议题和归档议题中的标签引用。
- 让标签管理、标签选择器和议题显示在刷新后读取同一份最新数据。
- 在本地到云端迁移中保留并补齐项目标签目录。

## 根因

前端原来每次用硬编码默认标签和活动议题标签临时生成可用标签。项目没有正式标签字段，也没有标签删除 API。

## 直接验证

- `npm run typecheck`
- `npm run build:web`
- JavaScript 语法检查和 `git diff --check`
- 本地数据库：创建自定义标签、重启、删除自定义和默认标签、再次重启
- 活动议题和归档议题标签清理
- 旧本地数据库标签目录迁移
- D1 迁移和 Worker API 主路径
- 旧迁移包和旧本地库到 D1 的标签补齐

按项目开发顺序，本次未新增或运行回归测试套件。

Issue 由 @s83sun 报告，保留原作者记录。

Closes #103