### PR TITLE
Prepare Codex Taskboard v1.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-taskboard",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-taskboard",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "dependencies": {
         "@lobehub/icons-static-svg": "^1.94.0",
         "@xyflow/react": "^12.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-taskboard",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "codex-taskboard-launcher"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "dispatch2",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-taskboard-launcher"
-version = "1.0.4"
+version = "1.0.5"
 description = "Codex Taskboard macOS launcher"
 edition = "2021"
 rust-version = "1.88"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex Taskboard",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "identifier": "com.chuspeeism.codex-taskboard",
   "app": {
     "windows": []


### PR DESCRIPTION
## 变更

- 将 5 个版本文件中的 Codex Taskboard 应用版本从 1.0.4 更新为 1.0.5。
- 保持 npm、Cargo 和 Tauri 的应用版本一致。

## 验证

- `package.json`、`package-lock.json` 顶层和根包、`src-tauri/Cargo.toml`、`src-tauri/Cargo.lock` 根包、`src-tauri/tauri.conf.json` 均为 1.0.5。
- `git diff --check` 通过。