### PR TITLE
fix(codex): open HTTP Markdown links in default browser

### DIFF
--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -932,7 +932,7 @@
   function handleExternalOpen(payload) {
     try {
       const url = new URL(payload?.url);
-      if (url.protocol !== "https:") return;
+      if (url.protocol !== "http:" && url.protocol !== "https:") return;
       void requestHost("open-external", { url: url.href }).catch(() => {});
     } catch (_) {}
   }

--- a/scripts/codex-injector-runtime.mjs
+++ b/scripts/codex-injector-runtime.mjs
@@ -30,7 +30,7 @@ function parseHostRequest(payload, parseAutomationRequest) {
   if (request.action === "open-external" && typeof request.url === "string") {
     try {
       const url = new URL(request.url);
-      if (url.protocol === "https:" && url.href.length <= 2_048) {
+      if ((url.protocol === "http:" || url.protocol === "https:") && url.href.length <= 2_048) {
         return { id, request: { ...request, url: url.href }, error: null };
       }
     } catch {}

--- a/test/inject.test.mjs
+++ b/test/inject.test.mjs
@@ -169,14 +169,15 @@ test("opaque iframe messages require the current document capability", () => {
   assert.match(source, /postMessage\(message, frameOrigin === "null" \? "\*" : frameOrigin\)/);
 });
 
-test("packaged HTTPS links are opened by the authenticated host instead of a sandbox popup", () => {
+test("HTTP and HTTPS links are opened by the authenticated host instead of a sandbox popup", () => {
   assert.match(embeddedHost, /a\[target="_blank"\]/);
-  assert.match(embeddedHost, /url\.protocol !== "https:"/);
+  assert.match(embeddedHost, /url\.protocol !== "http:" && url\.protocol !== "https:"/);
   assert.match(embeddedHost, /event\.preventDefault\(\)/);
   assert.match(embeddedHost, /type: "taskboard:open-external"/);
   assert.match(embeddedHost, /challenge: activeFrameChallenge/);
   assert.match(source, /message\.type === "taskboard:open-external"/);
   assert.match(source, /requestHost\("open-external", \{ url: url\.href \}\)/);
+  assert.match(source, /url\.protocol !== "http:" && url\.protocol !== "https:"/);
 });
 
 test("the iframe automation contract is forwarded through the fixed host binding", () => {

--- a/test/injector-host-runtime.test.mjs
+++ b/test/injector-host-runtime.test.mjs
@@ -67,6 +67,14 @@ test("frame loading and external links require bounded authenticated values", as
   }, handlers);
   await handleHostBindingPayload({
     payload: JSON.stringify({
+      id: "external-request-http",
+      action: "open-external",
+      url: "http://10.0.203.86:30842/projects",
+    }),
+    executionContextId: 12,
+  }, handlers);
+  await handleHostBindingPayload({
+    payload: JSON.stringify({
       id: "external-request-1",
       action: "open-external",
       url: "https://example.com/review",
@@ -77,13 +85,15 @@ test("frame loading and external links require bounded authenticated values", as
     payload: JSON.stringify({
       id: "external-request-2",
       action: "open-external",
-      url: "http://example.com/not-allowed",
+      url: "javascript:alert(1)",
     }),
     executionContextId: 12,
   }, handlers);
 
   assert.deepEqual(calls, [
     ["load", "30c3d0c4-aa0f-4169-93c0-bb3da20bc654"],
+    ["response", true],
+    ["open", "http://10.0.203.86:30842/projects"],
     ["response", true],
     ["open", "https://example.com/review"],
     ["response", true],

--- a/web/src/embeddedHost.mjs
+++ b/web/src/embeddedHost.mjs
@@ -25,9 +25,12 @@ export function installEmbeddedExternalLinkHandler() {
       : null;
     if (!link) return;
 
+    const rawHref = link.getAttribute("href");
+    if (!rawHref) return;
+
     let url;
     try {
-      url = new URL(link.href, window.location.href);
+      url = new URL(rawHref);
     } catch {
       return;
     }

--- a/web/src/embeddedHost.mjs
+++ b/web/src/embeddedHost.mjs
@@ -31,7 +31,7 @@ export function installEmbeddedExternalLinkHandler() {
     } catch {
       return;
     }
-    if (url.protocol !== "https:") return;
+    if (url.protocol !== "http:" && url.protocol !== "https:") return;
     event.preventDefault();
     postEmbeddedHostMessage({
       type: "taskboard:open-external",


### PR DESCRIPTION
Closes #125

## Summary
- route HTTP and HTTPS Markdown links through the authenticated Codex host bridge
- keep non-HTTP(S) protocols rejected
- add regression coverage for an internal Phoenix-style HTTP URL

## Verification
- `node --test test/inject.test.mjs test/injector-host-runtime.test.mjs test/inject-fullheight-regression.test.mjs`
- `npm test`
- `npm run typecheck`
- `npm run build:web`

This is intentionally separate from PR #120, which contains the Mermaid/Markdown renderer change.