### PR TITLE
chore: bump version to 1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-taskboard",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-taskboard",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@lobehub/icons-static-svg": "^1.94.0",
         "@xyflow/react": "^12.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-taskboard",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "codex-taskboard-launcher"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "libc",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-taskboard-launcher"
-version = "1.0.2"
+version = "1.0.3"
 description = "Codex Taskboard macOS launcher"
 edition = "2021"
 rust-version = "1.88"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex Taskboard",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "identifier": "com.chuspeeism.codex-taskboard",
   "app": {
     "windows": []


### PR DESCRIPTION
## 变更

- 将 npm 包、Tauri Launcher 和应用配置版本统一更新为 1.0.3。
- 同步 package-lock.json 与 Cargo.lock 中对应的根包版本记录。

## 核对

- 五个指定文件的版本均为 1.0.3。
- git diff --check 通过。

## 产品功能说明（建议）

- 附件下载后在 Finder 中显示并选中，无法直接预览的文件也可定位。
- Launcher 持续运行时每 30 分钟检查更新，发现新版本继续弹窗，现有下载/验证/安装/重启进度保持在状态栏菜单。