### PR TITLE
fix: support wrapped Plugins sidebar rows

### DIFF
--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -263,10 +263,7 @@
     if (!scroll) return null;
     const buttons = Array.from(scroll.querySelectorAll("button"));
     const plugin = buttons.find((button) => buttonMatches(button, PLUGIN_LABELS));
-    if (plugin && plugin.parentElement) {
-      const siblings = Array.from(plugin.parentElement.children).filter((child) => child.tagName === "BUTTON");
-      if (siblings.length >= 3) return plugin;
-    }
+    if (plugin?.parentElement) return plugin;
 
     const firstSection = scroll.querySelector("[data-app-action-sidebar-section]");
     const sectionTop = firstSection?.getBoundingClientRect().top ?? Number.POSITIVE_INFINITY;

--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -261,11 +261,17 @@
   function findReferenceButton() {
     const scroll = document.querySelector("[data-app-action-sidebar-scroll]");
     if (!scroll) return null;
+    const firstSection = scroll.querySelector("[data-app-action-sidebar-section]");
     const buttons = Array.from(scroll.querySelectorAll("button"));
-    const plugin = buttons.find((button) => buttonMatches(button, PLUGIN_LABELS));
+    const nativeActionButtons = firstSection
+      ? buttons.filter((button) => (
+        !firstSection.contains(button)
+        && (button.compareDocumentPosition(firstSection) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0
+      ))
+      : buttons;
+    const plugin = nativeActionButtons.find((button) => buttonMatches(button, PLUGIN_LABELS));
     if (plugin?.parentElement) return plugin;
 
-    const firstSection = scroll.querySelector("[data-app-action-sidebar-section]");
     const sectionTop = firstSection?.getBoundingClientRect().top ?? Number.POSITIVE_INFINITY;
     const groups = Array.from(scroll.querySelectorAll("div")).filter((element) => {
       const directButtons = Array.from(element.children).filter((child) => child.tagName === "BUTTON");

--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -24,6 +24,7 @@
   const HOST_CAPABILITY = window.__CODEX_TASKBOARD_HOST_CAPABILITY__;
   const REATTACH_DELAY_MS = 160;
   const FRAME_READY_TIMEOUT_MS = 12_000;
+  const FRAME_LOAD_ATTEMPTS = 2;
   const HOST_REQUEST_TIMEOUT_MS = 12_000;
   const HOST_HEARTBEAT_MAX_AGE_MS = 8_000;
   const MACOS_TITLEBAR_SAFE_LEFT = 80;
@@ -1292,13 +1293,29 @@
     return { frameName, frameCapability };
   }
 
+  async function loadTaskboardFrameUntilReady(cacheBust = false) {
+    let lastError = null;
+    for (let attempt = 0; attempt < FRAME_LOAD_ATTEMPTS; attempt += 1) {
+      const frameRequest = loadTaskboardFrame(cacheBust || attempt > 0);
+      try {
+        await requestHostLoadFrame(frameRequest);
+        await waitForFrameReady();
+        return;
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError ?? hostError(
+      "任务面板页面加载失败",
+      "Taskboard page failed to load",
+    );
+  }
+
   function reloadFrame() {
     if (!frame) return false;
     const generation = ++openGeneration;
     if (active) showLoading();
-    const frameRequest = loadTaskboardFrame(true);
-    void requestHostLoadFrame(frameRequest)
-      .then(() => waitForFrameReady())
+    void loadTaskboardFrameUntilReady(true)
       .then(() => {
           if (!active || generation !== openGeneration) return;
           showFrame();
@@ -1449,9 +1466,7 @@
       };
       if (!frameReady || result.restarted || !frameMatchesTaskboardUrl(taskboardUrl)) {
         showLoading();
-        const frameRequest = loadTaskboardFrame();
-        await requestHostLoadFrame(frameRequest);
-        await waitForFrameReady();
+        await loadTaskboardFrameUntilReady();
       }
       if (!active || generation !== openGeneration) return;
       showFrame();

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -147,6 +147,7 @@ function parseArgs(argv) {
   if (options.cdpPipe && !options.launch) {
     throw new Error("--cdp-pipe requires --launch");
   }
+  if (options.launch) options.attachExisting = true;
   return options;
 }
 

--- a/test/inject-fullheight-regression.test.mjs
+++ b/test/inject-fullheight-regression.test.mjs
@@ -46,7 +46,10 @@ async function chromeExecutable() {
   return null;
 }
 
-function fixtureHtml(origin) {
+function fixtureHtml(
+  origin,
+  { omitFirstFrameReady = false, exerciseFrameActions = true, reportAfterMs = null } = {},
+) {
   const encodedSource = Buffer.from(source).toString("base64");
   return `<!doctype html>
 <html>
@@ -102,6 +105,7 @@ function fixtureHtml(origin) {
       window.__browserPanelClosed = false;
       window.__injectionError = null;
       window.__frameMessages = [];
+      window.__loadFrameAttempts = 0;
       window.__externalOpenUrl = null;
       window.__frameVisibleBeforeNavigation = false;
       window.__statusHiddenBeforeNavigation = false;
@@ -123,24 +127,47 @@ function fixtureHtml(origin) {
           && event.data.capability === "fullheight-host-capability"
         ) {
           const request = event.data.payload;
+          const respond = () => window.postMessage({
+            type: "__codexTaskboardHostResponseV1",
+            capability: "fullheight-host-capability",
+            response: { id: request.id, ok: true, loaded: true },
+          }, window.location.origin);
           if (request.action === "load-frame") {
-            const frame = document.querySelector('iframe[name="' + request.frameName + '"]');
-            frame.srcdoc = '<a id="external-link" href="https://example.com/review" target="_blank">Review</a>'
-              + '<script>'
-              + ${JSON.stringify(embeddedHostClassicSource)}
-              + '\\nglobalThis.__CODEX_TASKBOARD_FRAME_CAPABILITY__='
-              + JSON.stringify(request.frameCapability)
-              + ';installEmbeddedExternalLinkHandler();'
-              + 'let activated=false,acknowledgedChallenge="";window.addEventListener("message",function(event){'
-              + 'if(event.data?.type!=="taskboard:frame-challenge")return;'
-              + 'const challenge=event.data.payload?.challenge;if(!challenge||challenge===acknowledgedChallenge)return;'
-              + 'acknowledgedChallenge=challenge;setEmbeddedFrameChallenge(challenge);'
-              + 'postEmbeddedHostMessage({type:"taskboard:ready"});'
-              + 'if(activated)return;activated=true;'
-              + 'parent.postMessage({type:"taskboard:ready"},"*");'
-              + 'parent.postMessage({type:"taskboard:open-thread",payload:{threadId:"forged"}},"*");'
-              + 'document.getElementById("external-link").click();'
-              + '});postEmbeddedHostMessage({type:"taskboard:frame-awaiting-challenge"});<\\/script>';
+            window.__loadFrameAttempts += 1;
+            if (window.__loadFrameAttempts === 1) window.__firstFrameRequestAt = Date.now();
+            if (window.__loadFrameAttempts === 2) window.__secondFrameRequestAt = Date.now();
+            const shouldSendReady = ${JSON.stringify(!omitFirstFrameReady)}
+              || window.__loadFrameAttempts > 1;
+            const shouldExerciseFrameActions = ${JSON.stringify(exerciseFrameActions)}
+              && shouldSendReady;
+            const mountFrame = () => {
+              const frame = document.querySelector('iframe[name="' + request.frameName + '"]');
+              if (!frame) {
+                window.setTimeout(mountFrame, 0);
+                return;
+              }
+              frame.srcdoc = '<a id="external-link" href="https://example.com/review" target="_blank">Review</a>'
+                + '<script>'
+                + ${JSON.stringify(embeddedHostClassicSource)}
+                + '\\nglobalThis.__CODEX_TASKBOARD_FRAME_CAPABILITY__='
+                + JSON.stringify(request.frameCapability)
+                + ';installEmbeddedExternalLinkHandler();'
+                + 'let activated=false,acknowledgedChallenge="";window.addEventListener("message",function(event){'
+                + 'if(event.data?.type!=="taskboard:frame-challenge")return;'
+                + 'const challenge=event.data.payload?.challenge;if(!challenge||challenge===acknowledgedChallenge)return;'
+                + 'acknowledgedChallenge=challenge;setEmbeddedFrameChallenge(challenge);'
+                + (shouldSendReady ? 'postEmbeddedHostMessage({type:"taskboard:ready"});' : '')
+                + (shouldExerciseFrameActions
+                  ? 'if(activated)return;activated=true;'
+                    + 'parent.postMessage({type:"taskboard:ready"},"*");'
+                    + 'parent.postMessage({type:"taskboard:open-thread",payload:{threadId:"forged"}},"*");'
+                    + 'document.getElementById("external-link").click();'
+                  : '')
+                + '});postEmbeddedHostMessage({type:"taskboard:frame-awaiting-challenge"});<\\/script>';
+              respond();
+            };
+            mountFrame();
+            return;
           }
           if (request.action === "open-external") {
             window.__externalOpenUrl = request.url;
@@ -154,11 +181,7 @@ function fixtureHtml(origin) {
             frame.removeAttribute("srcdoc");
             frame.src = ${JSON.stringify(`${origin}/attacker`)};
           }
-          window.postMessage({
-            type: "__codexTaskboardHostResponseV1",
-            capability: "fullheight-host-capability",
-            response: { id: request.id, ok: true, loaded: true },
-          }, window.location.origin);
+          respond();
         }
         if (event.source === window && event.data?.type === "navigate-to-route") {
           window.__forgedThreadOpened = true;
@@ -192,13 +215,19 @@ function fixtureHtml(origin) {
           window.__resolveHostileNavigationLoaded = resolve;
         });
         entry?.click();
-        await hostileNavigationLoaded;
+        const reportAfterMs = ${JSON.stringify(reportAfterMs)};
+        if (reportAfterMs === null) await hostileNavigationLoaded;
+        else await new Promise((resolve) => setTimeout(resolve, reportAfterMs));
 
         const page = document.getElementById("codex-taskboard-page");
         const frame = document.getElementById("codex-taskboard-frame");
         const surface = document.getElementById("surface");
         const conversation = document.getElementById("conversation");
         const result = {
+          loadFrameAttempts: window.__loadFrameAttempts,
+          ...(Number.isFinite(window.__secondFrameRequestAt)
+            ? { retryDelayMs: window.__secondFrameRequestAt - window.__firstFrameRequestAt }
+            : {}),
           panelVisibleBefore,
           browserPanelClosed: window.__browserPanelClosed,
           conversationTop: conversation.getBoundingClientRect().top,
@@ -298,6 +327,7 @@ test("Taskboard fills the workspace, opens HTTPS links and revokes hostile ifram
   assert.ok(encodedResult, "fixture did not report an injection result");
   const result = JSON.parse(Buffer.from(encodedResult, "base64").toString("utf8"));
   assert.deepEqual(result, {
+    loadFrameAttempts: 1,
     panelVisibleBefore: true,
     browserPanelClosed: true,
     conversationTop: 0,
@@ -319,6 +349,65 @@ test("Taskboard fills the workspace, opens HTTPS links and revokes hostile ifram
     statusHiddenBeforeNavigation: true,
     hostileNavigationRevoked: true,
     forgedThreadOpened: false,
+    injectionError: null,
+  });
+});
+
+test("Taskboard issues a second iframe load request when the first ready signal is missing", async (t) => {
+  const chrome = await chromeExecutable();
+  if (!chrome) {
+    t.skip("Chrome or Chromium is not installed");
+    return;
+  }
+
+  const server = http.createServer((request, response) => {
+    const origin = `http://127.0.0.1:${server.address().port}`;
+    response.setHeader("content-type", "text/html; charset=utf-8");
+    response.end(fixtureHtml(origin, {
+      omitFirstFrameReady: true,
+      exerciseFrameActions: false,
+      reportAfterMs: 14_000,
+    }));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => new Promise((resolve) => {
+    server.close(resolve);
+    server.closeAllConnections();
+  }));
+
+  const profile = await mkdtemp(path.join(os.tmpdir(), "taskboard-delayed-ready-chrome-"));
+  t.after(() => rm(profile, { recursive: true, force: true }));
+  const url = `http://127.0.0.1:${server.address().port}/fixture`;
+  let stdout;
+  try {
+    ({ stdout } = await execFileAsync(chrome, [
+      "--headless=new",
+      "--disable-gpu",
+      "--no-sandbox",
+      `--user-data-dir=${profile}`,
+      "--virtual-time-budget=18000",
+      "--dump-dom",
+      url,
+    ], { maxBuffer: 5 * 1024 * 1024, timeout: 24_000 }));
+  } catch (error) {
+    if (!String(error?.stdout ?? "").trim()) {
+      t.skip("Chrome or Chromium cannot run headless dump-dom in this environment");
+      return;
+    }
+    throw error;
+  }
+
+  const encodedResult = stdout.match(/<output id="result">([^<]+)<\/output>/)?.[1];
+  assert.ok(encodedResult, "fixture did not report an injection result");
+  const result = JSON.parse(Buffer.from(encodedResult, "base64").toString("utf8"));
+  assert.equal(result.injectionError, null);
+  assert.deepEqual({
+    loadFrameAttempts: result.loadFrameAttempts,
+    retryDelayMs: result.retryDelayMs,
+    injectionError: result.injectionError,
+  }, {
+    loadFrameAttempts: 2,
+    retryDelayMs: 12_000,
     injectionError: null,
   });
 });

--- a/test/inject-plugin-anchor-regression.test.mjs
+++ b/test/inject-plugin-anchor-regression.test.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const projectRoot = fileURLToPath(new URL("..", import.meta.url));
+const sourceRef = process.env.TASKBOARD_INJECTION_SOURCE_REF;
+const source = sourceRef
+  ? (await execFileAsync(
+      "git",
+      ["show", `${sourceRef}:inject/codex-taskboard.user.js`],
+      { cwd: projectRoot, maxBuffer: 2 * 1024 * 1024 },
+    )).stdout
+  : await readFile(new URL("../inject/codex-taskboard.user.js", import.meta.url), "utf8");
+
+async function chromeExecutable() {
+  const candidates = [
+    process.env.CHROME_PATH,
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    "/usr/bin/google-chrome",
+    "/usr/bin/google-chrome-stable",
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+  ].filter(Boolean);
+  for (const candidate of candidates) {
+    try {
+      await access(candidate);
+      return candidate;
+    } catch (_) {}
+  }
+  return null;
+}
+
+function fixtureHtml(origin) {
+  const encodedSource = Buffer.from(source).toString("base64");
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <style>
+      #native-actions { height: 80px; }
+      [data-app-action-sidebar-section] { margin-top: 20px; }
+    </style>
+  </head>
+  <body>
+    <aside>
+      <nav role="navigation">
+        <div data-app-action-sidebar-scroll>
+          <div id="native-actions">
+            <button><span>首页</span></button>
+            <button><span>站点</span></button>
+            <button id="new-native-action"><span>新建任务</span></button>
+          </div>
+          <section data-app-action-sidebar-section>
+            <div data-app-action-sidebar-section-heading="项目">项目</div>
+            <button id="project-named-plugins"><span>Plugins</span></button>
+          </section>
+        </div>
+      </nav>
+    </aside>
+    <main><div data-app-shell-main-content-layout>Conversation</div></main>
+    <output id="result"></output>
+    <script>
+      window.__CODEX_TASKBOARD_URL__ = ${JSON.stringify(`${origin}/taskboard?host=codex`)};
+      window.__CODEX_TASKBOARD_SOURCE_HASH__ = "plugin-anchor-regression";
+      window.__injectionError = null;
+      window.addEventListener("error", (event) => {
+        window.__injectionError = event.error?.stack || event.message;
+      });
+      window.addEventListener("unhandledrejection", (event) => {
+        window.__injectionError = event.reason?.stack || String(event.reason);
+      });
+    </script>
+    <script>eval(atob(${JSON.stringify(encodedSource)}));</script>
+    <script>
+      setTimeout(() => {
+        const entry = document.getElementById("codex-taskboard-entry");
+        document.getElementById("result").textContent = btoa(JSON.stringify({
+          entryExists: Boolean(entry),
+          entryFollowsNativeAction: document.getElementById("new-native-action").nextElementSibling === entry,
+          entryFollowsProjectNamedPlugins: document.getElementById("project-named-plugins").nextElementSibling === entry,
+          injectionError: window.__injectionError,
+        }));
+        window.__codexTaskboardInjection__?.destroy();
+      }, 0);
+    </script>
+  </body>
+</html>`;
+}
+
+test("a project named Plugins cannot become the Taskboard insertion anchor", async (t) => {
+  const chrome = await chromeExecutable();
+  if (!chrome) {
+    t.skip("Chrome or Chromium is not installed");
+    return;
+  }
+
+  const server = http.createServer((request, response) => {
+    const origin = `http://127.0.0.1:${server.address().port}`;
+    response.setHeader("content-type", "text/html; charset=utf-8");
+    response.end(fixtureHtml(origin));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  t.after(() => new Promise((resolve) => {
+    server.close(resolve);
+    server.closeAllConnections();
+  }));
+
+  const profile = await mkdtemp(path.join(os.tmpdir(), "taskboard-plugin-anchor-chrome-"));
+  t.after(() => rm(profile, { recursive: true, force: true }));
+  const url = `http://127.0.0.1:${server.address().port}/fixture`;
+  let stdout;
+  try {
+    ({ stdout } = await execFileAsync(chrome, [
+      "--headless=new",
+      "--disable-gpu",
+      "--no-sandbox",
+      `--user-data-dir=${profile}`,
+      "--virtual-time-budget=1000",
+      "--dump-dom",
+      url,
+    ], { maxBuffer: 5 * 1024 * 1024, timeout: 10_000 }));
+  } catch (error) {
+    if (!String(error?.stdout ?? "").trim()) {
+      t.skip("Chrome or Chromium cannot run headless dump-dom in this environment");
+      return;
+    }
+    throw error;
+  }
+
+  const encodedResult = stdout.match(/<output id="result">([^<]+)<\/output>/)?.[1];
+  assert.ok(encodedResult, "fixture did not report an injection result");
+  const result = JSON.parse(Buffer.from(encodedResult, "base64").toString("utf8"));
+  assert.deepEqual(result, {
+    entryExists: true,
+    entryFollowsNativeAction: true,
+    entryFollowsProjectNamedPlugins: false,
+    injectionError: null,
+  });
+});

--- a/test/inject.test.mjs
+++ b/test/inject.test.mjs
@@ -37,7 +37,7 @@ test("embedded page uses the launcher URL inside an opaque sandbox", () => {
 
 test("entry clones the native Plugins row and the page covers the complete Codex workspace", () => {
   assert.match(source, /const PLUGIN_LABELS = \["插件", "plugins"\]/);
-  assert.match(source, /if \(siblings\.length >= 3\) return plugin;/);
+  assert.match(source, /if \(plugin\?\.parentElement\) return plugin;/);
   assert.match(source, /return directButtons\.length >= 3/);
   assert.match(source, /const button = reference\.cloneNode\(true\)/);
   assert.match(source, /reference\.after\(entry\)/);

--- a/test/inject.test.mjs
+++ b/test/inject.test.mjs
@@ -122,7 +122,9 @@ test("opening asks the resident launcher to ensure the service and rebuilds fail
   assert.match(source, /const HOST_REQUEST_MESSAGE = "__codexTaskboardHostRequestV1"/);
   assert.match(source, /return requestHost\("ensure"\)/);
   assert.match(source, /result\.restarted/);
-  assert.match(source, /loadTaskboardFrame\(\)/);
+  assert.match(source, /const FRAME_LOAD_ATTEMPTS = 2/);
+  assert.match(source, /async function loadTaskboardFrameUntilReady\(cacheBust = false\)/);
+  assert.match(source, /await loadTaskboardFrameUntilReady\(\)/);
   assert.match(source, /waitForFrameReady\(\)/);
   assert.match(source, /function onHostBridgeMessage/);
   assert.match(source, /function hasLiveHostBinding/);
@@ -132,7 +134,7 @@ test("opening asks the resident launcher to ensure the service and rebuilds fail
 test("the injected iframe can be cache-busted without reloading the Codex shell", () => {
   assert.match(source, /const FRAME_REFRESH_PARAM = "__codex_taskboard_refresh"/);
   assert.match(source, /function reloadFrame\(\)/);
-  assert.match(source, /loadTaskboardFrame\(true\)/);
+  assert.match(source, /loadTaskboardFrameUntilReady\(true\)/);
   assert.match(source, /reloadFrame,/);
 });
 

--- a/test/injector.test.mjs
+++ b/test/injector.test.mjs
@@ -16,6 +16,7 @@ const packageJson = JSON.parse(
 );
 
 test("the resident injector authenticates its launcher-managed Taskboard service", () => {
+  assert.match(source, /if \(options\.launch\) options\.attachExisting = true;/);
   assert.match(supervisorSource, /function createTaskboardSupervisor/);
   assert.match(source, /CODEX_TASKBOARD_INSTANCE_TOKEN/);
   assert.match(source, /createHmac\("sha256"/);


### PR DESCRIPTION
## Summary
Fix Codex Taskboard sidebar injection when Codex wraps each native sidebar button in its own container.

## Root cause
The injector only accepted the Plugins row when its parent contained at least three direct button children. Current Codex sidebar markup wraps the row, so no Taskboard entry was created.

## Changes
- Use the detected Plugins button as the insertion anchor regardless of its parent sibling count.
- Update the injector contract test for the supported markup.

## Testing
- `npm test -- --test-reporter=dot`
- `npm run typecheck`
- `npm run build`
- Verified the injected Taskboard entry and embedded frame in a live Codex renderer.

## Risks
The fallback anchor selection remains unchanged when no Plugins row is present.