### PR TITLE
docs: prepare SignPath Foundation application

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Open `src-tauri/target/universal-apple-darwin/release/bundle/macos/Codex Taskboa
 
 The App contains its own Node runtime, Taskboard service, built web UI, Skill, CLI wrapper, and injection script. It starts the service, launches the official Codex app, waits for the renderer, injects the sidebar entry, and opens the panel without showing a terminal window. The App can be copied away from this checkout; the target Mac only needs the official Codex app and does not need this repository, a system Node installation, or a separate Codex CLI installation. Taskboard data is stored in `~/Library/Application Support/Codex Taskboard`, and launcher output is written to `~/Library/Logs/Codex Taskboard/codex-taskboard-launcher.log`.
 
+### Windows code signing
+
+For official Windows releases after the application is approved: **Free code signing provided by [SignPath.io](https://signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).** Current Windows CI artifacts remain unsigned until that approval. See the [Code signing policy](docs/code-signing-policy.md), [Privacy policy](PRIVACY.md), and [Windows uninstall instructions](docs/windows-uninstall.md).
+
 The local build uses ad-hoc code signing for direct verification. A public macOS download still needs Developer ID signing and Apple notarization.
 
 Codex 26.715.52143 ships a renderer CSP that blocks arbitrary HTTP iframes. The launcher therefore enables CDP CSP bypass, reloads that renderer once, installs the document-start script, and waits until the Taskboard OOPIF is actually loaded. CDP is unauthenticated to other processes on the same machine, so only run trusted local code while the launcher is active.

--- a/docs/code-signing-policy.md
+++ b/docs/code-signing-policy.md
@@ -1,15 +1,26 @@
 # Code signing policy
 
-Codex Taskboard does not sign the Windows artifacts produced by the current
-continuous-integration workflow. A future public Windows release can use
-SignPath Foundation only after the project has completed its application and
-the signing service has approved it.
+For official Windows releases after the application is approved: **Free code
+signing provided by [SignPath.io](https://signpath.io/), certificate by
+[SignPath Foundation](https://signpath.org/).** Current Windows
+continuous-integration artifacts remain unsigned until that approval.
 
 ## Scope
 
 This policy applies to official Windows executables and installers published
 by the Codex Taskboard project. Development builds, pull-request artifacts,
 and local builds are not signed.
+
+## Team roles
+
+- Authors and committers: [@jadon7](https://github.com/jadon7) and
+  [@chuspeeism](https://github.com/chuspeeism).
+- Reviewers: [@jadon7](https://github.com/jadon7) and
+  [@chuspeeism](https://github.com/chuspeeism). Changes from other
+  contributors are reviewed through pull requests before merge.
+- Approver: repository owner
+  [@chuspeeism](https://github.com/chuspeeism). Every signing request requires
+  manual approval.
 
 ## Build and approval
 
@@ -22,6 +33,11 @@ and local builds are not signed.
 - Signing roles must use individual accounts with multi-factor authentication.
   Signing credentials must not be stored in the repository or workflow logs.
 - A signed artifact must be published without modification after signing.
+
+## Privacy
+
+Codex Taskboard's data handling and network activity are documented in the
+[Privacy policy](../PRIVACY.md).
 
 ## Incident response
 


### PR DESCRIPTION
## What changed

- add the SignPath Foundation wording and public policy links to the README download page
- define the project authors, reviewers, signing approver, and privacy-policy link
- keep current Windows CI artifacts explicitly marked as unsigned until approval

## Why

SignPath Foundation requires the download page to identify its code-signing service and requires a public Code signing policy with team roles and privacy information before an open-source application is submitted.

## Validation

- `git diff --check origin/main...HEAD`
- reviewed the public README links and policy text against the current SignPath Foundation application requirements

Related: LOCAL-182
