### PR TITLE
完善面板 AI 对话功能链

### DIFF
--- a/shared/codex-environment.mjs
+++ b/shared/codex-environment.mjs
@@ -1,5 +1,7 @@
 export function withoutTaskboardLauncherEnvironment(environment = process.env) {
   return Object.fromEntries(
-    Object.entries(environment).filter(([name]) => !name.startsWith("CODEX_TASKBOARD_")),
+    Object.entries(environment).filter(([name]) => (
+      name !== "CODEX_API_KEY" && !name.startsWith("CODEX_TASKBOARD_")
+    )),
   );
 }

--- a/shared/codex-environment.mjs
+++ b/shared/codex-environment.mjs
@@ -1,7 +1,5 @@
 export function withoutTaskboardLauncherEnvironment(environment = process.env) {
   return Object.fromEntries(
-    Object.entries(environment).filter(([name]) => (
-      name !== "CODEX_API_KEY" && !name.startsWith("CODEX_TASKBOARD_")
-    )),
+    Object.entries(environment).filter(([name]) => !name.startsWith("CODEX_TASKBOARD_")),
   );
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -667,6 +667,7 @@ fn start_launcher_locked(
         .env("CODEX_TASKBOARD_INSTANCE_TOKEN", &instance_token)
         .env("CODEX_TASKBOARD_INSTANCE_SECRET", &instance_secret)
         .env("CODEX_TASKBOARD_VERSION", &version)
+        .env_remove("CODEX_API_KEY")
         .env(
             "CODEX_TASKBOARD_CODEX_PROFILE",
             codex_profile.to_string_lossy().as_ref(),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,6 +29,7 @@ import {
   deleteArchivedTask as deleteArchivedTaskRequest,
   deleteProjectLabel as deleteProjectLabelRequest,
   deleteProject as deleteProjectRequest,
+  getAiChatCatalog,
   getCodexThreadProgress,
   getHostRuntime,
   getJiraConnection,
@@ -636,6 +637,7 @@ export function App() {
   const [manageTaskboardSkillPath, setManageTaskboardSkillPath] = useState("");
   const [taskboardMetadata, setTaskboardMetadata] = useState<TaskboardMetadata | null>(null);
   const [localAiChatAvailable, setLocalAiChatAvailable] = useState(false);
+  const [aiImportReadyProjectId, setAiImportReadyProjectId] = useState<string | null>(null);
   const [aiThreads, setAiThreads] = useState<AiChatThread[]>([]);
   const [aiOpenThreadRequest, setAiOpenThreadRequest] = useState<AiChatOpenThreadRequest | null>(null);
   const [readActivityKeys, setReadActivityKeys] = useState<Record<string, string>>({});
@@ -787,6 +789,25 @@ export function App() {
 
   const selectedProject = projects.find((project) => project.id === selectedProjectId) ?? null;
   const isJiraProject = selectedProject?.source === "jira";
+  const aiImportProjectId = hasLoadedTasks
+    && tasks.length === 0
+    && selectedProject
+    && selectedProject.id !== GLOBAL_PROJECT_ID
+    && !isJiraProject
+    && localAiChatAvailable
+      ? selectedProject.id
+      : null;
+  useEffect(() => {
+    setAiImportReadyProjectId(null);
+    if (!aiImportProjectId) return;
+    const controller = new AbortController();
+    void getAiChatCatalog(aiImportProjectId, controller.signal)
+      .then(() => {
+        if (!controller.signal.aborted) setAiImportReadyProjectId(aiImportProjectId);
+      })
+      .catch(() => {});
+    return () => controller.abort();
+  }, [aiImportProjectId, selectedProject]);
   useLayoutEffect(() => {
     if (selectedProject) rememberProjectOpen(selectedProject.id);
   }, [rememberProjectOpen, selectedProject]);
@@ -2935,10 +2956,7 @@ export function App() {
         ) : hasLoadedTasks
           && tasks.length === 0
           && selectedProject
-          && selectedProject.id !== GLOBAL_PROJECT_ID
-          && Boolean(selectedDeviceWorkspacePath ?? selectedProject.workspacePath)
-          && !isJiraProject
-          && localAiChatAvailable ? (
+          && aiImportReadyProjectId === selectedProject.id ? (
           <div className="page-empty">
             <h2>{text("当前项目还没有任务", "This project has no issues yet")}</h2>
             <p>{text(

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2929,6 +2929,33 @@ export function App() {
             openingThread={openingThreadTaskId === detailTask.id}
             onError={setActionError}
           />
+        ) : hasLoadedTasks
+          && tasks.length === 0
+          && selectedProject
+          && !isJiraProject
+          && localAiChatAvailable ? (
+          <div className="page-empty">
+            <h2>{text("当前项目还没有任务", "This project has no issues yet")}</h2>
+            <p>{text(
+              "让 Codex 检查当前项目目录对应的对话，并整理任务状态。",
+              "Ask Codex to inspect conversations for this project directory and organize their task status.",
+            )}</p>
+            <button
+              className="button primary"
+              type="button"
+              onClick={() => setAiOpenThreadRequest((current) => ({
+                projectId: selectedProject.id,
+                issueId: null,
+                composerText: text(
+                  "只检查当前项目目录对应的 Codex 对话。请将其中已完成、处理中和待执行的任务整理并导入当前项目的 Taskboard。",
+                  "Only inspect Codex conversations associated with the current project directory. Organize completed, in-progress, and pending tasks, then import them into this project's Taskboard.",
+                ),
+                requestId: (current?.requestId ?? 0) + 1,
+              }))}
+            >
+              {text("导入当前项目任务状态", "Import current project task status")}
+            </button>
+          </div>
         ) : boardView === "dashboard" ? (
           <DashboardView
             key={selectedProjectId}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2935,6 +2935,8 @@ export function App() {
         ) : hasLoadedTasks
           && tasks.length === 0
           && selectedProject
+          && selectedProject.id !== GLOBAL_PROJECT_ID
+          && Boolean(selectedDeviceWorkspacePath ?? selectedProject.workspacePath)
           && !isJiraProject
           && localAiChatAvailable ? (
           <div className="page-empty">

--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -1424,9 +1424,7 @@ export function AiChat({
     sendBlocked,
     attachments.length > 0,
   );
-  const anyRunning = threads.some((thread) => thread.status === "running");
-  const anyFailed = threads.some((thread) => thread.status === "failed");
-  const launcherState = anyRunning ? "running" : anyFailed ? "failed" : unread ? "unread" : "idle";
+  const launcherState = unread ? "unread" : "idle";
   const lastUserEvent = snapshot?.thread.status === "failed"
     ? [...snapshot.events].reverse().find((event) => (
         event.role === "user"

--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -1174,18 +1174,18 @@ export function AiChat({
     });
   }, []);
 
-  const observeRunTransitions = useCallback((runs: AiChatRun[]) => {
-    let completedWhileClosed = false;
+  const observeRunTransitions = useCallback((threadId: string, runs: AiChatRun[]) => {
+    let unreadCompletion = false;
     for (const run of runs) {
       const previous = observedRunStatusesRef.current.get(run.id);
       observedRunStatusesRef.current.set(run.id, run.status);
       if (
         previous === "running"
         && run.status !== "running"
-        && !panelOpenRef.current
-      ) completedWhileClosed = true;
+        && (!panelOpenRef.current || selectedThreadRef.current !== threadId)
+      ) unreadCompletion = true;
     }
-    if (completedWhileClosed) setUnread(true);
+    if (unreadCompletion) setUnread(true);
   }, []);
 
   const loadSnapshot = useCallback(async (threadId: string, quiet = false) => {
@@ -1199,7 +1199,7 @@ export function AiChat({
       if (requestId !== snapshotRequestRef.current || selectedThreadRef.current !== threadId) return;
       setSnapshot(next);
       replaceThread(next.thread);
-      observeRunTransitions(next.runs);
+      observeRunTransitions(threadId, next.runs);
       if (!quiet) setError(null);
     } catch (nextError) {
       if (
@@ -1281,7 +1281,7 @@ export function AiChat({
       try {
         const next = await getAiChatThread(threadId);
         replaceThread(next.thread);
-        observeRunTransitions(next.runs);
+        observeRunTransitions(threadId, next.runs);
       } catch {
         // The selected thread surfaces request errors; background history refresh stays quiet.
       }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6951,15 +6951,6 @@ kbd {
   background: var(--accent);
 }
 
-.ai-chat-launcher.is-running .ai-chat-launcher-state {
-  background: var(--success);
-  animation: ai-chat-status-pulse 1.35s ease-in-out infinite;
-}
-
-.ai-chat-launcher.is-failed .ai-chat-launcher-state {
-  background: var(--danger);
-}
-
 .ai-chat-panel {
   --ai-chat-composer-gap: 12px;
   --ai-chat-composer-radius: 13px;
@@ -8473,12 +8464,6 @@ kbd {
 
 @keyframes ai-chat-spin {
   to { transform: rotate(360deg); }
-}
-
-@keyframes ai-chat-status-pulse {
-  0%,
-  100% { transform: scale(.86); opacity: .72; }
-  50% { transform: scale(1); opacity: 1; }
 }
 
 @keyframes ai-chat-panel-in {


### PR DESCRIPTION
## 变更

- LOCAL-198：过滤 Taskboard 启动 Codex 子进程时继承的 CODEX_API_KEY，避免它覆盖可用的 ChatGPT 登录并触发 401 invalid_issuer。
- LOCAL-199：浮动 AI 对话入口只显示未读消息蓝点，不再显示运行或错误状态点；面板内真实错误内容保持不变。
- LOCAL-197：当前项目没有面板任务时显示导入按钮；点击后复用现有 AI 对话，打开面板并预填当前项目任务状态整理请求。

## 路径验证

- 实际失败记录证明两条相同消息属于首次请求和失败后重试，不是单次请求双写。
- 隔离实例继承 CODEX_API_KEY 时，修复后的真实 AI turn 成功完成并返回预期内容。
- 面板关闭后回复完成，浮动入口为 is-unread，只有一个状态点，颜色为 rgb(49, 124, 255)。
- 空项目按钮可见；点击后 AI 对话打开，默认请求完整预填。
- npm run typecheck 通过。
- npm run build:web 通过。

## 同步

已普通合并包含 PR #128 的最新 main。保留 AiChat React.lazy、localAiChatAvailable 和 Suspense 懒加载逻辑。