### PR TITLE
fix: remove success toasts from issue operations

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -189,7 +189,6 @@ interface ProjectContextMenuState {
 
 interface UndoOperation {
   id: number;
-  message: string;
   undo: () => Promise<void>;
 }
 
@@ -1731,9 +1730,10 @@ export function App() {
     refreshWorkflowOptions,
   ]);
 
-  function pushUndo(message: string, undo: () => Promise<void>) {
-    const operation = { id: ++undoSequenceRef.current, message, undo };
+  function pushUndo(message: string | null, undo: () => Promise<void>) {
+    const operation = { id: ++undoSequenceRef.current, undo };
     undoStackRef.current = [...undoStackRef.current.slice(-19), operation];
+    if (!message) return;
     setAnnouncementValue("");
     setUndoNotice({ id: operation.id, message });
   }
@@ -1978,12 +1978,7 @@ export function App() {
         ));
       }
       if (creating) {
-        const totalUploaded = uploadedAttachments + inlineImages.length;
-        const message = text(
-          `${saved.identifier} 已创建${totalUploaded > 0 ? `，已上传 ${totalUploaded} 个附件` : ""}。`,
-          `${saved.identifier} was created${totalUploaded > 0 ? ` with ${totalUploaded} attachments uploaded` : ""}.`,
-        );
-        pushUndo(message, async () => {
+        pushUndo(null, async () => {
           const candidate = tasksRef.current.find((task) => task.id === saved.id);
           const current = candidate && candidate.version >= saved.version ? candidate : saved;
           await archiveTaskRequest(current);
@@ -1993,9 +1988,8 @@ export function App() {
         const previous = editor.task;
         const previousAssigneeTarget = assigneeTargetForActor(previous.assignee, currentUser);
         if (!draft.assigneeTarget || previousAssigneeTarget) {
-          const displayIdentifier = saved.externalKey ?? saved.identifier;
           pushUndo(
-            text(`${displayIdentifier} 已更新。`, `${displayIdentifier} was updated.`),
+            null,
             () => restoreTaskDetails(previous, saved, previousAssigneeTarget),
           );
         }
@@ -2063,14 +2057,7 @@ export function App() {
       setTasks((current) => sortTasks(current.map((candidate) =>
         candidate.id === moved.id ? moved : candidate,
       )));
-      const displayIdentifier = task.externalKey ?? task.identifier;
-      const message = task.status === status
-        ? text(`${displayIdentifier} 排序已调整。`, `${displayIdentifier} was reordered.`)
-        : text(
-          `${displayIdentifier} 已移至${taskStatusLabel(language, status)}。`,
-          `${displayIdentifier} was moved to ${taskStatusLabel(language, status)}.`,
-        );
-      pushUndo(message, async () => {
+      pushUndo(null, async () => {
         const candidate = tasksRef.current.find((current) => current.id === moved.id);
         const current = candidate && candidate.version >= moved.version ? candidate : moved;
         const restored = await moveTaskRequest(current, previous.status, previous.sortOrder);
@@ -2144,9 +2131,8 @@ export function App() {
       )));
       const previousAssigneeTarget = assigneeTargetForActor(previous.assignee, currentUser);
       if (!assigneeTarget || previousAssigneeTarget) {
-        const displayIdentifier = task.externalKey ?? task.identifier;
         pushUndo(
-          text(`${displayIdentifier} 已更新。`, `${displayIdentifier} was updated.`),
+          null,
           () => restoreTaskDetails(previous, updated, previousAssigneeTarget),
         );
       }


### PR DESCRIPTION
## 功能

- 拖拽排序、创建议题、编辑内容和改变状态成功后不再显示 toast。
- 撤回操作仍写入 undo 栈，键盘撤回能力保持不变。
- 失败提示、复制、归档等其他通知保持不变。

## 根因

`pushUndo` 同时负责登记撤回操作和创建 `undoNotice`。四类成功操作调用它时，都会被强制渲染为 `.toast.undo-toast`。本次改动允许撤回记录不带通知，并只让这四类调用静默登记。

## E3 真实操作路径

- 拖拽排序：`TaskCard` 拖拽 → `BoardColumn.handleDrop` → `App.finishTaskDrop/moveTask` → `POST /api/tasks/:id/move` 更新 `sortOrder` → 静默登记撤回。
- 创建议题：列头“添加” → `TaskEditor` 提交 → `App.saveEditor` → `POST /api/tasks` 创建记录 → 静默登记撤回。
- 改变内容：卡片详情的标题或描述保存 → `TaskDetail.saveTask` → `App.updateTaskProperties` → `PATCH /api/tasks/:id` 更新字段 → 静默登记撤回。
- 改变状态：右键状态菜单、详情状态选择器或跨列拖拽 → `App.moveTask/updateTaskProperties` → `/move` 或 `PATCH /api/tasks/:id` 更新状态 → 静默登记撤回。
- 失败路径仍走 `setActionError → .error-banner`，本次没有修改。

## 直接验证

在 61223 独立预览中通过真实浏览器创建 LOCAL-208，并依次完成：

- 创建议题：卡片出现，`toastCount = 0`。
- 同列拖拽排序：卡片位置从索引 0 移到索引 1，`toastCount = 0`。
- 内容修改：标题保存为“LOCAL-204 浏览器直验（已编辑）”，`toastCount = 0`。
- 状态修改：状态保存为“等你确认”，`toastCount = 0`。
- 指定 61223 `taskctl issue get LOCAL-208` 确认标题、状态、排序和版本均已落库。
- `npm run build:web` 成功。
- `git diff --check` 通过。

## 交付

- Taskboard：LOCAL-204
- Commit：`488ac374c5b5cde3e8261b05bc8507850623160b`
