### PR TITLE
fix(LOCAL-210): restore Codex sidebar entry

### DIFF
--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -263,10 +263,7 @@
     if (!scroll) return null;
     const buttons = Array.from(scroll.querySelectorAll("button"));
     const plugin = buttons.find((button) => buttonMatches(button, PLUGIN_LABELS));
-    if (plugin && plugin.parentElement) {
-      const siblings = Array.from(plugin.parentElement.children).filter((child) => child.tagName === "BUTTON");
-      if (siblings.length >= 3) return plugin;
-    }
+    if (plugin?.parentElement) return plugin;
 
     const firstSection = scroll.querySelector("[data-app-action-sidebar-section]");
     const sectionTop = firstSection?.getBoundingClientRect().top ?? Number.POSITIVE_INFINITY;

--- a/test/inject.test.mjs
+++ b/test/inject.test.mjs
@@ -37,7 +37,7 @@ test("embedded page uses the launcher URL inside an opaque sandbox", () => {
 
 test("entry clones the native Plugins row and the page covers the complete Codex workspace", () => {
   assert.match(source, /const PLUGIN_LABELS = \["插件", "plugins"\]/);
-  assert.match(source, /if \(siblings\.length >= 3\) return plugin;/);
+  assert.match(source, /if \(plugin\?\.parentElement\) return plugin;/);
   assert.match(source, /return directButtons\.length >= 3/);
   assert.match(source, /const button = reference\.cloneNode\(true\)/);
   assert.match(source, /reference\.after\(entry\)/);


### PR DESCRIPTION
## What changed

- Use the scoped native Plugins button directly as the sidebar reference.
- Align the existing injection source-contract assertion with that direct lookup.

## Root cause

Latest Codex wraps each primary sidebar row in its own `div.contents`. The old locator required the Plugins button to share a parent with at least two other direct buttons, so it returned `null` and skipped Taskboard entry insertion.

## Impact

Taskboard returns immediately after Plugins and opens the existing embedded panel. Native sidebar pages continue to work.

## Validation

- Live Codex 1.0.3, launched through Taskboard: entry visible once after Plugins; clicking it opens the existing panel containing LOCAL-210.
- Native Plugins still opens the Codex plugin marketplace.
- Renderer refresh followed by development injector restart restores one Taskboard entry, and it opens the panel again.
- `node --check inject/codex-taskboard.user.js`
- `node --test test/inject.test.mjs` (24/24)
- `git diff --check`