### PR TITLE
LOCAL-170：在 Finder 中显示下载附件

### DIFF
--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -948,8 +948,8 @@
         type: "taskboard:attachment-open-error",
         payload: {
           error: hostText(
-            "无法用系统默认应用打开附件，请重试。",
-            "Could not open the attachment in its default app. Try again.",
+            "无法在 Finder 中显示附件，请重试。",
+            "Could not reveal the attachment in Finder. Try again.",
           ),
         },
       });

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -869,6 +869,24 @@ async function openWithDefaultApplication(target) {
   });
 }
 
+async function revealAttachmentInFinder(attachmentPath, directory) {
+  try {
+    await new Promise((resolve, reject) => {
+      const child = spawn("/usr/bin/open", ["-R", attachmentPath], {
+        env: withoutTaskboardLauncherEnvironment(process.env),
+        stdio: "ignore",
+      });
+      child.once("error", reject);
+      child.once("close", (code) => {
+        if (code === 0) resolve();
+        else reject(new Error("Finder could not reveal the attachment"));
+      });
+    });
+  } catch {
+    await openWithDefaultApplication(directory);
+  }
+}
+
 async function openExternalUrl(request) {
   await openWithDefaultApplication(request.url);
   return { opened: true };
@@ -888,7 +906,7 @@ async function openAttachment(request) {
   await mkdir(directory, { recursive: true, mode: 0o700 });
   const attachmentPath = path.join(directory, request.filename);
   await writeFile(attachmentPath, Buffer.from(await response.arrayBuffer()), { mode: 0o600 });
-  await openWithDefaultApplication(attachmentPath);
+  await revealAttachmentInFinder(attachmentPath, directory);
   return { opened: true };
 }
 


### PR DESCRIPTION
## 关联

- LOCAL-170

## 问题

Codex 内的附件已写入稳定本地目录，但宿主随后把文件交给默认应用。未知或不可预览格式会失败，也不会向用户显示文件位置。

## 改动

- 保留现有 `open-attachment` 消息、标准 `/content` 读取和 `opened-attachments/<id>/<filename>` 写入路径。
- 写入后调用 Finder reveal，显示并选中本地文件。
- Finder 无法选中文件时，打开对应附件目录。
- 更新宿主失败文案。普通浏览器下载路径不变。

## 直接验证

- 用现有真实附件 `68905349-f465-49b9-ab16-deb00f61c432` 验证，内容为 PNG，大小 185,919 字节，SHA-256 为 `5aad2fafe2e06afd7f7ba4566e6158b3b82bb8a7ee27d1ec58bdb063b3b8892e`。
- `/usr/bin/open -R <file>` 返回 0，Finder 收到显示并选中请求。
- 对不存在文件执行 reveal 返回 1；打开对应目录返回 0。
- `node --check scripts/codex-injector.mjs` 通过。
- `node --check inject/codex-taskboard.user.js` 通过。
- `git diff --check` 通过。

按项目规则，本次未新增测试、兼容层或无关防御分支。
