### PR TITLE
修复 Launcher 持续运行时的更新发现延迟

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -33,7 +33,7 @@ use uuid::Uuid;
 const STOP_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(target_os = "macos")]
 const LAUNCHER_STOP_TIMEOUT: Duration = Duration::from_secs(36);
-const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
+const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(30 * 60);
 #[cfg(target_os = "macos")]
 const TASKBOARD_LISTEN_FD: i32 = 5;
 


### PR DESCRIPTION
## 结果

- 将 Launcher 持续运行期间的自动更新检查周期从 24 小时改为 30 分钟。
- 保留启动时立即检查和手动检查。
- 三类入口继续共用现有 CAS，不会并发检查。
- “重新打开 Codex”只重启受管子进程，不会重建周期 timer。
- 未改 updater endpoint、发布资产逻辑、确认框或状态栏进度路径。

## LOCAL-162 根因

v1.0.2 的 updater 资产在 2026-08-12 16:43Z 进入 Draft Release，但 Release 到 2026-08-13 01:21:17Z 才公开。持续运行实例在公开前已完成启动检查，并得到“无更新”。公开后，原 24 小时周期尚未再次触发检查，所以没有确认框，也没有进入下载进度路径。

已排除 endpoint、latest.json、平台资产、签名、版本比较和 install_update 普遍失效。现有日志后来记录了完整成功链：发现 1.0.2、显示确认框、用户接受、安装、重启。

## 验证

- `rustup 1.88.0 cargo check`：通过。
- `cargo fmt -- --check`：通过。
- `git diff --check`：通过。
- 最终差异：1 个文件，1 行常量修改。
- 受控 updater endpoint 的隔离 App 验证：启动请求立即发生；延迟请求期间周期入口被 CAS 拒绝，最大并发为 1；自动无更新和自动 500 只写日志；较高版本进入确认框分支。
- 现有下载、验签、安装和重启状态栏路径保持不变。

本 PR 不发布版本。
