### PR TITLE
Place comment edit attachment icon on the left

### DIFF
--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -1271,46 +1271,51 @@ export function TaskDetail({
                             }}
                           />
                           <div className="comment-edit-actions">
-                            <button
-                              className="button secondary"
-                              type="button"
-                              disabled={savingCommentId === comment.id}
-                              onClick={() => editCommentImageInputRef.current?.click()}
-                            >
-                              <LinearIcon name="attachment" />
-                              {text("添加附件", "Add attachment")}
-                            </button>
-                            <input
-                              ref={editCommentImageInputRef}
-                              type="file"
-                              accept="image/*"
-                              multiple
-                              hidden
-                              onChange={(event) => {
-                                if (event.currentTarget.files) {
-                                  editingComposerRef.current?.addImages(event.currentTarget.files);
-                                }
-                                event.currentTarget.value = "";
-                              }}
-                            />
-                            <button
-                              className="button secondary"
-                              type="button"
-                              disabled={savingCommentId === comment.id}
-                              onClick={endCommentEdit}
-                            >
-                              {text("取消", "Cancel")}
-                            </button>
-                            <button
-                              className="button primary"
-                              type="button"
-                              disabled={!editingDraft.trim() || savingCommentId === comment.id}
-                              onClick={() => void saveComment(comment)}
-                            >
-                              {savingCommentId === comment.id
-                                ? text("保存中…", "Saving…")
-                                : text("保存", "Save")}
-                            </button>
+                            <div className="composer-footer-leading">
+                              <button
+                                className="comment-attach-button"
+                                type="button"
+                                disabled={savingCommentId === comment.id}
+                                aria-label={text("添加评论附件", "Add comment attachments")}
+                                title={text("添加附件", "Add attachments")}
+                                onClick={() => editCommentImageInputRef.current?.click()}
+                              >
+                                <LinearIcon name="attachment" />
+                              </button>
+                              <input
+                                ref={editCommentImageInputRef}
+                                type="file"
+                                accept="image/*"
+                                multiple
+                                hidden
+                                onChange={(event) => {
+                                  if (event.currentTarget.files) {
+                                    editingComposerRef.current?.addImages(event.currentTarget.files);
+                                  }
+                                  event.currentTarget.value = "";
+                                }}
+                              />
+                            </div>
+                            <div>
+                              <button
+                                className="button secondary"
+                                type="button"
+                                disabled={savingCommentId === comment.id}
+                                onClick={endCommentEdit}
+                              >
+                                {text("取消", "Cancel")}
+                              </button>
+                              <button
+                                className="button primary"
+                                type="button"
+                                disabled={!editingDraft.trim() || savingCommentId === comment.id}
+                                onClick={() => void saveComment(comment)}
+                              >
+                                {savingCommentId === comment.id
+                                  ? text("保存中…", "Saving…")
+                                  : text("保存", "Save")}
+                              </button>
+                            </div>
                           </div>
                         </div>
                       ) : (

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3897,9 +3897,16 @@ kbd {
 
 .comment-edit-actions {
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  justify-content: space-between;
   gap: 6px;
   margin: 7px 16px 0;
+}
+
+.comment-edit-actions > div {
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .comments-loading {


### PR DESCRIPTION
## What changed

- Reused the existing comment composer paperclip icon for the comment edit attachment entry.
- Positioned the icon at the lower left of the edit area.
- Kept Cancel and Save on the right.
- Kept the hidden file input, `accept="image/*"`, `multiple`, `InlineMediaComposer.addImages`, upload API, and save path unchanged.

## Why

LOCAL-212 feedback asked for the edit attachment entry to match the Add Comment composer: an icon-only paperclip at the lower left instead of a text button.

## Verification

- Opened the real LOCAL-212 detail page in the modified web client and entered comment edit mode.
- The edit DOM exposes one icon-only `添加评论附件` button before Cancel and Save.
- Clicking that button opened the existing file chooser.
- `npm run typecheck`
- `npm run build:web`
- `git diff --check`

No tests, guardrails, compatibility layer, or unrelated refactor were added.