### PR TITLE
fix(ai-chat): tolerate large Codex events

### DIFF
--- a/server/ai-chat-process.mjs
+++ b/server/ai-chat-process.mjs
@@ -315,9 +315,9 @@ export function normalizeCodexEvent(raw) {
     return {
       kind: "event",
       type: raw.type,
-      role: "error",
+      role: "activity",
       content: errorMessage(raw.message ?? raw.error),
-      data: { status: "failed" },
+      data: { status: "warning" },
     };
   }
 

--- a/server/ai-chat-process.mjs
+++ b/server/ai-chat-process.mjs
@@ -6,6 +6,7 @@ import { signalProcessTree } from "../shared/process-tree.mjs";
 
 const VISIBLE_TEXT_LIMIT = 65_536;
 const STDERR_LIMIT = 65_536;
+const MAX_CODEX_JSONL_LINE_BYTES = 16 * 1024 * 1024;
 const SKILL_MARKER = "\uFFFC";
 const TURN_OWNER_PATH = fileURLToPath(new URL("./ai-turn-owner.mjs", import.meta.url));
 const ITEM_TYPES = new Set([
@@ -339,7 +340,7 @@ export function spawnCodexTurn({
   prompt,
   env,
   onRawEvent,
-  maxLineBytes = 1_048_576,
+  maxLineBytes = MAX_CODEX_JSONL_LINE_BYTES,
 }) {
   const child = spawn(process.execPath, [TURN_OWNER_PATH, executable, JSON.stringify(args)], {
     detached: true,

--- a/server/ai-chat.mjs
+++ b/server/ai-chat.mjs
@@ -291,6 +291,7 @@ export class AiChatService {
       let startedThreadId = null;
       let terminalOutcome = null;
       let terminalError = "";
+      let pendingError = "";
       const { child, completion } = spawnCodexTurn({
         executable: this.codexExecutable,
         args,
@@ -323,6 +324,8 @@ export class AiChatService {
           } else if (raw.type === "turn.failed") {
             terminalOutcome = "failed";
             terminalError ||= normalized.content;
+          } else if (raw.type === "error") {
+            pendingError ||= normalized.content;
           }
           this.#emit(threadId, { type: "ai.event", event });
         },
@@ -339,6 +342,7 @@ export class AiChatService {
           startedThreadId: () => startedThreadId,
           terminalOutcome: () => terminalOutcome,
           terminalError: () => terminalError,
+          pendingError: () => pendingError,
         }),
         (error) => this.#finishRun({
           run,
@@ -348,6 +352,7 @@ export class AiChatService {
           startedThreadId: () => startedThreadId,
           terminalOutcome: () => terminalOutcome,
           terminalError: () => terminalError,
+          pendingError: () => pendingError,
         }),
       );
       this.completions.set(run.id, finalization);
@@ -519,6 +524,7 @@ export class AiChatService {
     startedThreadId,
     terminalOutcome,
     terminalError,
+    pendingError,
   }) {
     let status;
     let publicError = null;
@@ -538,7 +544,7 @@ export class AiChatService {
         : `Codex exited with code ${result.exitCode}`;
     } else if (terminalOutcome() !== "completed") {
       status = "failed";
-      publicError = "Codex exited without reporting turn completion";
+      publicError = pendingError() || "Codex exited without reporting turn completion";
     } else if (!resumingThreadId && !startedThreadId()) {
       status = "failed";
       publicError = "Codex did not provide a thread id";

--- a/server/ai-chat.mjs
+++ b/server/ai-chat.mjs
@@ -320,7 +320,7 @@ export class AiChatService {
           });
           if (raw.type === "turn.completed" && terminalOutcome === null) {
             terminalOutcome = "completed";
-          } else if (raw.type === "turn.failed" || raw.type === "error") {
+          } else if (raw.type === "turn.failed") {
             terminalOutcome = "failed";
             terminalError ||= normalized.content;
           }

--- a/test/ai-chat-runner.test.mjs
+++ b/test/ai-chat-runner.test.mjs
@@ -369,6 +369,39 @@ test("protocol terminal events determine run success and item errors remain non-
   }
 });
 
+test("a root Codex error remains the run diagnostic when completion never arrives", async () => {
+  const fixture = await createFixture();
+  try {
+    const thread = await fixture.service.createThread({ projectId: "project" });
+    const run = await fixture.service.startTurn(thread.id, { message: "ROOT_ERROR_ZERO" });
+    await waitFor(() => fixture.service.getRun(run.id)?.status !== "running");
+
+    const finished = fixture.service.getRun(run.id);
+    assert.equal(finished.status, "failed");
+    assert.equal(finished.error, "Protocol root error");
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("a root Codex error preceding completion is recorded as a warning", async () => {
+  const fixture = await createFixture();
+  try {
+    const thread = await fixture.service.createThread({ projectId: "project" });
+    const run = await fixture.service.startTurn(thread.id, { message: "WARNING_THEN_COMPLETED" });
+    await waitFor(() => fixture.service.getRun(run.id)?.status !== "running");
+
+    const warning = fixture.service.getThreadSnapshot(thread.id).events.find(
+      (event) => event.type === "error" && event.content === "Skill descriptions were shortened",
+    );
+    assert.equal(fixture.service.getRun(run.id).status, "completed");
+    assert.equal(warning?.role, "activity");
+    assert.equal(warning?.data.status, "warning");
+  } finally {
+    await fixture.close();
+  }
+});
+
 test("a Codex command event slightly over one MiB completes and keeps only bounded output", async () => {
   const fixture = await createFixture();
   try {

--- a/test/ai-chat-runner.test.mjs
+++ b/test/ai-chat-runner.test.mjs
@@ -111,6 +111,9 @@ if (args[0] === "app-server") {
     emit({type:"item.completed",item:{type:"reasoning",text:"SECRET REASONING"}});
     emit({type:"item.completed",item:{type:"agent_message",text:"Visible answer"}});
     emit({type:"item.completed",item:{type:"command_execution",command:"npm test",status:"completed",exit_code:0,aggregated_output:"ok"}});
+    if (prompt.includes("LARGE_COMMAND_OUTPUT")) {
+      emit({type:"item.completed",item:{type:"command_execution",command:"large output",status:"completed",exit_code:0,aggregated_output:"x".repeat(1_048_577)}});
+    }
     if (prompt.includes("TURN_FAILED_ZERO")) {
       emit({type:"turn.failed",error:{message:"Protocol turn failed"}});
       return;
@@ -118,6 +121,9 @@ if (args[0] === "app-server") {
     if (prompt.includes("ROOT_ERROR_ZERO")) {
       emit({type:"error",message:"Protocol root error"});
       return;
+    }
+    if (prompt.includes("WARNING_THEN_COMPLETED")) {
+      emit({type:"error",message:"Skill descriptions were shortened"});
     }
     if (prompt.includes("NO_TERMINAL")) return;
     if (prompt.includes("ITEM_ERROR")) {
@@ -351,12 +357,30 @@ test("protocol terminal events determine run success and item errors remain non-
       ["ROOT_ERROR_ZERO", "failed"],
       ["NO_TERMINAL", "failed"],
       ["ITEM_ERROR", "completed"],
+      ["WARNING_THEN_COMPLETED", "completed"],
     ]) {
       const thread = await fixture.service.createThread({ projectId: "project" });
       const run = await fixture.service.startTurn(thread.id, { message });
       await waitFor(() => fixture.service.getRun(run.id).status !== "running");
       assert.equal(fixture.service.getRun(run.id).status, expectedStatus, message);
     }
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("a Codex command event slightly over one MiB completes and keeps only bounded output", async () => {
+  const fixture = await createFixture();
+  try {
+    const thread = await fixture.service.createThread({ projectId: "project" });
+    const run = await fixture.service.startTurn(thread.id, { message: "LARGE_COMMAND_OUTPUT" });
+    await waitFor(() => fixture.service.getRun(run.id)?.status !== "running");
+
+    assert.equal(fixture.service.getRun(run.id).status, "completed");
+    const largeOutputEvent = fixture.service.getThreadSnapshot(thread.id).events.find(
+      (event) => event.type === "command_execution" && event.content === "large output",
+    );
+    assert.equal(largeOutputEvent.data.output.length, 65_536);
   } finally {
     await fixture.close();
   }

--- a/test/ai-chat-state.test.mjs
+++ b/test/ai-chat-state.test.mjs
@@ -224,6 +224,13 @@ test("activity status treats started, running and in_progress as active and fail
     content: "",
     data: { status: "completed" },
   }), "completed");
+  assert.equal(aiChatEventStatus({
+    id: "5",
+    type: "error",
+    role: "activity",
+    content: "Skill descriptions were shortened",
+    data: { status: "warning" },
+  }), "completed");
 });
 
 test("snapshot hint refreshes allow one in-flight request and one queued request", async () => {

--- a/web/src/aiChatState.ts
+++ b/web/src/aiChatState.ts
@@ -187,7 +187,7 @@ export function filterVisibleAiEvents<
 export function aiChatEventStatus(
   event: Pick<AiChatEvent, "role" | "type" | "data">,
 ): "running" | "completed" | "failed" {
-  if (event.role === "error" || event.type === "error" || event.type === "turn.failed") {
+  if (event.role === "error" || event.type === "turn.failed") {
     return "failed";
   }
   const status = event.data?.status;

--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -578,6 +578,7 @@ const ACTIVITY_LABELS: Record<string, readonly [string, string]> = {
   error: ["执行失败", "Failed"],
   "turn.failed": ["执行失败", "Failed"],
 };
+const WARNING_ACTIVITY_LABEL: readonly [string, string] = ["警告", "Warning"];
 
 const ACTIVITY_ICONS: Record<string, LinearIconName> = {
   plan: "write",
@@ -795,7 +796,9 @@ function ThinkingSteps({
             {events.map((event, index) => {
               const eventStatus = aiChatEventStatus(event);
               const detail = activityDetail(event, text);
-              const activityLabel = ACTIVITY_LABELS[event.type];
+              const activityLabel = event.type === "error" && event.data?.status === "warning"
+                ? WARNING_ACTIVITY_LABEL
+                : ACTIVITY_LABELS[event.type];
               const content = detail?.kind === "lines"
                 && (event.type === "file" || event.type === "file_change")
                 ? text(


### PR DESCRIPTION
## Summary

Prevent Taskboard AI runs from failing on a Codex command event slightly above 1 MiB, and keep non-terminal Codex error notifications from overriding a later successful completion.

## Changes

- Raise the bounded JSONL event limit to 16 MiB while preserving the 64 KiB public output cap.
- Treat only `turn.failed` as a terminal protocol failure.
- Add regression coverage for large command events and warning-then-complete turns.

## Testing

- `npm run typecheck`
- `npm test -- test/ai-chat-runner.test.mjs`
- `npm test` in an isolated worktree after `npm ci` (the local Cloud migration integration tests are slow).

## Risks

Each raw Codex JSONL event may now use up to 16 MiB of process memory before normalization; persisted and visible command output remains capped at 64 KiB. No schema migration or user-data mutation is involved.