### PR TITLE
Release v1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-taskboard",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-taskboard",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@lobehub/icons-static-svg": "^1.94.0",
         "@xyflow/react": "^12.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-taskboard",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "codex-taskboard-launcher"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "libc",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-taskboard-launcher"
-version = "1.0.1"
+version = "1.0.2"
 description = "Codex Taskboard macOS launcher"
 edition = "2021"
 rust-version = "1.88"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex Taskboard",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "identifier": "com.chuspeeism.codex-taskboard",
   "app": {
     "windows": []


### PR DESCRIPTION
## What changed

- Bump the application version from `1.0.1` to `1.0.2`.
- Keep `package.json`, `package-lock.json`, `Cargo.toml`, `Cargo.lock`, and `tauri.conf.json` aligned.

## Release path

After this PR passes CI and is merged, an annotated `v1.0.2` tag will trigger the existing signed and notarized macOS release workflow. The DMG remains the first uploaded asset, and GitHub will generate notes from the changes merged since `v1.0.1`.

## Verification

- All six application version fields are `1.0.2`.
- Rust 1.88 `cargo metadata --no-deps` passed.
- Release workflow YAML parsing passed.
- `git diff --check` passed.

No runtime code or release workflow behavior changed.