### PR TITLE
fix(ai-chat): complete large Codex event handling

### DIFF
--- a/server/ai-chat-process.mjs
+++ b/server/ai-chat-process.mjs
@@ -315,9 +315,9 @@ export function normalizeCodexEvent(raw) {
     return {
       kind: "event",
       type: raw.type,
-      role: "error",
+      role: "activity",
       content: errorMessage(raw.message ?? raw.error),
-      data: { status: "failed" },
+      data: { status: "warning" },
     };
   }
 

--- a/server/ai-chat-process.mjs
+++ b/server/ai-chat-process.mjs
@@ -6,6 +6,7 @@ import { signalProcessTree } from "../shared/process-tree.mjs";
 
 const VISIBLE_TEXT_LIMIT = 65_536;
 const STDERR_LIMIT = 65_536;
+const MAX_CODEX_JSONL_LINE_BYTES = 16 * 1024 * 1024;
 const SKILL_MARKER = "\uFFFC";
 const TURN_OWNER_PATH = fileURLToPath(new URL("./ai-turn-owner.mjs", import.meta.url));
 const ITEM_TYPES = new Set([
@@ -339,7 +340,7 @@ export function spawnCodexTurn({
   prompt,
   env,
   onRawEvent,
-  maxLineBytes = 1_048_576,
+  maxLineBytes = MAX_CODEX_JSONL_LINE_BYTES,
 }) {
   const child = spawn(process.execPath, [TURN_OWNER_PATH, executable, JSON.stringify(args)], {
     detached: true,

--- a/server/ai-chat-process.mjs
+++ b/server/ai-chat-process.mjs
@@ -153,12 +153,13 @@ function normalizedItem(rawType, item) {
   }
 
   const message = errorMessage(item.message ?? item.error);
+  const completedNotice = rawType === "item.completed" && status === "completed";
   return {
     kind: "event",
     type: item.type,
-    role: "error",
+    role: completedNotice ? "activity" : "error",
     content: message,
-    data: baseData,
+    data: completedNotice ? { ...baseData, status: "warning" } : baseData,
   };
 }
 
@@ -348,7 +349,8 @@ export function spawnCodexTurn({
     stdio: ["pipe", "pipe", "pipe", "pipe"],
   });
 
-  let stdoutBuffer = Buffer.alloc(0);
+  let stdoutChunks = [];
+  let stdoutLength = 0;
   let stderrBuffer = Buffer.alloc(0);
   let settled = false;
   let fatalError = null;
@@ -401,24 +403,28 @@ export function spawnCodexTurn({
       const newline = bytes.indexOf(10, offset);
       if (newline === -1) {
         const remainder = bytes.subarray(offset);
-        if (stdoutBuffer.length + remainder.length > maxLineBytes) {
+        if (stdoutLength + remainder.length > maxLineBytes) {
           rejectWithDiagnostic(new Error(`Codex JSONL line exceeded ${maxLineBytes} bytes`));
           return;
         }
-        stdoutBuffer = stdoutBuffer.length === 0
-          ? Buffer.from(remainder)
-          : Buffer.concat([stdoutBuffer, remainder]);
+        stdoutChunks.push(remainder);
+        stdoutLength += remainder.length;
         return;
       }
       const segment = bytes.subarray(offset, newline);
-      if (stdoutBuffer.length + segment.length > maxLineBytes) {
+      const lineLength = stdoutLength + segment.length;
+      if (lineLength > maxLineBytes) {
         rejectWithDiagnostic(new Error(`Codex JSONL line exceeded ${maxLineBytes} bytes`));
         return;
       }
-      const line = stdoutBuffer.length === 0
+      if (segment.length > 0) stdoutChunks.push(segment);
+      const line = stdoutChunks.length === 0
         ? segment
-        : Buffer.concat([stdoutBuffer, segment]);
-      stdoutBuffer = Buffer.alloc(0);
+        : stdoutChunks.length === 1
+          ? stdoutChunks[0]
+          : Buffer.concat(stdoutChunks, lineLength);
+      stdoutChunks = [];
+      stdoutLength = 0;
       consumeLine(line);
       offset = newline + 1;
     }
@@ -427,9 +433,12 @@ export function spawnCodexTurn({
   function finishStdout() {
     if (stdoutEnded) return;
     stdoutEnded = true;
-    if (!fatalError && stdoutBuffer.length > 0) {
-      const line = stdoutBuffer;
-      stdoutBuffer = Buffer.alloc(0);
+    if (!fatalError && stdoutLength > 0) {
+      const line = stdoutChunks.length === 1
+        ? stdoutChunks[0]
+        : Buffer.concat(stdoutChunks, stdoutLength);
+      stdoutChunks = [];
+      stdoutLength = 0;
       consumeLine(line);
     }
   }

--- a/server/ai-chat.mjs
+++ b/server/ai-chat.mjs
@@ -291,6 +291,7 @@ export class AiChatService {
       let startedThreadId = null;
       let terminalOutcome = null;
       let terminalError = "";
+      let pendingError = "";
       const { child, completion } = spawnCodexTurn({
         executable: this.codexExecutable,
         args,
@@ -323,6 +324,8 @@ export class AiChatService {
           } else if (raw.type === "turn.failed") {
             terminalOutcome = "failed";
             terminalError ||= normalized.content;
+          } else if (raw.type === "error") {
+            pendingError ||= normalized.content;
           }
           this.#emit(threadId, { type: "ai.event", event });
         },
@@ -339,6 +342,7 @@ export class AiChatService {
           startedThreadId: () => startedThreadId,
           terminalOutcome: () => terminalOutcome,
           terminalError: () => terminalError,
+          pendingError: () => pendingError,
         }),
         (error) => this.#finishRun({
           run,
@@ -348,6 +352,7 @@ export class AiChatService {
           startedThreadId: () => startedThreadId,
           terminalOutcome: () => terminalOutcome,
           terminalError: () => terminalError,
+          pendingError: () => pendingError,
         }),
       );
       this.completions.set(run.id, finalization);
@@ -519,6 +524,7 @@ export class AiChatService {
     startedThreadId,
     terminalOutcome,
     terminalError,
+    pendingError,
   }) {
     let status;
     let publicError = null;
@@ -538,7 +544,7 @@ export class AiChatService {
         : `Codex exited with code ${result.exitCode}`;
     } else if (terminalOutcome() !== "completed") {
       status = "failed";
-      publicError = "Codex exited without reporting turn completion";
+      publicError = pendingError() || "Codex exited without reporting turn completion";
     } else if (!resumingThreadId && !startedThreadId()) {
       status = "failed";
       publicError = "Codex did not provide a thread id";

--- a/server/ai-chat.mjs
+++ b/server/ai-chat.mjs
@@ -320,7 +320,7 @@ export class AiChatService {
           });
           if (raw.type === "turn.completed" && terminalOutcome === null) {
             terminalOutcome = "completed";
-          } else if (raw.type === "turn.failed" || raw.type === "error") {
+          } else if (raw.type === "turn.failed") {
             terminalOutcome = "failed";
             terminalError ||= normalized.content;
           }

--- a/test/ai-chat-runner.test.mjs
+++ b/test/ai-chat-runner.test.mjs
@@ -369,6 +369,39 @@ test("protocol terminal events determine run success and item errors remain non-
   }
 });
 
+test("a root Codex error remains the run diagnostic when completion never arrives", async () => {
+  const fixture = await createFixture();
+  try {
+    const thread = await fixture.service.createThread({ projectId: "project" });
+    const run = await fixture.service.startTurn(thread.id, { message: "ROOT_ERROR_ZERO" });
+    await waitFor(() => fixture.service.getRun(run.id)?.status !== "running");
+
+    const finished = fixture.service.getRun(run.id);
+    assert.equal(finished.status, "failed");
+    assert.equal(finished.error, "Protocol root error");
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("a root Codex error preceding completion is recorded as a warning", async () => {
+  const fixture = await createFixture();
+  try {
+    const thread = await fixture.service.createThread({ projectId: "project" });
+    const run = await fixture.service.startTurn(thread.id, { message: "WARNING_THEN_COMPLETED" });
+    await waitFor(() => fixture.service.getRun(run.id)?.status !== "running");
+
+    const warning = fixture.service.getThreadSnapshot(thread.id).events.find(
+      (event) => event.type === "error" && event.content === "Skill descriptions were shortened",
+    );
+    assert.equal(fixture.service.getRun(run.id).status, "completed");
+    assert.equal(warning?.role, "activity");
+    assert.equal(warning?.data.status, "warning");
+  } finally {
+    await fixture.close();
+  }
+});
+
 test("a Codex command event slightly over one MiB completes and keeps only bounded output", async () => {
   const fixture = await createFixture();
   try {

--- a/test/ai-chat-runner.test.mjs
+++ b/test/ai-chat-runner.test.mjs
@@ -33,6 +33,42 @@ test("normalized item events retain a bounded public item id", () => {
   assert.equal(normalized.data.itemId, itemId.slice(0, 65_536));
 });
 
+test("completed item errors are warnings while failed item errors remain errors", () => {
+  const completed = normalizeCodexEvent({
+    type: "item.completed",
+    item: {
+      id: "notice",
+      type: "error",
+      status: "completed",
+      message: "Skill descriptions were shortened",
+    },
+  });
+  const failed = normalizeCodexEvent({
+    type: "item.completed",
+    item: {
+      id: "failure",
+      type: "error",
+      status: "failed",
+      message: "Tool failed",
+    },
+  });
+
+  assert.deepEqual(completed, {
+    kind: "event",
+    type: "error",
+    role: "activity",
+    content: "Skill descriptions were shortened",
+    data: { status: "warning", itemId: "notice" },
+  });
+  assert.deepEqual(failed, {
+    kind: "event",
+    type: "error",
+    role: "error",
+    content: "Tool failed",
+    data: { status: "failed", itemId: "failure" },
+  });
+});
+
 async function createFixture() {
   const directory = await mkdtemp(path.join(os.tmpdir(), "taskboard-ai-runner-"));
   const workspacePath = path.join(directory, "workspace");

--- a/test/ai-chat-runner.test.mjs
+++ b/test/ai-chat-runner.test.mjs
@@ -111,6 +111,9 @@ if (args[0] === "app-server") {
     emit({type:"item.completed",item:{type:"reasoning",text:"SECRET REASONING"}});
     emit({type:"item.completed",item:{type:"agent_message",text:"Visible answer"}});
     emit({type:"item.completed",item:{type:"command_execution",command:"npm test",status:"completed",exit_code:0,aggregated_output:"ok"}});
+    if (prompt.includes("LARGE_COMMAND_OUTPUT")) {
+      emit({type:"item.completed",item:{type:"command_execution",command:"large output",status:"completed",exit_code:0,aggregated_output:"x".repeat(1_048_577)}});
+    }
     if (prompt.includes("TURN_FAILED_ZERO")) {
       emit({type:"turn.failed",error:{message:"Protocol turn failed"}});
       return;
@@ -118,6 +121,9 @@ if (args[0] === "app-server") {
     if (prompt.includes("ROOT_ERROR_ZERO")) {
       emit({type:"error",message:"Protocol root error"});
       return;
+    }
+    if (prompt.includes("WARNING_THEN_COMPLETED")) {
+      emit({type:"error",message:"Skill descriptions were shortened"});
     }
     if (prompt.includes("NO_TERMINAL")) return;
     if (prompt.includes("ITEM_ERROR")) {
@@ -351,12 +357,30 @@ test("protocol terminal events determine run success and item errors remain non-
       ["ROOT_ERROR_ZERO", "failed"],
       ["NO_TERMINAL", "failed"],
       ["ITEM_ERROR", "completed"],
+      ["WARNING_THEN_COMPLETED", "completed"],
     ]) {
       const thread = await fixture.service.createThread({ projectId: "project" });
       const run = await fixture.service.startTurn(thread.id, { message });
       await waitFor(() => fixture.service.getRun(run.id).status !== "running");
       assert.equal(fixture.service.getRun(run.id).status, expectedStatus, message);
     }
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("a Codex command event slightly over one MiB completes and keeps only bounded output", async () => {
+  const fixture = await createFixture();
+  try {
+    const thread = await fixture.service.createThread({ projectId: "project" });
+    const run = await fixture.service.startTurn(thread.id, { message: "LARGE_COMMAND_OUTPUT" });
+    await waitFor(() => fixture.service.getRun(run.id)?.status !== "running");
+
+    assert.equal(fixture.service.getRun(run.id).status, "completed");
+    const largeOutputEvent = fixture.service.getThreadSnapshot(thread.id).events.find(
+      (event) => event.type === "command_execution" && event.content === "large output",
+    );
+    assert.equal(largeOutputEvent.data.output.length, 65_536);
   } finally {
     await fixture.close();
   }

--- a/test/ai-chat-state.test.mjs
+++ b/test/ai-chat-state.test.mjs
@@ -224,6 +224,13 @@ test("activity status treats started, running and in_progress as active and fail
     content: "",
     data: { status: "completed" },
   }), "completed");
+  assert.equal(aiChatEventStatus({
+    id: "5",
+    type: "error",
+    role: "activity",
+    content: "Skill descriptions were shortened",
+    data: { status: "warning" },
+  }), "completed");
 });
 
 test("snapshot hint refreshes allow one in-flight request and one queued request", async () => {

--- a/web/src/aiChatState.ts
+++ b/web/src/aiChatState.ts
@@ -187,7 +187,7 @@ export function filterVisibleAiEvents<
 export function aiChatEventStatus(
   event: Pick<AiChatEvent, "role" | "type" | "data">,
 ): "running" | "completed" | "failed" {
-  if (event.role === "error" || event.type === "error" || event.type === "turn.failed") {
+  if (event.role === "error" || event.type === "turn.failed") {
     return "failed";
   }
   const status = event.data?.status;

--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -578,6 +578,7 @@ const ACTIVITY_LABELS: Record<string, readonly [string, string]> = {
   error: ["执行失败", "Failed"],
   "turn.failed": ["执行失败", "Failed"],
 };
+const WARNING_ACTIVITY_LABEL: readonly [string, string] = ["警告", "Warning"];
 
 const ACTIVITY_ICONS: Record<string, LinearIconName> = {
   plan: "write",
@@ -795,7 +796,9 @@ function ThinkingSteps({
             {events.map((event, index) => {
               const eventStatus = aiChatEventStatus(event);
               const detail = activityDetail(event, text);
-              const activityLabel = ACTIVITY_LABELS[event.type];
+              const activityLabel = event.type === "error" && event.data?.status === "warning"
+                ? WARNING_ACTIVITY_LABEL
+                : ACTIVITY_LABELS[event.type];
               const content = detail?.kind === "lines"
                 && (event.type === "file" || event.type === "file_change")
                 ? text(


### PR DESCRIPTION
## Summary

- Retains the large Codex JSONL event support and root-error diagnostics contributed in #151.
- Classifies `item.completed` error items with completed status as non-fatal activity warnings, while failed items remain errors.
- Accumulates an in-progress JSONL line with a bounded chunk list and byte count, then concatenates once when the line completes.

## Contribution history

Supersedes #151 only because maintainer push access to the contributor fork is disabled.

Preserves JnyRoad’s original authored commits:

- `1f597cfd692b7786e85ec632a517895d3d6d7fb7` → `656d4cf4ac8d3da6246d1e7cb1ec0b46cd35e0da`
- `c300877127511c84dd375bdd424baec7ad1f0cf7` → `8639221608e2e0226447e03d48f90d90da865ec8`

Both commits remain separate and authored by `JnyRoad <jnyroad@gmail.com>`. They were cherry-picked onto the latest `main` without conflicts. The maintainer follow-up is `e725b232753150c2b91d1ed10d8598336c1b23f9`.

## Verification

- `node --test test/ai-chat-runner.test.mjs test/ai-chat-state.test.mjs`: 24 passed.
- `npm run test:components`: 9 passed.
- `npm run check`: typecheck and build passed; the Node test phase had 436 passed, 1 skipped, and 1 environment failure because port 5173 was already held by a Vite server in a separate worktree.
- `git diff --check origin/main...HEAD`: passed.
