### PR TITLE
fix: restore managed Codex microphone access

### DIFF
--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -1674,7 +1674,7 @@ async function main() {
 
   let codexProcess = null;
   let managedCodex = null;
-  let managedCodexLaunchPromise = null;
+  let pendingCodexLaunch = null;
   let cdpRuntime = null;
   let runtimePublishPromise = null;
   const injectedTargets = new Map();
@@ -1755,9 +1755,19 @@ async function main() {
   const startManagedCodex = async () => {
     if (stopping) return;
     if (options.cdpPipe) {
-      const launched = await launchCodexWithPipe(options.appPath);
-      codexProcess = launched.child;
-      cdpRuntime = pipeCdpRuntime(launched.browser);
+      const launchPromise = (async () => {
+        const launched = await launchCodexWithPipe(options.appPath);
+        codexProcess = launched.child;
+        cdpRuntime = pipeCdpRuntime(launched.browser);
+      })();
+      pendingCodexLaunch = launchPromise;
+      try {
+        await launchPromise;
+      } catch (error) {
+        if (!stopping) throw error;
+      } finally {
+        if (pendingCodexLaunch === launchPromise) pendingCodexLaunch = null;
+      }
       return;
     }
     const launchPromise = launchCodexWithLaunchServices(
@@ -1765,13 +1775,13 @@ async function main() {
       options.port,
       () => stopping,
     );
-    managedCodexLaunchPromise = launchPromise;
+    pendingCodexLaunch = launchPromise;
     try {
       managedCodex = await launchPromise;
     } catch (error) {
       if (!stopping) throw error;
     } finally {
-      if (managedCodexLaunchPromise === launchPromise) managedCodexLaunchPromise = null;
+      if (pendingCodexLaunch === launchPromise) pendingCodexLaunch = null;
     }
     if (stopping) return;
     try {
@@ -1806,11 +1816,13 @@ async function main() {
       })();
       supervisorCleanupPromise.catch(() => {});
       runtimeCleanupPromise.catch(() => {});
-      const pendingManagedCodexLaunch = managedCodexLaunchPromise;
-      if (pendingManagedCodexLaunch) {
+      const launchPromise = pendingCodexLaunch;
+      if (launchPromise) {
         try {
-          await pendingManagedCodexLaunch;
+          await launchPromise;
         } catch (_) {}
+        cdpRuntime?.close();
+        cdpRuntime = null;
       }
       const launchedCodex = codexProcess;
       let launchedManagedCodex = managedCodex;

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -1931,10 +1931,18 @@ async function main() {
             );
             continue;
           }
-          throw error;
+          if (
+            !launchedCodex
+            || (launchedCodex.exitCode === null && launchedCodex.signalCode === null)
+          ) {
+            throw error;
+          }
         }
-        const managedCodexExited = managedCodex && !isManagedCodexRunning(managedCodex);
-        if (managedCodexExited) {
+        const launchedCodexExited = options.cdpPipe
+          ? codexProcess
+            && (codexProcess.exitCode !== null || codexProcess.signalCode !== null)
+          : managedCodex && !isManagedCodexRunning(managedCodex);
+        if (launchedCodexExited) {
           injectedTargets.forEach((connection) => {
             unregisterQuotaPolicyCdp(connection);
             connection.close();
@@ -1942,6 +1950,25 @@ async function main() {
           injectedTargets.clear();
           cdpRuntime?.close();
           cdpRuntime = null;
+          if (options.cdpPipe) {
+            const exitCode = codexProcess.exitCode;
+            codexProcess = null;
+            if (exitCode === 0) {
+              idleAfterNormalExit = true;
+              console.error(
+                "Waiting for Codex after normal exit; open Codex Taskboard again to restart it.",
+              );
+              continue;
+            }
+            console.error("Codex exited unexpectedly; restarting it for the taskboard launcher.");
+            try {
+              await startManagedCodex();
+              if (options.open) openRequestGeneration += 1;
+            } catch (restartError) {
+              console.error(`Waiting to restart Codex: ${restartError.message}`);
+            }
+            continue;
+          }
           managedCodex = null;
           idleAfterNormalExit = true;
           console.error(

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -294,10 +294,67 @@ function codexExecutablePath(appPath) {
   );
 }
 
-function launchCodex(appPath, port) {
-  return spawn(
-    codexExecutablePath(appPath),
+function managedCodexProcesses(appPath) {
+  const processes = spawnSync("/bin/ps", ["-ww", "-axo", "pid=,command="], {
+    encoding: "utf8",
+    env: withoutTaskboardLauncherEnvironment(process.env),
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  if (processes.status !== 0) throw new Error("Unable to inspect the launched Codex process");
+
+  const executable = codexExecutablePath(appPath);
+  const profileArgument = `--user-data-dir=${independentCodexProfilePath}`;
+  const matches = [];
+  for (const line of processes.stdout.split("\n")) {
+    const match = line.match(/^\s*(\d+)\s+(.+)$/);
+    if (
+      match
+      && match[2].startsWith(`${executable} `)
+      && match[2].includes(` ${profileArgument} `)
+    ) {
+      matches.push({ pid: Number(match[1]), command: match[2] });
+    }
+  }
+  return matches;
+}
+
+function managedCodexProcess(appPath) {
+  const processes = managedCodexProcesses(appPath);
+  if (processes.length > 1) throw new Error("Multiple managed Codex processes are running");
+  return processes[0] ?? null;
+}
+
+function managedCodexUsesPort(record, port) {
+  return record.command.includes(` --remote-debugging-port=${port} `);
+}
+
+function isManagedCodexRunning(record) {
+  const result = spawnSync(
+    "/bin/ps",
+    ["-ww", "-p", String(record.pid), "-o", "command="],
+    {
+      encoding: "utf8",
+      env: withoutTaskboardLauncherEnvironment(process.env),
+    },
+  );
+  return result.status === 0 && result.stdout.trimEnd() === record.command;
+}
+
+async function launchCodexWithLaunchServices(appPath, port) {
+  const existing = managedCodexProcess(appPath);
+  if (existing && managedCodexUsesPort(existing, port)) return existing;
+  if (existing) await stopManagedCodex(existing);
+  if (await isReachable(`http://127.0.0.1:${port}/json/version`)) {
+    throw new Error(`Codex CDP port ${port} is already in use`);
+  }
+
+  const launcher = spawn(
+    "/usr/bin/open",
     [
+      "-n",
+      "-a",
+      appPath,
+      "--args",
       `--user-data-dir=${independentCodexProfilePath}`,
       "--remote-debugging-address=127.0.0.1",
       `--remote-debugging-port=${port}`,
@@ -308,6 +365,51 @@ function launchCodex(appPath, port) {
       stdio: "ignore",
     },
   );
+  await new Promise((resolve, reject) => {
+    launcher.once("error", reject);
+    launcher.once("exit", (code, signal) => {
+      if (code === 0) resolve();
+      else reject(new Error(`LaunchServices failed to start Codex (${signal || code})`));
+    });
+  });
+
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const launched = managedCodexProcess(appPath);
+    if (launched && managedCodexUsesPort(launched, port)) return launched;
+    if (launched) throw new Error("LaunchServices started Codex on an unexpected CDP port");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error("LaunchServices did not start the managed Codex process");
+}
+
+async function stopManagedCodex(record) {
+  if (!isManagedCodexRunning(record)) return;
+  try {
+    process.kill(record.pid, "SIGTERM");
+  } catch (error) {
+    if (error.code === "ESRCH") return;
+    throw error;
+  }
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    if (!isManagedCodexRunning(record)) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  if (!isManagedCodexRunning(record)) return;
+  try {
+    process.kill(record.pid, "SIGKILL");
+  } catch (error) {
+    if (error.code !== "ESRCH") throw error;
+  }
+  const killDeadline = Date.now() + 1_000;
+  while (Date.now() < killDeadline) {
+    if (!isManagedCodexRunning(record)) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  if (isManagedCodexRunning(record)) {
+    throw new Error("Unable to stop the managed Codex process");
+  }
 }
 
 async function launchCodexWithPipe(appPath) {
@@ -1567,6 +1669,7 @@ async function main() {
   }
 
   let codexProcess = null;
+  let managedCodex = null;
   let cdpRuntime = null;
   const injectedTargets = new Map();
   let openRequestGeneration = options.open ? 1 : 0;
@@ -1630,6 +1733,18 @@ async function main() {
     },
   });
 
+  const startManagedCodex = async () => {
+    if (options.cdpPipe) {
+      const launched = await launchCodexWithPipe(options.appPath);
+      codexProcess = launched.child;
+      cdpRuntime = pipeCdpRuntime(launched.browser);
+      return;
+    }
+    managedCodex = await launchCodexWithLaunchServices(options.appPath, options.port);
+    await waitUntilReachable(cdpVersionUrl, 30_000);
+    cdpRuntime = tcpCdpRuntime(options.port);
+  };
+
   let cleanupPromise = null;
   const cleanup = () => {
     if (cleanupPromise) return cleanupPromise;
@@ -1642,7 +1757,10 @@ async function main() {
       cdpRuntime?.close();
       cdpRuntime = null;
       const launchedCodex = codexProcess;
+      const launchedManagedCodex = managedCodex;
       codexProcess = null;
+      managedCodex = null;
+      if (launchedManagedCodex) await stopManagedCodex(launchedManagedCodex);
       if (
         launchedCodex
         && launchedCodex.exitCode === null
@@ -1686,15 +1804,15 @@ async function main() {
     await publishTaskboardRuntime();
     if (options.launch) await importCodexBrowserProfile();
 
-    if (options.cdpPipe) {
-      const launched = await launchCodexWithPipe(options.appPath);
-      codexProcess = launched.child;
-      cdpRuntime = pipeCdpRuntime(launched.browser);
-    } else if (!cdpReachable) {
-      codexProcess = launchCodex(options.appPath, options.port);
-      await waitUntilReachable(cdpVersionUrl, 30_000);
-      cdpRuntime = tcpCdpRuntime(options.port);
+    if (options.cdpPipe || !cdpReachable) {
+      await startManagedCodex();
     } else {
+      if (options.launch) {
+        managedCodex = managedCodexProcess(options.appPath);
+        if (!managedCodex || !managedCodexUsesPort(managedCodex, options.port)) {
+          throw new Error(`Codex CDP port ${options.port} belongs to another process`);
+        }
+      }
       cdpRuntime = tcpCdpRuntime(options.port);
     }
 
@@ -1731,7 +1849,7 @@ async function main() {
     let idleAfterNormalExit = false;
 
     if (!options.watch) {
-      codexProcess?.unref();
+      if (options.cdpPipe) codexProcess?.unref();
       return;
     }
 
@@ -1758,9 +1876,7 @@ async function main() {
       if (idleAfterNormalExit) {
         if (!hasOpenPending()) continue;
         try {
-          const launched = await launchCodexWithPipe(options.appPath);
-          codexProcess = launched.child;
-          cdpRuntime = pipeCdpRuntime(launched.browser);
+          await startManagedCodex();
           idleAfterNormalExit = false;
         } catch (restartError) {
           console.error(`Waiting to restart Codex: ${restartError.message}`);
@@ -1817,9 +1933,8 @@ async function main() {
           }
           throw error;
         }
-        const launchedCodexExited = codexProcess
-          && (codexProcess.exitCode !== null || codexProcess.signalCode !== null);
-        if (launchedCodexExited) {
+        const managedCodexExited = managedCodex && !isManagedCodexRunning(managedCodex);
+        if (managedCodexExited) {
           injectedTargets.forEach((connection) => {
             unregisterQuotaPolicyCdp(connection);
             connection.close();
@@ -1827,30 +1942,11 @@ async function main() {
           injectedTargets.clear();
           cdpRuntime?.close();
           cdpRuntime = null;
-          const exitCode = codexProcess.exitCode;
-          codexProcess = null;
-          if (exitCode === 0) {
-            idleAfterNormalExit = true;
-            console.error(
-              "Waiting for Codex after normal exit; open Codex Taskboard again to restart it.",
-            );
-            continue;
-          }
-          console.error("Codex exited unexpectedly; restarting it for the taskboard launcher.");
-          try {
-            if (options.cdpPipe) {
-              const launched = await launchCodexWithPipe(options.appPath);
-              codexProcess = launched.child;
-              cdpRuntime = pipeCdpRuntime(launched.browser);
-            } else {
-              codexProcess = launchCodex(options.appPath, options.port);
-              await waitUntilReachable(cdpVersionUrl, 30_000);
-              cdpRuntime = tcpCdpRuntime(options.port);
-            }
-            if (options.open) openRequestGeneration += 1;
-          } catch (restartError) {
-            console.error(`Waiting to restart Codex: ${restartError.message}`);
-          }
+          managedCodex = null;
+          idleAfterNormalExit = true;
+          console.error(
+            "Waiting for Codex after exit; open Codex Taskboard again to restart it.",
+          );
           continue;
         }
         console.error(`Waiting for Codex renderer: ${error.message}`);

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -181,10 +181,12 @@ async function isTaskboardReachable() {
   }
 }
 
-async function waitUntilReachable(url, timeoutMs) {
+async function waitUntilReachable(url, timeoutMs, shouldStop = () => false) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
+    if (shouldStop()) throw new Error(`Stopped waiting for ${url}`);
     if (await isReachable(url)) return;
+    if (shouldStop()) throw new Error(`Stopped waiting for ${url}`);
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
   throw new Error(`Timed out waiting for ${url}`);
@@ -340,13 +342,15 @@ function isManagedCodexRunning(record) {
   return result.status === 0 && result.stdout.trimEnd() === record.command;
 }
 
-async function launchCodexWithLaunchServices(appPath, port) {
+async function launchCodexWithLaunchServices(appPath, port, shouldStop = () => false) {
   const existing = managedCodexProcess(appPath);
   if (existing && managedCodexUsesPort(existing, port)) return existing;
   if (existing) await stopManagedCodex(existing);
+  if (shouldStop()) throw new Error("Managed Codex launch stopped");
   if (await isReachable(`http://127.0.0.1:${port}/json/version`)) {
     throw new Error(`Codex CDP port ${port} is already in use`);
   }
+  if (shouldStop()) throw new Error("Managed Codex launch stopped");
 
   const launcher = spawn(
     "/usr/bin/open",
@@ -1670,7 +1674,9 @@ async function main() {
 
   let codexProcess = null;
   let managedCodex = null;
+  let managedCodexLaunchPromise = null;
   let cdpRuntime = null;
+  let runtimePublishPromise = null;
   const injectedTargets = new Map();
   let openRequestGeneration = options.open ? 1 : 0;
   let openedRequestGeneration = 0;
@@ -1718,6 +1724,9 @@ async function main() {
     if (stopping) return;
     stopping = true;
     wakeStop();
+    cleanup().catch((error) => {
+      console.error(`Cleanup failed: ${error.message}`);
+    });
   };
   const detached = !options.watch;
   const supervisor = createTaskboardSupervisor({
@@ -1733,16 +1742,45 @@ async function main() {
     },
   });
 
+  const publishRuntime = async () => {
+    const pending = publishTaskboardRuntime();
+    runtimePublishPromise = pending;
+    try {
+      await pending;
+    } finally {
+      if (runtimePublishPromise === pending) runtimePublishPromise = null;
+    }
+  };
+
   const startManagedCodex = async () => {
+    if (stopping) return;
     if (options.cdpPipe) {
       const launched = await launchCodexWithPipe(options.appPath);
       codexProcess = launched.child;
       cdpRuntime = pipeCdpRuntime(launched.browser);
       return;
     }
-    managedCodex = await launchCodexWithLaunchServices(options.appPath, options.port);
-    await waitUntilReachable(cdpVersionUrl, 30_000);
-    cdpRuntime = tcpCdpRuntime(options.port);
+    const launchPromise = launchCodexWithLaunchServices(
+      options.appPath,
+      options.port,
+      () => stopping,
+    );
+    managedCodexLaunchPromise = launchPromise;
+    try {
+      managedCodex = await launchPromise;
+    } catch (error) {
+      if (!stopping) throw error;
+    } finally {
+      if (managedCodexLaunchPromise === launchPromise) managedCodexLaunchPromise = null;
+    }
+    if (stopping) return;
+    try {
+      await waitUntilReachable(cdpVersionUrl, 30_000, () => stopping);
+    } catch (error) {
+      if (stopping) return;
+      throw error;
+    }
+    if (!stopping) cdpRuntime = tcpCdpRuntime(options.port);
   };
 
   let cleanupPromise = null;
@@ -1756,8 +1794,32 @@ async function main() {
       injectedTargets.clear();
       cdpRuntime?.close();
       cdpRuntime = null;
+      const supervisorCleanupPromise = supervisor.stop();
+      const runtimeCleanupPromise = (async () => {
+        const pendingRuntimePublish = runtimePublishPromise;
+        if (pendingRuntimePublish) {
+          try {
+            await pendingRuntimePublish;
+          } catch (_) {}
+        }
+        await removeTaskboardRuntime();
+      })();
+      supervisorCleanupPromise.catch(() => {});
+      runtimeCleanupPromise.catch(() => {});
+      const pendingManagedCodexLaunch = managedCodexLaunchPromise;
+      if (pendingManagedCodexLaunch) {
+        try {
+          await pendingManagedCodexLaunch;
+        } catch (_) {}
+      }
       const launchedCodex = codexProcess;
-      const launchedManagedCodex = managedCodex;
+      let launchedManagedCodex = managedCodex;
+      if (!launchedManagedCodex && !options.cdpPipe) {
+        const discovered = managedCodexProcess(options.appPath);
+        if (discovered && managedCodexUsesPort(discovered, options.port)) {
+          launchedManagedCodex = discovered;
+        }
+      }
       codexProcess = null;
       managedCodex = null;
       if (launchedManagedCodex) await stopManagedCodex(launchedManagedCodex);
@@ -1782,12 +1844,16 @@ async function main() {
           ]);
         }
       }
-      await supervisor.stop();
-      await removeTaskboardRuntime();
+      await Promise.all([supervisorCleanupPromise, runtimeCleanupPromise]);
     })();
     return cleanupPromise;
   };
+  if (options.watch) {
+    process.once("SIGINT", requestStop);
+    process.once("SIGTERM", requestStop);
+  }
   try {
+    if (stopping) return;
     let cdpReachable = false;
     if (!options.cdpPipe) {
       cdpReachable = await isReachable(cdpVersionUrl);
@@ -1799,10 +1865,16 @@ async function main() {
         throw new Error(`Codex CDP is not listening on 127.0.0.1:${options.port}`);
       }
     }
+    if (stopping) return;
 
     await supervisor.ensure({ force: true });
-    await publishTaskboardRuntime();
-    if (options.launch) await importCodexBrowserProfile();
+    if (stopping) return;
+    await publishRuntime();
+    if (stopping) return;
+    if (options.launch) {
+      await importCodexBrowserProfile();
+      if (stopping) return;
+    }
 
     if (options.cdpPipe || !cdpReachable) {
       await startManagedCodex();
@@ -1815,8 +1887,10 @@ async function main() {
       }
       cdpRuntime = tcpCdpRuntime(options.port);
     }
+    if (stopping) return;
 
     const { source, sourceHash } = await currentInjectionSource();
+    if (stopping) return;
     let firstResults = [];
     const firstOpenGeneration = openRequestGeneration;
     const shouldOpenFirstTarget = firstOpenGeneration > openedRequestGeneration;
@@ -1837,6 +1911,7 @@ async function main() {
       if (!options.watch) throw error;
       console.error(`Waiting for Codex renderer: ${error.message}`);
     }
+    if (stopping) return;
     if (firstResults.length > 0) {
       if (shouldOpenFirstTarget) {
         openedRequestGeneration = Math.max(openedRequestGeneration, firstOpenGeneration);
@@ -1853,8 +1928,6 @@ async function main() {
       return;
     }
 
-    process.once("SIGINT", requestStop);
-    process.once("SIGTERM", requestStop);
     while (!stopping) {
       await Promise.race([
         new Promise((resolve) => setTimeout(resolve, 2_000)),
@@ -1863,7 +1936,7 @@ async function main() {
       if (stopping) break;
       try {
         const service = await supervisor.ensure();
-        if (service.restarted) await publishTaskboardRuntime();
+        if (service.restarted && !stopping) await publishRuntime();
       } catch (error) {
         console.error(`Waiting for Taskboard service: ${error.message}`);
       }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -61,6 +61,7 @@ struct LauncherState {
     generation: AtomicU64,
     lifecycle: Mutex<()>,
     taskboard_listener: Mutex<Option<TcpListener>>,
+    codex_port: Mutex<Option<u16>>,
     _instance_lock: File,
     data_directory: PathBuf,
     log_path: PathBuf,
@@ -94,6 +95,7 @@ impl LauncherState {
             generation: AtomicU64::new(0),
             lifecycle: Mutex::new(()),
             taskboard_listener: Mutex::new(None),
+            codex_port: Mutex::new(None),
             _instance_lock: instance_lock,
             pid_record_path: data_directory.join("launcher-child.json"),
             data_directory,
@@ -135,10 +137,14 @@ fn copy_directory(source: &Path, destination: &Path) -> Result<(), std::io::Erro
     Ok(())
 }
 
+fn loopback_listener() -> Result<TcpListener, String> {
+    TcpListener::bind(("127.0.0.1", 0)).map_err(|error| error.to_string())
+}
+
 fn taskboard_listener(state: &LauncherState) -> Result<(i32, u16), String> {
     let mut listener = state.taskboard_listener.lock().unwrap();
     if listener.is_none() {
-        *listener = Some(TcpListener::bind(("127.0.0.1", 0)).map_err(|error| error.to_string())?);
+        *listener = Some(loopback_listener()?);
     }
     let listener = listener.as_ref().unwrap();
     let port = listener
@@ -146,6 +152,20 @@ fn taskboard_listener(state: &LauncherState) -> Result<(i32, u16), String> {
         .map_err(|error| error.to_string())?
         .port();
     Ok((listener.as_raw_fd(), port))
+}
+
+fn codex_port(state: &LauncherState) -> Result<u16, String> {
+    let mut port = state.codex_port.lock().unwrap();
+    if let Some(port) = *port {
+        return Ok(port);
+    }
+    let listener = loopback_listener()?;
+    let selected = listener
+        .local_addr()
+        .map_err(|error| error.to_string())?
+        .port();
+    *port = Some(selected);
+    Ok(selected)
 }
 
 fn update_snapshot(
@@ -423,6 +443,7 @@ fn start_launcher_locked(
         resource_directory.join("bin").display()
     );
     let (taskboard_listener_fd, taskboard_port) = taskboard_listener(state)?;
+    let codex_port = codex_port(state)?.to_string();
     let instance_token = Uuid::new_v4().to_string();
     let instance_secret = Uuid::new_v4().to_string();
     let version = state.snapshot.lock().unwrap().version.clone();
@@ -431,7 +452,7 @@ fn start_launcher_locked(
     let mut command = StdCommand::new(&node_path);
     command
         .arg(&injector_path)
-        .args(["--launch", "--watch", "--open", "--cdp-pipe"])
+        .args(["--launch", "--watch", "--open", "--port", &codex_port])
         .args(["--startup-token", &instance_token, "--app-path"])
         .arg(&codex_app)
         .env("CODEX_TASKBOARD_DATA_DIR", &state.data_directory)
@@ -486,7 +507,7 @@ fn start_launcher_locked(
     append_log(
         state,
         &format!(
-            "Started launcher child {pid} on Taskboard {taskboard_port} with private CDP pipe"
+            "Started launcher child {pid} on Taskboard {taskboard_port} with Codex CDP {codex_port}"
         ),
     );
     if let Some(stdout) = stdout {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -26,6 +26,7 @@ use tauri_plugin_updater::{Update, UpdaterExt};
 use uuid::Uuid;
 
 const STOP_TIMEOUT: Duration = Duration::from_secs(5);
+const LAUNCHER_STOP_TIMEOUT: Duration = Duration::from_secs(36);
 const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 const TASKBOARD_LISTEN_FD: i32 = 5;
 
@@ -270,6 +271,16 @@ fn terminate_process_group(pid: u32) {
     }
 }
 
+fn stop_launcher_process_group(pid: u32) {
+    unsafe {
+        libc::kill(pid as i32, libc::SIGTERM);
+    }
+    if !wait_for_process_group_exit(pid, LAUNCHER_STOP_TIMEOUT) {
+        send_process_group_signal(pid, libc::SIGKILL);
+        let _ = wait_for_process_group_exit(pid, Duration::from_secs(1));
+    }
+}
+
 fn process_matches_record(record: &LauncherPidRecord) -> bool {
     let output = StdCommand::new("/bin/ps")
         .args(["-p", &record.pid.to_string(), "-o", "command="])
@@ -289,7 +300,7 @@ fn stop_recorded_child(state: &LauncherState) {
         .and_then(|content| serde_json::from_str::<LauncherPidRecord>(&content).ok());
     if let Some(record) = record {
         if process_matches_record(&record) {
-            terminate_process_group(record.pid);
+            stop_launcher_process_group(record.pid);
         }
     }
     let _ = fs::remove_file(&state.pid_record_path);
@@ -325,7 +336,7 @@ fn stop_managed_child_locked(app: &AppHandle, state: &Arc<LauncherState>) {
     state.intentional_stop.store(true, Ordering::SeqCst);
     if let Some(pid) = state.child.lock().unwrap().take() {
         append_log(state, &format!("Stopping launcher child {pid}"));
-        terminate_process_group(pid);
+        stop_launcher_process_group(pid);
         clear_pid_record(state, pid);
     }
     update_snapshot(app, state, |snapshot| {

--- a/test/launcher-release.test.mjs
+++ b/test/launcher-release.test.mjs
@@ -7,14 +7,15 @@ const tauriConfig = JSON.parse(await readFile(new URL("../src-tauri/tauri.conf.j
 const releaseWorkflow = await readFile(new URL("../.github/workflows/release-macos.yml", import.meta.url), "utf8");
 const checkWorkflow = await readFile(new URL("../.github/workflows/check.yml", import.meta.url), "utf8");
 
-test("the macOS launcher uses one instance, serialized lifecycle changes, and a private CDP pipe", () => {
+test("the macOS launcher uses one instance, serialized lifecycle changes, and a loopback CDP port", () => {
   assert.match(launcherSource, /libc::flock/);
   assert.match(launcherSource, /lifecycle: Mutex/);
   assert.match(launcherSource, /generation: AtomicU64/);
   assert.match(launcherSource, /TcpListener::bind\(\("127\.0\.0\.1", 0\)\)/);
   assert.equal(launcherSource.match(/TcpListener::bind/g)?.length, 1);
-  assert.match(launcherSource, /"--cdp-pipe"/);
-  assert.doesNotMatch(launcherSource, /cdp_port/);
+  assert.match(launcherSource, /codex_port: Mutex<Option<u16>>/);
+  assert.match(launcherSource, /"--port", &codex_port/);
+  assert.doesNotMatch(launcherSource, /"--cdp-pipe"/);
   assert.doesNotMatch(launcherSource, /const LAUNCHER_PORT/);
 });
 


### PR DESCRIPTION
## Summary

- launch managed Codex through LaunchServices so macOS attributes microphone access to the official Codex app
- keep the managed profile isolated and use one loopback CDP port for the launcher lifetime
- identify, recover, and stop only the matching managed Codex instance
- preserve explicit `--cdp-pipe` exit handling: normal exit waits for a user reopen, while nonzero or signal exit restarts automatically
- accept watch-mode stop signals before the first launch and serialize cleanup with any pending LaunchServices or pipe launch
- merge the latest `main` changes from #117 and #119 while retaining the `.data/launcher-runtime.json` default

## Operation path

Taskboard Launcher starts the injector with a fixed loopback CDP port. The injector uses `/usr/bin/open -n -a` to create an independent `com.openai.codex` application job, while preserving the Taskboard-specific `user-data-dir`. TCC then attributes microphone access to Codex instead of Taskboard.

For an intentional stop, the macOS Launcher first signals the injector process and lets it finish its registered cleanup. The injector waits for any in-flight launch to settle before cleaning it up. A LaunchServices launch returns the exact managed profile and CDP-port record; a pipe launch publishes its child and pipe runtime through the same pending-launch protocol. Cleanup then closes the runtime and stops the corresponding Codex process, removes the runtime descriptor, and stops the Taskboard child service. A late pipe child can no longer land after cleanup has completed.

The explicit `--cdp-pipe` command-line path still tracks its child through `codexProcess`. The installed LaunchServices/TCP path tracks the independent app through `managedCodex`.

## Direct verification

- reproduced the old managed-process TCC denial and confirmed Taskboard was the responsible app
- launched an isolated Codex profile through LaunchServices and confirmed CDP connectivity
- confirmed microphone preflight resolves to `com.openai.codex` with allowed authorization
- executed the current catch branch with controlled pipe nonzero, pipe signal, pipe normal, and managed TCP exit states
- confirmed pipe nonzero and signal exits restart, pipe normal exit stays idle, and TCP exit stays idle
- used a temporary controlled lifecycle harness against the current production launch and cleanup functions for:
  - stop before a deferred pipe child is returned: cleanup waited, closed the late runtime, and stopped the child
  - normal pipe launch: child and runtime became ready and cleanup stopped both
  - nonzero pipe exit: failed runtime closed and the existing automatic restart path ran once
  - LaunchServices stop after `open -n` but before PID/CDP readiness
  - LaunchServices stop after CDP readiness but before first injection completion
  - normal watch-mode stop
- LaunchServices stop points removed the runtime descriptor, stopped the Taskboard child service, stopped only the exact managed profile and port, and left the direct Codex record untouched
- latest `origin/main` is merged; `taskboardRuntimeFile` still defaults to `path.join(taskboardDataDirectory, "launcher-runtime.json")`
- `node --check scripts/codex-injector.mjs`
- `node --test test/injector.test.mjs test/codex-cdp-pipe.test.mjs test/launcher-release.test.mjs`: 14/14
- `npm run typecheck`
- `git diff --check`
- exact head: `2d3c92d1f5c1dbde03b30d5a5f64e4ec0f40425b`
- exact-head CI: both macOS launcher jobs passed; the pull-request `check` passed all 414 tests; the push `check` passed 413/414 and only timed out in the existing `inject-fullheight-regression` fixture while the same head passed that suite in the pull-request run

The final UI waveform and Chinese transcription check will be done with a build containing this PR before release.

Reported by @jack1231222.

Closes #112
