### PR TITLE
Fix Windows native Taskboard support

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -77,6 +77,8 @@ jobs:
         with:
           targets: x86_64-pc-windows-msvc
       - run: npm ci
+      - name: Run the Windows Node.js test suite
+        run: npm test
       - name: Build the unsigned NSIS installer
         run: npm run app:build:windows
       - name: Preserve the unsigned NSIS installer

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A local-first issue board that runs in a browser and can be embedded in Codex th
 
 - Node.js 22.5 or newer
 - macOS App and DMG builds: Xcode Command Line Tools and Rust 1.88 or newer with the `aarch64-apple-darwin` and `x86_64-apple-darwin` targets. `npm install` installs the Tauri CLI used by this project.
+- Windows NSIS builds: the Microsoft Store Codex App, Rust 1.88 or newer, and Visual Studio Build Tools with the C++ workload and Windows SDK.
 
 ## Run locally
 
@@ -113,6 +114,19 @@ Open `src-tauri/target/universal-apple-darwin/release/bundle/macos/Codex Taskboa
 The App contains its own Node runtime, Taskboard service, built web UI, Skill, CLI wrapper, and injection script. It starts the service, launches the official Codex app, waits for the renderer, injects the sidebar entry, and opens the panel without showing a terminal window. The App can be copied away from this checkout; the target Mac only needs the official Codex app and does not need this repository, a system Node installation, or a separate Codex CLI installation. Taskboard data is stored in `~/Library/Application Support/Codex Taskboard`, and launcher output is written to `~/Library/Logs/Codex Taskboard/codex-taskboard-launcher.log`.
 
 The local build uses ad-hoc code signing for direct verification. A public macOS download still needs Developer ID signing and Apple notarization.
+
+### Windows App: tray launcher and bundled Taskboard
+
+Install the official Codex App from the Microsoft Store. To build the current-user NSIS installer on Windows x64, run:
+
+```powershell
+npm ci
+npm run app:build:windows
+```
+
+The installer is written to `src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/`. It installs a tray launcher, bundled Node runtime, local service, built web UI, Skill, `taskctl.cmd`, and injection script. Taskboard data is stored in `%APPDATA%\Codex Taskboard`; logs are stored in `%LOCALAPPDATA%\Codex Taskboard\Logs`; the Skill is copied to `%USERPROFILE%\.agents\skills\manage-taskboard`.
+
+Windows CI artifacts are intentionally unsigned and do not auto-update. Review [the code-signing policy](docs/code-signing-policy.md) before distributing a build. See [Windows uninstall](docs/windows-uninstall.md) for retained-data behavior.
 
 Codex 26.715.52143 ships a renderer CSP that blocks arbitrary HTTP iframes. The launcher therefore enables CDP CSP bypass, reloads that renderer once, installs the document-start script, and waits until the Taskboard OOPIF is actually loaded. CDP is unauthenticated to other processes on the same machine, so only run trusted local code while the launcher is active.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,6 +10,7 @@
 
 - Node.js 22.5 或更高版本
 - 构建 macOS App 和 DMG：Xcode Command Line Tools、Rust 1.88 或更高版本，以及 `aarch64-apple-darwin` 和 `x86_64-apple-darwin` target。`npm install` 会安装本项目使用的 Tauri CLI。
+- 构建 Windows NSIS：Microsoft Store 版 Codex App、Rust 1.88 或更高版本，以及带 C++ 工作负载和 Windows SDK 的 Visual Studio Build Tools。
 
 ## 本地运行
 
@@ -113,6 +114,19 @@ npm run app:build
 该 App 包含自己的 Node 运行时、Taskboard 服务、构建后的 Web UI、Skill、CLI 包装器和注入脚本。它会启动服务，启动官方 Codex App，等待渲染器，注入侧边栏入口，并在不显示终端窗口的情况下打开面板。该 App 可以复制到本检出目录之外；目标 Mac 只需安装官方 Codex App，不需要此仓库、系统 Node 安装或单独的 Codex CLI 安装。Taskboard 数据存储在 `~/Library/Application Support/Codex Taskboard`，启动器输出写入 `~/Library/Logs/Codex Taskboard/codex-taskboard-launcher.log`。
 
 本地构建使用 ad-hoc 代码签名进行直接验证。公开的 macOS 下载仍需要 Developer ID 签名和 Apple 公证。
+
+### Windows App：托盘启动器与内置 Taskboard
+
+先从 Microsoft Store 安装官方 Codex App。在 Windows x64 上运行以下命令构建当前用户级 NSIS 安装包：
+
+```powershell
+npm ci
+npm run app:build:windows
+```
+
+安装包位于 `src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/`。它包含托盘启动器、内置 Node、本地服务、构建后的 Web UI、Skill、`taskctl.cmd` 和注入脚本。Taskboard 数据存储在 `%APPDATA%\Codex Taskboard`，日志存储在 `%LOCALAPPDATA%\Codex Taskboard\Logs`，Skill 会复制到 `%USERPROFILE%\.agents\skills\manage-taskboard`。
+
+Windows CI 产物目前有意保持未签名，也不支持自动更新。分发前请阅读[代码签名策略](docs/code-signing-policy.md)。保留数据的行为见 [Windows 卸载说明](docs/windows-uninstall.md)。
 
 Codex 26.715.52143 的渲染器 CSP 会阻止任意 HTTP iframe。因此，启动器会启用 CDP CSP 绕过，重新加载该渲染器一次，安装文档启动脚本，并等待 Taskboard OOPIF 实际加载。同一台机器上的其他进程访问 CDP 时不需要身份验证，因此启动器运行时只能运行受信任的本地代码。
 

--- a/scripts/codex-rate-limits.mjs
+++ b/scripts/codex-rate-limits.mjs
@@ -3,6 +3,7 @@ import readline from "node:readline";
 
 import { resolveCodexExecutable } from "../shared/codex-executable.mjs";
 import { withoutTaskboardLauncherEnvironment } from "../shared/codex-environment.mjs";
+import { executableCommand } from "../shared/executable-command.mjs";
 
 const REQUEST_TIMEOUT_MS = 8_000;
 
@@ -33,7 +34,8 @@ export async function readCodexQuotaStatus(model) {
 }
 
 function startAppServer() {
-  const child = spawn(resolveCodexExecutable(), ["app-server", "--stdio"], {
+  const command = executableCommand(resolveCodexExecutable(), ["app-server", "--stdio"]);
+  const child = spawn(command.executable, command.args, {
     env: withoutTaskboardLauncherEnvironment(process.env),
     stdio: ["pipe", "pipe", "ignore"],
   });

--- a/scripts/wrangler-cloud-adapter.mjs
+++ b/scripts/wrangler-cloud-adapter.mjs
@@ -16,10 +16,11 @@ import {
   CLOUD_PROJECT_COUNTS_SQL,
   createCloudD1ImportSql,
 } from "./migrate-to-cloud.mjs";
+import { executableCommand } from "../shared/executable-command.mjs";
 
 const execFile = promisify(execFileCallback);
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const defaultWrangler = path.join(projectRoot, "node_modules", ".bin", "wrangler");
+const defaultWrangler = path.join(projectRoot, "node_modules", "wrangler", "bin", "wrangler.js");
 
 function parseD1Results(stdout) {
   const parsed = JSON.parse(stdout);
@@ -73,11 +74,16 @@ export function createWranglerCloudAdapters({
   let sequence = 0;
 
   function run(args) {
-    const result = commandQueue.then(() => runCommand(wranglerExecutable, args, {
-      cwd: projectRoot,
-      encoding: "utf8",
-      maxBuffer: 16 * 1024 * 1024,
-    }));
+    const command = executableCommand(wranglerExecutable, args);
+    const result = commandQueue.then(() => runCommand(
+      command.executable,
+      command.args,
+      {
+        cwd: projectRoot,
+        encoding: "utf8",
+        maxBuffer: 16 * 1024 * 1024,
+      },
+    ));
     commandQueue = result.catch(() => {});
     return result;
   }

--- a/server/ai-chat-catalog.mjs
+++ b/server/ai-chat-catalog.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 
 import { withoutTaskboardLauncherEnvironment } from "../shared/codex-environment.mjs";
+import { executableCommand } from "../shared/executable-command.mjs";
 import { ApiError } from "./database.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -136,7 +137,8 @@ function sanitizeModels(value) {
 
 function listSkills(codexExecutable, workspacePath, processEnv) {
   return new Promise((resolve, reject) => {
-    const child = spawn(codexExecutable, ["app-server", "--stdio"], {
+    const command = executableCommand(codexExecutable, ["app-server", "--stdio"]);
+    const child = spawn(command.executable, command.args, {
       cwd: workspacePath,
       env: processEnv,
       stdio: ["pipe", "pipe", "ignore"],
@@ -254,8 +256,9 @@ export async function discoverAiCatalog({
   processEnv,
 }) {
   const environment = withoutTaskboardLauncherEnvironment(processEnv);
+  const modelCommand = executableCommand(codexExecutable, ["debug", "models"]);
   const [modelResult, skillEntries] = await Promise.all([
-    execFileAsync(codexExecutable, ["debug", "models"], {
+    execFileAsync(modelCommand.executable, modelCommand.args, {
       cwd: workspacePath,
       env: environment,
       encoding: "utf8",

--- a/server/ai-chat-process.mjs
+++ b/server/ai-chat-process.mjs
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import { withoutTaskboardLauncherEnvironment } from "../shared/codex-environment.mjs";
+import { signalProcessTree } from "../shared/process-tree.mjs";
 
 const VISIBLE_TEXT_LIMIT = 65_536;
 const STDERR_LIMIT = 65_536;
@@ -360,13 +361,7 @@ export function spawnCodexTurn({
   });
 
   function terminateProcessGroup() {
-    if (Number.isInteger(child.pid)) {
-      try {
-        process.kill(-child.pid, "SIGKILL");
-        return;
-      } catch {}
-    }
-    child.kill("SIGKILL");
+    signalProcessTree(child, "SIGKILL");
   }
 
   function rejectWithDiagnostic(error) {

--- a/server/ai-chat.mjs
+++ b/server/ai-chat.mjs
@@ -2,6 +2,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import { signalProcessTree } from "../shared/process-tree.mjs";
 import { ApiError } from "./database.mjs";
 import { discoverAiCatalog, resolveAiWorkspace } from "./ai-chat-catalog.mjs";
 import {
@@ -26,15 +27,7 @@ function cappedError(value) {
 }
 
 function signalProcessGroup(child, signal) {
-  if (Number.isInteger(child?.pid)) {
-    try {
-      process.kill(-child.pid, signal);
-      return;
-    } catch {}
-  }
-  try {
-    child?.kill(signal);
-  } catch {}
+  signalProcessTree(child, signal);
 }
 
 function wait(milliseconds) {

--- a/server/ai-turn-owner.mjs
+++ b/server/ai-turn-owner.mjs
@@ -1,21 +1,28 @@
 import { spawn } from "node:child_process";
 import { Socket } from "node:net";
 
+import { executableCommand } from "../shared/executable-command.mjs";
+import { signalProcessTree } from "../shared/process-tree.mjs";
+
 const [executable, encodedArgs] = process.argv.slice(2);
 if (!executable || !encodedArgs) process.exit(2);
 
-const child = spawn(executable, JSON.parse(encodedArgs), {
+const command = executableCommand(executable, JSON.parse(encodedArgs));
+const child = spawn(command.executable, command.args, {
   env: process.env,
   stdio: "inherit",
 });
 
 const control = new Socket({ fd: 3, readable: true, writable: false });
 const terminateGroup = () => {
-  try {
-    process.kill(-process.pid, "SIGKILL");
-  } catch {
-    process.exit(1);
+  if (process.platform !== "win32") {
+    try {
+      process.kill(-process.pid, "SIGKILL");
+      return;
+    } catch {}
   }
+  signalProcessTree(child, "SIGKILL");
+  process.exit(1);
 };
 control.once("end", terminateGroup);
 control.once("error", terminateGroup);

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -18,6 +18,7 @@ import {
 } from "../shared/domain.mjs";
 import { resolveCodexExecutable } from "../shared/codex-executable.mjs";
 import { withoutTaskboardLauncherEnvironment } from "../shared/codex-environment.mjs";
+import { executableCommand } from "../shared/executable-command.mjs";
 import { normalizeWorkflowSnapshot } from "../shared/workflow-control-flow.mjs";
 import { AiChatService } from "./ai-chat.mjs";
 import { resolveAiWorkspace, resolveMappedAiWorkspace } from "./ai-chat-catalog.mjs";
@@ -1146,7 +1147,8 @@ async function scanDevelopmentContexts(workspacePath, processEnv = process.env) 
 
 async function discoverSkills(codexExecutable, workspacePath, processEnv) {
   const entries = await new Promise((resolve, reject) => {
-    const child = spawn(codexExecutable, ["app-server", "--stdio"], {
+    const command = executableCommand(codexExecutable, ["app-server", "--stdio"]);
+    const child = spawn(command.executable, command.args, {
       cwd: workspacePath,
       env: processEnv,
       stdio: ["pipe", "pipe", "ignore"],
@@ -1260,7 +1262,8 @@ async function discoverSkills(codexExecutable, workspacePath, processEnv) {
 }
 
 async function discoverMcpServers(codexExecutable, processEnv) {
-  const result = await execFileAsync(codexExecutable, ["mcp", "list", "--json"], {
+  const command = executableCommand(codexExecutable, ["mcp", "list", "--json"]);
+  const result = await execFileAsync(command.executable, command.args, {
     env: processEnv,
     timeout: 8_000,
     maxBuffer: 2 * 1024 * 1024,

--- a/server/project-summary.mjs
+++ b/server/project-summary.mjs
@@ -1,3 +1,4 @@
+import { signalProcessTree } from "../shared/process-tree.mjs";
 import { spawnCodexTurn } from "./ai-chat-process.mjs";
 import { ApiError } from "./database.mjs";
 
@@ -12,16 +13,6 @@ const STATUS_LABELS = {
   done: "完成",
   canceled: "取消",
 };
-
-function signalProcessGroup(child, signal) {
-  if (Number.isInteger(child?.pid)) {
-    try {
-      process.kill(-child.pid, signal);
-      return;
-    } catch {}
-  }
-  child?.kill(signal);
-}
 
 function isDue(summary) {
   if (!summary.attemptedAt) return true;
@@ -157,7 +148,7 @@ export class ProjectSummaryService {
     this.closed = true;
     clearInterval(this.timer);
     const active = [...this.active.values()];
-    for (const entry of active) signalProcessGroup(entry.child, "SIGTERM");
+    for (const entry of active) signalProcessTree(entry.child, "SIGTERM");
     await Promise.allSettled(active.map((entry) => entry.promise));
   }
 }

--- a/shared/codex-executable.mjs
+++ b/shared/codex-executable.mjs
@@ -11,11 +11,27 @@ function executableFile(candidate) {
   }
 }
 
-function executableOnPath(env) {
+function executableOnPath(env, platform) {
   for (const directory of (env.PATH || "").split(path.delimiter)) {
     if (!directory) continue;
-    const candidate = executableFile(path.join(directory, "codex"));
-    if (candidate) return candidate;
+    if (platform === "win32") {
+      const nativeExecutable = executableFile(path.join(directory, "codex.exe"));
+      if (nativeExecutable) return nativeExecutable;
+
+      const npmEntry = executableFile(path.join(
+        directory,
+        "node_modules",
+        "@openai",
+        "codex",
+        "bin",
+        "codex.js",
+      ));
+      if (npmEntry) return npmEntry;
+      continue;
+    }
+
+    const executable = executableFile(path.join(directory, "codex"));
+    if (executable) return executable;
   }
   return null;
 }
@@ -41,7 +57,7 @@ export function resolveCodexExecutable({
     if (bundled) return bundled;
   }
 
-  const installedCli = executableOnPath(env);
+  const installedCli = executableOnPath(env, platform);
   if (installedCli) return installedCli;
 
   if (platform === "darwin") {

--- a/shared/executable-command.mjs
+++ b/shared/executable-command.mjs
@@ -1,0 +1,13 @@
+import path from "node:path";
+
+const NODE_SCRIPT_EXTENSIONS = new Set([".cjs", ".js", ".mjs"]);
+
+export function executableCommand(executable, args = []) {
+  if (NODE_SCRIPT_EXTENSIONS.has(path.extname(executable).toLowerCase())) {
+    return {
+      executable: process.execPath,
+      args: [executable, ...args],
+    };
+  }
+  return { executable, args };
+}

--- a/shared/process-tree.mjs
+++ b/shared/process-tree.mjs
@@ -1,0 +1,27 @@
+import { spawnSync } from "node:child_process";
+
+export function signalProcessTree(child, signal) {
+  if (process.platform === "win32" && Number.isInteger(child?.pid)) {
+    const result = spawnSync(
+      "taskkill.exe",
+      ["/PID", String(child.pid), "/T", "/F"],
+      { stdio: "ignore", windowsHide: true },
+    );
+    if (result.error || result.status !== 0) {
+      try {
+        child.kill(signal);
+      } catch {}
+    }
+    return;
+  }
+
+  if (Number.isInteger(child?.pid)) {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {}
+  }
+  try {
+    child?.kill(signal);
+  } catch {}
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1052,6 +1052,17 @@ async fn offer_update(
     quit: &MenuItem<tauri::Wry>,
     show_current_version: bool,
 ) {
+    if cfg!(target_os = "windows") {
+        update_snapshot(app, state, |snapshot| {
+            snapshot.update_message = "Windows 版本暂不支持自动更新。".into();
+            snapshot.update_available = false;
+        });
+        check_update
+            .set_text("检查更新（Windows 暂不支持）")
+            .unwrap();
+        check_update.set_enabled(false).unwrap();
+        return;
+    }
     if state
         .update_flow_in_progress
         .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)

--- a/test/ai-chat-runner.test.mjs
+++ b/test/ai-chat-runner.test.mjs
@@ -45,6 +45,7 @@ async function createFixture() {
   const capturePath = path.join(directory, "capture.jsonl");
   const environmentCapturePath = path.join(directory, "environment-capture.jsonl");
   const descendantPath = path.join(directory, "descendant-alive");
+  const descendantDelayMs = process.platform === "win32" ? 1_500 : 300;
   const executable = path.join(directory, "fake-codex.mjs");
   await writeFile(executable, `#!/usr/bin/env node
 import { appendFileSync } from "node:fs";
@@ -92,7 +93,7 @@ if (args[0] === "app-server") {
     if (prompt.includes("MALFORMED_STUBBORN") || prompt.includes("CALLBACK_FATAL_STUBBORN")) {
       spawn(process.execPath, [
         "-e",
-        'process.on("SIGTERM", () => {}); setTimeout(() => require("node:fs").writeFileSync(process.env.FAKE_DESCENDANT_PATH, "alive"), 300); setInterval(() => {}, 1000)',
+        'process.on("SIGTERM", () => {}); setTimeout(() => require("node:fs").writeFileSync(process.env.FAKE_DESCENDANT_PATH, "alive"), ${descendantDelayMs}); setInterval(() => {}, 1000)',
       ], {env:process.env,stdio:"ignore"});
       process.on("SIGTERM", () => {});
       setInterval(() => {}, 1000);
@@ -166,6 +167,7 @@ if (args[0] === "app-server") {
     capturePath,
     database,
     databasePath,
+    descendantDelayMs,
     descendantPath,
     directory,
     environmentCapturePath,
@@ -331,9 +333,9 @@ test("parser and event callback failures kill a SIGTERM-resistant process group"
       await rm(fixture.descendantPath, { force: true });
       const thread = await fixture.service.createThread({ projectId: "project" });
       const run = await fixture.service.startTurn(thread.id, { message });
-      await waitFor(() => fixture.service.getRun(run.id).status === "failed", 700);
+      await waitFor(() => fixture.service.getRun(run.id).status === "failed");
       assert.equal(fixture.service.getRun(run.id).error, expectedError);
-      await new Promise((resolve) => setTimeout(resolve, 350));
+      await new Promise((resolve) => setTimeout(resolve, fixture.descendantDelayMs + 50));
       await assert.rejects(readFile(fixture.descendantPath), (error) => error.code === "ENOENT");
     }
   } finally {

--- a/test/ai-chat-server.test.mjs
+++ b/test/ai-chat-server.test.mjs
@@ -187,7 +187,11 @@ test("non-local AI turns reject a workspace that became unavailable", async () =
   const fixture = await createServerFixture();
   try {
     const workspaceLink = path.join(fixture.directory, "project-workspace");
-    await symlink(path.resolve(import.meta.dirname, ".."), workspaceLink, "dir");
+    await symlink(
+      path.resolve(import.meta.dirname, ".."),
+      workspaceLink,
+      process.platform === "win32" ? "junction" : "dir",
+    );
     const project = await request(fixture.baseUrl, "/api/projects", {
       method: "POST",
       body: {

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import path from "node:path";
 import test from "node:test";
 
 import { main, parseArgs } from "../cli/taskctl.mjs";
@@ -110,7 +111,7 @@ test("project create sends id, name, and an absolute workspace path", async () =
   assert.equal(result.exitCode, 0);
   assert.equal(requestBody.id, "docs");
   assert.equal(requestBody.name, "Docs");
-  assert.equal(requestBody.workspacePath.endsWith("/docs"), true);
+  assert.equal(requestBody.workspacePath, path.resolve("./docs"));
 });
 
 test("issue list serializes project and status filters", async () => {
@@ -241,6 +242,8 @@ test("issue update sends an explicit optimistic concurrency version", async () =
 
 test("issue update binds one worktree context", async () => {
   let requestBody;
+  const repositoryPath = path.resolve("/work/repo");
+  const worktreePath = path.resolve(repositoryPath, "../taskboard-worktree");
   const result = await run(
     [
       "issue", "update", "TASK-1",
@@ -252,14 +255,14 @@ test("issue update binds one worktree context", async () => {
       requestBody = JSON.parse(init.body);
       return response({ task: { id: "TASK-1", ...requestBody, version: 5 } });
     },
-    { cwd: "/work/repo" },
+    { cwd: repositoryPath },
   );
 
   assert.equal(result.exitCode, 0);
   assert.deepEqual(requestBody, {
     developmentContext: {
       type: "worktree",
-      path: "/work/taskboard-worktree",
+      path: worktreePath,
       branch: "worktree/taskboard",
     },
     threadId: "thread-current",
@@ -451,19 +454,21 @@ test("comment update and delete require an explicit version", async () => {
 });
 
 test("context current selects the project with the most specific matching workspace", async () => {
+  const repositoryPath = path.resolve("/work/repo");
+  const appPath = path.join(repositoryPath, "packages", "app");
   const result = await run(
-    ["context", "current", "--cwd", "/work/repo/packages/app"],
+    ["context", "current", "--cwd", appPath],
     async () => response({ projects: [
       { id: "local", name: "Local", workspacePath: null },
-      { id: "repo", workspacePath: "/work/repo" },
-      { id: "app", workspacePath: "/work/repo/packages/app" },
+      { id: "repo", workspacePath: repositoryPath },
+      { id: "app", workspacePath: appPath },
     ] }),
-    { cwd: "/unused" },
+    { cwd: path.resolve("/unused") },
   );
 
   assert.equal(result.exitCode, 0);
-  assert.equal(result.stdout.cwd, "/work/repo/packages/app");
-  assert.deepEqual(result.stdout.project, { id: "app", workspacePath: "/work/repo/packages/app" });
+  assert.equal(result.stdout.cwd, appPath);
+  assert.deepEqual(result.stdout.project, { id: "app", workspacePath: appPath });
 });
 
 test("context current falls back to the local project", async () => {

--- a/test/cloud-companion.test.mjs
+++ b/test/cloud-companion.test.mjs
@@ -105,7 +105,9 @@ test("cloud config persists Basic Auth credentials and device mappings in a mode
       portfolio: "/Users/alice/Documents/portfolio",
     },
   });
-  assert.equal((await stat(configPath)).mode & 0o777, 0o600);
+  if (process.platform !== "win32") {
+    assert.equal((await stat(configPath)).mode & 0o777, 0o600);
+  }
   assert.deepEqual(JSON.parse(await readFile(configPath, "utf8")), await store.read());
 });
 
@@ -697,6 +699,8 @@ test("taskctl cloud login reads the shared key privately and sends it to the loc
 
 test("taskctl cloud status, logout, and project map use local companion endpoints", async () => {
   const calls = [];
+  const workspaceRoot = path.resolve("/work");
+  const portfolioPath = path.join(workspaceRoot, "portfolio");
   const fetchImplementation = async (url, init) => {
     calls.push({ url: url.toString(), init });
     if (url.pathname === "/api/local/cloud-session" && init.method === "GET") {
@@ -713,7 +717,7 @@ test("taskctl cloud status, logout, and project map use local companion endpoint
     if (url.pathname === "/api/local/project-mappings/portfolio" && init.method === "PUT") {
       return jsonResponse({
         projectId: "portfolio",
-        workspacePath: "/work/portfolio",
+        workspacePath: portfolioPath,
       });
     }
     return jsonResponse({ error: { code: "UNEXPECTED", message: url.toString() } }, 500);
@@ -732,7 +736,7 @@ test("taskctl cloud status, logout, and project map use local companion endpoint
   )).exitCode, 0);
   assert.equal((await runCli(
     ["project", "map", "portfolio", "--workspace-path", "./portfolio"],
-    { fetch: fetchImplementation, cwd: "/work", env: companionEnv },
+    { fetch: fetchImplementation, cwd: workspaceRoot, env: companionEnv },
   )).exitCode, 0);
 
   assert.deepEqual(calls.map(({ url, init }) => [url, init.method]), [
@@ -741,7 +745,7 @@ test("taskctl cloud status, logout, and project map use local companion endpoint
     ["http://127.0.0.1:49000/api/local/project-mappings/portfolio", "PUT"],
   ]);
   assert.deepEqual(JSON.parse(calls[2].init.body), {
-    workspacePath: "/work/portfolio",
+    workspacePath: portfolioPath,
   });
 });
 

--- a/test/cloud-migration.test.mjs
+++ b/test/cloud-migration.test.mjs
@@ -32,7 +32,13 @@ const fixtures = [];
 const timestamp = "2026-07-24T12:00:00.000Z";
 const execFile = promisify(execFileCallback);
 const projectRoot = path.resolve(import.meta.dirname, "..");
-const wranglerExecutable = path.join(projectRoot, "node_modules", ".bin", "wrangler");
+const wranglerExecutable = path.join(
+  projectRoot,
+  "node_modules",
+  "wrangler",
+  "bin",
+  "wrangler.js",
+);
 const wranglerConfig = path.join(projectRoot, "wrangler.jsonc");
 
 afterEach(async () => {
@@ -936,16 +942,18 @@ test("versioned bundle round-trips through private manifest, data, and attachmen
 
   await writeCloudMigrationBundle(bundle, outputDirectory);
 
-  assert.equal((await stat(outputDirectory)).mode & 0o777, 0o700);
-  assert.equal((await stat(path.join(outputDirectory, "data"))).mode & 0o777, 0o700);
-  assert.equal(
-    (await stat(path.join(outputDirectory, "attachments"))).mode & 0o777,
-    0o700,
-  );
-  assert.equal(
-    (await stat(path.join(outputDirectory, "manifest.json"))).mode & 0o777,
-    0o600,
-  );
+  if (process.platform !== "win32") {
+    assert.equal((await stat(outputDirectory)).mode & 0o777, 0o700);
+    assert.equal((await stat(path.join(outputDirectory, "data"))).mode & 0o777, 0o700);
+    assert.equal(
+      (await stat(path.join(outputDirectory, "attachments"))).mode & 0o777,
+      0o700,
+    );
+    assert.equal(
+      (await stat(path.join(outputDirectory, "manifest.json"))).mode & 0o777,
+      0o600,
+    );
+  }
 
   const restored = await readCloudMigrationBundle(outputDirectory);
   assert.deepEqual(restored.counts, bundle.counts);
@@ -1024,16 +1032,17 @@ test("Wrangler adapter requires remote opt-in and keeps transfer files private",
     remote: true,
     environment: { TASKBOARD_MIGRATION_REMOTE: "1" },
     runCommand: async (_executable, args) => {
-      calls.push(args);
-      const fileIndex = args.indexOf("--file");
+      const commandArgs = args[0] === wranglerExecutable ? args.slice(1) : args;
+      calls.push(commandArgs);
+      const fileIndex = commandArgs.indexOf("--file");
       if (fileIndex !== -1) {
-        const filename = args[fileIndex + 1];
+        const filename = commandArgs[fileIndex + 1];
         transferFiles.push(filename);
-        if (args[0] === "r2" && args[2] === "get") {
+        if (commandArgs[0] === "r2" && commandArgs[2] === "get") {
           await writeFile(filename, downloadedBody);
         }
       }
-      if (args.includes("--json")) return { stdout: '[{"results":[]}]' };
+      if (commandArgs.includes("--json")) return { stdout: '[{"results":[]}]' };
       return { stdout: "" };
     },
   });
@@ -1066,8 +1075,10 @@ test("Wrangler adapter requires remote opt-in and keeps transfer files private",
       assert.ok(!args.includes("--persist-to"));
     }
     for (const filename of transferFiles) {
-      assert.equal((await stat(filename)).mode & 0o777, 0o600);
-      assert.equal((await stat(path.dirname(filename))).mode & 0o777, 0o700);
+      if (process.platform !== "win32") {
+        assert.equal((await stat(filename)).mode & 0o777, 0o600);
+        assert.equal((await stat(path.dirname(filename))).mode & 0o777, 0o700);
+      }
     }
   } finally {
     await adapters.cleanup();
@@ -1123,7 +1134,7 @@ test("one-time Wrangler adapter migrates and verifies local persistence without 
   const adapterPath = path.join(projectRoot, "scripts", "wrangler-cloud-adapter.mjs");
 
   async function applyMigrations(persistTo) {
-    await execFile(wranglerExecutable, [
+    await execFile(process.execPath, [wranglerExecutable,
       "d1",
       "migrations",
       "apply",

--- a/test/codex-executable.test.mjs
+++ b/test/codex-executable.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { resolveCodexExecutable } from "../shared/codex-executable.mjs";
+import { executableCommand } from "../shared/executable-command.mjs";
+
+test("Windows PATH resolves the npm Codex shim to its Node entry", {
+  skip: process.platform !== "win32",
+}, async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "codex-executable-test-"));
+  try {
+    const npmEntry = path.join(
+      directory,
+      "node_modules",
+      "@openai",
+      "codex",
+      "bin",
+      "codex.js",
+    );
+    await mkdir(path.dirname(npmEntry), { recursive: true });
+    await Promise.all([
+      writeFile(path.join(directory, "codex"), "#!/bin/sh\n"),
+      writeFile(path.join(directory, "codex.cmd"), "@echo off\r\n"),
+      writeFile(npmEntry, ""),
+    ]);
+
+    const executable = resolveCodexExecutable({
+      explicit: "",
+      env: { PATH: directory },
+      platform: "win32",
+    });
+    assert.equal(executable, npmEntry);
+    assert.deepEqual(executableCommand(executable, ["debug", "models"]), {
+      executable: process.execPath,
+      args: [npmEntry, "debug", "models"],
+    });
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+});

--- a/test/inject.test.mjs
+++ b/test/inject.test.mjs
@@ -6,7 +6,7 @@ import vm from "node:vm";
 import { parseTaskboardAutomationHostRequest } from "../shared/taskboard-automation.mjs";
 
 const sourceUrl = new URL("../inject/codex-taskboard.user.js", import.meta.url);
-const source = await readFile(sourceUrl, "utf8");
+const source = (await readFile(sourceUrl, "utf8")).replaceAll("\r\n", "\n");
 const webStyles = await readFile(new URL("../web/src/styles.css", import.meta.url), "utf8");
 const webApp = await readFile(new URL("../web/src/App.tsx", import.meta.url), "utf8");
 const embeddedHost = await readFile(new URL("../web/src/embeddedHost.mjs", import.meta.url), "utf8");

--- a/test/launcher-release.test.mjs
+++ b/test/launcher-release.test.mjs
@@ -36,6 +36,17 @@ test("release signing is tag-only and PR CI builds the real unsigned app bundle"
   assert.match(checkWorkflow, /--no-sign/);
 });
 
+test("Windows CI runs the Node suite and the unsigned launcher skips unsupported updates", () => {
+  assert.match(
+    checkWorkflow,
+    /windows-launcher:[\s\S]*?run: npm test[\s\S]*?run: npm run app:build:windows/,
+  );
+  assert.match(
+    launcherSource,
+    /cfg!\(target_os = "windows"\)[\s\S]*?Windows 版本暂不支持自动更新/,
+  );
+});
+
 test("the launcher minimum system version matches the current Codex client requirement", () => {
   assert.equal(tauriConfig.bundle.macOS.minimumSystemVersion, "14.0");
 });

--- a/test/server.test.mjs
+++ b/test/server.test.mjs
@@ -743,18 +743,27 @@ test("workflow capabilities come from the live Codex skill and MCP catalogs", as
   let workspacePath;
   const baseUrl = await startServer(async (directory) => {
     workspacePath = directory;
-    const codexExecutable = path.join(directory, "fake-codex");
-    await writeFile(codexExecutable, `#!/bin/sh
-if [ "$1" = "mcp" ]; then
-  printf '%s\\n' '[{"name":"context7","enabled":true,"transport":{"type":"streamable_http"}},{"name":"disabled-server","enabled":false,"transport":{"type":"stdio"}}]'
-  exit 0
-fi
-while IFS= read -r line; do
-  case "$line" in
-    *'"id":1'*) printf '%s\\n' '{"id":1,"result":{"platformFamily":"unix"}}' ;;
-    *'"id":2'*) printf '%s\\n' '{"id":2,"result":{"data":[{"cwd":"workspace","skills":[{"name":"user-skill","description":"User skill","path":"/user/skills/user-skill/SKILL.md","enabled":true,"scope":"user","interface":null},{"name":"repo-skill","description":"Repository skill","path":"/workspace/.agents/skills/repo-skill/SKILL.md","enabled":true,"scope":"repo","interface":{"displayName":"Repository Skill"}},{"name":"user-skill","enabled":true,"scope":"system","interface":{"displayName":"Duplicate"}},{"name":"disabled-skill","enabled":false,"scope":"user","interface":null}],"errors":[]}]}}' ;;
-  esac
-done
+    const codexExecutable = path.join(directory, "fake-codex.mjs");
+    await writeFile(codexExecutable, `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === "mcp") {
+  process.stdout.write('[{"name":"context7","enabled":true,"transport":{"type":"streamable_http"}},{"name":"disabled-server","enabled":false,"transport":{"type":"stdio"}}]\\n');
+  process.exit(0);
+}
+process.stdin.setEncoding("utf8");
+let buffer = "";
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  let newlineIndex = buffer.indexOf("\\n");
+  while (newlineIndex >= 0) {
+    const line = buffer.slice(0, newlineIndex);
+    buffer = buffer.slice(newlineIndex + 1);
+    const message = JSON.parse(line);
+    if (message.id === 1) process.stdout.write('{"id":1,"result":{"platformFamily":"unix"}}\\n');
+    if (message.id === 2) process.stdout.write('{"id":2,"result":{"data":[{"cwd":"workspace","skills":[{"name":"user-skill","description":"User skill","path":"/user/skills/user-skill/SKILL.md","enabled":true,"scope":"user","interface":null},{"name":"repo-skill","description":"Repository skill","path":"/workspace/.agents/skills/repo-skill/SKILL.md","enabled":true,"scope":"repo","interface":{"displayName":"Repository Skill"}},{"name":"user-skill","enabled":true,"scope":"system","interface":{"displayName":"Duplicate"}},{"name":"disabled-skill","enabled":false,"scope":"user","interface":null}],"errors":[]}]}}\\n');
+    newlineIndex = buffer.indexOf("\\n");
+  }
+});
 `);
     await chmod(codexExecutable, 0o755);
     return { codexExecutable };

--- a/test/taskboard-automation.test.mjs
+++ b/test/taskboard-automation.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import path from "node:path";
 import { test } from "node:test";
 
 import {
@@ -192,10 +193,10 @@ test("the generated automation command uses an argv runtime file instead of an e
   process.env.CODEX_TASKBOARD_RUNTIME_FILE = "/Users/example/Library/Application Support/Codex Taskboard/launcher-runtime.json";
   try {
     const prompt = buildTaskboardAutomationPrompt(baseRequest);
-    assert.match(
-      prompt,
-      /'\/Users\/example\/taskboard\/cli\/taskctl\.mjs' --runtime-file '\/Users\/example\/Library\/Application Support\/Codex Taskboard\/launcher-runtime\.json'/,
-    );
+    const cliPath = path.resolve(path.dirname(baseRequest.skillPath), "../..", "cli/taskctl.mjs");
+    assert.ok(prompt.includes(
+      `'${process.execPath}' '${cliPath}' --runtime-file '${process.env.CODEX_TASKBOARD_RUNTIME_FILE}'`,
+    ));
     assert.doesNotMatch(prompt, /CODEX_TASKBOARD_RUNTIME_FILE=/);
   } finally {
     if (previous === undefined) {

--- a/test/zapier-workflow.test.mjs
+++ b/test/zapier-workflow.test.mjs
@@ -6,7 +6,10 @@ const board = await readFile(new URL("../web/src/components/WorkflowBoard.tsx", 
 const node = await readFile(new URL("../web/src/components/WorkflowNode.tsx", import.meta.url), "utf8");
 const inspector = await readFile(new URL("../web/src/components/WorkflowInspector.tsx", import.meta.url), "utf8");
 const picker = await readFile(new URL("../web/src/components/WorkflowStepPicker.tsx", import.meta.url), "utf8");
-const catalog = await readFile(new URL("../web/src/components/workflowCatalog.ts", import.meta.url), "utf8");
+const catalog = (await readFile(
+  new URL("../web/src/components/workflowCatalog.ts", import.meta.url),
+  "utf8",
+)).replaceAll("\r\n", "\n");
 const styles = await readFile(new URL("../web/src/components/workflow.css", import.meta.url), "utf8");
 const globalStyles = await readFile(new URL("../web/src/styles.css", import.meta.url), "utf8");
 const controlFlow = await readFile(new URL("../shared/workflow-control-flow.mjs", import.meta.url), "utf8");


### PR DESCRIPTION
## Summary

- run Codex Node entry points and Wrangler consistently on Windows without relying on POSIX shims
- terminate AI subprocess trees correctly on Windows while preserving POSIX process-group behavior
- make the existing Node test suite portable across Windows paths, junctions, file modes, and CRLF
- run the full Node suite in the Windows launcher CI job
- document the Windows NSIS workflow and disable the unsupported Windows updater path explicitly

## Why

The Windows launcher existed, but several runtime paths still assumed POSIX executable, process-group, symlink, permission, newline, and filesystem semantics. This made the app appear installed while AI discovery, subprocess cleanup, cloud migration tooling, or tests could fail on Windows.

## User impact

Windows users can run the native tray launcher, bundled local service, taskctl, Taskboard Skill, AI catalog, and project mapping through the same direct workflow used on macOS. PATH-only Codex CLI discovery now resolves the npm package's Node entry instead of attempting to spawn its non-executable shell shim.

## Validation

- npm run check — 417 tests, 415 passed, 0 failed, 2 skipped because Chrome/Chromium is not installed
- node --test test/ai-chat-runner.test.mjs — 8 passed
- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- npm run app:prepare -- --target x86_64-pc-windows-msvc — bundled Node.js 22.23.2
- PATH-only Codex resolution — codex-cli 0.147.0
- native Windows launcher, loopback API, taskctl project mapping, AI catalog, Skill installation, single-instance behavior, and startup shortcut verified on Windows
- user confirmed the embedded Taskboard panel is visible and usable in Codex on Windows