### PR TITLE
fix: prevent activity flicker after comments

### DIFF
--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -486,7 +486,6 @@ export function TaskDetail({
 
   useEffect(() => {
     const controller = new AbortController();
-    setCommentsLoading(true);
     setCommentsError(null);
     void Promise.all([
       listComments(task.id, controller.signal),


### PR DESCRIPTION
## What changed

- Keep the existing activity timeline visible while comments and task activity refresh in the background.
- Preserve the initial loading state when opening a different issue.
- Keep the existing comment switch, comment semantics, status update flow, and conversation launch flow unchanged.

## Root cause

Comment-created realtime events update `commentsRevision` and then refresh the task `activityKey`. The activity-fetch effect treated both background refreshes as initial loads by setting `commentsLoading` to `true`, so the current timeline was replaced by the loading shimmer twice.

## User impact

Posting a comment no longer makes the activity area flash or collapse. This applies to both plain comments and comments that also change the issue to Todo.

## Validation

- Base: `v1.0.4` / `49bf2c5ff13d27d2fe639b5a1d4827bc6f9f1752`
- Real browser, switch off: comment created, status stayed In Progress, no loading element appeared.
- Real browser, switch on: comment created, status changed to Todo, no loading element appeared.
- Both paths kept the same issue-detail DOM node; the composer and switch reset after success.
- `npm run typecheck`
- `npm run build:web`
- `git diff --check`

No tests were added or run, per the task scope.

Taskboard: LOCAL-190
Commit: `a34d550ee0693be871504b602deecbc09edf6fc8`