### PR TITLE
LOCAL-202 显示看板列任务数量

### DIFF
--- a/web/src/components/BoardColumn.tsx
+++ b/web/src/components/BoardColumn.tsx
@@ -187,7 +187,11 @@ export function BoardColumn({
           <span className={`column-status-icon status-icon-${details.tone}`}>
             <ColumnStatusIcon status={status} />
           </span>
-          <h2 id={`column-${status}`}>{label}</h2>
+          <h2 id={`column-${status}`}>
+            {label}{tasks.length > 0 && (
+              status === "todo" || status === "in_progress" || status === "in_review"
+            ) ? ` ${tasks.length}` : ""}
+          </h2>
         </div>
         {createEnabled && (
           <div className="column-actions">


### PR DESCRIPTION
## 改动

- 在“等待认领”“处理中”“等你确认”列标题的原文字样式后显示任务数量。
- 数量为 0 时不显示；其他列不改。

## 原因

看板列标题此前只显示状态名称，用户不能直接看到三个主要流程列中的当前任务数量。

## 影响

用户可以直接从列标题读取当前筛选结果中的任务数量。界面没有新增徽章或特殊样式。

## 验证

- 直接界面：空列显示原标题，不显示 `0`。
- 直接界面：三个目标列各有一条议题时，显示“等待认领 1”“处理中 1”“等你确认 1”。
- `npm run typecheck`
- `npm run build`
