### PR TITLE
fix: restore source launcher and local build paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A local-first issue board that runs in a browser and can be embedded in Codex th
 ## Requirements
 
 - Node.js 22.5 or newer
+- macOS App and DMG builds: Xcode Command Line Tools and Rust 1.88 or newer with the `aarch64-apple-darwin` and `x86_64-apple-darwin` targets. `npm install` installs the Tauri CLI used by this project.
 
 ## Run locally
 
@@ -90,15 +91,26 @@ CODEX_TASKBOARD_HOST=127.0.0.1 npm run codex
 
 This starts the local Taskboard service when needed, launches the official macOS Codex app with an independent profile and loopback-only port `9231`, waits for the main renderer and sidebar, injects a native-looking Taskboard entry after Plugins, and keeps watching both the service and replacement renderers. Existing Codex windows remain unchanged. Keep this command running while using the embedded panel. The launcher does not modify `ChatGPT.app` or its `app.asar`.
 
+The source launcher writes its authenticated endpoint to `.data/launcher-runtime.json`. A `taskctl` command installed with `npm link` reads this file by default, so a normal shell and a Codex task opened from the panel use the same Taskboard service without an extra environment variable.
+
 ### macOS App: open and inject without a terminal
 
-Build the local launcher once:
+For Tauri development, run:
 
 ```bash
-npm run app:codex
+npm run app:dev
 ```
 
-Then open `dist/macos/Codex Taskboard.app` from Finder. The App contains its own Node runtime, Taskboard service, built web UI, Skill, CLI wrapper, and injection script. It starts the service, launches the official Codex app, waits for the renderer, injects the sidebar entry, and opens the panel without showing a terminal window. The App can be copied away from this checkout; the target Mac only needs the official Codex app and does not need this repository, a system Node installation, or a separate Codex CLI installation. Taskboard data is stored in `~/Library/Application Support/Codex Taskboard`, and launcher output is written to `~/Library/Logs/Codex Taskboard/codex-taskboard-launcher.log`.
+To build the local App and DMG, install the two Rust targets once, then run the build:
+
+```bash
+rustup target add aarch64-apple-darwin x86_64-apple-darwin
+npm run app:build
+```
+
+Open `src-tauri/target/universal-apple-darwin/release/bundle/macos/Codex Taskboard.app` from Finder. The DMG is in `src-tauri/target/universal-apple-darwin/release/bundle/dmg/`. If you only want the stable App, download the current DMG from [GitHub Releases](https://github.com/chuspeeism/dashi-taskboard/releases/latest).
+
+The App contains its own Node runtime, Taskboard service, built web UI, Skill, CLI wrapper, and injection script. It starts the service, launches the official Codex app, waits for the renderer, injects the sidebar entry, and opens the panel without showing a terminal window. The App can be copied away from this checkout; the target Mac only needs the official Codex app and does not need this repository, a system Node installation, or a separate Codex CLI installation. Taskboard data is stored in `~/Library/Application Support/Codex Taskboard`, and launcher output is written to `~/Library/Logs/Codex Taskboard/codex-taskboard-launcher.log`.
 
 The local build uses ad-hoc code signing for direct verification. A public macOS download still needs Developer ID signing and Apple notarization.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,6 +9,7 @@
 ## 系统要求
 
 - Node.js 22.5 或更高版本
+- 构建 macOS App 和 DMG：Xcode Command Line Tools、Rust 1.88 或更高版本，以及 `aarch64-apple-darwin` 和 `x86_64-apple-darwin` target。`npm install` 会安装本项目使用的 Tauri CLI。
 
 ## 本地运行
 
@@ -90,15 +91,26 @@ CODEX_TASKBOARD_HOST=127.0.0.1 npm run codex
 
 该命令会在需要时启动本地 Taskboard 服务，使用独立配置文件和仅限回环访问的端口 `9231` 启动官方 macOS Codex App，等待主渲染器和侧边栏，在 Plugins 后注入一个原生外观的 Taskboard 入口，并持续监视服务和替换后的渲染器。现有 Codex 窗口不会变化。使用嵌入式面板时，请让该命令保持运行。启动器不会修改 `ChatGPT.app` 或其 `app.asar`。
 
+源码启动器会把带身份信息的服务地址写入 `.data/launcher-runtime.json`。通过 `npm link` 安装的 `taskctl` 默认读取此文件。因此，普通 shell 和从面板打开的 Codex 任务无需设置额外环境变量，即可使用同一个 Taskboard 服务。
+
 ### macOS App：无需终端即可打开和注入
 
-构建一次本地启动器：
+如需进行 Tauri 开发，请运行：
 
 ```bash
-npm run app:codex
+npm run app:dev
 ```
 
-然后从 Finder 打开 `dist/macos/Codex Taskboard.app`。该 App 包含自己的 Node 运行时、Taskboard 服务、构建后的 Web UI、Skill、CLI 包装器和注入脚本。它会启动服务，启动官方 Codex App，等待渲染器，注入侧边栏入口，并在不显示终端窗口的情况下打开面板。该 App 可以复制到本检出目录之外；目标 Mac 只需安装官方 Codex App，不需要此仓库、系统 Node 安装或单独的 Codex CLI 安装。Taskboard 数据存储在 `~/Library/Application Support/Codex Taskboard`，启动器输出写入 `~/Library/Logs/Codex Taskboard/codex-taskboard-launcher.log`。
+如需构建本地 App 和 DMG，请先安装两个 Rust target，然后运行构建：
+
+```bash
+rustup target add aarch64-apple-darwin x86_64-apple-darwin
+npm run app:build
+```
+
+从 Finder 打开 `src-tauri/target/universal-apple-darwin/release/bundle/macos/Codex Taskboard.app`。DMG 位于 `src-tauri/target/universal-apple-darwin/release/bundle/dmg/`。如果只需安装稳定版，请从 [GitHub Releases](https://github.com/chuspeeism/dashi-taskboard/releases/latest) 下载当前 DMG。
+
+该 App 包含自己的 Node 运行时、Taskboard 服务、构建后的 Web UI、Skill、CLI 包装器和注入脚本。它会启动服务，启动官方 Codex App，等待渲染器，注入侧边栏入口，并在不显示终端窗口的情况下打开面板。该 App 可以复制到本检出目录之外；目标 Mac 只需安装官方 Codex App，不需要此仓库、系统 Node 安装或单独的 Codex CLI 安装。Taskboard 数据存储在 `~/Library/Application Support/Codex Taskboard`，启动器输出写入 `~/Library/Logs/Codex Taskboard/codex-taskboard-launcher.log`。
 
 本地构建使用 ad-hoc 代码签名进行直接验证。公开的 macOS 下载仍需要 Developer ID 签名和 Apple 公证。
 

--- a/cli/taskctl.mjs
+++ b/cli/taskctl.mjs
@@ -16,6 +16,12 @@ import {
 export const SCHEMA_VERSION = 2;
 export const DEFAULT_API_URL = "http://127.0.0.1:47823";
 
+const sourceRuntimeFile = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  ".data",
+  "launcher-runtime.json",
+);
 const BOOLEAN_OPTIONS = new Set(["json"]);
 const GLOBAL_OPTIONS = new Set(["runtime-file"]);
 
@@ -918,13 +924,18 @@ function resolveApiUrl(baseUrl, pathname) {
 
 async function resolveTaskboardBaseUrl(env, overrides) {
   if (env.CODEX_TASKBOARD_URL !== undefined) return env.CODEX_TASKBOARD_URL;
-  const descriptorPath = env.CODEX_TASKBOARD_RUNTIME_FILE;
-  if (!descriptorPath) return DEFAULT_API_URL;
+  const configuredDescriptorPath = env.CODEX_TASKBOARD_RUNTIME_FILE;
+  const descriptorPath = configuredDescriptorPath ?? sourceRuntimeFile;
   let descriptor;
   try {
-    const read = overrides.readFile ?? readFile;
+    const read = configuredDescriptorPath === undefined
+      ? readFile
+      : (overrides.readFile ?? readFile);
     descriptor = JSON.parse(await read(descriptorPath, "utf8"));
   } catch (error) {
+    if (configuredDescriptorPath === undefined && error?.code === "ENOENT") {
+      return DEFAULT_API_URL;
+    }
     throw new TaskctlError("Cannot read the active Taskboard launcher endpoint", {
       code: "SERVICE_UNAVAILABLE",
       exitCode: 3,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "codex:refresh": "node scripts/codex-injector.mjs --refresh",
     "app:prepare": "npm run build:web && node scripts/prepare-tauri-app.mjs",
     "app:dev": "npm run app:prepare && tauri dev",
-    "app:build": "npm run app:prepare -- --target universal-apple-darwin && CI=true tauri build --target universal-apple-darwin --bundles app,dmg",
+    "app:build": "npm run app:prepare -- --target universal-apple-darwin && CI=true tauri build --target universal-apple-darwin --bundles app,dmg --config '{\"bundle\":{\"createUpdaterArtifacts\":false}}'",
     "app:preflight": "node scripts/preflight-macos-app.mjs",
     "app:verify-packaged-taskctl": "node scripts/verify-packaged-taskctl.mjs",
     "app:verify-release": "node scripts/verify-macos-release.mjs",

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -42,7 +42,7 @@ const taskboardDataDirectory = process.env.CODEX_TASKBOARD_DATA_DIR
   : path.join(projectRoot, ".data");
 const taskboardRuntimeFile = process.env.CODEX_TASKBOARD_RUNTIME_FILE
   ? path.resolve(process.env.CODEX_TASKBOARD_RUNTIME_FILE)
-  : null;
+  : path.join(taskboardDataDirectory, "launcher-runtime.json");
 const taskboardListenFd = process.env.CODEX_TASKBOARD_LISTEN_FD === undefined
   ? null
   : Number(process.env.CODEX_TASKBOARD_LISTEN_FD);


### PR DESCRIPTION
## Summary

- publish the source launcher endpoint at `.data/launcher-runtime.json` and let a source-linked `taskctl` discover it by default
- make the local `app:build` path produce App and DMG artifacts without requiring the release updater private key
- update the English and Chinese READMEs with the real source, Tauri development, local build, artifact, and stable release paths

## Root cause

The source distribution did not provide one maintained runtime and build contract. The injector kept the authenticated service endpoint private unless an environment variable was set, while the linked CLI fell back to the unauthenticated default port. The documented macOS commands and output paths had also drifted from the current Tauri scripts, and the local build inherited release-only updater signing.

This branch is rebased onto the two commits merged from PR #113: `35dd181` and `76e9322`. It preserves the contributed global `--runtime-file` automation path and adds source `.data/launcher-runtime.json` discovery only when no URL or explicit runtime file is configured. The integration commit includes the requested `Co-authored-by` trailer for ltx0633.

## Direct verification

- used the source `cli/taskctl.mjs` with `--runtime-file` and the current Launcher descriptor to read `LOCAL-174`
- used the same source CLI without Taskboard environment variables or runtime arguments to read `LOCAL-174` through `.data/launcher-runtime.json` discovery
- ran `node --test test/cli.test.mjs test/taskboard-automation.test.mjs`: 39/39 passed
- ran `node --check` for both changed modules and `git diff --check`
- ran `npm run app:build` with Rust 1.88; it exited 0 and produced the universal App and DMG in the documented Tauri bundle paths
- confirmed the App launcher contains both x86_64 and arm64 slices and has ad-hoc signing

No new tests, compatibility layer, or broad fallback was added.

Fixes #106
Fixes #107