### PR TITLE
fix(launcher): add updater progress bar

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -345,11 +345,15 @@ dependencies = [
 name = "codex-taskboard-launcher"
 version = "1.0.5"
 dependencies = [
+ "base64 0.22.1",
  "dispatch2",
+ "futures-util",
  "libc",
+ "minisign-verify",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "reqwest",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,5 +21,5 @@ uuid = { version = "1", features = ["v4"] }
 [target.'cfg(target_os = "macos")'.dependencies]
 dispatch2 = "0.3.1"
 objc2 = "0.6.4"
-objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSAlert", "NSApplication", "NSButton", "NSControl", "NSResponder", "NSView", "NSWindow"] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSAlert", "NSApplication", "NSButton", "NSControl", "NSProgressIndicator", "NSResponder", "NSView", "NSWindow"] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSString"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,7 +9,11 @@ rust-version = "1.88"
 tauri-build = { version = "2.6.0", features = [] }
 
 [dependencies]
+base64 = "0.22"
+futures-util = "0.3"
 libc = "0.2"
+minisign-verify = "0.2"
+reqwest = { version = "0.13", default-features = false, features = ["stream", "rustls-no-provider"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2.11.5", features = ["tray-icon"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,9 +10,11 @@ use objc2::{
     sel, DefinedClass, MainThreadMarker, MainThreadOnly,
 };
 #[cfg(target_os = "macos")]
-use objc2_app_kit::{NSAlert, NSApplication, NSButton};
+use objc2_app_kit::{
+    NSAlert, NSApplication, NSButton, NSProgressIndicator, NSProgressIndicatorStyle,
+};
 #[cfg(target_os = "macos")]
-use objc2_foundation::{NSObject, NSString};
+use objc2_foundation::{NSObject, NSSize, NSString};
 use serde::{Deserialize, Serialize};
 #[cfg(target_os = "macos")]
 use std::cell::RefCell;
@@ -142,6 +144,7 @@ impl UpdateDialogTarget {
 #[cfg(target_os = "macos")]
 struct NativeUpdateDialog {
     alert: Retained<NSAlert>,
+    progress_indicator: Retained<NSProgressIndicator>,
     install_button: Retained<NSButton>,
     defer_button: Retained<NSButton>,
     _target: Retained<UpdateDialogTarget>,
@@ -161,6 +164,13 @@ impl UpdateDialog {
         let dialog = run_on_main(move |mtm| {
             let alert = NSAlert::new(mtm);
             let target = UpdateDialogTarget::new(mtm, response);
+            let progress_indicator = NSProgressIndicator::new(mtm);
+            progress_indicator.setStyle(NSProgressIndicatorStyle::Bar);
+            progress_indicator.setMinValue(0.0);
+            progress_indicator.setMaxValue(100.0);
+            progress_indicator.setFrameSize(NSSize::new(280.0, 20.0));
+            progress_indicator.sizeToFit();
+            progress_indicator.setDisplayedWhenStopped(true);
             alert.setMessageText(&NSString::from_str("Codex Taskboard 更新"));
             alert.setInformativeText(&NSString::from_str(&message));
             let install_button = alert.addButtonWithTitle(&NSString::from_str("立即更新"));
@@ -180,6 +190,7 @@ impl UpdateDialog {
                 native: Arc::new(MainThreadBound::new(
                     NativeUpdateDialog {
                         alert,
+                        progress_indicator,
                         install_button,
                         defer_button,
                         _target: target,
@@ -204,19 +215,40 @@ impl UpdateDialog {
             native
                 .alert
                 .setInformativeText(&NSString::from_str(&message));
+            native.progress_indicator.setIndeterminate(true);
+            unsafe {
+                native.progress_indicator.startAnimation(None);
+            }
+            native
+                .alert
+                .setAccessoryView(Some(&native.progress_indicator));
             native.install_button.setHidden(true);
             native.defer_button.setHidden(true);
             native.alert.layout();
         });
     }
 
-    fn set_message(&self, message: &str) {
+    fn set_progress(&self, message: &str, progress: Option<u64>) {
         let native = Arc::clone(&self.native);
         let message = message.to_owned();
         run_on_main(move |mtm| {
-            let alert = &native.get(mtm).alert;
-            alert.setInformativeText(&NSString::from_str(&message));
-            alert.layout();
+            let native = native.get(mtm);
+            native
+                .alert
+                .setInformativeText(&NSString::from_str(&message));
+            if let Some(progress) = progress {
+                native.progress_indicator.setIndeterminate(false);
+                unsafe {
+                    native.progress_indicator.stopAnimation(None);
+                }
+                native.progress_indicator.setDoubleValue(progress as f64);
+            } else {
+                native.progress_indicator.setIndeterminate(true);
+                unsafe {
+                    native.progress_indicator.startAnimation(None);
+                }
+            }
+            native.alert.layout();
         });
     }
 
@@ -240,7 +272,7 @@ impl UpdateDialog {
 
     fn show_progress(&self, _message: &str) {}
 
-    fn set_message(&self, _message: &str) {}
+    fn set_progress(&self, _message: &str, _progress: Option<u64>) {}
 
     fn close(&self) {}
 }
@@ -1109,25 +1141,27 @@ async fn install_update(
         .download(
             move |chunk_length, content_length| {
                 downloaded = downloaded.saturating_add(chunk_length as u64);
+                let progress = content_length.filter(|total| *total > 0).map(|total| {
+                    downloaded
+                        .saturating_mul(100)
+                        .saturating_div(total)
+                        .min(100)
+                });
                 let snapshot = update_snapshot(&progress_app, &progress_state, |snapshot| {
-                    snapshot.update_message = match content_length.filter(|total| *total > 0) {
-                        Some(total) => format!(
-                            "正在下载 {progress_version} · {}%",
-                            downloaded
-                                .saturating_mul(100)
-                                .saturating_div(total)
-                                .min(100)
-                        ),
+                    snapshot.update_message = match progress {
+                        Some(progress) => {
+                            format!("正在下载 {progress_version} · {progress}%")
+                        }
                         None => format!("正在下载 {progress_version}…"),
                     };
                 });
-                progress_dialog.set_message(&snapshot.update_message);
+                progress_dialog.set_progress(&snapshot.update_message, progress);
             },
             move || {
                 let snapshot = update_snapshot(&finish_app, &finish_state, |snapshot| {
                     snapshot.update_message = "正在验证更新…".into();
                 });
-                finish_dialog.set_message(&snapshot.update_message);
+                finish_dialog.set_progress(&snapshot.update_message, None);
             },
         )
         .await
@@ -1147,7 +1181,7 @@ async fn install_update(
     let snapshot = update_snapshot(app, state, |snapshot| {
         snapshot.update_message = "正在安装更新…".into();
     });
-    update_dialog.set_message(&snapshot.update_message);
+    update_dialog.set_progress(&snapshot.update_message, None);
     {
         let _lifecycle = state.lifecycle.lock().unwrap();
         if state.intentional_stop.load(Ordering::SeqCst) {
@@ -1193,7 +1227,7 @@ async fn install_update(
     let snapshot = update_snapshot(app, state, |snapshot| {
         snapshot.update_message = "正在重启…".into();
     });
-    update_dialog.set_message(&snapshot.update_message);
+    update_dialog.set_progress(&snapshot.update_message, None);
     app.restart()
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -22,6 +22,7 @@ use std::cell::RefCell;
 use std::os::{fd::AsRawFd, unix::process::CommandExt};
 use std::{
     fs::{self, File, OpenOptions},
+    future::{poll_fn, Future},
     io::{BufRead, BufReader, Write},
     net::TcpListener,
     path::{Path, PathBuf},
@@ -30,6 +31,7 @@ use std::{
         atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, Mutex,
     },
+    task::Poll,
     thread,
     time::{Duration, Instant},
 };
@@ -100,6 +102,7 @@ struct LauncherState {
 #[cfg(target_os = "macos")]
 struct UpdateDialogTargetIvars {
     response: RefCell<Option<std::sync::mpsc::Sender<bool>>>,
+    cancel: RefCell<Option<tauri::async_runtime::Sender<()>>>,
 }
 
 #[cfg(target_os = "macos")]
@@ -122,6 +125,13 @@ define_class!(
         fn defer_update(&self, _sender: &AnyObject) {
             self.respond(false);
         }
+
+        #[unsafe(method(cancelUpdate:))]
+        fn cancel_update(&self, _sender: &AnyObject) {
+            if let Some(cancel) = self.ivars().cancel.borrow_mut().take() {
+                let _ = cancel.try_send(());
+            }
+        }
     }
 );
 
@@ -130,6 +140,7 @@ impl UpdateDialogTarget {
     fn new(mtm: MainThreadMarker, response: std::sync::mpsc::Sender<bool>) -> Retained<Self> {
         let this = Self::alloc(mtm).set_ivars(UpdateDialogTargetIvars {
             response: RefCell::new(Some(response)),
+            cancel: RefCell::new(None),
         });
         unsafe { msg_send![super(this), init] }
     }
@@ -139,6 +150,14 @@ impl UpdateDialogTarget {
             let _ = response.send(accepted);
         }
     }
+
+    fn set_cancel(&self, cancel: tauri::async_runtime::Sender<()>) {
+        *self.ivars().cancel.borrow_mut() = Some(cancel);
+    }
+
+    fn clear_cancel(&self) {
+        self.ivars().cancel.borrow_mut().take();
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -147,7 +166,7 @@ struct NativeUpdateDialog {
     progress_indicator: Retained<NSProgressIndicator>,
     install_button: Retained<NSButton>,
     defer_button: Retained<NSButton>,
-    _target: Retained<UpdateDialogTarget>,
+    target: Retained<UpdateDialogTarget>,
 }
 
 #[cfg(target_os = "macos")]
@@ -193,7 +212,7 @@ impl UpdateDialog {
                         progress_indicator,
                         install_button,
                         defer_button,
-                        _target: target,
+                        target,
                     },
                     mtm,
                 )),
@@ -207,28 +226,34 @@ impl UpdateDialog {
         }
     }
 
-    fn show_progress(&self, message: &str) {
+    fn show_progress(&self, message: &str, cancel: tauri::async_runtime::Sender<()>) {
         let native = Arc::clone(&self.native);
         let message = message.to_owned();
         run_on_main(move |mtm| {
             let native = native.get(mtm);
+            native.target.set_cancel(cancel);
             native
                 .alert
                 .setInformativeText(&NSString::from_str(&message));
-            native.progress_indicator.setIndeterminate(true);
-            unsafe {
-                native.progress_indicator.startAnimation(None);
-            }
+            native.progress_indicator.setIndeterminate(false);
+            native.progress_indicator.setDoubleValue(0.0);
             native
                 .alert
                 .setAccessoryView(Some(&native.progress_indicator));
             native.install_button.setHidden(true);
-            native.defer_button.setHidden(true);
+            native.defer_button.setTitle(&NSString::from_str("取消"));
+            unsafe {
+                native.defer_button.setAction(Some(sel!(cancelUpdate:)));
+            }
+            native.defer_button.setEnabled(true);
+            native.defer_button.setHidden(false);
             native.alert.layout();
+            native.progress_indicator.setNeedsDisplay(true);
+            native.progress_indicator.displayIfNeeded();
         });
     }
 
-    fn set_progress(&self, message: &str, progress: Option<u64>) {
+    fn set_progress(&self, message: &str, progress: Option<u64>, cancellable: bool) {
         let native = Arc::clone(&self.native);
         let message = message.to_owned();
         run_on_main(move |mtm| {
@@ -236,26 +261,27 @@ impl UpdateDialog {
             native
                 .alert
                 .setInformativeText(&NSString::from_str(&message));
+            native.progress_indicator.setIndeterminate(false);
             if let Some(progress) = progress {
-                native.progress_indicator.setIndeterminate(false);
-                unsafe {
-                    native.progress_indicator.stopAnimation(None);
-                }
                 native.progress_indicator.setDoubleValue(progress as f64);
-            } else {
-                native.progress_indicator.setIndeterminate(true);
-                unsafe {
-                    native.progress_indicator.startAnimation(None);
-                }
+            }
+            if !cancellable {
+                native.target.clear_cancel();
+                native.defer_button.setEnabled(false);
+                native.defer_button.setHidden(true);
             }
             native.alert.layout();
+            native.progress_indicator.setNeedsDisplay(true);
+            native.progress_indicator.displayIfNeeded();
         });
     }
 
     fn close(&self) {
         let native = Arc::clone(&self.native);
         run_on_main(move |mtm| {
-            native.get(mtm).alert.window().close();
+            let native = native.get(mtm);
+            native.target.clear_cancel();
+            native.alert.window().close();
         });
     }
 }
@@ -270,9 +296,9 @@ impl UpdateDialog {
         None
     }
 
-    fn show_progress(&self, _message: &str) {}
+    fn show_progress(&self, _message: &str, _cancel: tauri::async_runtime::Sender<()>) {}
 
-    fn set_progress(&self, _message: &str, _progress: Option<u64>) {}
+    fn set_progress(&self, _message: &str, _progress: Option<u64>, _cancellable: bool) {}
 
     fn close(&self) {}
 }
@@ -1128,7 +1154,8 @@ async fn install_update(
         snapshot.update_message = format!("正在下载 {update_version}…");
         snapshot.update_available = false;
     });
-    update_dialog.show_progress(&snapshot.update_message);
+    let (cancel, mut cancel_receiver) = tauri::async_runtime::channel(1);
+    update_dialog.show_progress(&snapshot.update_message, cancel);
     let progress_app = app.clone();
     let progress_state = Arc::clone(state);
     let progress_version = update_version.clone();
@@ -1137,8 +1164,8 @@ async fn install_update(
     let finish_state = Arc::clone(state);
     let finish_dialog = update_dialog.clone();
     let mut downloaded = 0_u64;
-    let bytes = match update
-        .download(
+    let download_result = {
+        let download = update.download(
             move |chunk_length, content_length| {
                 downloaded = downloaded.saturating_add(chunk_length as u64);
                 let progress = content_length.filter(|total| *total > 0).map(|total| {
@@ -1155,19 +1182,48 @@ async fn install_update(
                         None => format!("正在下载 {progress_version}…"),
                     };
                 });
-                progress_dialog.set_progress(&snapshot.update_message, progress);
+                progress_dialog.set_progress(&snapshot.update_message, progress, true);
             },
             move || {
                 let snapshot = update_snapshot(&finish_app, &finish_state, |snapshot| {
                     snapshot.update_message = "正在验证更新…".into();
                 });
-                finish_dialog.set_progress(&snapshot.update_message, None);
+                finish_dialog.set_progress(&snapshot.update_message, Some(100), false);
             },
-        )
+        );
+        let mut download = std::pin::pin!(download);
+        poll_fn(|cx| {
+            if let Poll::Ready(Some(())) = cancel_receiver.poll_recv(cx) {
+                return Poll::Ready(None);
+            }
+            match download.as_mut().poll(cx) {
+                Poll::Ready(result) => {
+                    if let Poll::Ready(Some(())) = cancel_receiver.poll_recv(cx) {
+                        Poll::Ready(None)
+                    } else {
+                        Poll::Ready(Some(result))
+                    }
+                }
+                Poll::Pending => Poll::Pending,
+            }
+        })
         .await
-    {
-        Ok(bytes) => bytes,
-        Err(error) => {
+    };
+    let bytes = match download_result {
+        None => {
+            append_log(
+                state,
+                &format!("Update {update_version} download cancelled by user"),
+            );
+            state.update_in_progress.store(false, Ordering::SeqCst);
+            update_snapshot(app, state, |snapshot| {
+                snapshot.update_message = "更新已取消。".into();
+                snapshot.update_available = true;
+            });
+            return Ok(());
+        }
+        Some(Ok(bytes)) => bytes,
+        Some(Err(error)) => {
             append_log(state, &format!("Update download failed: {error}"));
             state.update_in_progress.store(false, Ordering::SeqCst);
             update_snapshot(app, state, |snapshot| {
@@ -1181,7 +1237,7 @@ async fn install_update(
     let snapshot = update_snapshot(app, state, |snapshot| {
         snapshot.update_message = "正在安装更新…".into();
     });
-    update_dialog.set_progress(&snapshot.update_message, None);
+    update_dialog.set_progress(&snapshot.update_message, None, false);
     {
         let _lifecycle = state.lifecycle.lock().unwrap();
         if state.intentional_stop.load(Ordering::SeqCst) {
@@ -1227,7 +1283,7 @@ async fn install_update(
     let snapshot = update_snapshot(app, state, |snapshot| {
         snapshot.update_message = "正在重启…".into();
     });
-    update_dialog.set_progress(&snapshot.update_message, None);
+    update_dialog.set_progress(&snapshot.update_message, None, false);
     app.restart()
 }
 
@@ -1309,21 +1365,29 @@ async fn offer_update(
     };
     append_log(state, &format!("Update {version} accepted by user"));
     quit.set_enabled(false).unwrap();
-    if let Err(error) = install_update(app, state, update, &update_dialog).await {
-        append_log(state, &format!("Update installation failed: {error}"));
-        let service_recovered = state.snapshot.lock().unwrap().child_pid.is_some();
-        let service_message = if service_recovered {
-            "任务面板服务已恢复。"
-        } else {
-            "任务面板服务未能恢复，请重新打开 App。"
-        };
-        update_dialog.close();
-        show_error_dialog(
-            app,
-            "Codex Taskboard 更新失败",
-            &format!("更新未完成。{service_message}\n\n请稍后重试。详情见启动日志。\n\n{error}"),
-        );
-        finish_update_flow(state, check_update, quit);
+    match install_update(app, state, update, &update_dialog).await {
+        Ok(()) => {
+            update_dialog.close();
+            finish_update_flow(state, check_update, quit);
+        }
+        Err(error) => {
+            append_log(state, &format!("Update installation failed: {error}"));
+            let service_recovered = state.snapshot.lock().unwrap().child_pid.is_some();
+            let service_message = if service_recovered {
+                "任务面板服务已恢复。"
+            } else {
+                "任务面板服务未能恢复，请重新打开 App。"
+            };
+            update_dialog.close();
+            show_error_dialog(
+                app,
+                "Codex Taskboard 更新失败",
+                &format!(
+                    "更新未完成。{service_message}\n\n请稍后重试。详情见启动日志。\n\n{error}"
+                ),
+            );
+            finish_update_flow(state, check_update, quit);
+        }
     }
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,7 +1,10 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use base64::Engine;
 #[cfg(target_os = "macos")]
 use dispatch2::{run_on_main, MainThreadBound};
+use futures_util::StreamExt;
+use minisign_verify::{PublicKey, Signature};
 #[cfg(target_os = "macos")]
 use objc2::{
     define_class, msg_send,
@@ -15,6 +18,7 @@ use objc2_app_kit::{
 };
 #[cfg(target_os = "macos")]
 use objc2_foundation::{NSObject, NSSize, NSString};
+use reqwest::header::{HeaderValue, ACCEPT};
 use serde::{Deserialize, Serialize};
 #[cfg(target_os = "macos")]
 use std::cell::RefCell;
@@ -102,7 +106,7 @@ struct LauncherState {
 #[cfg(target_os = "macos")]
 struct UpdateDialogTargetIvars {
     response: RefCell<Option<std::sync::mpsc::Sender<bool>>>,
-    cancel: RefCell<Option<tauri::async_runtime::Sender<()>>>,
+    cancel: RefCell<Option<(tauri::async_runtime::Sender<()>, Arc<AtomicBool>)>>,
 }
 
 #[cfg(target_os = "macos")]
@@ -128,7 +132,8 @@ define_class!(
 
         #[unsafe(method(cancelUpdate:))]
         fn cancel_update(&self, _sender: &AnyObject) {
-            if let Some(cancel) = self.ivars().cancel.borrow_mut().take() {
+            if let Some((cancel, cancel_requested)) = self.ivars().cancel.borrow_mut().take() {
+                cancel_requested.store(true, Ordering::SeqCst);
                 let _ = cancel.try_send(());
             }
         }
@@ -151,8 +156,12 @@ impl UpdateDialogTarget {
         }
     }
 
-    fn set_cancel(&self, cancel: tauri::async_runtime::Sender<()>) {
-        *self.ivars().cancel.borrow_mut() = Some(cancel);
+    fn set_cancel(
+        &self,
+        cancel: tauri::async_runtime::Sender<()>,
+        cancel_requested: Arc<AtomicBool>,
+    ) {
+        *self.ivars().cancel.borrow_mut() = Some((cancel, cancel_requested));
     }
 
     fn clear_cancel(&self) {
@@ -226,12 +235,17 @@ impl UpdateDialog {
         }
     }
 
-    fn show_progress(&self, message: &str, cancel: tauri::async_runtime::Sender<()>) {
+    fn show_progress(
+        &self,
+        message: &str,
+        cancel: tauri::async_runtime::Sender<()>,
+        cancel_requested: Arc<AtomicBool>,
+    ) {
         let native = Arc::clone(&self.native);
         let message = message.to_owned();
         run_on_main(move |mtm| {
             let native = native.get(mtm);
-            native.target.set_cancel(cancel);
+            native.target.set_cancel(cancel, cancel_requested);
             native
                 .alert
                 .setInformativeText(&NSString::from_str(&message));
@@ -296,7 +310,13 @@ impl UpdateDialog {
         None
     }
 
-    fn show_progress(&self, _message: &str, _cancel: tauri::async_runtime::Sender<()>) {}
+    fn show_progress(
+        &self,
+        _message: &str,
+        _cancel: tauri::async_runtime::Sender<()>,
+        _cancel_requested: Arc<AtomicBool>,
+    ) {
+    }
 
     fn set_progress(&self, _message: &str, _progress: Option<u64>, _cancellable: bool) {}
 
@@ -1142,6 +1162,96 @@ async fn check_for_startup_update(
     Ok(update)
 }
 
+async fn download_update<C: FnMut(usize, Option<u64>), D: FnOnce()>(
+    app: &AppHandle,
+    update: &Update,
+    cancel_requested: &AtomicBool,
+    mut on_chunk: C,
+    on_download_finish: D,
+) -> Result<Option<Vec<u8>>, String> {
+    let pubkey = app
+        .config()
+        .plugins
+        .0
+        .get("updater")
+        .and_then(|value| value.get("pubkey"))
+        .and_then(serde_json::Value::as_str)
+        .ok_or("Updater public key is unavailable")?;
+    let mut headers = update.headers.clone();
+    if !headers.contains_key(ACCEPT) {
+        headers.insert(ACCEPT, HeaderValue::from_static("application/octet-stream"));
+    }
+    let mut request = reqwest::Client::builder().user_agent("tauri-plugin-updater/2.10.1");
+    if let Some(timeout) = update.timeout {
+        request = request.timeout(timeout);
+    }
+    if update.no_proxy {
+        request = request.no_proxy();
+    } else if let Some(proxy) = &update.proxy {
+        request =
+            request.proxy(reqwest::Proxy::all(proxy.as_str()).map_err(|error| error.to_string())?);
+    }
+    let response = request
+        .build()
+        .map_err(|error| error.to_string())?
+        .get(update.download_url.clone())
+        .headers(headers)
+        .send()
+        .await
+        .map_err(|error| error.to_string())?;
+    if !response.status().is_success() {
+        return Err(format!(
+            "Download request failed with status: {}",
+            response.status()
+        ));
+    }
+    let content_length = response
+        .headers()
+        .get("Content-Length")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse().ok());
+    let mut buffer = Vec::new();
+    let mut stream = response.bytes_stream();
+    loop {
+        if cancel_requested.load(Ordering::SeqCst) {
+            return Ok(None);
+        }
+        let Some(chunk) = stream.next().await else {
+            break;
+        };
+        let chunk = chunk.map_err(|error| error.to_string())?;
+        if cancel_requested.load(Ordering::SeqCst) {
+            return Ok(None);
+        }
+        on_chunk(chunk.len(), content_length);
+        if cancel_requested.load(Ordering::SeqCst) {
+            return Ok(None);
+        }
+        buffer.extend_from_slice(&chunk);
+    }
+    if cancel_requested.load(Ordering::SeqCst) {
+        return Ok(None);
+    }
+    on_download_finish();
+    if cancel_requested.load(Ordering::SeqCst) {
+        return Ok(None);
+    }
+    let pubkey = base64::engine::general_purpose::STANDARD
+        .decode(pubkey)
+        .map_err(|error| error.to_string())?;
+    let pubkey = std::str::from_utf8(&pubkey).map_err(|error| error.to_string())?;
+    let pubkey = PublicKey::decode(pubkey).map_err(|error| error.to_string())?;
+    let signature = base64::engine::general_purpose::STANDARD
+        .decode(&update.signature)
+        .map_err(|error| error.to_string())?;
+    let signature = std::str::from_utf8(&signature).map_err(|error| error.to_string())?;
+    let signature = Signature::decode(signature).map_err(|error| error.to_string())?;
+    pubkey
+        .verify(&buffer, &signature, true)
+        .map_err(|error| error.to_string())?;
+    Ok(Some(buffer))
+}
+
 async fn install_update(
     app: &AppHandle,
     state: &Arc<LauncherState>,
@@ -1155,7 +1265,12 @@ async fn install_update(
         snapshot.update_available = false;
     });
     let (cancel, mut cancel_receiver) = tauri::async_runtime::channel(1);
-    update_dialog.show_progress(&snapshot.update_message, cancel);
+    let cancel_requested = Arc::new(AtomicBool::new(false));
+    update_dialog.show_progress(
+        &snapshot.update_message,
+        cancel,
+        Arc::clone(&cancel_requested),
+    );
     let progress_app = app.clone();
     let progress_state = Arc::clone(state);
     let progress_version = update_version.clone();
@@ -1165,7 +1280,10 @@ async fn install_update(
     let finish_dialog = update_dialog.clone();
     let mut downloaded = 0_u64;
     let download_result = {
-        let download = update.download(
+        let download = download_update(
+            app,
+            &update,
+            &cancel_requested,
             move |chunk_length, content_length| {
                 downloaded = downloaded.saturating_add(chunk_length as u64);
                 let progress = content_length.filter(|total| *total > 0).map(|total| {
@@ -1193,15 +1311,19 @@ async fn install_update(
         );
         let mut download = std::pin::pin!(download);
         poll_fn(|cx| {
-            if let Poll::Ready(Some(())) = cancel_receiver.poll_recv(cx) {
-                return Poll::Ready(None);
+            if cancel_requested.load(Ordering::SeqCst)
+                || matches!(cancel_receiver.poll_recv(cx), Poll::Ready(Some(())))
+            {
+                return Poll::Ready(Ok(None));
             }
             match download.as_mut().poll(cx) {
                 Poll::Ready(result) => {
-                    if let Poll::Ready(Some(())) = cancel_receiver.poll_recv(cx) {
-                        Poll::Ready(None)
+                    if cancel_requested.load(Ordering::SeqCst)
+                        || matches!(cancel_receiver.poll_recv(cx), Poll::Ready(Some(())))
+                    {
+                        Poll::Ready(Ok(None))
                     } else {
-                        Poll::Ready(Some(result))
+                        Poll::Ready(result)
                     }
                 }
                 Poll::Pending => Poll::Pending,
@@ -1210,7 +1332,7 @@ async fn install_update(
         .await
     };
     let bytes = match download_result {
-        None => {
+        Ok(None) => {
             append_log(
                 state,
                 &format!("Update {update_version} download cancelled by user"),
@@ -1222,15 +1344,15 @@ async fn install_update(
             });
             return Ok(());
         }
-        Some(Ok(bytes)) => bytes,
-        Some(Err(error)) => {
+        Ok(Some(bytes)) => bytes,
+        Err(error) => {
             append_log(state, &format!("Update download failed: {error}"));
             state.update_in_progress.store(false, Ordering::SeqCst);
             update_snapshot(app, state, |snapshot| {
                 snapshot.update_message = format!("更新下载或签名验证失败：{error}");
                 snapshot.update_available = true;
             });
-            return Err(error.to_string());
+            return Err(error);
         }
     };
 


### PR DESCRIPTION
## 变更

- 在现有 macOS 更新 `NSAlert` 内加入原生 `NSProgressIndicator`，不创建第二个窗口。
- 已知总量时使用 determinate 模式，条长与百分比同步增长；未知总量时显示静态空条，不显示假百分比或跑马灯。
- 下载阶段显示“取消”。点击后立即终止 HTTP 字节流并丢弃部分数据；关闭同一弹窗并恢复“检查更新”和“退出”菜单。
- 验证、安装和重启阶段隐藏取消，保持静态 100% 进度条；现有 `LauncherSnapshot`、失败处理、安装和重启语义不变。

## 根因与修复

- v1.0.5 只在 `informativeText` 显示文字百分比，没有图形进度条。
- 旧实现先切 determinate，再停止 indeterminate 动画，导致旧跑马灯帧继续显示。修复后下载阶段从静态 0 开始，已知总量直接写入数值并强制刷新。
- `tauri-plugin-updater 2.10.1` 可在一次 poll 内完成 final chunk、finish 回调和同步验签。外层取消选择只能在验签之后观察到取消信号。
- 本次用一个共享取消令牌接入真实字节流循环：每个 chunk 前后检查；下载完成界面切换后、签名验证前再检查一次。待 I/O 时仍由外层 channel 立即丢弃下载 future。只有未取消且签名通过的字节才交给现有 `update.install`。

## 直接验证

- 中途取消：真实签名包下载到 `76,021,760 / 86,435,357` 字节后连接关闭，`writableEnded=false`；没有进入验签、安装或重启，App 保持 v1.0.1，两个菜单恢复可用。
- final chunk 竞态：弹窗真实显示 100% 时点击取消；服务端已发送 `86,435,357 / 86,435,357` 字节但响应未结束，连接立即关闭。只出现 final-chunk 回调标记，没有签名验证标记；App 保持 v1.0.1。
- 未知总量：弹窗无百分比，进度条静态为 0；取消后连接在 `53,477,376 / 86,435,357` 字节关闭，没有验签、安装或重启。
- 完整路径：AX 分别捕获 20% 和 60%，截图分别捕获 39% 和 68%，同一条形进度与文字同步单向增长；完整发送后验签、安装和原重启路径均到达，隔离 App 从 v1.0.1 更新为 v1.0.2。

## 检查

- Rust 1.88 `cargo fmt -- --check`
- Rust 1.88 `cargo check`
- Rust 1.88 `cargo build --release --target x86_64-apple-darwin`
- `git diff --check`
- 最终生产二进制不含隔离预览标记或本机 updater 端点；正式 `/Applications/Codex Taskboard.app` 保持 v1.0.5。
- 隔离 App、数据、日志和服务已清理。

未新增或运行测试。最新 exact head：`7384f59b1f0da864c745771d44ea8e009b25b25a`。旧 head `da15930d` 的 Pro 审核不适用于本提交，需要重新审核。

Taskboard：LOCAL-162
