### PR TITLE
Refine issue references, property menus, and relations

### DIFF
--- a/test/board-interactions.test.mjs
+++ b/test/board-interactions.test.mjs
@@ -156,8 +156,8 @@ test("issues expose processing conversations without manual binding", () => {
   assert.match(detailSource, /onOpenLegacyLocalThread\(comment\.legacyLocalThreadId!\)/);
   assert.doesNotMatch(detailSource, /compact/);
   assert.doesNotMatch(styles, /issue-conversation-link\.compact/);
-  assert.match(detailSource, /代码分支/);
-  assert.match(detailSource, /Worktree/);
+  assert.match(detailSource, /\.\.\.developmentOptions\.map\(\(context\) => \(\{/);
+  assert.match(detailSource, /context\.type === "branch" \? "branch" : "folder"/);
   assert.match(detailSource, /developmentContext/);
   assert.doesNotMatch(detailSource, /placeholder="绑定分支/);
   assert.doesNotMatch(contextMenuSource, /打开关联 Codex 对话/);

--- a/test/comment-activity-style.test.mjs
+++ b/test/comment-activity-style.test.mjs
@@ -22,7 +22,7 @@ test("comment floors use Linear-style cards with the author inside the card", ()
 test("comment body renders document formatting at Linear typography", () => {
   assert.match(
     detailSource,
-    /comment\.body && \(\s*<div className="comment-body">\s*<DescriptionDocument value=\{comment\.body\} tasks=\{tasks\} onOpenTask=\{onOpenTask\} \/>\s*<\/div>\s*\)/s,
+    /comment\.body && \(\s*<div className="comment-body">\s*<DescriptionDocument\s*value=\{comment\.body\}\s*referenceTasks=\{referenceTasks\}\s*onOpenTask=\{onOpenTask\}\s*\/>\s*<\/div>\s*\)/s,
   );
   assert.match(styles, /\.comment-body\s*\{[^}]*font-size:\s*15px;[^}]*line-height:\s*24px;/s);
   assert.match(styles, /\.comment-body \.issue-description-document\s*\{/);

--- a/test/issue-detail-markdown.test.mjs
+++ b/test/issue-detail-markdown.test.mjs
@@ -33,11 +33,11 @@ test("issue detail renders descriptions and comments with GFM markdown", () => {
   );
   assert.match(
     detailSource,
-    /\{description\s*\?\s*<DescriptionDocument value=\{description\} tasks=\{tasks\} onOpenTask=\{onOpenTask\} \/>\s*:\s*text\("添加描述…", "Add description…"\)\}/,
+    /\{description\s*\?\s*<DescriptionDocument\s*value=\{description\}\s*referenceTasks=\{referenceTasks\}\s*onOpenTask=\{onOpenTask\}\s*\/>\s*:\s*text\("添加描述…", "Add description…"\)\}/,
   );
   assert.match(
     detailSource,
-    /comment\.body && \(\s*<div className="comment-body">\s*<DescriptionDocument value=\{comment\.body\} tasks=\{tasks\} onOpenTask=\{onOpenTask\} \/>\s*<\/div>\s*\)/s,
+    /comment\.body && \(\s*<div className="comment-body">\s*<DescriptionDocument\s*value=\{comment\.body\}\s*referenceTasks=\{referenceTasks\}\s*onOpenTask=\{onOpenTask\}\s*\/>\s*<\/div>\s*\)/s,
   );
   assert.doesNotMatch(detailSource, /value\.split\("\\n"\)/);
 });

--- a/test/project-automation-settings.test.mjs
+++ b/test/project-automation-settings.test.mjs
@@ -137,7 +137,7 @@ test("the automation menu reuses the board switches and keeps form focus chrome 
   assert.match(menuSource, /className=\{`board-setting-switch\$\{draft\.quotaAware \? " is-on" : ""\}`\}/);
   assert.match(menuSource, /aria-checked=\{draft\.quotaAware\}/);
   assert.doesNotMatch(menuSource, /type="checkbox"/);
-  assert.match(styles, /\.project-automation-field select:focus-visible\s*\{[^}]*outline:\s*0;[^}]*box-shadow:\s*none;/s);
+  assert.match(styles, /\.project-automation-picker-trigger:focus-visible\s*\{[^}]*outline:\s*0;[^}]*box-shadow:\s*0 0 0 2px var\(--accent-soft\);/s);
   assert.doesNotMatch(styles, /\.project-automation-switch input:focus-visible/);
 });
 
@@ -160,9 +160,9 @@ test("automation changes submit immediately with model-specific effort normaliza
   assert.match(menuSource, /onChange: \(options: AutomationOptions\) => void/);
   assert.match(menuSource, /const disabled = pending \|\| Boolean\(unavailableReason\)/);
   assert.match(menuSource, /const submitChange = \(next: AutomationOptions\) => \{[\s\S]*?setDraft\(next\);[\s\S]*?onChange\(next\);[\s\S]*?\}/);
-  assert.match(menuSource, /submitChange\(withAutomationModel\(draft, event\.target\.value as AutomationModel\)\)/);
+  assert.match(menuSource, /submitChange\(withAutomationModel\(draft, value as AutomationModel\)\)/);
   assert.match(menuSource, /getAutomationModel\(draft\.model\)\.efforts\.map/);
-  assert.match(menuSource, /<option key=\{effort\} value=\{effort\}>\{text\(\.\.\.EFFORT_LABELS\[effort\]\)\}<\/option>/);
+  assert.match(menuSource, /getAutomationModel\(draft\.model\)\.efforts\.map[\s\S]*?label: text\(\.\.\.EFFORT_LABELS\[effort\]\)/);
   assert.match(menuSource, /low: \["轻度", "Low"\]/);
   assert.match(menuSource, /xhigh: \["极高 \(xhigh\)", "Extra high \(xhigh\)"\]/);
   assert.match(menuSource, /max: \["最高", "Maximum"\]/);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1001,8 +1001,9 @@ export function App() {
       skillPath: manageTaskboardSkillPath,
     };
   }, [automationProjectContext, hostContext, manageTaskboardSkillPath, selectedProject]);
+  const referenceTasks = useMemo(() => [...tasks, ...archivedTasks], [archivedTasks, tasks]);
   const detailTask = detailTaskIdentifier
-    ? tasks.find((task) => task.identifier === detailTaskIdentifier) ?? null
+    ? referenceTasks.find((task) => task.identifier === detailTaskIdentifier) ?? null
     : null;
   const detailTaskId = detailTask?.id ?? null;
   const contextMenuTask = contextMenu
@@ -3550,6 +3551,7 @@ export function App() {
             key={detailTask.id}
             task={detailTask}
             tasks={tasks}
+            referenceTasks={referenceTasks}
             currentUser={currentUser}
             availableLabels={availableLabels}
             developmentScan={developmentScan}
@@ -3968,6 +3970,7 @@ export function App() {
           key={editor.task?.id ?? `new-${selectedProjectId}-${editor.status}`}
           task={editor.task}
           tasks={tasks.filter((task) => task.projectId === selectedProjectId)}
+          referenceTasks={referenceTasks.filter((task) => task.projectId === selectedProjectId)}
           initialStatus={editor.status}
           initialDraft={editor.task || newTaskDraft?.projectId !== selectedProjectId
             ? null

--- a/web/src/components/BoardColumn.tsx
+++ b/web/src/components/BoardColumn.tsx
@@ -58,7 +58,7 @@ export function StatusIcon({ status }: { status: TaskStatus }) {
   return <TaskboardIcon name={STATUS_ICONS[status]} />;
 }
 
-function ColumnStatusIcon({ status }: { status: TaskStatus }) {
+export function ColumnStatusIcon({ status }: { status: TaskStatus }) {
   return <TaskboardIcon name={COLUMN_STATUS_ICONS[status]} />;
 }
 

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -606,6 +606,17 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       },
     }), [onChange, onError, segments]);
 
+    function directRootTextSegment(): InlineTextSegment | null {
+      const root = rootRef.current;
+      const segment = segments.length === 1 && segments[0].type === "text"
+        ? segments[0]
+        : null;
+      if (!root || !segment || root.childNodes.length !== 1) return null;
+      return root.firstChild instanceof Text || root.firstChild instanceof HTMLBRElement
+        ? segment
+        : null;
+    }
+
     function segmentElement(node: Node | null): HTMLElement | null {
       const root = rootRef.current;
       if (!root || !node || !root.contains(node)) return null;
@@ -629,6 +640,16 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
     ): number | null {
       const root = rootRef.current;
       if (!root || !root.contains(node)) return null;
+      const directText = directRootTextSegment();
+      if (directText) {
+        const child = root.firstChild;
+        if (node === child && child instanceof Text) {
+          return Math.max(0, Math.min(offset, child.length));
+        }
+        if (node === root) {
+          return child instanceof Text && offset > 0 ? directText.text.length : 0;
+        }
+      }
       if (node === root) {
         for (let index = offset; index < root.childNodes.length; index += 1) {
           const child = root.childNodes[index];
@@ -674,6 +695,14 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
     function domPointAtOffset(offset: number): { node: Node; offset: number } | null {
       const root = rootRef.current;
       if (!root) return null;
+      const directText = directRootTextSegment();
+      if (directText) {
+        const child = root.firstChild;
+        if (child instanceof Text) {
+          return { node: child, offset: Math.max(0, Math.min(offset, child.length)) };
+        }
+        return { node: root, offset: 0 };
+      }
       let current = 0;
       for (const segment of segments) {
         const element = elementForSegment(segment.id);
@@ -778,8 +807,9 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
         setMention(null);
         return;
       }
-      const element = segmentElement(range.startContainer);
-      const id = element?.dataset.inlineMediaSegment;
+      const directText = directRootTextSegment();
+      const element = segmentElement(range.startContainer) ?? (directText ? root : null);
+      const id = element === root ? directText?.id : element?.dataset.inlineMediaSegment;
       const segment = id
         ? segments.find((candidate): candidate is InlineTextSegment => (
             candidate.id === id && candidate.type === "text"
@@ -897,31 +927,6 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       const targetRange = input.getTargetRanges()[0];
       if (!targetRange) return;
       const root = rootRef.current;
-      const emptySegment = segments.length === 1 && segments[0].type === "text"
-        && segments[0].text.length === 0
-        ? segments[0]
-        : null;
-      if (
-        root
-        && emptySegment
-        && targetRange.startContainer === root
-        && root.childNodes.length === 1
-        && root.firstChild instanceof HTMLBRElement
-        && ["insertText", "insertReplacementText"].includes(input.inputType)
-      ) {
-        const element = document.createElement("span");
-        element.dataset.inlineMediaSegment = emptySegment.id;
-        element.className = "inline-media-text";
-        element.append(document.createElement("br"));
-        root.replaceChildren(element);
-        const range = document.createRange();
-        range.setStart(element, 0);
-        range.collapse(true);
-        const selection = window.getSelection();
-        selection?.removeAllRanges();
-        selection?.addRange(range);
-        return;
-      }
       const start = logicalOffsetForPoint(
         targetRange.startContainer,
         targetRange.startOffset,
@@ -935,10 +940,19 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       if (start === null || end === null) return;
       const startElement = segmentElement(targetRange.startContainer);
       const endElement = segmentElement(targetRange.endContainer);
+      const directText = directRootTextSegment();
+      const directTextTarget = Boolean(
+        root
+        && directText
+        && [targetRange.startContainer, targetRange.endContainer].every((node) => (
+          node === root || node.parentNode === root
+        )),
+      );
       const targetSegment = startElement?.dataset.inlineMediaSegment
         ? segments.find((segment) => segment.id === startElement.dataset.inlineMediaSegment)
-        : null;
-      const sameTextSegment = targetSegment?.type === "text" && startElement === endElement;
+        : directTextTarget ? directText : null;
+      const sameTextSegment = targetSegment?.type === "text"
+        && (directTextTarget || startElement === endElement);
       const fullDelete = start === 0 && end > start && end === segmentsLength(segments);
       const nativeTextEdit = (
         sameTextSegment
@@ -1004,11 +1018,14 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       if (!root) return;
       const existing = nativeSegments.current;
       for (const segment of segments) existing.set(segment.id, segment);
+      const directText = directRootTextSegment();
       const next: InlineMediaSegment[] = [];
       const nextAtomHosts = new Map<string, HTMLElement>();
       for (const child of root.childNodes) {
         if (child instanceof Text) {
-          if (child.data) next.push(textSegment(child.data));
+          if (child.data) {
+            next.push(directText ? { ...directText, text: child.data } : textSegment(child.data));
+          }
           continue;
         }
         if (!(child instanceof HTMLElement)) continue;

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -17,6 +17,8 @@ import { unified } from "unified";
 import type { Attachment, Task } from "../types";
 import { attachmentContentUrl, resolvePersistedAttachmentUrl } from "../api";
 import { useTaskboardI18n } from "../i18n";
+import { readIssueIdentifier } from "../issueRoute";
+import { ColumnStatusIcon, STATUS_DETAILS } from "./BoardColumn";
 import { clipboardImages, fileKey, MAX_ATTACHMENT_SIZE } from "./PendingAttachments";
 import { LinearIcon } from "./LinearIcon";
 import { IssueMentionMenu } from "./IssueMentionMenu";
@@ -42,6 +44,13 @@ interface PersistedImageSegment {
   url: string;
 }
 
+interface IssueReferenceSegment {
+  id: string;
+  type: "issue-reference";
+  markdown: string;
+  taskId: string;
+}
+
 interface MarkdownAstNode {
   type: string;
   position: {
@@ -54,7 +63,11 @@ interface MarkdownAstNode {
   url?: string;
 }
 
-export type InlineMediaSegment = InlineTextSegment | InlineImageSegment | PersistedImageSegment;
+export type InlineMediaSegment =
+  | InlineTextSegment
+  | InlineImageSegment
+  | PersistedImageSegment
+  | IssueReferenceSegment;
 export type PendingInlineImage = InlineImageSegment;
 type InlineMediaError = string | readonly [string, string];
 
@@ -106,9 +119,15 @@ function imageSegment(file: File): InlineImageSegment {
   };
 }
 
-export function createInlineMediaSegments(text = ""): InlineMediaSegment[] {
+export function createInlineMediaSegments(
+  text = "",
+  mentionTasks: readonly Task[] = EMPTY_MENTION_TASKS,
+): InlineMediaSegment[] {
   const segments: InlineMediaSegment[] = [];
-  const images: Array<{ start: number; end: number; alt: string; url: string }> = [];
+  const items: Array<
+    | { type: "persisted-image"; start: number; end: number; alt: string; url: string }
+    | { type: "issue-reference"; start: number; end: number; taskId: string }
+  > = [];
   const root = inlineMediaMarkdownParser.parse(text);
   const getDefinition = definitions(root);
   const nodes = [root as MarkdownAstNode];
@@ -116,7 +135,8 @@ export function createInlineMediaSegments(text = ""): InlineMediaSegment[] {
   while (nodes.length > 0) {
     const node = nodes.pop()!;
     if (node.type === "image") {
-      images.push({
+      items.push({
+        type: "persisted-image",
         start: node.position.start.offset,
         end: node.position.end.offset,
         alt: node.alt ?? "",
@@ -126,7 +146,8 @@ export function createInlineMediaSegments(text = ""): InlineMediaSegment[] {
     if (node.type === "imageReference") {
       const definition = getDefinition(node.identifier);
       if (definition) {
-        images.push({
+        items.push({
+          type: "persisted-image",
           start: node.position.start.offset,
           end: node.position.end.offset,
           alt: node.alt ?? "",
@@ -134,22 +155,48 @@ export function createInlineMediaSegments(text = ""): InlineMediaSegment[] {
         });
       }
     }
+    if (node.type === "link" && node.url?.startsWith("?")) {
+      const projectId = new URLSearchParams(node.url).get("project");
+      const identifier = readIssueIdentifier(node.url);
+      const task = projectId && identifier
+        ? mentionTasks.find((candidate) => (
+            candidate.projectId === projectId && candidate.identifier === identifier
+          ))
+        : null;
+      if (task) {
+        items.push({
+          type: "issue-reference",
+          start: node.position.start.offset,
+          end: node.position.end.offset,
+          taskId: task.id,
+        });
+      }
+    }
     if (node.children) nodes.push(...node.children);
   }
 
-  images.sort((a, b) => a.start - b.start);
+  items.sort((a, b) => a.start - b.start);
   let offset = 0;
 
-  for (const image of images) {
-    if (image.start > offset) segments.push(textSegment(text.slice(offset, image.start)));
-    segments.push({
-      id: segmentId("image"),
-      type: "persisted-image",
-      markdown: text.slice(image.start, image.end),
-      alt: image.alt,
-      url: image.url,
-    });
-    offset = image.end;
+  for (const item of items) {
+    if (item.start > offset) segments.push(textSegment(text.slice(offset, item.start)));
+    if (item.type === "persisted-image") {
+      segments.push({
+        id: segmentId("image"),
+        type: "persisted-image",
+        markdown: text.slice(item.start, item.end),
+        alt: item.alt,
+        url: item.url,
+      });
+    } else {
+      segments.push({
+        id: segmentId("issue"),
+        type: "issue-reference",
+        markdown: text.slice(item.start, item.end),
+        taskId: item.taskId,
+      });
+    }
+    offset = item.end;
   }
 
   if (offset < text.length) segments.push(textSegment(text.slice(offset)));
@@ -163,16 +210,16 @@ export function inlineMediaImages(segments: InlineMediaSegment[]): PendingInline
 export function inlineMediaText(segments: InlineMediaSegment[]): string {
   return segments.map((segment) => {
     if (segment.type === "text") return segment.text;
-    if (segment.type === "persisted-image") return segment.markdown;
-    return "";
+    if (segment.type === "pending-image") return "";
+    return segment.markdown;
   }).join("");
 }
 
 export function serializeInlineMedia(segments: InlineMediaSegment[]): string {
   return segments.map((segment) => {
     if (segment.type === "text") return segment.text;
-    if (segment.type === "persisted-image") return segment.markdown;
-    return `\n\n${segment.token}\n\n`;
+    if (segment.type === "pending-image") return `\n\n${segment.token}\n\n`;
+    return segment.markdown;
   }).join("");
 }
 
@@ -196,10 +243,17 @@ function normalizeSegments(segments: InlineMediaSegment[]): InlineMediaSegment[]
   const normalized: InlineMediaSegment[] = [];
   for (const segment of segments) {
     const previous = normalized.at(-1);
-    if (segment.type === "text" && previous?.type === "text") {
+    if (
+      (segment.type === "issue-reference" && previous?.type !== "text")
+      || (previous?.type === "issue-reference" && segment.type !== "text")
+    ) {
+      normalized.push(textSegment());
+    }
+    const adjacent = normalized.at(-1);
+    if (segment.type === "text" && adjacent?.type === "text") {
       normalized[normalized.length - 1] = {
-        ...previous,
-        text: previous.text + segment.text,
+        ...adjacent,
+        text: adjacent.text + segment.text,
       };
     } else {
       normalized.push(segment);
@@ -273,6 +327,44 @@ function PersistedImageBlock({
         <LinearIcon name="close" />
       </button>
     </figure>
+  );
+}
+
+function IssueReferenceChip({
+  segment,
+  task,
+  disabled,
+  onRemove,
+}: {
+  segment: IssueReferenceSegment;
+  task: Task;
+  disabled: boolean;
+  onRemove: () => void;
+}) {
+  const { text } = useTaskboardI18n();
+  const displayIdentifier = task.externalKey ?? task.identifier;
+
+  return (
+    <button
+      type="button"
+      className={`issue-reference-inline inline-media-issue-reference issue-reference-status-${task.status}`}
+      disabled={disabled}
+      aria-label={text(
+        `${displayIdentifier} ${task.title}，按退格键或删除键移除`,
+        `${displayIdentifier} ${task.title}, press Backspace or Delete to remove`,
+      )}
+      onKeyDown={(event) => {
+        if (event.key !== "Backspace" && event.key !== "Delete") return;
+        event.preventDefault();
+        onRemove();
+      }}
+    >
+      <span className={`status-icon issue-reference-status status-icon-${STATUS_DETAILS[task.status].tone}`}>
+        <ColumnStatusIcon status={task.status === "backlog" ? "todo" : task.status} />
+      </span>
+      <span className="issue-reference-id">{displayIdentifier}</span>
+      <span className="issue-reference-title">{task.title}</span>
+    </button>
   );
 }
 
@@ -363,6 +455,27 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       )));
     }
 
+    function removeIssueReference(id: string) {
+      const index = segments.findIndex((segment) => segment.id === id);
+      if (index < 0) return;
+      const previous = segments[index - 1];
+      const next = segments[index + 1];
+      const nextSegments = normalizeSegments(segments.filter((segment) => segment.id !== id));
+      const focusId = previous?.type === "text"
+        ? previous.id
+        : next?.type === "text"
+          ? next.id
+          : null;
+      if (focusId) {
+        pendingFocus.current = {
+          id: focusId,
+          offset: previous?.type === "text" ? previous.text.length : 0,
+        };
+      }
+      setMention(null);
+      onChange(nextSegments);
+    }
+
     function updateMention(
       segment: InlineTextSegment,
       value: string,
@@ -397,17 +510,26 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       const displayIdentifier = task.externalKey ?? task.identifier;
       const route = new URLSearchParams({ project: task.projectId, issue: task.identifier });
       const suffix = segment.text.slice(mention.end);
-      const reference = `[@${displayIdentifier}](?${route})${/^\s/.test(suffix) ? "" : " "}`;
-      const nextText = `${segment.text.slice(0, mention.start)}${reference}${suffix}`;
-      pendingFocus.current = { id: segment.id, offset: mention.start + reference.length };
+      const insertSpace = !/^\s/.test(suffix);
+      const before = { ...segment, text: segment.text.slice(0, mention.start) };
+      const reference: IssueReferenceSegment = {
+        id: segmentId("issue"),
+        type: "issue-reference",
+        markdown: `[@${displayIdentifier}](?${route})`,
+        taskId: task.id,
+      };
+      const after = textSegment(`${insertSpace ? " " : ""}${suffix}`);
+      pendingFocus.current = { id: after.id, offset: insertSpace ? 1 : 0 };
       setMention(null);
-      onChange(segments.map((candidate) => (
-        candidate.id === segment.id ? { ...segment, text: nextText } : candidate
-      )));
+      onChange(normalizeSegments(segments.flatMap((candidate) => (
+        candidate.id === segment.id ? [before, reference, after] : [candidate]
+      ))));
     }
 
     function handleTextareaKeyDown(
       event: KeyboardEvent<HTMLTextAreaElement>,
+      segment: InlineTextSegment,
+      index: number,
     ) {
       if (event.nativeEvent.isComposing || event.keyCode === 229) {
         onKeyDown?.(event);
@@ -431,6 +553,26 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       if (mention && event.key === "Escape") {
         event.preventDefault();
         setMention(null);
+        return;
+      }
+      if (
+        event.key === "Backspace"
+        && event.currentTarget.selectionStart === 0
+        && event.currentTarget.selectionEnd === 0
+        && segments[index - 1]?.type === "issue-reference"
+      ) {
+        event.preventDefault();
+        removeIssueReference(segments[index - 1].id);
+        return;
+      }
+      if (
+        event.key === "Delete"
+        && event.currentTarget.selectionStart === segment.text.length
+        && event.currentTarget.selectionEnd === segment.text.length
+        && segments[index + 1]?.type === "issue-reference"
+      ) {
+        event.preventDefault();
+        removeIssueReference(segments[index + 1].id);
         return;
       }
       onKeyDown?.(event);
@@ -483,9 +625,13 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
     const isEmpty = segments.every((segment) => (
       segment.type === "text" ? segment.text.length === 0 : false
     ));
+    const hasIssueReferences = segments.some((segment) => segment.type === "issue-reference");
 
     return (
-      <div className={`inline-media-composer ${className}`.trim()} aria-label={ariaLabel}>
+      <div
+        className={`inline-media-composer${hasIssueReferences ? " has-issue-references" : ""} ${className}`.trim()}
+        aria-label={ariaLabel}
+      >
         {segments.map((segment, index) => (
           segment.type === "text" ? (
             <textarea
@@ -505,7 +651,7 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
                 updateMention(segment, event.target.value, event.currentTarget);
               }}
               onPaste={(event) => pasteImages(event, segment)}
-              onKeyDown={handleTextareaKeyDown}
+              onKeyDown={(event) => handleTextareaKeyDown(event, segment, index)}
               onKeyUp={(event) => {
                 if (["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) {
                   updateMention(segment, event.currentTarget.value, event.currentTarget);
@@ -521,12 +667,20 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
               disabled={disabled}
               onRemove={() => removeImage(segment.id)}
             />
-          ) : (
+          ) : segment.type === "persisted-image" ? (
             <PersistedImageBlock
               key={segment.id}
               segment={segment}
               disabled={disabled}
               onRemove={() => removeImage(segment.id)}
+            />
+          ) : (
+            <IssueReferenceChip
+              key={segment.id}
+              segment={segment}
+              task={mentionTasks.find((task) => task.id === segment.taskId)!}
+              disabled={disabled}
+              onRemove={() => removeIssueReference(segment.id)}
             />
           )
         ))}

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -48,7 +48,8 @@ interface IssueReferenceSegment {
   id: string;
   type: "issue-reference";
   markdown: string;
-  taskId: string;
+  identifier: string;
+  taskId: string | null;
 }
 
 interface MarkdownAstNode {
@@ -79,13 +80,14 @@ export interface InlineMediaComposerHandle {
 interface InlineMediaComposerProps {
   segments: InlineMediaSegment[];
   mentionTasks?: readonly Task[];
+  referenceTasks: readonly Task[];
   placeholder: string;
   ariaLabel: string;
   disabled?: boolean;
   className?: string;
   onChange: (segments: InlineMediaSegment[]) => void;
   onError: (message: InlineMediaError | null) => void;
-  onKeyDown?: KeyboardEventHandler<HTMLTextAreaElement>;
+  onKeyDown?: KeyboardEventHandler<HTMLDivElement>;
 }
 
 interface IssueMention {
@@ -121,12 +123,18 @@ function imageSegment(file: File): InlineImageSegment {
 
 export function createInlineMediaSegments(
   text = "",
-  mentionTasks: readonly Task[] = EMPTY_MENTION_TASKS,
+  referenceTasks: readonly Task[] = EMPTY_MENTION_TASKS,
 ): InlineMediaSegment[] {
   const segments: InlineMediaSegment[] = [];
   const items: Array<
     | { type: "persisted-image"; start: number; end: number; alt: string; url: string }
-    | { type: "issue-reference"; start: number; end: number; taskId: string }
+    | {
+        type: "issue-reference";
+        start: number;
+        end: number;
+        identifier: string;
+        taskId: string | null;
+      }
   > = [];
   const root = inlineMediaMarkdownParser.parse(text);
   const getDefinition = definitions(root);
@@ -159,16 +167,17 @@ export function createInlineMediaSegments(
       const projectId = new URLSearchParams(node.url).get("project");
       const identifier = readIssueIdentifier(node.url);
       const task = projectId && identifier
-        ? mentionTasks.find((candidate) => (
+        ? referenceTasks.find((candidate) => (
             candidate.projectId === projectId && candidate.identifier === identifier
           ))
         : null;
-      if (task) {
+      if (projectId && identifier) {
         items.push({
           type: "issue-reference",
           start: node.position.start.offset,
           end: node.position.end.offset,
-          taskId: task.id,
+          identifier: task?.externalKey ?? identifier,
+          taskId: task?.id ?? null,
         });
       }
     }
@@ -193,6 +202,7 @@ export function createInlineMediaSegments(
         id: segmentId("issue"),
         type: "issue-reference",
         markdown: text.slice(item.start, item.end),
+        identifier: item.identifier,
         taskId: item.taskId,
       });
     }
@@ -337,33 +347,41 @@ function IssueReferenceChip({
   onRemove,
 }: {
   segment: IssueReferenceSegment;
-  task: Task;
+  task: Task | null;
   disabled: boolean;
   onRemove: () => void;
 }) {
   const { text } = useTaskboardI18n();
-  const displayIdentifier = task.externalKey ?? task.identifier;
+  const displayIdentifier = task?.externalKey ?? segment.identifier;
 
   return (
     <button
       type="button"
-      className={`issue-reference-inline inline-media-issue-reference issue-reference-status-${task.status}`}
+      className={`issue-reference-inline inline-media-issue-reference${task ? ` issue-reference-status-${task.status}` : ""}`}
       disabled={disabled}
-      aria-label={text(
-        `${displayIdentifier} ${task.title}，按退格键或删除键移除`,
-        `${displayIdentifier} ${task.title}, press Backspace or Delete to remove`,
-      )}
+      aria-label={task
+        ? text(
+            `${displayIdentifier} ${task.title}，按退格键或删除键移除`,
+            `${displayIdentifier} ${task.title}, press Backspace or Delete to remove`,
+          )
+        : text(
+            `${displayIdentifier}，按退格键或删除键移除`,
+            `${displayIdentifier}, press Backspace or Delete to remove`,
+          )}
       onKeyDown={(event) => {
+        if (event.defaultPrevented) return;
         if (event.key !== "Backspace" && event.key !== "Delete") return;
         event.preventDefault();
         onRemove();
       }}
     >
-      <span className={`status-icon issue-reference-status status-icon-${STATUS_DETAILS[task.status].tone}`}>
-        <ColumnStatusIcon status={task.status === "backlog" ? "todo" : task.status} />
-      </span>
+      {task && (
+        <span className={`status-icon issue-reference-status status-icon-${STATUS_DETAILS[task.status].tone}`}>
+          <ColumnStatusIcon status={task.status === "backlog" ? "todo" : task.status} />
+        </span>
+      )}
       <span className="issue-reference-id">{displayIdentifier}</span>
-      <span className="issue-reference-title">{task.title}</span>
+      {task && <span className="issue-reference-title">{task.title}</span>}
     </button>
   );
 }
@@ -372,6 +390,7 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
   function InlineMediaComposer({
     segments,
     mentionTasks = EMPTY_MENTION_TASKS,
+    referenceTasks,
     placeholder,
     ariaLabel,
     disabled = false,
@@ -380,6 +399,7 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
     onError,
     onKeyDown,
   }, ref) {
+    const rootRef = useRef<HTMLDivElement>(null);
     const textareas = useRef(new Map<string, HTMLTextAreaElement>());
     const pendingFocus = useRef<{ id: string; offset: number } | null>(null);
     const { text } = useTaskboardI18n();
@@ -418,6 +438,13 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
     useEffect(() => {
       if (disabled || mentionTasks.length === 0) setMention(null);
     }, [disabled, mentionTasks.length]);
+
+    useEffect(() => {
+      if (!allSelected) return;
+      const exitAllSelection = () => setAllSelected(false);
+      document.addEventListener("pointerdown", exitAllSelection, true);
+      return () => document.removeEventListener("pointerdown", exitAllSelection, true);
+    }, [allSelected]);
 
     useImperativeHandle(ref, () => ({
       focus() {
@@ -530,6 +557,7 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
         id: segmentId("issue"),
         type: "issue-reference",
         markdown: `[@${displayIdentifier}](?${route})`,
+        identifier: displayIdentifier,
         taskId: task.id,
       };
       const after = textSegment(`${insertSpace ? " " : ""}${suffix}`);
@@ -545,13 +573,62 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       segment: InlineTextSegment,
       index: number,
     ) {
+      if (event.defaultPrevented || event.nativeEvent.isComposing || event.keyCode === 229) return;
+      if (
+        event.key === "Backspace"
+        && event.currentTarget.selectionStart === 0
+        && event.currentTarget.selectionEnd === 0
+        && segments[index - 1]?.type === "issue-reference"
+      ) {
+        event.preventDefault();
+        removeIssueReference(segments[index - 1].id);
+        return;
+      }
+      if (
+        event.key === "Delete"
+        && event.currentTarget.selectionStart === segment.text.length
+        && event.currentTarget.selectionEnd === segment.text.length
+        && segments[index + 1]?.type === "issue-reference"
+      ) {
+        event.preventDefault();
+        removeIssueReference(segments[index + 1].id);
+        return;
+      }
+    }
+
+    function selectNearestTextSegment(target: EventTarget | null) {
+      const root = rootRef.current;
+      if (!root || !(target instanceof Element)) return;
+      let segmentElement = target;
+      while (segmentElement.parentElement && segmentElement.parentElement !== root) {
+        segmentElement = segmentElement.parentElement;
+      }
+      const childIndex = segmentElement.parentElement === root
+        ? Array.from(root.children).indexOf(segmentElement)
+        : 0;
+      const origin = Math.min(Math.max(childIndex, 0), segments.length - 1);
+      for (let distance = 0; distance < segments.length; distance += 1) {
+        const indexes = distance === 0 ? [origin] : [origin - distance, origin + distance];
+        for (const index of indexes) {
+          const candidate = segments[index];
+          if (candidate?.type !== "text") continue;
+          const textarea = textareas.current.get(candidate.id);
+          if (!textarea) continue;
+          textarea.focus();
+          textarea.setSelectionRange(0, candidate.text.length);
+          return;
+        }
+      }
+    }
+
+    function handleComposerKeyDown(event: KeyboardEvent<HTMLDivElement>) {
       if (event.nativeEvent.isComposing || event.keyCode === 229) {
         onKeyDown?.(event);
         return;
       }
       if ((event.metaKey || event.ctrlKey) && event.key.toLocaleLowerCase() === "a") {
         event.preventDefault();
-        event.currentTarget.setSelectionRange(0, segment.text.length);
+        selectNearestTextSegment(event.target);
         setAllSelected(true);
         setMention(null);
         return;
@@ -563,7 +640,16 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       }
       if (
         allSelected
-        && ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)
+        && [
+          "ArrowUp",
+          "ArrowDown",
+          "ArrowLeft",
+          "ArrowRight",
+          "Home",
+          "End",
+          "PageUp",
+          "PageDown",
+        ].includes(event.key)
       ) {
         setAllSelected(false);
       }
@@ -585,26 +671,6 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       if (mention && event.key === "Escape") {
         event.preventDefault();
         setMention(null);
-        return;
-      }
-      if (
-        event.key === "Backspace"
-        && event.currentTarget.selectionStart === 0
-        && event.currentTarget.selectionEnd === 0
-        && segments[index - 1]?.type === "issue-reference"
-      ) {
-        event.preventDefault();
-        removeIssueReference(segments[index - 1].id);
-        return;
-      }
-      if (
-        event.key === "Delete"
-        && event.currentTarget.selectionStart === segment.text.length
-        && event.currentTarget.selectionEnd === segment.text.length
-        && segments[index + 1]?.type === "issue-reference"
-      ) {
-        event.preventDefault();
-        removeIssueReference(segments[index + 1].id);
         return;
       }
       onKeyDown?.(event);
@@ -653,7 +719,7 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       }
 
       const pastedText = event.clipboardData.getData("text/plain");
-      const insertion = createInlineMediaSegments(pastedText, mentionTasks);
+      const insertion = createInlineMediaSegments(pastedText, referenceTasks);
       if (!insertion.some((candidate) => candidate.type !== "text")) return;
       event.preventDefault();
 
@@ -698,15 +764,20 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
 
     return (
       <div
+        ref={rootRef}
         className={`inline-media-composer${hasIssueReferences ? " has-issue-references" : ""}${allSelected ? " is-all-selected" : ""} ${className}`.trim()}
         aria-label={ariaLabel}
+        onKeyDownCapture={handleComposerKeyDown}
         onCopy={(event) => {
           if (!allSelected) return;
           event.preventDefault();
           event.clipboardData.setData("text/plain", serializeInlineMedia(segments));
         }}
-        onPointerDown={() => setAllSelected(false)}
-        onFocusCapture={() => setAllSelected(false)}
+        onBlurCapture={(event) => {
+          if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+            setAllSelected(false);
+          }
+        }}
       >
         {segments.map((segment, index) => (
           segment.type === "text" ? (
@@ -754,7 +825,9 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
             <IssueReferenceChip
               key={segment.id}
               segment={segment}
-              task={mentionTasks.find((task) => task.id === segment.taskId)!}
+              task={segment.taskId
+                ? referenceTasks.find((task) => task.id === segment.taskId) ?? null
+                : null}
               disabled={disabled}
               onRemove={() => removeIssueReference(segment.id)}
             />

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -475,6 +475,7 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
     const pendingMentionUpdate = useRef(false);
     const pendingAtomHostRevision = useRef(0);
     const composing = useRef(false);
+    const nativeInputPending = useRef(false);
     const [atomHostRevision, refreshAtomHosts] = useState(0);
     const [mention, setMention] = useState<IssueMention | null>(null);
     const [activeMentionIndex, setActiveMentionIndex] = useState(0);
@@ -495,6 +496,15 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
     useLayoutEffect(() => {
       const root = rootRef.current;
       if (!root) return;
+      if (nativeInputPending.current) {
+        nativeInputPending.current = false;
+        pendingSelection.current = null;
+        if (pendingMentionUpdate.current) {
+          pendingMentionUpdate.current = false;
+          updateMentionFromSelection();
+        }
+        return;
+      }
       const fragment = document.createDocumentFragment();
       const nextAtomHosts = new Map<string, HTMLElement>();
 
@@ -881,19 +891,37 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
 
     function handleBeforeInput(input: InputEvent) {
       if (disabled || composing.current) return;
-      const range = currentLogicalRange();
-      if (!range) return;
-      let { start, end } = range;
+      const targetRange = input.getTargetRanges()[0];
+      if (!targetRange) return;
+      const start = logicalOffsetForPoint(
+        targetRange.startContainer,
+        targetRange.startOffset,
+        "start",
+      );
+      const end = logicalOffsetForPoint(
+        targetRange.endContainer,
+        targetRange.endOffset,
+        "end",
+      );
+      if (start === null || end === null) return;
+      const startElement = segmentElement(targetRange.startContainer);
+      const endElement = segmentElement(targetRange.endContainer);
+      const targetSegment = startElement?.dataset.inlineMediaSegment
+        ? segments.find((segment) => segment.id === startElement.dataset.inlineMediaSegment)
+        : null;
+      const nativeTextEdit = targetSegment?.type === "text"
+        && startElement === endElement
+        && (
+          ["insertText", "insertReplacementText"].includes(input.inputType)
+          || input.inputType.startsWith("delete")
+        );
+      if (nativeTextEdit) return;
       let insertion: InlineMediaSegment[] | null = null;
       if (["insertText", "insertReplacementText"].includes(input.inputType)) {
         insertion = [textSegment(input.data ?? "")];
       } else if (["insertLineBreak", "insertParagraph"].includes(input.inputType)) {
         insertion = [textSegment("\n")];
       } else if (input.inputType.startsWith("delete")) {
-        if (start === end && input.inputType.includes("Backward")) start = Math.max(0, start - 1);
-        if (start === end && input.inputType.includes("Forward")) {
-          end = Math.min(segmentsLength(segments), end + 1);
-        }
         insertion = [];
       }
       if (insertion === null) return;
@@ -959,8 +987,8 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
           next.push(textSegment(child.textContent));
         }
       }
-      const range = currentLogicalRange();
-      if (range) pendingSelection.current = range.end;
+      nativeInputPending.current = true;
+      pendingSelection.current = null;
       pendingMentionUpdate.current = true;
       onChange(normalizeSegments(next));
     }
@@ -1029,7 +1057,9 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
               serializeInlineMediaRange(segments, range.start, range.end),
             );
           }}
-          onKeyUp={updateMentionFromSelection}
+          onKeyUp={(event) => {
+            if (event.key !== "Escape") updateMentionFromSelection();
+          }}
           onPointerUp={() => {
             syncAtomSelection();
             updateMentionFromSelection();

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -896,6 +896,32 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       if (disabled || composing.current) return;
       const targetRange = input.getTargetRanges()[0];
       if (!targetRange) return;
+      const root = rootRef.current;
+      const emptySegment = segments.length === 1 && segments[0].type === "text"
+        && segments[0].text.length === 0
+        ? segments[0]
+        : null;
+      if (
+        root
+        && emptySegment
+        && targetRange.startContainer === root
+        && root.childNodes.length === 1
+        && root.firstChild instanceof HTMLBRElement
+        && ["insertText", "insertReplacementText"].includes(input.inputType)
+      ) {
+        const element = document.createElement("span");
+        element.dataset.inlineMediaSegment = emptySegment.id;
+        element.className = "inline-media-text";
+        element.append(document.createElement("br"));
+        root.replaceChildren(element);
+        const range = document.createRange();
+        range.setStart(element, 0);
+        range.collapse(true);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+        return;
+      }
       const start = logicalOffsetForPoint(
         targetRange.startContainer,
         targetRange.startOffset,
@@ -912,12 +938,18 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       const targetSegment = startElement?.dataset.inlineMediaSegment
         ? segments.find((segment) => segment.id === startElement.dataset.inlineMediaSegment)
         : null;
-      const nativeTextEdit = input.inputType.startsWith("delete")
-        || (
-          targetSegment?.type === "text"
-          && startElement === endElement
-          && ["insertText", "insertReplacementText"].includes(input.inputType)
-        );
+      const sameTextSegment = targetSegment?.type === "text" && startElement === endElement;
+      const fullDelete = start === 0 && end > start && end === segmentsLength(segments);
+      const nativeTextEdit = (
+        sameTextSegment
+        && (
+          input.inputType.startsWith("delete")
+          || ["insertText", "insertReplacementText"].includes(input.inputType)
+        )
+      ) || (
+        input.inputType.startsWith("delete")
+        && fullDelete
+      );
       if (nativeTextEdit) return;
       let insertion: InlineMediaSegment[] | null = null;
       if (["insertText", "insertReplacementText"].includes(input.inputType)) {

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -385,6 +385,7 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
     const { text } = useTaskboardI18n();
     const [mention, setMention] = useState<IssueMention | null>(null);
     const [activeMentionIndex, setActiveMentionIndex] = useState(0);
+    const [allSelected, setAllSelected] = useState(false);
     const mentionResults = useMemo(() => {
       if (!mention) return [];
       const query = mention.query.toLocaleLowerCase();
@@ -450,9 +451,22 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
     }), [onChange, onError, segments]);
 
     function changeText(id: string, text: string) {
+      if (allSelected) {
+        setAllSelected(false);
+        onChange([{ id, type: "text", text }]);
+        return;
+      }
       onChange(segments.map((segment) => (
         segment.id === id && segment.type === "text" ? { ...segment, text } : segment
       )));
+    }
+
+    function clearAll() {
+      const empty = textSegment();
+      pendingFocus.current = { id: empty.id, offset: 0 };
+      setAllSelected(false);
+      setMention(null);
+      onChange([empty]);
     }
 
     function removeIssueReference(id: string) {
@@ -535,6 +549,24 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
         onKeyDown?.(event);
         return;
       }
+      if ((event.metaKey || event.ctrlKey) && event.key.toLocaleLowerCase() === "a") {
+        event.preventDefault();
+        event.currentTarget.setSelectionRange(0, segment.text.length);
+        setAllSelected(true);
+        setMention(null);
+        return;
+      }
+      if (allSelected && (event.key === "Backspace" || event.key === "Delete")) {
+        event.preventDefault();
+        clearAll();
+        return;
+      }
+      if (
+        allSelected
+        && ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)
+      ) {
+        setAllSelected(false);
+      }
       if (mention && event.key === "ArrowDown" && mentionResults.length > 0) {
         event.preventDefault();
         setActiveMentionIndex((index) => (index + 1) % mentionResults.length);
@@ -578,44 +610,81 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       onKeyDown?.(event);
     }
 
-    function pasteImages(
+    function pasteContent(
       event: ClipboardEvent<HTMLTextAreaElement>,
       segment: InlineTextSegment,
     ) {
       const clipboardFiles = clipboardImages(event.clipboardData);
-      if (clipboardFiles.length === 0) return;
-      event.preventDefault();
+      if (clipboardFiles.length > 0) {
+        event.preventDefault();
 
-      const oversized = clipboardFiles.find((file) => file.size > MAX_ATTACHMENT_SIZE);
-      if (oversized) {
-        onError([
-          `“${oversized.name}” 超过 25 MB，无法上传。`,
-          `“${oversized.name}” is larger than 25 MB and cannot be uploaded.`,
-        ]);
+        const oversized = clipboardFiles.find((file) => file.size > MAX_ATTACHMENT_SIZE);
+        if (oversized) {
+          onError([
+            `“${oversized.name}” 超过 25 MB，无法上传。`,
+            `“${oversized.name}” is larger than 25 MB and cannot be uploaded.`,
+          ]);
+          return;
+        }
+
+        const existing = new Set(inlineMediaImages(segments).map((image) => fileKey(image.file)));
+        const images = clipboardFiles.filter((file) => {
+          const key = fileKey(file);
+          if (existing.has(key)) return false;
+          existing.add(key);
+          return true;
+        });
+        if (images.length === 0) return;
+        onError(null);
+
+        const textarea = event.currentTarget;
+        const start = textarea.selectionStart;
+        const end = textarea.selectionEnd;
+        const before = { ...segment, text: segment.text.slice(0, start) };
+        const after = textSegment(segment.text.slice(end));
+        const insertion = images.map(imageSegment);
+        const next = segments.flatMap((candidate) => (
+          candidate.id === segment.id ? [before, ...insertion, after] : [candidate]
+        ));
+        pendingFocus.current = { id: after.id, offset: 0 };
+        setAllSelected(false);
+        onChange(next);
         return;
       }
 
-      const existing = new Set(inlineMediaImages(segments).map((image) => fileKey(image.file)));
-      const images = clipboardFiles.filter((file) => {
-        const key = fileKey(file);
-        if (existing.has(key)) return false;
-        existing.add(key);
-        return true;
-      });
-      if (images.length === 0) return;
-      onError(null);
+      const pastedText = event.clipboardData.getData("text/plain");
+      const insertion = createInlineMediaSegments(pastedText, mentionTasks);
+      if (!insertion.some((candidate) => candidate.type !== "text")) return;
+      event.preventDefault();
 
       const textarea = event.currentTarget;
       const start = textarea.selectionStart;
       const end = textarea.selectionEnd;
-      const before = { ...segment, text: segment.text.slice(0, start) };
-      const after = textSegment(segment.text.slice(end));
-      const insertion = images.map(imageSegment);
-      const next = segments.flatMap((candidate) => (
-        candidate.id === segment.id ? [before, ...insertion, after] : [candidate]
-      ));
-      pendingFocus.current = { id: after.id, offset: 0 };
-      onChange(next);
+      if (allSelected) {
+        const finalText = insertion.at(-1) as InlineTextSegment;
+        pendingFocus.current = { id: finalText.id, offset: finalText.text.length };
+        setAllSelected(false);
+        setMention(null);
+        onChange(insertion);
+        return;
+      }
+
+      const firstText = insertion[0] as InlineTextSegment;
+      const finalText = insertion.at(-1) as InlineTextSegment;
+      const focusOffset = finalText.text.length;
+      insertion[0] = {
+        ...segment,
+        text: segment.text.slice(0, start) + firstText.text,
+      };
+      insertion[insertion.length - 1] = {
+        ...finalText,
+        text: finalText.text + segment.text.slice(end),
+      };
+      pendingFocus.current = { id: finalText.id, offset: focusOffset };
+      setMention(null);
+      onChange(segments.flatMap((candidate) => (
+        candidate.id === segment.id ? insertion : [candidate]
+      )));
     }
 
     function removeImage(id: string) {
@@ -629,8 +698,15 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
 
     return (
       <div
-        className={`inline-media-composer${hasIssueReferences ? " has-issue-references" : ""} ${className}`.trim()}
+        className={`inline-media-composer${hasIssueReferences ? " has-issue-references" : ""}${allSelected ? " is-all-selected" : ""} ${className}`.trim()}
         aria-label={ariaLabel}
+        onCopy={(event) => {
+          if (!allSelected) return;
+          event.preventDefault();
+          event.clipboardData.setData("text/plain", serializeInlineMedia(segments));
+        }}
+        onPointerDown={() => setAllSelected(false)}
+        onFocusCapture={() => setAllSelected(false)}
       >
         {segments.map((segment, index) => (
           segment.type === "text" ? (
@@ -650,7 +726,7 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
                 resizeTextarea(event.currentTarget);
                 updateMention(segment, event.target.value, event.currentTarget);
               }}
-              onPaste={(event) => pasteImages(event, segment)}
+              onPaste={(event) => pasteContent(event, segment)}
               onKeyDown={(event) => handleTextareaKeyDown(event, segment, index)}
               onKeyUp={(event) => {
                 if (["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) {

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -471,6 +471,7 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
   }, ref) {
     const rootRef = useRef<HTMLDivElement>(null);
     const atomHosts = useRef(new Map<string, HTMLElement>());
+    const nativeSegments = useRef(new Map<string, InlineMediaSegment>());
     const pendingSelection = useRef<number | null>(null);
     const pendingMentionUpdate = useRef(false);
     const pendingAtomHostRevision = useRef(0);
@@ -509,11 +510,13 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       const nextAtomHosts = new Map<string, HTMLElement>();
 
       for (const segment of segments) {
+        nativeSegments.current.set(segment.id, segment);
         const element = document.createElement("span");
         element.dataset.inlineMediaSegment = segment.id;
         if (segment.type === "text") {
           element.className = "inline-media-text";
-          element.textContent = segment.text;
+          if (segment.text) element.textContent = segment.text;
+          else element.append(document.createElement("br"));
         } else {
           element.className = segment.type === "issue-reference"
             ? "inline-media-atom"
@@ -909,11 +912,11 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       const targetSegment = startElement?.dataset.inlineMediaSegment
         ? segments.find((segment) => segment.id === startElement.dataset.inlineMediaSegment)
         : null;
-      const nativeTextEdit = targetSegment?.type === "text"
-        && startElement === endElement
-        && (
-          ["insertText", "insertReplacementText"].includes(input.inputType)
-          || input.inputType.startsWith("delete")
+      const nativeTextEdit = input.inputType.startsWith("delete")
+        || (
+          targetSegment?.type === "text"
+          && startElement === endElement
+          && ["insertText", "insertReplacementText"].includes(input.inputType)
         );
       if (nativeTextEdit) return;
       let insertion: InlineMediaSegment[] | null = null;
@@ -967,8 +970,10 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
     function syncSegmentsFromDom() {
       const root = rootRef.current;
       if (!root) return;
-      const existing = new Map(segments.map((segment) => [segment.id, segment]));
+      const existing = nativeSegments.current;
+      for (const segment of segments) existing.set(segment.id, segment);
       const next: InlineMediaSegment[] = [];
+      const nextAtomHosts = new Map<string, HTMLElement>();
       for (const child of root.childNodes) {
         if (child instanceof Text) {
           if (child.data) next.push(textSegment(child.data));
@@ -981,16 +986,24 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
           next.push({ ...segment, text: child.textContent ?? "" });
         } else if (segment) {
           next.push(segment);
+          nextAtomHosts.set(segment.id, child);
         } else if (child.tagName === "BR" && root.childNodes.length > 1) {
           next.push(textSegment("\n"));
         } else if (child.textContent) {
           next.push(textSegment(child.textContent));
         }
       }
+      if (next.length === 0) {
+        const text = segments.find((segment): segment is InlineTextSegment => segment.type === "text");
+        if (text) next.push({ ...text, text: "" });
+      }
+      const normalized = normalizeSegments(next);
+      for (const segment of normalized) existing.set(segment.id, segment);
+      atomHosts.current = nextAtomHosts;
       nativeInputPending.current = true;
       pendingSelection.current = null;
       pendingMentionUpdate.current = true;
-      onChange(normalizeSegments(next));
+      onChange(normalized);
     }
 
     const isEmpty = segments.every((segment) => (

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -10,6 +10,7 @@ import {
   type KeyboardEvent,
   type KeyboardEventHandler,
 } from "react";
+import { createPortal } from "react-dom";
 import { definitions } from "mdast-util-definitions";
 import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
@@ -95,7 +96,8 @@ interface IssueMention {
   start: number;
   end: number;
   query: string;
-  anchor: HTMLTextAreaElement;
+  anchor: HTMLElement;
+  anchorRect: DOMRect;
 }
 
 let segmentSequence = 0;
@@ -275,10 +277,68 @@ function normalizeSegments(segments: InlineMediaSegment[]): InlineMediaSegment[]
   return normalized;
 }
 
-function resizeTextarea(element: HTMLTextAreaElement | null) {
-  if (!element) return;
-  element.style.height = "0px";
-  element.style.height = `${element.scrollHeight}px`;
+function segmentLength(segment: InlineMediaSegment): number {
+  return segment.type === "text" ? segment.text.length : 1;
+}
+
+function segmentsLength(segments: InlineMediaSegment[]): number {
+  return segments.reduce((length, segment) => length + segmentLength(segment), 0);
+}
+
+function serializeInlineMediaRange(
+  segments: InlineMediaSegment[],
+  start: number,
+  end: number,
+): string {
+  let offset = 0;
+  return segments.map((segment) => {
+    const length = segmentLength(segment);
+    const segmentStart = offset;
+    const segmentEnd = offset + length;
+    offset = segmentEnd;
+    if (end <= segmentStart || start >= segmentEnd) return "";
+    if (segment.type !== "text") return serializeInlineMedia([segment]);
+    return segment.text.slice(
+      Math.max(start - segmentStart, 0),
+      Math.min(end - segmentStart, length),
+    );
+  }).join("");
+}
+
+function replaceInlineMediaRange(
+  segments: InlineMediaSegment[],
+  start: number,
+  end: number,
+  insertion: InlineMediaSegment[],
+): { segments: InlineMediaSegment[]; caret: number } {
+  const before: InlineMediaSegment[] = [];
+  const after: InlineMediaSegment[] = [];
+  let offset = 0;
+
+  for (const segment of segments) {
+    const length = segmentLength(segment);
+    const segmentStart = offset;
+    const segmentEnd = offset + length;
+    offset = segmentEnd;
+    if (segmentEnd <= start) before.push(segment);
+    else if (segment.type === "text" && segmentStart < start) {
+      before.push({ ...segment, text: segment.text.slice(0, start - segmentStart) });
+    }
+    if (segmentStart >= end) after.push(segment);
+    else if (segment.type === "text" && segmentEnd > end) {
+      after.push({ ...segment, text: segment.text.slice(end - segmentStart) });
+    }
+  }
+
+  const usedIds = new Set([...before, ...insertion].map((segment) => segment.id));
+  const uniqueAfter = after.map((segment) => {
+    if (!usedIds.has(segment.id)) return segment;
+    return { ...segment, id: segmentId(segment.type === "text" ? "text" : "segment") };
+  });
+  return {
+    segments: normalizeSegments([...before, ...insertion, ...uniqueAfter]),
+    caret: segmentsLength(before) + segmentsLength(insertion),
+  };
 }
 
 function PendingImageBlock({
@@ -300,8 +360,12 @@ function PendingImageBlock({
   }, [segment.file]);
 
   return (
-    <figure className="inline-media-image">
-      {previewUrl && <img src={previewUrl} alt={segment.file.name} />}
+    <figure
+      className="inline-media-image"
+      contentEditable={false}
+      data-inline-media-segment={segment.id}
+    >
+      {previewUrl && <img src={previewUrl} alt={segment.file.name} draggable={false} />}
       <button
         type="button"
         disabled={disabled}
@@ -326,8 +390,12 @@ function PersistedImageBlock({
   const { text } = useTaskboardI18n();
 
   return (
-    <figure className="inline-media-image">
-      <img src={resolvePersistedAttachmentUrl(segment.url)} alt={segment.alt} />
+    <figure
+      className="inline-media-image"
+      contentEditable={false}
+      data-inline-media-segment={segment.id}
+    >
+      <img src={resolvePersistedAttachmentUrl(segment.url)} alt={segment.alt} draggable={false} />
       <button
         type="button"
         disabled={disabled}
@@ -358,6 +426,8 @@ function IssueReferenceChip({
     <button
       type="button"
       className={`issue-reference-inline inline-media-issue-reference${task ? ` issue-reference-status-${task.status}` : ""}`}
+      contentEditable={false}
+      data-inline-media-segment={segment.id}
       disabled={disabled}
       aria-label={task
         ? text(
@@ -400,12 +470,14 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
     onKeyDown,
   }, ref) {
     const rootRef = useRef<HTMLDivElement>(null);
-    const textareas = useRef(new Map<string, HTMLTextAreaElement>());
-    const pendingFocus = useRef<{ id: string; offset: number } | null>(null);
-    const { text } = useTaskboardI18n();
+    const atomHosts = useRef(new Map<string, HTMLElement>());
+    const pendingSelection = useRef<number | null>(null);
+    const pendingMentionUpdate = useRef(false);
+    const pendingAtomHostRevision = useRef(0);
+    const composing = useRef(false);
+    const [atomHostRevision, refreshAtomHosts] = useState(0);
     const [mention, setMention] = useState<IssueMention | null>(null);
     const [activeMentionIndex, setActiveMentionIndex] = useState(0);
-    const [allSelected, setAllSelected] = useState(false);
     const mentionResults = useMemo(() => {
       if (!mention) return [];
       const query = mention.query.toLocaleLowerCase();
@@ -421,15 +493,42 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
     );
 
     useLayoutEffect(() => {
-      for (const element of textareas.current.values()) resizeTextarea(element);
-      const focus = pendingFocus.current;
-      if (!focus) return;
-      const target = textareas.current.get(focus.id);
-      if (!target) return;
-      target.focus();
-      target.setSelectionRange(focus.offset, focus.offset);
-      pendingFocus.current = null;
+      const root = rootRef.current;
+      if (!root) return;
+      const fragment = document.createDocumentFragment();
+      const nextAtomHosts = new Map<string, HTMLElement>();
+
+      for (const segment of segments) {
+        const element = document.createElement("span");
+        element.dataset.inlineMediaSegment = segment.id;
+        if (segment.type === "text") {
+          element.className = "inline-media-text";
+          element.textContent = segment.text;
+        } else {
+          element.className = segment.type === "issue-reference"
+            ? "inline-media-atom"
+            : "inline-media-atom inline-media-image-atom";
+          element.contentEditable = "false";
+          nextAtomHosts.set(segment.id, element);
+        }
+        fragment.append(element);
+      }
+
+      root.replaceChildren(fragment);
+      atomHosts.current = nextAtomHosts;
+      pendingAtomHostRevision.current = atomHostRevision + 1;
+      refreshAtomHosts(pendingAtomHostRevision.current);
     }, [segments]);
+
+    useLayoutEffect(() => {
+      if (atomHostRevision !== pendingAtomHostRevision.current) return;
+      if (pendingSelection.current === null) return;
+      setCollapsedSelection(pendingSelection.current);
+      pendingSelection.current = null;
+      if (!pendingMentionUpdate.current) return;
+      pendingMentionUpdate.current = false;
+      updateMentionFromSelection();
+    }, [atomHostRevision, segments]);
 
     useEffect(() => {
       setActiveMentionIndex(0);
@@ -440,16 +539,33 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
     }, [disabled, mentionTasks.length]);
 
     useEffect(() => {
-      if (!allSelected) return;
-      const exitAllSelection = () => setAllSelected(false);
-      document.addEventListener("pointerdown", exitAllSelection, true);
-      return () => document.removeEventListener("pointerdown", exitAllSelection, true);
-    }, [allSelected]);
+      const root = rootRef.current;
+      if (!root) return;
+      root.addEventListener("beforeinput", handleBeforeInput);
+      return () => root.removeEventListener("beforeinput", handleBeforeInput);
+    }, [disabled, onChange, segments]);
+
+    useEffect(() => {
+      function collapseFromOutsidePointer(event: PointerEvent) {
+        const root = rootRef.current;
+        if (!root || root.contains(event.target as Node)) return;
+        collapseComposerSelection("focus");
+      }
+
+      document.addEventListener("pointerdown", collapseFromOutsidePointer, true);
+      return () => document.removeEventListener("pointerdown", collapseFromOutsidePointer, true);
+    }, [atomHostRevision, segments]);
+
+    useEffect(() => {
+      document.addEventListener("selectionchange", syncAtomSelection);
+      syncAtomSelection();
+      return () => document.removeEventListener("selectionchange", syncAtomSelection);
+    }, [atomHostRevision, segments]);
 
     useImperativeHandle(ref, () => ({
       focus() {
-        const firstText = segments.find((segment) => segment.type === "text");
-        if (firstText) textareas.current.get(firstText.id)?.focus();
+        rootRef.current?.focus();
+        setCollapsedSelection(segmentsLength(segments));
       },
       addImages(files) {
         const selected = Array.from(files).filter((file) => file.type.startsWith("image/"));
@@ -477,68 +593,217 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       },
     }), [onChange, onError, segments]);
 
-    function changeText(id: string, text: string) {
-      if (allSelected) {
-        setAllSelected(false);
-        onChange([{ id, type: "text", text }]);
-        return;
+    function segmentElement(node: Node | null): HTMLElement | null {
+      const root = rootRef.current;
+      if (!root || !node || !root.contains(node)) return null;
+      const element = node instanceof Element ? node : node.parentElement;
+      return element?.closest<HTMLElement>("[data-inline-media-segment]") ?? null;
+    }
+
+    function segmentOffset(id: string): number {
+      let offset = 0;
+      for (const segment of segments) {
+        if (segment.id === id) return offset;
+        offset += segmentLength(segment);
       }
-      onChange(segments.map((segment) => (
-        segment.id === id && segment.type === "text" ? { ...segment, text } : segment
-      )));
+      return offset;
     }
 
-    function clearAll() {
-      const empty = textSegment();
-      pendingFocus.current = { id: empty.id, offset: 0 };
-      setAllSelected(false);
+    function logicalOffsetForPoint(
+      node: Node,
+      offset: number,
+      edge: "start" | "end",
+    ): number | null {
+      const root = rootRef.current;
+      if (!root || !root.contains(node)) return null;
+      if (node === root) {
+        for (let index = offset; index < root.childNodes.length; index += 1) {
+          const child = root.childNodes[index];
+          const element = child instanceof HTMLElement
+            ? child.closest<HTMLElement>("[data-inline-media-segment]")
+            : null;
+          const id = element?.dataset.inlineMediaSegment;
+          if (id) return segmentOffset(id);
+        }
+        return segmentsLength(segments);
+      }
+      const element = segmentElement(node);
+      const id = element?.dataset.inlineMediaSegment;
+      if (!element || !id) return null;
+      const segment = segments.find((candidate) => candidate.id === id);
+      if (!segment) return null;
+      const start = segmentOffset(id);
+      if (segment.type !== "text") return start + (edge === "end" ? 1 : 0);
+      const range = document.createRange();
+      range.selectNodeContents(element);
+      range.setEnd(node, offset);
+      return start + range.toString().length;
+    }
+
+    function currentLogicalRange(): { start: number; end: number } | null {
+      const selection = window.getSelection();
+      if (!selection || selection.rangeCount === 0) return null;
+      const range = selection.getRangeAt(0);
+      const start = logicalOffsetForPoint(range.startContainer, range.startOffset, "start");
+      if (start === null) return null;
+      if (range.collapsed) return { start, end: start };
+      const end = logicalOffsetForPoint(range.endContainer, range.endOffset, "end");
+      return end === null ? null : { start, end };
+    }
+
+    function elementForSegment(id: string): HTMLElement | null {
+      const root = rootRef.current;
+      if (!root) return null;
+      return Array.from(root.querySelectorAll<HTMLElement>("[data-inline-media-segment]"))
+        .find((element) => element.dataset.inlineMediaSegment === id) ?? null;
+    }
+
+    function domPointAtOffset(offset: number): { node: Node; offset: number } | null {
+      const root = rootRef.current;
+      if (!root) return null;
+      let current = 0;
+      for (const segment of segments) {
+        const element = elementForSegment(segment.id);
+        if (!element) continue;
+        const length = segmentLength(segment);
+        if (segment.type === "text" && offset <= current + length) {
+          const textNode = element.firstChild;
+          if (textNode instanceof Text) {
+            return { node: textNode, offset: Math.max(0, Math.min(offset - current, textNode.length)) };
+          }
+          return { node: element, offset: 0 };
+        }
+        const childIndex = Array.from(root.childNodes).indexOf(element);
+        if (segment.type !== "text" && offset <= current) {
+          return { node: root, offset: Math.max(childIndex, 0) };
+        }
+        if (segment.type !== "text" && offset <= current + length) {
+          return { node: root, offset: Math.max(childIndex + 1, 0) };
+        }
+        current += length;
+      }
+      return { node: root, offset: root.childNodes.length };
+    }
+
+    function setCollapsedSelection(offset: number) {
+      const root = rootRef.current;
+      const point = domPointAtOffset(offset);
+      if (!root || !point) return;
+      root.focus();
+      const range = document.createRange();
+      range.setStart(point.node, point.offset);
+      range.collapse(true);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      syncAtomSelection();
+    }
+
+    function collapseComposerSelection(edge: "start" | "end" | "focus"): boolean {
+      const root = rootRef.current;
+      const selection = window.getSelection();
+      if (!root || !selection || selection.rangeCount === 0 || selection.isCollapsed) return false;
+      const range = selection.getRangeAt(0);
+      if (!root.contains(range.startContainer) || !root.contains(range.endContainer)) return false;
+      if (edge === "focus" && selection.focusNode && root.contains(selection.focusNode)) {
+        selection.collapse(selection.focusNode, selection.focusOffset);
+        syncAtomSelection();
+        return true;
+      }
+      const collapsed = range.cloneRange();
+      collapsed.collapse(edge === "start");
+      selection.removeAllRanges();
+      selection.addRange(collapsed);
+      syncAtomSelection();
+      return true;
+    }
+
+    function syncAtomSelection() {
+      const range = currentLogicalRange();
+      let offset = 0;
+      for (const segment of segments) {
+        const length = segmentLength(segment);
+        if (segment.type !== "text") {
+          elementForSegment(segment.id)?.classList.toggle(
+            "is-range-selected",
+            range !== null && range.start < offset + length && range.end > offset,
+          );
+        }
+        offset += length;
+      }
+    }
+
+    function applyRangeReplacement(
+      start: number,
+      end: number,
+      insertion: InlineMediaSegment[],
+      updateMention = true,
+    ) {
+      const replacement = replaceInlineMediaRange(segments, start, end, insertion);
+      pendingSelection.current = replacement.caret;
+      pendingMentionUpdate.current = updateMention;
       setMention(null);
-      onChange([empty]);
+      onChange(replacement.segments);
     }
 
-    function removeIssueReference(id: string) {
+    function removeSegment(id: string) {
       const index = segments.findIndex((segment) => segment.id === id);
       if (index < 0) return;
-      const previous = segments[index - 1];
-      const next = segments[index + 1];
-      const nextSegments = normalizeSegments(segments.filter((segment) => segment.id !== id));
-      const focusId = previous?.type === "text"
-        ? previous.id
-        : next?.type === "text"
-          ? next.id
-          : null;
-      if (focusId) {
-        pendingFocus.current = {
-          id: focusId,
-          offset: previous?.type === "text" ? previous.text.length : 0,
-        };
-      }
-      setMention(null);
-      onChange(nextSegments);
+      const start = segmentsLength(segments.slice(0, index));
+      applyRangeReplacement(start, start + segmentLength(segments[index]), [], false);
     }
 
-    function updateMention(
-      segment: InlineTextSegment,
-      value: string,
-      textarea: HTMLTextAreaElement,
-    ) {
-      if (mentionTasks.length === 0 || textarea.selectionStart !== textarea.selectionEnd) {
+    function updateMentionFromSelection() {
+      const root = rootRef.current;
+      const selection = window.getSelection();
+      if (!root || mentionTasks.length === 0 || !selection || selection.rangeCount === 0) {
         setMention(null);
         return;
       }
-      const end = textarea.selectionStart;
-      const prefix = value.slice(0, end);
+      const range = selection.getRangeAt(0);
+      if (!range.collapsed) {
+        setMention(null);
+        return;
+      }
+      const element = segmentElement(range.startContainer);
+      const id = element?.dataset.inlineMediaSegment;
+      const segment = id
+        ? segments.find((candidate): candidate is InlineTextSegment => (
+            candidate.id === id && candidate.type === "text"
+          ))
+        : null;
+      if (!element || !segment) {
+        setMention(null);
+        return;
+      }
+      const prefixRange = document.createRange();
+      prefixRange.selectNodeContents(element);
+      prefixRange.setEnd(range.startContainer, range.startOffset);
+      const end = prefixRange.toString().length;
+      const prefix = segment.text.slice(0, end);
       const match = /(?:^|\s)@([^\s@]*)$/.exec(prefix);
       if (!match) {
         setMention(null);
         return;
       }
+      const start = prefix.lastIndexOf("@");
+      const anchorRange = document.createRange();
+      const textNode = element.firstChild;
+      if (textNode instanceof Text) {
+        anchorRange.setStart(textNode, Math.min(start, textNode.length));
+        anchorRange.collapse(true);
+      } else {
+        anchorRange.selectNodeContents(element);
+        anchorRange.collapse(true);
+      }
+      const anchorRect = anchorRange.getBoundingClientRect();
       setMention({
         segmentId: segment.id,
-        start: prefix.lastIndexOf("@"),
+        start,
         end,
         query: match[1],
-        anchor: textarea,
+        anchor: root,
+        anchorRect,
       });
     }
 
@@ -552,7 +817,6 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       const route = new URLSearchParams({ project: task.projectId, issue: task.identifier });
       const suffix = segment.text.slice(mention.end);
       const insertSpace = !/^\s/.test(suffix);
-      const before = { ...segment, text: segment.text.slice(0, mention.start) };
       const reference: IssueReferenceSegment = {
         id: segmentId("issue"),
         type: "issue-reference",
@@ -560,65 +824,9 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
         identifier: displayIdentifier,
         taskId: task.id,
       };
-      const after = textSegment(`${insertSpace ? " " : ""}${suffix}`);
-      pendingFocus.current = { id: after.id, offset: insertSpace ? 1 : 0 };
-      setMention(null);
-      onChange(normalizeSegments(segments.flatMap((candidate) => (
-        candidate.id === segment.id ? [before, reference, after] : [candidate]
-      ))));
-    }
-
-    function handleTextareaKeyDown(
-      event: KeyboardEvent<HTMLTextAreaElement>,
-      segment: InlineTextSegment,
-      index: number,
-    ) {
-      if (event.defaultPrevented || event.nativeEvent.isComposing || event.keyCode === 229) return;
-      if (
-        event.key === "Backspace"
-        && event.currentTarget.selectionStart === 0
-        && event.currentTarget.selectionEnd === 0
-        && segments[index - 1]?.type === "issue-reference"
-      ) {
-        event.preventDefault();
-        removeIssueReference(segments[index - 1].id);
-        return;
-      }
-      if (
-        event.key === "Delete"
-        && event.currentTarget.selectionStart === segment.text.length
-        && event.currentTarget.selectionEnd === segment.text.length
-        && segments[index + 1]?.type === "issue-reference"
-      ) {
-        event.preventDefault();
-        removeIssueReference(segments[index + 1].id);
-        return;
-      }
-    }
-
-    function selectNearestTextSegment(target: EventTarget | null) {
-      const root = rootRef.current;
-      if (!root || !(target instanceof Element)) return;
-      let segmentElement = target;
-      while (segmentElement.parentElement && segmentElement.parentElement !== root) {
-        segmentElement = segmentElement.parentElement;
-      }
-      const childIndex = segmentElement.parentElement === root
-        ? Array.from(root.children).indexOf(segmentElement)
-        : 0;
-      const origin = Math.min(Math.max(childIndex, 0), segments.length - 1);
-      for (let distance = 0; distance < segments.length; distance += 1) {
-        const indexes = distance === 0 ? [origin] : [origin - distance, origin + distance];
-        for (const index of indexes) {
-          const candidate = segments[index];
-          if (candidate?.type !== "text") continue;
-          const textarea = textareas.current.get(candidate.id);
-          if (!textarea) continue;
-          textarea.focus();
-          textarea.setSelectionRange(0, candidate.text.length);
-          return;
-        }
-      }
+      const start = segmentOffset(segment.id) + mention.start;
+      const insertion = [reference, textSegment(insertSpace ? " " : "")];
+      applyRangeReplacement(start, start + mention.end - mention.start, insertion, false);
     }
 
     function handleComposerKeyDown(event: KeyboardEvent<HTMLDivElement>) {
@@ -628,30 +836,25 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       }
       if ((event.metaKey || event.ctrlKey) && event.key.toLocaleLowerCase() === "a") {
         event.preventDefault();
-        selectNearestTextSegment(event.target);
-        setAllSelected(true);
+        const root = rootRef.current;
+        if (!root) return;
+        root.focus();
+        const range = document.createRange();
+        range.selectNodeContents(root);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+        syncAtomSelection();
         setMention(null);
         return;
       }
-      if (allSelected && (event.key === "Backspace" || event.key === "Delete")) {
-        event.preventDefault();
-        clearAll();
-        return;
-      }
       if (
-        allSelected
-        && [
-          "ArrowUp",
-          "ArrowDown",
-          "ArrowLeft",
-          "ArrowRight",
-          "Home",
-          "End",
-          "PageUp",
-          "PageDown",
-        ].includes(event.key)
+        (event.key === "PageUp" || event.key === "PageDown")
+        && collapseComposerSelection(event.key === "PageUp" ? "start" : "end")
       ) {
-        setAllSelected(false);
+        event.preventDefault();
+        setMention(null);
+        return;
       }
       if (mention && event.key === "ArrowDown" && mentionResults.length > 0) {
         event.preventDefault();
@@ -676,10 +879,31 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       onKeyDown?.(event);
     }
 
-    function pasteContent(
-      event: ClipboardEvent<HTMLTextAreaElement>,
-      segment: InlineTextSegment,
-    ) {
+    function handleBeforeInput(input: InputEvent) {
+      if (disabled || composing.current) return;
+      const range = currentLogicalRange();
+      if (!range) return;
+      let { start, end } = range;
+      let insertion: InlineMediaSegment[] | null = null;
+      if (["insertText", "insertReplacementText"].includes(input.inputType)) {
+        insertion = [textSegment(input.data ?? "")];
+      } else if (["insertLineBreak", "insertParagraph"].includes(input.inputType)) {
+        insertion = [textSegment("\n")];
+      } else if (input.inputType.startsWith("delete")) {
+        if (start === end && input.inputType.includes("Backward")) start = Math.max(0, start - 1);
+        if (start === end && input.inputType.includes("Forward")) {
+          end = Math.min(segmentsLength(segments), end + 1);
+        }
+        insertion = [];
+      }
+      if (insertion === null) return;
+      input.preventDefault();
+      applyRangeReplacement(start, end, insertion);
+    }
+
+    function pasteContent(event: ClipboardEvent<HTMLDivElement>) {
+      const range = currentLogicalRange();
+      if (!range) return;
       const clipboardFiles = clipboardImages(event.clipboardData);
       if (clipboardFiles.length > 0) {
         event.preventDefault();
@@ -702,141 +926,127 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
         });
         if (images.length === 0) return;
         onError(null);
-
-        const textarea = event.currentTarget;
-        const start = textarea.selectionStart;
-        const end = textarea.selectionEnd;
-        const before = { ...segment, text: segment.text.slice(0, start) };
-        const after = textSegment(segment.text.slice(end));
-        const insertion = images.map(imageSegment);
-        const next = segments.flatMap((candidate) => (
-          candidate.id === segment.id ? [before, ...insertion, after] : [candidate]
-        ));
-        pendingFocus.current = { id: after.id, offset: 0 };
-        setAllSelected(false);
-        onChange(next);
+        applyRangeReplacement(range.start, range.end, images.map(imageSegment), false);
         return;
       }
 
       const pastedText = event.clipboardData.getData("text/plain");
       const insertion = createInlineMediaSegments(pastedText, referenceTasks);
-      if (!insertion.some((candidate) => candidate.type !== "text")) return;
       event.preventDefault();
-
-      const textarea = event.currentTarget;
-      const start = textarea.selectionStart;
-      const end = textarea.selectionEnd;
-      if (allSelected) {
-        const finalText = insertion.at(-1) as InlineTextSegment;
-        pendingFocus.current = { id: finalText.id, offset: finalText.text.length };
-        setAllSelected(false);
-        setMention(null);
-        onChange(insertion);
-        return;
-      }
-
-      const firstText = insertion[0] as InlineTextSegment;
-      const finalText = insertion.at(-1) as InlineTextSegment;
-      const focusOffset = finalText.text.length;
-      insertion[0] = {
-        ...segment,
-        text: segment.text.slice(0, start) + firstText.text,
-      };
-      insertion[insertion.length - 1] = {
-        ...finalText,
-        text: finalText.text + segment.text.slice(end),
-      };
-      pendingFocus.current = { id: finalText.id, offset: focusOffset };
-      setMention(null);
-      onChange(segments.flatMap((candidate) => (
-        candidate.id === segment.id ? insertion : [candidate]
-      )));
+      applyRangeReplacement(range.start, range.end, insertion);
     }
 
-    function removeImage(id: string) {
-      onChange(normalizeSegments(segments.filter((segment) => segment.id !== id)));
+    function syncSegmentsFromDom() {
+      const root = rootRef.current;
+      if (!root) return;
+      const existing = new Map(segments.map((segment) => [segment.id, segment]));
+      const next: InlineMediaSegment[] = [];
+      for (const child of root.childNodes) {
+        if (child instanceof Text) {
+          if (child.data) next.push(textSegment(child.data));
+          continue;
+        }
+        if (!(child instanceof HTMLElement)) continue;
+        const id = child.dataset.inlineMediaSegment;
+        const segment = id ? existing.get(id) : null;
+        if (segment?.type === "text") {
+          next.push({ ...segment, text: child.textContent ?? "" });
+        } else if (segment) {
+          next.push(segment);
+        } else if (child.tagName === "BR" && root.childNodes.length > 1) {
+          next.push(textSegment("\n"));
+        } else if (child.textContent) {
+          next.push(textSegment(child.textContent));
+        }
+      }
+      const range = currentLogicalRange();
+      if (range) pendingSelection.current = range.end;
+      pendingMentionUpdate.current = true;
+      onChange(normalizeSegments(next));
     }
 
     const isEmpty = segments.every((segment) => (
       segment.type === "text" ? segment.text.length === 0 : false
     ));
-    const hasIssueReferences = segments.some((segment) => segment.type === "issue-reference");
+    const atomPortals = segments.flatMap((segment) => {
+      if (segment.type === "text") return [];
+      const host = atomHosts.current.get(segment.id);
+      if (!host) return [];
+      const content = segment.type === "pending-image" ? (
+        <PendingImageBlock
+          segment={segment}
+          disabled={disabled}
+          onRemove={() => removeSegment(segment.id)}
+        />
+      ) : segment.type === "persisted-image" ? (
+        <PersistedImageBlock
+          segment={segment}
+          disabled={disabled}
+          onRemove={() => removeSegment(segment.id)}
+        />
+      ) : (
+        <IssueReferenceChip
+          segment={segment}
+          task={segment.taskId
+            ? referenceTasks.find((task) => task.id === segment.taskId) ?? null
+            : null}
+          disabled={disabled}
+          onRemove={() => removeSegment(segment.id)}
+        />
+      );
+      return [createPortal(content, host, segment.id)];
+    });
 
     return (
-      <div
-        ref={rootRef}
-        className={`inline-media-composer${hasIssueReferences ? " has-issue-references" : ""}${allSelected ? " is-all-selected" : ""} ${className}`.trim()}
-        aria-label={ariaLabel}
-        onKeyDownCapture={handleComposerKeyDown}
-        onCopy={(event) => {
-          if (!allSelected) return;
-          event.preventDefault();
-          event.clipboardData.setData("text/plain", serializeInlineMedia(segments));
-        }}
-        onBlurCapture={(event) => {
-          if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
-            setAllSelected(false);
-          }
-        }}
-      >
-        {segments.map((segment, index) => (
-          segment.type === "text" ? (
-            <textarea
-              key={segment.id}
-              ref={(element) => {
-                if (element) textareas.current.set(segment.id, element);
-                else textareas.current.delete(segment.id);
-              }}
-              value={segment.text}
-              rows={1}
-              disabled={disabled}
-              aria-label={index === 0 ? ariaLabel : text(`${ariaLabel}续写`, `${ariaLabel} continuation`)}
-              placeholder={isEmpty && index === 0 ? placeholder : undefined}
-              onChange={(event) => {
-                changeText(segment.id, event.target.value);
-                resizeTextarea(event.currentTarget);
-                updateMention(segment, event.target.value, event.currentTarget);
-              }}
-              onPaste={(event) => pasteContent(event, segment)}
-              onKeyDown={(event) => handleTextareaKeyDown(event, segment, index)}
-              onKeyUp={(event) => {
-                if (["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) {
-                  updateMention(segment, event.currentTarget.value, event.currentTarget);
-                }
-              }}
-              onClick={(event) => updateMention(segment, event.currentTarget.value, event.currentTarget)}
-              onBlur={() => setMention(null)}
-            />
-          ) : segment.type === "pending-image" ? (
-            <PendingImageBlock
-              key={segment.id}
-              segment={segment}
-              disabled={disabled}
-              onRemove={() => removeImage(segment.id)}
-            />
-          ) : segment.type === "persisted-image" ? (
-            <PersistedImageBlock
-              key={segment.id}
-              segment={segment}
-              disabled={disabled}
-              onRemove={() => removeImage(segment.id)}
-            />
-          ) : (
-            <IssueReferenceChip
-              key={segment.id}
-              segment={segment}
-              task={segment.taskId
-                ? referenceTasks.find((task) => task.id === segment.taskId) ?? null
-                : null}
-              disabled={disabled}
-              onRemove={() => removeIssueReference(segment.id)}
-            />
-          )
-        ))}
+      <>
+        <div
+          ref={rootRef}
+          className={`inline-media-composer ${className}`.trim()}
+          contentEditable={!disabled}
+          suppressContentEditableWarning
+          role="textbox"
+          aria-multiline="true"
+          aria-label={ariaLabel}
+          aria-disabled={disabled}
+          data-empty={isEmpty ? "true" : undefined}
+          data-placeholder={placeholder}
+          onKeyDownCapture={handleComposerKeyDown}
+          onInput={() => {
+            if (!composing.current) syncSegmentsFromDom();
+          }}
+          onCompositionStart={() => { composing.current = true; }}
+          onCompositionEnd={() => {
+            composing.current = false;
+            syncSegmentsFromDom();
+          }}
+          onPaste={pasteContent}
+          onCopy={(event) => {
+            const range = currentLogicalRange();
+            if (!range || range.start === range.end) return;
+            event.preventDefault();
+            event.clipboardData.setData(
+              "text/plain",
+              serializeInlineMediaRange(segments, range.start, range.end),
+            );
+          }}
+          onKeyUp={updateMentionFromSelection}
+          onPointerUp={() => {
+            syncAtomSelection();
+            updateMentionFromSelection();
+          }}
+          onBlur={(event) => {
+            setMention(null);
+            if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+              collapseComposerSelection("focus");
+            }
+          }}
+        >
+          {atomPortals}
+        </div>
         {mention && (
           <IssueMentionMenu
             anchor={mention.anchor}
-            anchorOffset={mention.start}
+            anchorRect={mention.anchorRect}
             tasks={mentionResults}
             activeIndex={selectedMentionIndex}
             onActiveIndexChange={setActiveMentionIndex}
@@ -844,7 +1054,7 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
             onClose={() => setMention(null)}
           />
         )}
-      </div>
+      </>
     );
   },
 );

--- a/web/src/components/IssueMentionMenu.tsx
+++ b/web/src/components/IssueMentionMenu.tsx
@@ -5,8 +5,8 @@ import { useTaskboardI18n } from "../i18n";
 import { LinearIcon } from "./LinearIcon";
 
 interface IssueMentionMenuProps {
-  anchor: HTMLTextAreaElement;
-  anchorOffset: number;
+  anchor: HTMLElement;
+  anchorRect: DOMRect;
   tasks: readonly Task[];
   activeIndex: number;
   onActiveIndexChange: (index: number) => void;
@@ -16,7 +16,7 @@ interface IssueMentionMenuProps {
 
 export function IssueMentionMenu({
   anchor,
-  anchorOffset,
+  anchorRect,
   tasks,
   activeIndex,
   onActiveIndexChange,
@@ -31,57 +31,6 @@ export function IssueMentionMenu({
   useLayoutEffect(() => {
     const menu = menuRef.current;
     if (!menu) return;
-    const textareaRect = anchor.getBoundingClientRect();
-    const style = getComputedStyle(anchor);
-    const mirror = document.createElement("div");
-    const mirroredProperties = [
-      "border-bottom-width",
-      "border-left-width",
-      "border-right-width",
-      "border-top-width",
-      "box-sizing",
-      "direction",
-      "font-family",
-      "font-size",
-      "font-style",
-      "font-weight",
-      "letter-spacing",
-      "line-height",
-      "padding-bottom",
-      "padding-left",
-      "padding-right",
-      "padding-top",
-      "tab-size",
-      "text-align",
-      "text-indent",
-      "text-transform",
-      "word-spacing",
-    ];
-    mirror.style.position = "fixed";
-    mirror.style.visibility = "hidden";
-    mirror.style.pointerEvents = "none";
-    mirror.style.top = `${textareaRect.top}px`;
-    mirror.style.left = `${textareaRect.left}px`;
-    mirror.style.width = `${textareaRect.width}px`;
-    mirror.style.borderStyle = "solid";
-    mirror.style.borderColor = "transparent";
-    mirror.style.whiteSpace = "pre-wrap";
-    mirror.style.overflowWrap = "break-word";
-    for (const property of mirroredProperties) {
-      mirror.style.setProperty(property, style.getPropertyValue(property));
-    }
-    mirror.textContent = anchor.value.slice(0, anchorOffset);
-    const marker = document.createElement("span");
-    marker.textContent = anchor.value.slice(anchorOffset, anchorOffset + 1) || "\u200b";
-    mirror.append(marker);
-    document.body.append(mirror);
-    const markerRect = marker.getBoundingClientRect();
-    mirror.remove();
-    const anchorRect = {
-      left: markerRect.left - anchor.scrollLeft,
-      top: markerRect.top - anchor.scrollTop,
-      bottom: markerRect.bottom - anchor.scrollTop,
-    };
     const menuRect = menu.getBoundingClientRect();
     const gap = 4;
     const edge = 8;
@@ -89,7 +38,7 @@ export function IssueMentionMenu({
     const left = Math.max(edge, Math.min(anchorRect.left, window.innerWidth - menuRect.width - edge));
     const top = openAbove ? anchorRect.top - menuRect.height - gap : anchorRect.bottom + gap;
     setPosition({ left, top: Math.max(edge, top) });
-  }, [activeIndex, anchor, anchorOffset, tasks.length]);
+  }, [activeIndex, anchorRect, tasks.length]);
 
   useLayoutEffect(() => {
     menuRef.current
@@ -100,7 +49,7 @@ export function IssueMentionMenu({
   useEffect(() => {
     function closeFromOutside(event: PointerEvent) {
       const target = event.target as Node;
-      if (target !== anchor && !menuRef.current?.contains(target)) onClose();
+      if (!anchor.contains(target) && !menuRef.current?.contains(target)) onClose();
     }
 
     document.addEventListener("pointerdown", closeFromOutside);

--- a/web/src/components/MarkdownDocument.tsx
+++ b/web/src/components/MarkdownDocument.tsx
@@ -470,9 +470,11 @@ function MarkdownPre({ children, ...props }: ComponentPropsWithoutRef<"pre">) {
 export function MarkdownDocument({
   value,
   onLinkClick,
+  renderLink,
 }: {
   value: string;
   onLinkClick?: (event: MouseEvent<HTMLAnchorElement>, href?: string) => void;
+  renderLink?: (href: string | undefined, children: ReactNode) => ReactNode | null;
 }) {
   return (
     <div className="issue-description-document">
@@ -480,15 +482,22 @@ export function MarkdownDocument({
         remarkPlugins={[remarkGfm, remarkStripMarkdownComments, remarkBreaks]}
         urlTransform={(url) => defaultUrlTransform(resolvePersistedAttachmentUrl(url))}
         components={{
-          a: ({ node: _node, href, ...props }) => (
-            <a
-              {...props}
-              href={href}
-              target="_blank"
-              rel="noreferrer"
-              onClick={(event) => onLinkClick?.(event, href)}
-            />
-          ),
+          a: ({ node: _node, href, children, className, ...props }) => {
+            const renderedLink = renderLink?.(href, children);
+            const isRenderedLink = renderedLink !== null && renderedLink !== undefined;
+            return (
+              <a
+                {...props}
+                className={[className, isRenderedLink ? "issue-reference-link" : ""].filter(Boolean).join(" ") || undefined}
+                href={href}
+                target="_blank"
+                rel="noreferrer"
+                onClick={(event) => onLinkClick?.(event, href)}
+              >
+                {isRenderedLink ? renderedLink : children}
+              </a>
+            );
+          },
           pre: MarkdownPre,
         }}
       >

--- a/web/src/components/ProjectAutomationMenu.tsx
+++ b/web/src/components/ProjectAutomationMenu.tsx
@@ -7,6 +7,8 @@ import {
   type AutomationModel,
   type AutomationReasoningEffort,
 } from "../../../shared/taskboard-automation-options.mjs";
+import { LinearIcon } from "./LinearIcon";
+import { TaskPropertyPicker } from "./TaskPropertyPicker";
 import { TaskboardIcon } from "./TaskboardIcon";
 import { useTaskboardI18n } from "../i18n";
 
@@ -71,6 +73,7 @@ export function ProjectAutomationMenu({
   const menuRef = useRef<HTMLDivElement>(null);
   const wasPendingRef = useRef(pending);
   const [open, setOpen] = useState(false);
+  const [pickerMenu, setPickerMenu] = useState<"interval" | "model" | "reasoning" | null>(null);
   const [position, setPosition] = useState({ left: 0, top: 0, ready: false });
   const [draft, setDraft] = useState<AutomationOptions>(DEFAULT_OPTIONS);
   const status = automation?.status ?? "PAUSED";
@@ -91,6 +94,10 @@ export function ProjectAutomationMenu({
   useEffect(() => {
     if (!open) return;
     setDraft({ ...DEFAULT_OPTIONS, ...automation });
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) setPickerMenu(null);
   }, [open]);
 
   useEffect(() => {
@@ -122,7 +129,7 @@ export function ProjectAutomationMenu({
       setOpen(false);
     }
     function closeFromEscape(event: KeyboardEvent) {
-      if (event.key === "Escape") {
+      if (event.key === "Escape" && !pickerMenu) {
         setOpen(false);
         triggerRef.current?.focus();
       }
@@ -137,7 +144,7 @@ export function ProjectAutomationMenu({
       window.removeEventListener("resize", closeFromViewportChange);
       window.removeEventListener("scroll", closeFromViewportChange, true);
     };
-  }, [open]);
+  }, [open, pickerMenu]);
 
   const submitChange = (next: AutomationOptions) => {
     if (disabled) return;
@@ -216,48 +223,66 @@ export function ProjectAutomationMenu({
           )}
         </div>
       )}
-      <label className="project-automation-field">
+      <div className="project-automation-field">
         <span>{text("间隔", "Interval")}</span>
-        <select
-          value={draft.intervalMinutes}
+        <TaskPropertyPicker
+          value={String(draft.intervalMinutes)}
+          options={[5, 10, 15, 30, 60].map((minutes) => ({
+            value: String(minutes),
+            label: text(`${minutes} 分钟`, `${minutes} min`),
+            icon: <LinearIcon name="recurrence" />,
+          }))}
+          open={pickerMenu === "interval"}
           disabled={disabled}
-          onChange={(event) => submitChange({
+          className="project-automation-picker"
+          triggerClassName="project-automation-picker-trigger"
+          ariaLabel={text("间隔", "Interval")}
+          onOpenChange={(open) => setPickerMenu(open ? "interval" : null)}
+          onChange={(value) => submitChange({
             ...draft,
-            intervalMinutes: Number(event.target.value) as IntervalMinutes,
+            intervalMinutes: Number(value) as IntervalMinutes,
           })}
-        >
-          {[5, 10, 15, 30, 60].map((minutes) => (
-            <option key={minutes} value={minutes}>{text(`${minutes} 分钟`, `${minutes} min`)}</option>
-          ))}
-        </select>
-      </label>
-      <label className="project-automation-field">
+        />
+      </div>
+      <div className="project-automation-field">
         <span>{text("模型", "Model")}</span>
-        <select
+        <TaskPropertyPicker
           value={draft.model}
+          options={AUTOMATION_MODELS.map((model) => ({
+            value: model.slug,
+            label: model.label,
+            icon: <LinearIcon name="project" />,
+          }))}
+          open={pickerMenu === "model"}
           disabled={disabled}
-          onChange={(event) => submitChange(withAutomationModel(draft, event.target.value as AutomationModel))}
-        >
-          {AUTOMATION_MODELS.map((model) => (
-            <option key={model.slug} value={model.slug}>{model.label}</option>
-          ))}
-        </select>
-      </label>
-      <label className="project-automation-field">
+          className="project-automation-picker"
+          triggerClassName="project-automation-picker-trigger"
+          ariaLabel={text("模型", "Model")}
+          onOpenChange={(open) => setPickerMenu(open ? "model" : null)}
+          onChange={(value) => submitChange(withAutomationModel(draft, value as AutomationModel))}
+        />
+      </div>
+      <div className="project-automation-field">
         <span>{text("推理强度", "Reasoning effort")}</span>
-        <select
+        <TaskPropertyPicker
           value={draft.reasoningEffort}
+          options={getAutomationModel(draft.model).efforts.map((effort) => ({
+            value: effort,
+            label: text(...EFFORT_LABELS[effort]),
+            icon: <LinearIcon name="displayOptions" />,
+          }))}
+          open={pickerMenu === "reasoning"}
           disabled={disabled}
-          onChange={(event) => submitChange({
+          className="project-automation-picker"
+          triggerClassName="project-automation-picker-trigger"
+          ariaLabel={text("推理强度", "Reasoning effort")}
+          onOpenChange={(open) => setPickerMenu(open ? "reasoning" : null)}
+          onChange={(value) => submitChange({
             ...draft,
-            reasoningEffort: event.target.value as AutomationReasoningEffort,
+            reasoningEffort: value as AutomationReasoningEffort,
           })}
-        >
-          {getAutomationModel(draft.model).efforts.map((effort) => (
-            <option key={effort} value={effort}>{text(...EFFORT_LABELS[effort])}</option>
-          ))}
-        </select>
-      </label>
+        />
+      </div>
       {unavailableReason && <p className="project-automation-note">{unavailableReason}</p>}
       {error && error !== unavailableReason && <p className="project-automation-error" role="alert">{error}</p>}
     </div>,

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -420,7 +420,7 @@ export function TaskDetail({
   const [title, setTitle] = useState(task.title);
   const [description, setDescription] = useState(task.description);
   const [descriptionSegments, setDescriptionSegments] = useState<InlineMediaSegment[]>(
-    () => createInlineMediaSegments(task.description),
+    () => createInlineMediaSegments(task.description, tasks),
   );
   const [editingDescription, setEditingDescription] = useState(false);
   const [propertyMenu, setPropertyMenu] = useState<
@@ -440,6 +440,7 @@ export function TaskDetail({
   const [commentSegments, setCommentSegments] = useState<InlineMediaSegment[]>(
     () => createInlineMediaSegments(
       taskboardStorage.getItem(`taskboard.comment-draft.${task.id}`) ?? "",
+      tasks,
     ),
   );
   const [pendingCommentFiles, setPendingCommentFiles] = useState<File[]>([]);
@@ -473,7 +474,7 @@ export function TaskDetail({
     if (document.activeElement !== titleRef.current) setTitle(task.title);
     if (taskChanged || !editingDescription) {
       setDescription(task.description);
-      setDescriptionSegments(createInlineMediaSegments(task.description));
+      setDescriptionSegments(createInlineMediaSegments(task.description, tasks));
     }
     if (taskChanged) {
       setEditingDescription(false);
@@ -676,7 +677,7 @@ export function TaskDetail({
       if (!saved) return;
       setCurrentTask(saved);
       setDescription(saved.description);
-      setDescriptionSegments(createInlineMediaSegments(saved.description));
+      setDescriptionSegments(createInlineMediaSegments(saved.description, tasks));
       setAttachments((current) => [
         ...current,
         ...uploaded.filter((attachment) => !current.some((item) => item.id === attachment.id)),
@@ -762,7 +763,7 @@ export function TaskDetail({
     if (savingCommentId !== null) return;
     editingUploadedAttachmentsRef.current.clear();
     setEditingId(comment.id);
-    setEditingSegments(createInlineMediaSegments(comment.body));
+    setEditingSegments(createInlineMediaSegments(comment.body, tasks));
     setActiveMenuId(null);
   }
 
@@ -961,7 +962,7 @@ export function TaskDetail({
                       onKeyDown={(event) => {
                         if (event.key === "Escape") {
                           event.preventDefault();
-                          setDescriptionSegments(createInlineMediaSegments(currentTask.description));
+                          setDescriptionSegments(createInlineMediaSegments(currentTask.description, tasks));
                           setEditingDescription(false);
                         }
                       }}
@@ -975,13 +976,13 @@ export function TaskDetail({
                     aria-label={text("编辑议题描述", "Edit issue description")}
                     onClick={() => {
                       if (window.getSelection()?.isCollapsed === false) return;
-                      setDescriptionSegments(createInlineMediaSegments(description));
+                      setDescriptionSegments(createInlineMediaSegments(description, tasks));
                       setEditingDescription(true);
                     }}
                     onKeyDown={(event) => {
                       if (event.key === "Enter" || event.key === " ") {
                         event.preventDefault();
-                        setDescriptionSegments(createInlineMediaSegments(description));
+                        setDescriptionSegments(createInlineMediaSegments(description, tasks));
                         setEditingDescription(true);
                       }
                     }}

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -81,6 +81,7 @@ type TaskDetailError = string | readonly [string, string];
 interface TaskDetailProps {
   task: Task;
   tasks: Task[];
+  referenceTasks: Task[];
   currentUser: ActorIdentity;
   availableLabels: string[];
   developmentScan: DevelopmentScan;
@@ -312,7 +313,10 @@ function ActivityChangeIcon({ field, before, after }: {
   return <LinearIcon name="write" />;
 }
 
-function referencedTask(href: string, tasks: Task[]): Task | null {
+function referencedTask(
+  href: string,
+  referenceTasks: Task[],
+): { identifier: string; task: Task | null } | null {
   try {
     const base = new URL(document.baseURI);
     base.search = "";
@@ -322,7 +326,10 @@ function referencedTask(href: string, tasks: Task[]): Task | null {
     const identifier = readIssueIdentifier(url.search);
     const projectId = url.searchParams.get("project");
     if (!identifier || !projectId) return null;
-    return tasks.find((task) => task.projectId === projectId && task.identifier === identifier) ?? null;
+    const task = referenceTasks.find((candidate) => (
+      candidate.projectId === projectId && candidate.identifier === identifier
+    )) ?? null;
+    return { identifier: task?.externalKey ?? identifier, task };
   } catch {
     return null;
   }
@@ -330,19 +337,27 @@ function referencedTask(href: string, tasks: Task[]): Task | null {
 
 function DescriptionDocument({
   value,
-  tasks,
+  referenceTasks,
   onOpenTask,
 }: {
   value: string;
-  tasks: Task[];
+  referenceTasks: Task[];
   onOpenTask: (task: TaskRelationSummary) => void;
 }) {
   return (
     <MarkdownDocument
       value={value}
       renderLink={(href) => {
-        const task = href ? referencedTask(href, tasks) : null;
-        if (!task) return null;
+        const reference = href ? referencedTask(href, referenceTasks) : null;
+        if (!reference) return null;
+        const { task } = reference;
+        if (!task) {
+          return (
+            <span className="issue-reference-inline">
+              <span className="issue-reference-id">{reference.identifier}</span>
+            </span>
+          );
+        }
         return (
           <span className={`issue-reference-inline issue-reference-status-${task.status}`}>
             <span className={`status-icon issue-reference-status status-icon-${STATUS_DETAILS[task.status].tone}`}>
@@ -354,9 +369,9 @@ function DescriptionDocument({
         );
       }}
       onLinkClick={(event, href) => {
-        const task = href ? referencedTask(href, tasks) : null;
+        const reference = href ? referencedTask(href, referenceTasks) : null;
         if (
-          !task
+          !reference
           || event.button !== 0
           || event.metaKey
           || event.ctrlKey
@@ -364,7 +379,7 @@ function DescriptionDocument({
           || event.altKey
         ) return;
         event.preventDefault();
-        onOpenTask(task);
+        if (reference.task) onOpenTask(reference.task);
       }}
     />
   );
@@ -396,6 +411,7 @@ function ConversationLink({
 export function TaskDetail({
   task,
   tasks,
+  referenceTasks,
   currentUser,
   availableLabels,
   developmentScan,
@@ -420,7 +436,7 @@ export function TaskDetail({
   const [title, setTitle] = useState(task.title);
   const [description, setDescription] = useState(task.description);
   const [descriptionSegments, setDescriptionSegments] = useState<InlineMediaSegment[]>(
-    () => createInlineMediaSegments(task.description, tasks),
+    () => createInlineMediaSegments(task.description, referenceTasks),
   );
   const [editingDescription, setEditingDescription] = useState(false);
   const [propertyMenu, setPropertyMenu] = useState<
@@ -440,7 +456,7 @@ export function TaskDetail({
   const [commentSegments, setCommentSegments] = useState<InlineMediaSegment[]>(
     () => createInlineMediaSegments(
       taskboardStorage.getItem(`taskboard.comment-draft.${task.id}`) ?? "",
-      tasks,
+      referenceTasks,
     ),
   );
   const [pendingCommentFiles, setPendingCommentFiles] = useState<File[]>([]);
@@ -474,7 +490,7 @@ export function TaskDetail({
     if (document.activeElement !== titleRef.current) setTitle(task.title);
     if (taskChanged || !editingDescription) {
       setDescription(task.description);
-      setDescriptionSegments(createInlineMediaSegments(task.description, tasks));
+      setDescriptionSegments(createInlineMediaSegments(task.description, referenceTasks));
     }
     if (taskChanged) {
       setEditingDescription(false);
@@ -677,7 +693,7 @@ export function TaskDetail({
       if (!saved) return;
       setCurrentTask(saved);
       setDescription(saved.description);
-      setDescriptionSegments(createInlineMediaSegments(saved.description, tasks));
+      setDescriptionSegments(createInlineMediaSegments(saved.description, referenceTasks));
       setAttachments((current) => [
         ...current,
         ...uploaded.filter((attachment) => !current.some((item) => item.id === attachment.id)),
@@ -752,7 +768,7 @@ export function TaskDetail({
     });
   }
 
-  function handleSubmitShortcut(event: KeyboardEvent<HTMLTextAreaElement>) {
+  function handleSubmitShortcut(event: KeyboardEvent<HTMLDivElement>) {
     if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
       event.preventDefault();
       void submitComment();
@@ -763,7 +779,7 @@ export function TaskDetail({
     if (savingCommentId !== null) return;
     editingUploadedAttachmentsRef.current.clear();
     setEditingId(comment.id);
-    setEditingSegments(createInlineMediaSegments(comment.body, tasks));
+    setEditingSegments(createInlineMediaSegments(comment.body, referenceTasks));
     setActiveMenuId(null);
   }
 
@@ -954,6 +970,7 @@ export function TaskDetail({
                       ref={descriptionComposerRef}
                       segments={descriptionSegments}
                       mentionTasks={tasks}
+                      referenceTasks={referenceTasks}
                       placeholder={text("添加描述…", "Add description…")}
                       ariaLabel={text("议题描述", "Issue description")}
                       disabled={savingProperty === "description"}
@@ -962,7 +979,11 @@ export function TaskDetail({
                       onKeyDown={(event) => {
                         if (event.key === "Escape") {
                           event.preventDefault();
-                          setDescriptionSegments(createInlineMediaSegments(currentTask.description, tasks));
+                          event.stopPropagation();
+                          setDescriptionSegments(createInlineMediaSegments(
+                            currentTask.description,
+                            referenceTasks,
+                          ));
                           setEditingDescription(false);
                         }
                       }}
@@ -976,19 +997,23 @@ export function TaskDetail({
                     aria-label={text("编辑议题描述", "Edit issue description")}
                     onClick={() => {
                       if (window.getSelection()?.isCollapsed === false) return;
-                      setDescriptionSegments(createInlineMediaSegments(description, tasks));
+                      setDescriptionSegments(createInlineMediaSegments(description, referenceTasks));
                       setEditingDescription(true);
                     }}
                     onKeyDown={(event) => {
                       if (event.key === "Enter" || event.key === " ") {
                         event.preventDefault();
-                        setDescriptionSegments(createInlineMediaSegments(description, tasks));
+                        setDescriptionSegments(createInlineMediaSegments(description, referenceTasks));
                         setEditingDescription(true);
                       }
                     }}
                   >
                     {description
-                      ? <DescriptionDocument value={description} tasks={tasks} onOpenTask={onOpenTask} />
+                      ? <DescriptionDocument
+                          value={description}
+                          referenceTasks={referenceTasks}
+                          onOpenTask={onOpenTask}
+                        />
                       : text("添加描述…", "Add description…")}
                   </div>
                 )}
@@ -1273,13 +1298,19 @@ export function TaskDetail({
                             className="comment-inline-media"
                             segments={editingSegments}
                             mentionTasks={tasks}
+                            referenceTasks={referenceTasks}
                             placeholder={text("编辑评论", "Edit comment")}
                             ariaLabel={text("编辑评论", "Edit comment")}
                             disabled={savingCommentId === comment.id}
                             onChange={setEditingSegments}
                             onError={setCommentsError}
                             onKeyDown={(event) => {
-                              if (event.key === "Escape") endCommentEdit();
+                              if (event.key === "Escape") {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                endCommentEdit();
+                                return;
+                              }
                               if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
                                 event.preventDefault();
                                 void saveComment(comment);
@@ -1337,7 +1368,11 @@ export function TaskDetail({
                       ) : (
                         comment.body && (
                           <div className="comment-body">
-                            <DescriptionDocument value={comment.body} tasks={tasks} onOpenTask={onOpenTask} />
+                            <DescriptionDocument
+                              value={comment.body}
+                              referenceTasks={referenceTasks}
+                              onOpenTask={onOpenTask}
+                            />
                           </div>
                         )
                       )}
@@ -1412,6 +1447,7 @@ export function TaskDetail({
                   className="comment-inline-media"
                   segments={commentSegments}
                   mentionTasks={tasks}
+                  referenceTasks={referenceTasks}
                   placeholder={text("留下评论…", "Leave a comment…")}
                   ariaLabel={text("留下评论", "Leave a comment")}
                   onChange={setCommentSegments}

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -340,6 +340,19 @@ function DescriptionDocument({
   return (
     <MarkdownDocument
       value={value}
+      renderLink={(href) => {
+        const task = href ? referencedTask(href, tasks) : null;
+        if (!task) return null;
+        return (
+          <span className="issue-reference-inline">
+            <span className={`status-icon issue-reference-status status-icon-${STATUS_DETAILS[task.status].tone}`}>
+              <StatusIcon status={task.status} />
+            </span>
+            <span className="issue-reference-id">{task.externalKey ?? task.identifier}</span>
+            <span className="issue-reference-title">{task.title}</span>
+          </span>
+        );
+      }}
       onLinkClick={(event, href) => {
         const task = href ? referencedTask(href, tasks) : null;
         if (
@@ -410,7 +423,9 @@ export function TaskDetail({
     () => createInlineMediaSegments(task.description),
   );
   const [editingDescription, setEditingDescription] = useState(false);
-  const [propertyMenu, setPropertyMenu] = useState<"status" | "priority" | "assignee" | "labels" | null>(null);
+  const [propertyMenu, setPropertyMenu] = useState<
+    "status" | "priority" | "assignee" | "labels" | "development" | "recurrence" | null
+  >(null);
   const [savingProperty, setSavingProperty] = useState<string | null>(null);
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [attachmentsLoading, setAttachmentsLoading] = useState(true);
@@ -1606,34 +1621,36 @@ export function TaskDetail({
                 onDeleteLabel={currentTask.source === "jira" ? undefined : onDeleteLabel}
               />
             </div>
-            <label className="detail-property-row development-property">
-              <span className="detail-property-icon" aria-hidden="true">
-                <LinearIcon name="branch" />
-              </span>
+            <div className="detail-property-row development-property">
               <span className="detail-property-label">{text("开发上下文", "Development context")}</span>
-              <select
+              <TaskPropertyPicker
                 value={contextValue(currentTask.developmentContext)}
+                options={[
+                  {
+                    value: "",
+                    label: developmentScanLoading
+                      ? text("正在扫描 Git…", "Scanning Git…")
+                      : text("未绑定", "Not linked"),
+                    icon: <LinearIcon name="branch" />,
+                  },
+                  ...developmentOptions.map((context) => ({
+                    value: contextValue(context),
+                    label: contextLabel(context, text),
+                    icon: <LinearIcon name={context.type === "branch" ? "branch" : "folder"} />,
+                  })),
+                ]}
+                open={propertyMenu === "development"}
                 disabled={developmentScanLoading || savingProperty === "developmentContext"}
+                className="detail-property-picker"
+                triggerClassName="detail-property-trigger"
+                ariaLabel={text("开发上下文", "Development context")}
                 title={currentTask.developmentContext?.type === "worktree" ? currentTask.developmentContext.path : undefined}
-                onChange={(event) => void saveTask({
-                  developmentContext: event.target.value ? JSON.parse(event.target.value) as DevelopmentContext : null,
+                onOpenChange={(open) => setPropertyMenu(open ? "development" : null)}
+                onChange={(value) => void saveTask({
+                  developmentContext: value ? JSON.parse(value) as DevelopmentContext : null,
                 }, "developmentContext")}
-              >
-                <option value="">{developmentScanLoading
-                  ? text("正在扫描 Git…", "Scanning Git…")
-                  : text("未绑定", "Not linked")}</option>
-                <optgroup label={text("代码分支", "Code branches")}>
-                  {developmentOptions.filter((context) => context.type === "branch").map((context) => (
-                    <option value={contextValue(context)} key={contextValue(context)}>{contextLabel(context, text)}</option>
-                  ))}
-                </optgroup>
-                <optgroup label="Worktree">
-                  {developmentOptions.filter((context) => context.type === "worktree").map((context) => (
-                    <option value={contextValue(context)} key={contextValue(context)}>{contextLabel(context, text)}</option>
-                  ))}
-                </optgroup>
-              </select>
-            </label>
+              />
+            </div>
             <label className="detail-property-row">
               <span className="detail-property-icon" aria-hidden="true"><LinearIcon name="calendar" /></span>
               <span className="detail-property-label">{text("开始日期", "Start date")}</span>
@@ -1659,14 +1676,25 @@ export function TaskDetail({
                 }, "dueDate")}
               />
             </label>
-            <label className="detail-property-row">
-              <span className="detail-property-icon" aria-hidden="true"><LinearIcon name="recurrence" /></span>
+            <div className="detail-property-row">
               <span className="detail-property-label">{text("重复", "Recurrence")}</span>
-              <select
+              <TaskPropertyPicker
                 value={currentTask.recurrence?.unit ?? ""}
+                options={[
+                  { value: "", label: text("不重复", "Does not repeat"), icon: <LinearIcon name="recurrence" /> },
+                  { value: "day", label: text("每天", "Daily"), icon: <LinearIcon name="recurrence" /> },
+                  { value: "week", label: text("每周", "Weekly"), icon: <LinearIcon name="recurrence" /> },
+                  { value: "month", label: text("每月", "Monthly"), icon: <LinearIcon name="recurrence" /> },
+                  { value: "year", label: text("每年", "Yearly"), icon: <LinearIcon name="recurrence" /> },
+                ]}
+                open={propertyMenu === "recurrence"}
                 disabled={savingProperty === "recurrence"}
-                onChange={(event) => {
-                  const unit = event.target.value as Recurrence["unit"] | "";
+                className="detail-property-picker"
+                triggerClassName="detail-property-trigger"
+                ariaLabel={text("重复", "Recurrence")}
+                onOpenChange={(open) => setPropertyMenu(open ? "recurrence" : null)}
+                onChange={(value) => {
+                  const unit = value as Recurrence["unit"] | "";
                   const changes: Partial<TaskDraft> = {
                     recurrence: unit ? { interval: 1, unit } : null,
                   };
@@ -1678,14 +1706,8 @@ export function TaskDetail({
                   }
                   void saveTask(changes, "recurrence");
                 }}
-              >
-                <option value="">{text("不重复", "Does not repeat")}</option>
-                <option value="day">{text("每天", "Daily")}</option>
-                <option value="week">{text("每周", "Weekly")}</option>
-                <option value="month">{text("每月", "Monthly")}</option>
-                <option value="year">{text("每年", "Yearly")}</option>
-              </select>
-            </label>
+              />
+            </div>
             <IssueRelationSidebar
               task={currentTask}
               tasks={tasks}

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -44,7 +44,7 @@ import {
   assigneeTargetForActor,
 } from "../actors";
 import { ActorAvatar } from "./ActorAvatar";
-import { STATUS_DETAILS, StatusIcon } from "./BoardColumn";
+import { ColumnStatusIcon, STATUS_DETAILS, StatusIcon } from "./BoardColumn";
 import { LabelPicker } from "./LabelPicker";
 import { LinearIcon, LinearPriorityIcon } from "./LinearIcon";
 import { TaskboardIcon } from "./TaskboardIcon";
@@ -344,9 +344,9 @@ function DescriptionDocument({
         const task = href ? referencedTask(href, tasks) : null;
         if (!task) return null;
         return (
-          <span className="issue-reference-inline">
+          <span className={`issue-reference-inline issue-reference-status-${task.status}`}>
             <span className={`status-icon issue-reference-status status-icon-${STATUS_DETAILS[task.status].tone}`}>
-              <StatusIcon status={task.status} />
+              <ColumnStatusIcon status={task.status === "backlog" ? "todo" : task.status} />
             </span>
             <span className="issue-reference-id">{task.externalKey ?? task.identifier}</span>
             <span className="issue-reference-title">{task.title}</span>

--- a/web/src/components/TaskEditor.tsx
+++ b/web/src/components/TaskEditor.tsx
@@ -91,6 +91,7 @@ export interface NewTaskEditorDraft {
 interface TaskEditorProps {
   task: Task | null;
   tasks: Task[];
+  referenceTasks: Task[];
   initialStatus: TaskStatus;
   initialDraft: NewTaskEditorDraft | null;
   labels: string[];
@@ -146,6 +147,7 @@ function contextLabel(
 export function TaskEditor({
   task,
   tasks,
+  referenceTasks,
   initialStatus,
   initialDraft,
   labels: availableLabels,
@@ -517,6 +519,7 @@ export function TaskEditor({
               className="composer-description inline-media-description"
               segments={descriptionSegments}
               mentionTasks={tasks}
+              referenceTasks={referenceTasks}
               placeholder={text("添加描述…", "Add description…")}
               ariaLabel={text("描述", "Description")}
               disabled={saving}

--- a/web/src/components/TaskEditor.tsx
+++ b/web/src/components/TaskEditor.tsx
@@ -640,9 +640,16 @@ export function TaskEditor({
 
             {!task && selectedRelationChips.map(({ type, issue }) => {
               const identifier = issue.externalKey ?? issue.identifier;
+              const relationLabel = type === "subIssue"
+                ? text("子", "Sub")
+                : type === "parent"
+                  ? text("父", "Parent")
+                  : text("关联", "Related");
               return (
                 <span className="property-control property-relation-chip" key={`${type}:${issue.id}`}>
+                  <span className="property-relation-kind">{relationLabel}</span>
                   <span>{identifier}</span>
+                  <span className="property-relation-tooltip" role="tooltip">{issue.title}</span>
                   <button
                     className="property-relation-remove"
                     type="button"

--- a/web/src/components/TaskPropertyPicker.tsx
+++ b/web/src/components/TaskPropertyPicker.tsx
@@ -48,7 +48,7 @@ export function TaskPropertyPicker<Value extends string>({
   const [position, setPosition] = useState({ left: 0, top: 0 });
   const [focusedIndex, setFocusedIndex] = useState(0);
   const selected = options.find((option) => option.value === value) ?? options[0];
-  const portalTarget = triggerRef.current?.closest("dialog") ?? document.body;
+  const portalTarget = triggerRef.current?.closest("dialog, [role='dialog']") ?? document.body;
 
   function optionElements(): HTMLButtonElement[] {
     return Array.from(menuRef.current?.querySelectorAll<HTMLButtonElement>("[role='option']") ?? []);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2689,7 +2689,7 @@ kbd {
   gap: 5px;
   padding: 0 6px 0 4px;
   border-radius: 5px;
-  background: var(--surface-hover);
+  background: var(--column-status-background, var(--surface-hover));
   box-shadow: inset 0 0 0 var(--border-hairline) var(--border);
   color: var(--text-secondary);
   font-size: 0.94em;
@@ -2698,7 +2698,7 @@ kbd {
 }
 
 .issue-reference-link:hover .issue-reference-inline {
-  background: var(--surface-active);
+  background: var(--column-status-background, var(--surface-active));
 }
 
 .issue-reference-status {
@@ -2718,7 +2718,7 @@ kbd {
 
 .issue-reference-id {
   flex: 0 0 auto;
-  color: var(--text-secondary);
+  color: var(--column-status-color, var(--text-secondary));
   font-weight: 550;
   font-variant-numeric: tabular-nums;
 }
@@ -9435,20 +9435,47 @@ kbd {
   background: transparent;
 }
 
-.board-column.status-todo .column-header {
-  background: rgba(151, 71, 255, .1);
+.board-column.status-todo,
+.issue-reference-inline.issue-reference-status-backlog,
+.issue-reference-inline.issue-reference-status-todo {
+  --column-status-color: #9747ff;
+  --column-status-background: rgba(151, 71, 255, .1);
 }
 
-.board-column.status-in_progress .column-header {
-  background: rgba(0, 165, 88, .15);
+.board-column.status-in_progress,
+.issue-reference-inline.issue-reference-status-in_progress {
+  --column-status-color: #00a558;
+  --column-status-background: rgba(0, 165, 88, .15);
 }
 
-.board-column.status-in_review .column-header {
-  background: rgba(49, 124, 255, .1);
+.board-column.status-in_review,
+.issue-reference-inline.issue-reference-status-in_review {
+  --column-status-color: #317cff;
+  --column-status-background: rgba(49, 124, 255, .1);
 }
 
+.board-column.status-blocked,
+.issue-reference-inline.issue-reference-status-blocked {
+  --column-status-color: #e5484d;
+  --column-status-background: rgba(229, 72, 77, .1);
+}
+
+.issue-reference-inline.issue-reference-status-done {
+  --column-status-color: var(--status-done);
+  --column-status-background: color-mix(in srgb, var(--status-done) 10%, transparent);
+}
+
+.issue-reference-inline.issue-reference-status-canceled {
+  --column-status-color: var(--status-canceled);
+  --column-status-background: color-mix(in srgb, var(--status-canceled) 10%, transparent);
+}
+
+.board-column.status-todo .column-header,
+.board-column.status-in_progress .column-header,
+.board-column.status-in_review .column-header,
 .board-column.status-blocked .column-header {
-  background: rgba(229, 72, 77, .1);
+  background: var(--column-status-background);
+  color: var(--column-status-color);
 }
 
 .board-column:not(:first-child) .column-header::before {
@@ -9492,11 +9519,6 @@ kbd {
   max-width: 14px;
   max-height: 14px;
 }
-
-.board-column.status-todo .column-header { color: #9747ff; }
-.board-column.status-in_progress .column-header { color: #00a558; }
-.board-column.status-in_review .column-header { color: #317cff; }
-.board-column.status-blocked .column-header { color: #e5484d; }
 
 .column-actions {
   color: inherit;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1269,9 +1269,17 @@ kbd {
   flex: 0 0 auto;
 }
 
-.project-automation-field select {
-  min-width: 98px;
+.project-automation-picker {
+  flex: 0 0 132px;
+  width: 132px;
+}
+
+.project-automation-picker-trigger {
+  display: flex;
+  align-items: center;
+  width: 100%;
   height: 26px;
+  gap: 6px;
   padding: 0 6px;
   border: var(--border-hairline) solid var(--border);
   border-radius: 5px;
@@ -1279,11 +1287,20 @@ kbd {
   background: var(--surface);
   color: var(--text-primary);
   font: inherit;
+  text-align: left;
 }
 
-.project-automation-field select:focus-visible {
+.project-automation-picker-trigger:hover:not(:disabled) {
+  background: var(--surface-hover);
+}
+
+.project-automation-picker-trigger:focus-visible {
   outline: 0;
-  box-shadow: none;
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+.project-automation-picker-trigger .task-property-trigger-label {
+  flex: 1 1 auto;
 }
 
 .project-automation-note,
@@ -2653,6 +2670,62 @@ kbd {
 
 .issue-description-document a:hover {
   text-decoration: underline;
+}
+
+.issue-description-document a.issue-reference-link {
+  color: inherit;
+}
+
+.issue-description-document a.issue-reference-link:hover {
+  text-decoration: none;
+}
+
+.issue-reference-inline {
+  display: inline-flex;
+  align-items: center;
+  max-width: min(440px, calc(100vw - 48px));
+  min-height: 22px;
+  gap: 5px;
+  padding: 0 6px 0 4px;
+  border-radius: 5px;
+  background: var(--surface-hover);
+  box-shadow: inset 0 0 0 var(--border-hairline) var(--border);
+  color: var(--text-secondary);
+  font-size: 0.94em;
+  line-height: 22px;
+  vertical-align: middle;
+}
+
+.issue-reference-link:hover .issue-reference-inline {
+  background: var(--surface-active);
+}
+
+.issue-reference-status {
+  display: grid;
+  place-items: center;
+  flex: 0 0 15px;
+  width: 15px;
+  height: 15px;
+}
+
+.issue-reference-status .taskboard-icon {
+  width: 15px;
+  height: 15px;
+}
+
+.issue-reference-id {
+  flex: 0 0 auto;
+  color: var(--text-secondary);
+  font-weight: 550;
+  font-variant-numeric: tabular-nums;
+}
+
+.issue-reference-title {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .issue-description-document ul,
@@ -6262,6 +6335,39 @@ kbd {
 .property-relation-chip {
   flex: 0 0 auto;
   white-space: nowrap;
+}
+
+.property-relation-kind {
+  color: var(--text-tertiary);
+  font-size: 10px;
+  font-weight: 650;
+}
+
+.property-relation-tooltip {
+  position: absolute;
+  z-index: 40;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  display: none;
+  width: max-content;
+  max-width: min(280px, calc(100vw - 24px));
+  padding: 5px 8px;
+  border: var(--border-hairline) solid var(--border-strong);
+  border-radius: 6px;
+  background: var(--surface-raised);
+  color: var(--text-primary);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.14);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 16px;
+  pointer-events: none;
+  transform: translateX(-50%);
+  white-space: normal;
+}
+
+.property-relation-chip:hover .property-relation-tooltip,
+.property-relation-chip:focus-within .property-relation-tooltip {
+  display: block;
 }
 
 .property-relation-remove {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2673,7 +2673,9 @@ kbd {
 }
 
 .issue-description-document a.issue-reference-link {
+  display: inline-flex;
   color: inherit;
+  vertical-align: middle;
 }
 
 .issue-description-document a.issue-reference-link:hover {
@@ -2683,7 +2685,6 @@ kbd {
 .issue-reference-inline {
   display: inline-flex;
   align-items: center;
-  max-width: min(440px, calc(100vw - 48px));
   min-height: 22px;
   gap: 5px;
   padding: 0 6px 0 4px;
@@ -2693,7 +2694,7 @@ kbd {
   color: var(--text-secondary);
   font-size: 0.94em;
   line-height: 22px;
-  vertical-align: middle;
+  white-space: nowrap;
 }
 
 .issue-reference-link:hover .issue-reference-inline {
@@ -2711,6 +2712,8 @@ kbd {
 .issue-reference-status .taskboard-icon {
   width: 15px;
   height: 15px;
+  margin: 0;
+  border-radius: 0;
 }
 
 .issue-reference-id {
@@ -2721,10 +2724,8 @@ kbd {
 }
 
 .issue-reference-title {
-  min-width: 0;
-  overflow: hidden;
+  flex: 0 0 auto;
   color: var(--text-primary);
-  text-overflow: ellipsis;
   white-space: nowrap;
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6574,6 +6574,38 @@ kbd {
   width: 100%;
 }
 
+.inline-media-composer.has-issue-references {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 2px 4px;
+}
+
+.inline-media-composer.has-issue-references > textarea {
+  display: inline-block;
+  flex: 0 1 auto;
+  field-sizing: content;
+  width: auto;
+  min-width: 1ch;
+  max-width: 100%;
+}
+
+.inline-media-composer.has-issue-references > textarea:last-of-type {
+  flex-grow: 1;
+}
+
+.inline-media-composer.has-issue-references > .inline-media-image {
+  flex: 0 0 100%;
+}
+
+.inline-media-issue-reference {
+  flex: 0 0 auto;
+  appearance: none;
+  border: 0;
+  font-family: inherit;
+  cursor: text;
+}
+
 .inline-media-image {
   position: relative;
   width: fit-content;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6574,6 +6574,13 @@ kbd {
   width: 100%;
 }
 
+.inline-media-composer.is-all-selected {
+  border-radius: 6px;
+  background: var(--accent-soft);
+  outline: 2px solid color-mix(in srgb, var(--accent) 45%, transparent);
+  outline-offset: 2px;
+}
+
 .inline-media-composer.has-issue-references {
   display: flex;
   align-items: center;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2586,7 +2586,7 @@ kbd {
   border-radius: 7px;
 }
 
-.issue-description-composer .inline-media-composer textarea {
+.issue-description-composer .inline-media-composer {
   min-height: 24px;
   padding: 0;
   font-size: inherit;
@@ -2594,7 +2594,7 @@ kbd {
   line-height: inherit;
 }
 
-.issue-description-composer .inline-media-composer > textarea:only-child {
+.issue-description-composer .inline-media-composer[data-empty="true"] {
   min-height: 42px;
 }
 
@@ -3957,16 +3957,22 @@ kbd {
   padding: 0 0 16px;
 }
 
-.inline-media-composer textarea {
-  display: block;
+.inline-media-composer {
   width: 100%;
-  resize: none;
   border: 0;
   outline: 0;
   background: transparent;
   color: var(--text-primary);
   font-size: 12px;
   line-height: 19px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.inline-media-composer[data-empty="true"]::before {
+  content: attr(data-placeholder);
+  color: var(--text-tertiary);
+  pointer-events: none;
 }
 
 .comment-edit-actions {
@@ -4046,19 +4052,13 @@ kbd {
   padding: 10px 16px 14px;
 }
 
-.comment-inline-media textarea {
-  min-height: 24px;
-  padding: 0;
+.comment-inline-media {
   font-size: 15px;
   line-height: 24px;
 }
 
-.comment-inline-media > textarea:only-child {
+.comment-inline-media[data-empty="true"] {
   min-height: 82px;
-}
-
-.comment-inline-media textarea::placeholder {
-  color: var(--text-tertiary);
 }
 
 .comment-composer-files {
@@ -6287,13 +6287,7 @@ kbd {
   padding: 6px 0 12px;
 }
 
-.inline-media-description textarea {
-  min-height: 24px;
-  margin: 0;
-  padding: 0;
-}
-
-.inline-media-description > textarea:only-child {
+.inline-media-description[data-empty="true"] {
   min-height: 100px;
 }
 
@@ -6574,39 +6568,33 @@ kbd {
   width: 100%;
 }
 
-.inline-media-composer.is-all-selected {
-  border-radius: 6px;
-  background: var(--accent-soft);
-  outline: 2px solid color-mix(in srgb, var(--accent) 45%, transparent);
+.inline-media-text {
+  white-space: pre-wrap;
+}
+
+.inline-media-atom {
+  display: inline;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.inline-media-image-atom {
+  display: block;
+}
+
+.inline-media-atom.is-range-selected > .inline-media-issue-reference {
+  background: color-mix(in srgb, var(--accent) 14%, var(--surface));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 58%, transparent);
+}
+
+.inline-media-image-atom.is-range-selected > .inline-media-image {
+  border-radius: 8px;
+  outline: 1px solid color-mix(in srgb, var(--accent) 72%, transparent);
   outline-offset: 2px;
-}
-
-.inline-media-composer.has-issue-references {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 2px 4px;
-}
-
-.inline-media-composer.has-issue-references > textarea {
-  display: inline-block;
-  flex: 0 1 auto;
-  field-sizing: content;
-  width: auto;
-  min-width: 1ch;
-  max-width: 100%;
-}
-
-.inline-media-composer.has-issue-references > textarea:last-of-type {
-  flex-grow: 1;
-}
-
-.inline-media-composer.has-issue-references > .inline-media-image {
-  flex: 0 0 100%;
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
 .inline-media-issue-reference {
-  flex: 0 0 auto;
   appearance: none;
   border: 0;
   font-family: inherit;


### PR DESCRIPTION
## Summary

- LOCAL-184: keep saved and editing issue references as one status-colored inline tag with the app status icon, ID, and full title; make mixed text, persisted images, and issue references one continuous editable document flow with ordered mouse selection, metadata-preserving copy, and style-restoring paste.
- LOCAL-185: replace the five screenshot-proven native selects in automation and task details with the existing TaskPropertyPicker style while preserving their current data paths.
- LOCAL-211: label new-issue relation tags as 子、父、关联 in the existing order and show the full issue title on hover.

## LOCAL-184 follow-up

- Replace the split textarea layout with one contenteditable root. Text segments are real text nodes; persisted images and issue references remain non-editable atomic segments in the existing segment order.
- Map the normalized DOM Range to the existing segment offsets. Forward and reverse mouse selection, Cmd/Ctrl+A, ordered Markdown copy, range input, and Delete/Backspace all use that same document order.
- Keep the existing segment model, Markdown serialization, image upload path, mention filtering, keyboard selection, draft handling, task and comment save APIs, and reference navigation.
- Keep active tasks as picker candidates and active plus archived tasks as reference lookup. Deleted targets remain stable ID-only references.
- Match the supplied Linear selection reference: ordinary text uses the native pale-blue range; selected issue tags keep the app status icon, ID, and title with a pale-blue selected surface; selected images keep their original pixels and use a thin blue rounded outline.

## Latest LOCAL-184 Pro delta

- Do not rescan the mention query on the Escape keyup. The first Escape closes the @ menu and keeps the editor open; the next Escape reaches the existing outer cancel handler.
- Read the current beforeinput target range instead of deleting one UTF-16 code unit. Native Backspace/Delete now remove a complete emoji, and native word deletion keeps the operating-system range.
- Let same-text input and deletion complete as native contenteditable edits. Sync the resulting DOM back to the existing segments without immediately replacing that native DOM, so the browser retains its undo transaction.
- Keep cross-media segment replacement, structured Markdown paste, mention insertion, serialization, and save APIs unchanged. No UI styles changed.

## Latest LOCAL-184 undo identity delta

- Render the existing empty text segment with a `<br>` inside its own segment span. Chromium now places the first `beforeinput` target range inside that span, so the first ordinary input creates a native undo transaction.
- Let browser deletion use its real target range, including a full mixed-content selection, then sync the resulting DOM back into the existing segment model.
- Keep a component-local ID-to-segment registry for DOM restored by native Undo, and reuse the existing empty text segment ID when the DOM temporarily contains only the root `<br>`. Restored text, image, and issue-reference nodes therefore reconnect to the same segment metadata and atom hosts.
- The delta changes only `InlineMediaComposer.tsx`; it does not change UI styles, Markdown, APIs, LOCAL-185, or LOCAL-211.

## Final LOCAL-184 DOM synchronization delta

- Keep the browser-owned direct Text or `<br>` after a full native deletion in the same native history chain. Do not create a new wrapper between the deletion and the next input.
- Treat that single root-owned node as the existing sole text segment for DOM offsets, caret restoration, native input, mention queries, and DOM-to-segment synchronization. Undo can therefore restore the original wrapped `abc` node, and Redo can restore the direct `a` node, without duplicate segment IDs or synthesized newlines.
- Keep native deletion only when the target range stays in one text segment, plus the full-document deletion needed for native Undo. A partial range that crosses a persisted image, issue reference, or text-segment boundary still uses the existing normalized segment replacement.
- The final delta changes only `InlineMediaComposer.tsx`. It does not alter the accepted UI styles, Markdown format, save APIs, LOCAL-185, or LOCAL-211.

## Direct verification

- Real Chromium strict chain: `abc` was one wrapped text segment; full deletion was one root `<br>`; typing `a` was one direct text node; Undo returned to the root `<br>`; the second Undo restored exactly one original `abc` span with its original ID; the two Redo operations returned to one root `<br>` and one direct `a` text node.
- At those seven steps, `innerText` and real Copy serialization were respectively `abc/abc`, placeholder newline/empty, `a/a`, placeholder newline/empty, `abc/abc`, placeholder newline/empty, and `a/a`. No duplicate ID, ghost leading newline, or trailing newline remained.
- From the final direct `a` text node, typing ` @LOCAL` opened the real issue listbox, proving the root-owned text still maps to the existing text segment and mention path.
- In the exact mixed flow `abc → image → def → issue reference → ghi`, Delete at the end of `abc` and Backspace at the start of `def` each removed only the image and rebuilt adjacent text as one synchronized segment. Both directions then opened the real `@LOCAL` listbox and copied the remaining issue reference as Markdown.
- A fresh empty editor still allowed the first typed `a` to Undo to empty. The earlier direct-input first Undo path remains covered by the strict seven-step chain.
- In a real mixed description, full deletion then Undo restored the original five direct children, persisted image, issue reference, and atom hosts. Forward and reverse mouse drags crossed all content and copied Markdown in document order: text before → image Markdown → middle text → issue-reference Markdown → text after.
- Backspace and forward Delete removed the complete 🚀 emoji; Cmd+Z restored it. Option+Backspace removed the browser-selected whole word; Cmd+Z restored it.
- The first Escape closed a visible @ menu without reopening it; the second Escape canceled description editing.
- The existing description blur path saved and restored a temporary marker through successful `PATCH /api/tasks/:id` requests. Reload showed the original text, image, and issue tag.
- Fresh Chromium verification reported 0 console errors.
- Archived-reference drafts, saved descriptions, and comments retained full tags; deleted targets rendered ID-only tags without crashes.
- Real automation and task-detail picker paths, plus relation-tag rendering and hover, remain covered by the prior accepted LOCAL-185 and LOCAL-211 evidence.

## Checks

- `npm run typecheck`
- `npm run build:web`
- `git diff --check`
- GitHub CI: 6/6 jobs passed across the push and pull_request runs for exact head `5c556173bc49e29356536f22ba742622a7b787e2`.

All three issues remain in_progress. This PR does not merge or release the changes.
