### PR TITLE
维护：升级 upload-artifact 至 v7.0.1

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Build the unsigned NSIS installer
         run: npm run app:build:windows
       - name: Preserve the unsigned NSIS installer
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: windows-x64-nsis-${{ github.sha }}
           path: src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/*-setup.exe

--- a/test/launcher-release.test.mjs
+++ b/test/launcher-release.test.mjs
@@ -36,6 +36,14 @@ test("release signing is tag-only and PR CI builds the real unsigned app bundle"
   assert.match(checkWorkflow, /--no-sign/);
 });
 
+test("Windows CI uploads the NSIS installer with the pinned Node 24 artifact action", () => {
+  assert.match(
+    checkWorkflow,
+    /actions\/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7\.0\.1/,
+  );
+  assert.doesNotMatch(checkWorkflow, /actions\/upload-artifact@[^\s]+ # v4/);
+});
+
 test("the launcher minimum system version matches the current Codex client requirement", () => {
   assert.equal(tauriConfig.bundle.macOS.minimumSystemVersion, "14.0");
 });


### PR DESCRIPTION
## 背景

Windows CI 在构建 NSIS 安装包后使用 `actions/upload-artifact@v4.6.2` 保存产物。该版本运行于 Node.js 20，GitHub Actions 已在日志中给出运行时弃用提示。

真实路径：Windows runner 构建 NSIS 安装包 → `upload-artifact` 上传 `*-setup.exe` → 维护者从工作流下载并验证安装包。

## 改动

- 将 `actions/upload-artifact` 升级到官方最新的 v7.0.1。
- 继续使用完整提交 SHA 固定依赖：`043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`。
- v7 使用 Node.js 24 运行时，移除当前 Node.js 20 弃用来源。
- 增加工作流契约测试，锁定 v7.0.1 SHA，并防止意外回退到 v4。

官方版本说明：https://github.com/actions/upload-artifact/releases/tag/v7.0.1

## 用户与维护影响

- Windows NSIS 产物的名称和路径保持不变。
- 上传步骤改用受支持的 Node.js 24 运行时。
- SHA 固定策略保持不变，供应链边界没有放宽。

## 验证

- `node --test test/launcher-release.test.mjs`：4/4 通过。
- `npm run typecheck`：通过。
- `npm run build`：通过。
- PR CI 将继续真实构建 Windows NSIS，并验证 v7 上传产物。

## 兼容性

本仓库运行于 GitHub.com 的托管 runner，满足 v7 的使用场景；本 PR 不改变应用代码或发布产物格式。