### PR TITLE
优化：按需加载 AI 对话模块，缩小看板首屏包

### DIFF
--- a/test/ai-chat-ui.test.mjs
+++ b/test/ai-chat-ui.test.mjs
@@ -134,6 +134,9 @@ test("reasoning and raw JSONL events never enter the visible activity timeline",
 });
 
 test("App wires the global panel outside project/detail branches and hides it without local capability", () => {
+  assert.match(appSource, /const AiChat = lazy\(\(\) => import\("\.\/components\/AiChat"\)/);
+  assert.match(appSource, /localAiChatAvailable && \([\s\S]*?<Suspense fallback=\{null\}>[\s\S]*?<AiChat/);
+  assert.doesNotMatch(appSource, /import \{ AiChat,/);
   assert.match(appSource, /<AiChat/);
   assert.match(appSource, /projectId=\{selectedProjectId \|\| null\}/);
   assert.match(appSource, /issueId=\{detailTaskId\}/);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -57,7 +57,7 @@ import {
   assigneeTargetForActor,
 } from "./actors";
 import { BoardColumn } from "./components/BoardColumn";
-import { AiChat, type AiChatOpenThreadRequest } from "./components/AiChat";
+import type { AiChatOpenThreadRequest } from "./components/AiChat";
 import { DashboardView } from "./components/DashboardView";
 import { IssueListView } from "./components/IssueListView";
 import { JiraConnectionDialog } from "./components/JiraConnectionDialog";
@@ -151,6 +151,9 @@ type LoadError = ProjectLoadError | TasksLoadError;
 const SHOW_WORKFLOW_BOARD_ENTRY = false;
 const GANTT_ZOOM_OPTIONS: GanttZoom[] = ["day", "week", "month"];
 
+const AiChat = lazy(() => import("./components/AiChat").then((module) => ({
+  default: module.AiChat,
+})));
 const WorkflowBoard = lazy(() => import("./components/WorkflowBoard").then((module) => ({
   default: module.WorkflowBoard,
 })));
@@ -3335,13 +3338,17 @@ export function App() {
         />
       )}
 
-      <AiChat
-        available={localAiChatAvailable}
-        projectId={selectedProjectId || null}
-        issueId={detailTaskId}
-        onThreadsChange={setAiThreads}
-        openThreadRequest={aiOpenThreadRequest}
-      />
+      {localAiChatAvailable && (
+        <Suspense fallback={null}>
+          <AiChat
+            available
+            projectId={selectedProjectId || null}
+            issueId={detailTaskId}
+            onThreadsChange={setAiThreads}
+            openThreadRequest={aiOpenThreadRequest}
+          />
+        </Suspense>
+      )}
 
       <div className="sr-only" role="status" aria-live="polite">{announcement}</div>
       {undoNotice && (


### PR DESCRIPTION
## 背景

看板入口目前静态导入 AI 对话模块。即使本地服务没有暴露 AI 能力，浏览器首屏仍会下载、解析该模块及其 Markdown 依赖。

真实路径：打开看板 → 加载主入口 → 请求 `/api/meta` 确认本地 AI 能力 → 用户打开 AI 对话。AI 代码只需要在能力确认后进入页面。

## 改动

- 将 `AiChat` 改为 `React.lazy` 动态导入。
- 保留 `AiChatOpenThreadRequest` 的纯类型导入，避免进入运行时包。
- 仅在 `localAiChatAvailable` 为真时加载并渲染 AI 对话模块。
- 使用现有 `Suspense` 边界，加载期间不增加额外视觉元素。
- 补充 UI 契约断言，确保 AI 模块保持按需加载且无静态导入回退。

## 用户影响

- 没有本地 AI 能力时，不再下载 AI 对话代码。
- 支持本地 AI 时，能力确认后才加载模块；现有入口和交互不变。
- 首屏主入口 chunk 从 674.99 kB 降至 589.64 kB，减少 85.35 kB（约 12.6%）。
- 计入新增的首屏共享 chunk 后，首屏 JS 仍减少 45.74 kB；AI 对话代码 46.36 kB 被延后加载。

## 验证

- `node --test test/ai-chat-ui.test.mjs`：18/18 通过。
- `npm run typecheck`：通过。
- `npm run build:web`：通过。
- Vite 生产构建确认生成独立的 `AiChat` chunk。

## 范围

本 PR 只调整 AI 对话模块的加载时机，不修改 API、数据模型或用户交互。