### PR TITLE
Show draft issue relations and rename comment attachment action

### DIFF
--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -1279,7 +1279,7 @@ export function TaskDetail({
                               onClick={() => editCommentImageInputRef.current?.click()}
                             >
                               <LinearIcon name="attachment" />
-                              {text("添加图片", "Add images")}
+                              {text("添加附件", "Add attachment")}
                             </button>
                             <input
                               ref={editCommentImageInputRef}

--- a/web/src/components/TaskEditor.tsx
+++ b/web/src/components/TaskEditor.tsx
@@ -206,6 +206,11 @@ export function TaskEditor({
   const selectedSubIssues = subIssueIds
     .map((id) => taskById.get(id))
     .filter((candidate): candidate is Task => candidate !== undefined);
+  const selectedRelationChips = [
+    ...selectedSubIssues.map((issue) => ({ type: "subIssue" as const, issue })),
+    ...(selectedParent ? [{ type: "parent" as const, issue: selectedParent }] : []),
+    ...selectedRelated.map((issue) => ({ type: "related" as const, issue })),
+  ];
   const selectedParentAncestorIds = useMemo(() => {
     const ids = new Set<string>();
     let currentId = parentId;
@@ -632,6 +637,30 @@ export function TaskEditor({
                 )}</span>
               </button>
             )}
+
+            {!task && selectedRelationChips.map(({ type, issue }) => {
+              const identifier = issue.externalKey ?? issue.identifier;
+              return (
+                <span className="property-control property-relation-chip" key={`${type}:${issue.id}`}>
+                  <span>{identifier}</span>
+                  <button
+                    className="property-relation-remove"
+                    type="button"
+                    aria-label={text(`移除 ${identifier}`, `Remove ${identifier}`)}
+                    onClick={() => {
+                      if (type === "parent") setParentId(null);
+                      else if (type === "related") {
+                        setRelatedIds((current) => current.filter((id) => id !== issue.id));
+                      } else {
+                        setSubIssueIds((current) => current.filter((id) => id !== issue.id));
+                      }
+                    }}
+                  >
+                    <LinearIcon name="close" />
+                  </button>
+                </span>
+              );
+            })}
 
             <div className="composer-menu-anchor" ref={moreMenuRef}>
               <button className="property-control property-more" type="button" aria-label={text("更多属性", "More properties")} onClick={() => { setRelationMenu(null); setMenu(menu === "more" ? null : "more"); }}><LinearIcon name="more" /></button>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6252,6 +6252,42 @@ kbd {
   color: var(--text-primary);
 }
 
+.property-relation-chip {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+.property-relation-remove {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  display: grid;
+  place-items: center;
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  border: 0.5px solid var(--border-strong);
+  border-radius: 50%;
+  background: var(--surface-raised);
+  color: var(--text-tertiary);
+  opacity: 0;
+}
+
+.property-relation-chip:hover .property-relation-remove,
+.property-relation-chip:focus-within .property-relation-remove {
+  opacity: 1;
+}
+
+.property-relation-remove:hover {
+  background: var(--surface-active);
+  color: var(--text-primary);
+}
+
+.property-control .property-relation-remove svg {
+  width: 8px;
+  height: 8px;
+}
+
 .property-control svg {
   width: 14px;
   height: 14px;


### PR DESCRIPTION
## 摘要

- LOCAL-211：在新建议题底部现有属性行中显示已选父议题、子议题和关联议题。每项只显示 ID；悬停或聚焦时，右上角显示叉并可独立取消；空间不足时整项换行。
- LOCAL-212：评论进入编辑状态后，入口文案改为“添加附件”与“Add attachment”。文件选择、图片类型、多选、上传和保存路径不变。
- 未触及 blockedBy 或 blocks，未新增测试。

## 直接路径验证

- LOCAL-211：在隔离本地 Taskboard 的新建议题弹窗中选择父、子和多项关联议题。关闭菜单后确认仅显示 ID；八项分成两行；移入后右上角叉可见；分别移除子、父和关联项，其他类型不受影响。
- LOCAL-212：打开已有评论的操作菜单，进入编辑评论，确认入口显示“添加附件”；同一入口下的隐藏文件控件仍为 image/* 且 multiple=true。

## 检查

- npm run typecheck
- npm run build:web
- git diff --check

Base: 49bf2c5ff13d27d2fe639b5a1d4827bc6f9f1752
Commit: 58d1421d99ed683c0fc36a972a55cb1ad251bed1