### PR TITLE
Add board card display settings and custom assignee picker

### DIFF
--- a/test/issue-assignee.test.mjs
+++ b/test/issue-assignee.test.mjs
@@ -46,15 +46,16 @@ test("issue card assignee control uses compact participant avatars", async () =>
     source("web/src/styles.css"),
   ]);
 
-  assert.match(cardSource, /className="task-participants-control card-property-control"/);
-  assert.match(cardSource, /<ParticipantAvatars participants=\{participants\} \/>/);
-  assert.match(cardSource, /aria-label=\{text\(`\$\{displayIdentifier\} 负责人`, `\$\{displayIdentifier\} assignee`\)\}/);
+  assert.match(
+    cardSource,
+    /<TaskPropertyPicker[\s\S]*?className="task-participants-control card-property-control"[\s\S]*?triggerClassName="task-assignee-trigger"[\s\S]*?triggerContent=\{<ParticipantAvatars participants=\{participants\} \/>\}[\s\S]*?ariaLabel=\{text\(`\$\{displayIdentifier\} 负责人`, `\$\{displayIdentifier\} assignee`\)\}/,
+  );
   assert.match(
     styles,
     /\.task-participant-avatar\s*\{[^}]*width:\s*16px;[^}]*height:\s*16px;/s,
   );
   assert.match(
     styles,
-    /\.task-participants-control select\s*\{[^}]*position:\s*absolute;[^}]*inset:\s*0;[^}]*opacity:\s*0;/s,
+    /\.task-assignee-trigger\s*\{[^}]*display:\s*inline-flex;[^}]*height:\s*20px;[^}]*padding:\s*0;[^}]*border:\s*0;[^}]*background:\s*transparent;/s,
   );
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -62,6 +62,7 @@ import {
 } from "./actors";
 import { BoardColumn } from "./components/BoardColumn";
 import type { AiChatOpenThreadRequest } from "./components/AiChat";
+import { BoardCardDisplayMenu } from "./components/BoardCardDisplayMenu";
 import { DashboardView } from "./components/DashboardView";
 import { IssueListView } from "./components/IssueListView";
 import { JiraConnectionDialog } from "./components/JiraConnectionDialog";
@@ -145,6 +146,7 @@ type DetailSourceScroll =
   | { projectId: string; view: "issues"; status: TaskStatus; scrollTop: number }
   | { projectId: string; view: "list"; scrollTop: number };
 type GanttZoom = "day" | "week" | "month";
+type BoardCardDisplay = { cover: boolean; body: boolean };
 type ActionError = string | readonly [string, string];
 type ProjectLoadError = {
   source: "projects";
@@ -311,6 +313,7 @@ const PROJECT_VIEW_KEY_PREFIX = "taskboard.project-view.v1.";
 const DEVICE_WORKSPACE_PATHS_KEY = "taskboard.deviceWorkspacePaths.v1";
 const PROJECT_CODEX_IDENTITIES_KEY = "taskboard.projectCodexIdentities.v1";
 const PROJECT_AUTOMATIONS_KEY = "taskboard.projectAutomations.v1";
+const BOARD_CARD_DISPLAY_KEY = "taskboard.board-card-display.v1";
 const ISSUE_READ_KEY_PREFIX = "taskboard.issue-read.v1";
 const FIRST_USE_COMPLETE_KEY = "taskboard.first-use-complete.v1";
 const DEFAULT_AUTOMATION_OPTIONS = {
@@ -338,6 +341,18 @@ function readProjectBoardView(projectId: string): BoardView {
   return view === "dashboard" || view === "list" || view === "gantt" || view === "issues"
     ? view
     : "issues";
+}
+
+function readBoardCardDisplay(): BoardCardDisplay {
+  try {
+    const value = JSON.parse(taskboardStorage.getItem(BOARD_CARD_DISPLAY_KEY) ?? "{}");
+    return {
+      cover: value.cover !== false,
+      body: value.body === true,
+    };
+  } catch {
+    return { cover: true, body: false };
+  }
 }
 
 function readRecentProjectIds(): string[] {
@@ -719,6 +734,7 @@ export function App() {
   const [search, setSearch] = useState("");
   const [filters, setFilters] = useState(readTaskFilters);
   const [boardView, setBoardView] = useState<BoardView>(() => readProjectBoardView(initialProjectId));
+  const [boardCardDisplay, setBoardCardDisplay] = useState<BoardCardDisplay>(readBoardCardDisplay);
   const [dashboardSummaryAnimatedProjectId, setDashboardSummaryAnimatedProjectId] = useState<string | null>(null);
   const [ganttZoom, setGanttZoom] = useState<GanttZoom>("week");
   const [ganttHideCompleted, setGanttHideCompleted] = useState(false);
@@ -2108,6 +2124,11 @@ export function App() {
     if (selectedProjectId) {
       taskboardStorage.setItem(`${PROJECT_VIEW_KEY_PREFIX}${selectedProjectId}`, view);
     }
+  }
+
+  function updateBoardCardDisplay(value: BoardCardDisplay) {
+    setBoardCardDisplay(value);
+    taskboardStorage.setItem(BOARD_CARD_DISPLAY_KEY, JSON.stringify(value));
   }
 
   async function saveEditor(
@@ -3508,6 +3529,13 @@ export function App() {
               onChange={setFilters}
             />
             {boardView === "issues" && (
+              <BoardCardDisplayMenu
+                cover={boardCardDisplay.cover}
+                body={boardCardDisplay.body}
+                onChange={updateBoardCardDisplay}
+              />
+            )}
+            {boardView === "issues" && (
               <button
                 className={`other-tasks-trigger${otherTasksOpen ? " is-open" : ""}`}
                 type="button"
@@ -3695,6 +3723,8 @@ export function App() {
                         contextMenuTaskId={contextMenu?.taskId ?? null}
                         availableLabels={availableLabels}
                         currentUser={currentUser}
+                        showCover={boardCardDisplay.cover}
+                        showBody={boardCardDisplay.body}
                         createEnabled={!isJiraProject}
                         onCreateLabel={persistProjectLabel}
                         onCreate={(initialStatus) => setEditor({ task: null, status: initialStatus })}
@@ -3728,6 +3758,8 @@ export function App() {
                     contextMenuTaskId={contextMenu?.taskId ?? null}
                     availableLabels={availableLabels}
                     currentUser={currentUser}
+                    showCover={boardCardDisplay.cover}
+                    showBody={boardCardDisplay.body}
                     onCreateLabel={persistProjectLabel}
                     restoringTaskId={restoringTaskId}
                     deletingTaskId={deletingArchivedTaskId}

--- a/web/src/components/BoardCardDisplayMenu.tsx
+++ b/web/src/components/BoardCardDisplayMenu.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useTaskboardI18n } from "../i18n";
+import { LinearIcon } from "./LinearIcon";
+
+interface BoardCardDisplayMenuProps {
+  cover: boolean;
+  body: boolean;
+  onChange: (value: { cover: boolean; body: boolean }) => void;
+}
+
+export function BoardCardDisplayMenu({
+  cover,
+  body,
+  onChange,
+}: BoardCardDisplayMenuProps) {
+  const { text } = useTaskboardI18n();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState({ left: 0, top: 0, ready: false });
+
+  useLayoutEffect(() => {
+    if (!open || !triggerRef.current || !menuRef.current) return;
+    const trigger = triggerRef.current.getBoundingClientRect();
+    const menu = menuRef.current.getBoundingClientRect();
+    const left = Math.max(8, Math.min(trigger.right - menu.width, window.innerWidth - menu.width - 8));
+    const top = trigger.bottom + 8 + menu.height <= window.innerHeight
+      ? trigger.bottom + 8
+      : Math.max(8, trigger.top - menu.height - 8);
+    setPosition({ left, top, ready: true });
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function closeFromOutside(event: PointerEvent) {
+      if (!menuRef.current?.contains(event.target as Node) && !triggerRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function closeFromViewportChange() {
+      setOpen(false);
+    }
+    function closeFromEscape(event: KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      setOpen(false);
+      triggerRef.current?.focus();
+    }
+    document.addEventListener("pointerdown", closeFromOutside);
+    document.addEventListener("keydown", closeFromEscape);
+    window.addEventListener("resize", closeFromViewportChange);
+    window.addEventListener("scroll", closeFromViewportChange, true);
+    return () => {
+      document.removeEventListener("pointerdown", closeFromOutside);
+      document.removeEventListener("keydown", closeFromEscape);
+      window.removeEventListener("resize", closeFromViewportChange);
+      window.removeEventListener("scroll", closeFromViewportChange, true);
+    };
+  }, [open]);
+
+  const menu = open ? createPortal(
+    <div
+      ref={menuRef}
+      className="project-automation-menu no-drag"
+      role="dialog"
+      aria-label={text("卡片显示设置", "Card display settings")}
+      style={{ left: position.left, top: position.top, visibility: position.ready ? "visible" : "hidden" }}
+    >
+      <div className="project-automation-menu-heading">
+        <strong>{text("卡片显示", "Card display")}</strong>
+      </div>
+      <div className="project-automation-switch">
+        <span>{text("封面", "Cover")}</span>
+        <button
+          type="button"
+          className={`board-setting-switch${cover ? " is-on" : ""}`}
+          role="switch"
+          aria-label={text("封面", "Cover")}
+          aria-checked={cover}
+          onClick={() => onChange({ cover: !cover, body })}
+        >
+          <span aria-hidden="true" />
+        </button>
+      </div>
+      <div className="project-automation-switch">
+        <span>{text("正文", "Body")}</span>
+        <button
+          type="button"
+          className={`board-setting-switch${body ? " is-on" : ""}`}
+          role="switch"
+          aria-label={text("正文", "Body")}
+          aria-checked={body}
+          onClick={() => onChange({ cover, body: !body })}
+        >
+          <span aria-hidden="true" />
+        </button>
+      </div>
+    </div>,
+    document.body,
+  ) : null;
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        className={`task-filter-trigger board-card-display-trigger${open ? " is-open" : ""}`}
+        type="button"
+        aria-label={text("卡片显示设置", "Card display settings")}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        title={text("卡片显示", "Card display")}
+        onClick={() => {
+          if (!open) setPosition({ left: 0, top: 0, ready: false });
+          setOpen((current) => !current);
+        }}
+      >
+        <LinearIcon name="displayOptions" />
+      </button>
+      {menu}
+    </>
+  );
+}

--- a/web/src/components/BoardColumn.tsx
+++ b/web/src/components/BoardColumn.tsx
@@ -77,6 +77,8 @@ interface BoardColumnProps {
   contextMenuTaskId: string | null;
   availableLabels: string[];
   currentUser: ActorIdentity;
+  showCover: boolean;
+  showBody: boolean;
   createEnabled?: boolean;
   onCreateLabel: (label: string) => Promise<void>;
   onCreate: (status: TaskStatus) => void;
@@ -106,6 +108,8 @@ export function BoardColumn({
   contextMenuTaskId,
   availableLabels,
   currentUser,
+  showCover,
+  showBody,
   createEnabled = true,
   onCreateLabel,
   onCreate,
@@ -224,6 +228,8 @@ export function BoardColumn({
               isContextMenuOpen={contextMenuTaskId === task.id}
               availableLabels={availableLabels}
               currentUser={currentUser}
+              showCover={showCover}
+              showBody={showBody}
               onCreateLabel={onCreateLabel}
               onEdit={onEdit}
               onUpdate={onUpdate}

--- a/web/src/components/OtherTasksPanel.tsx
+++ b/web/src/components/OtherTasksPanel.tsx
@@ -95,6 +95,8 @@ interface OtherTasksPanelProps {
   contextMenuTaskId: string | null;
   availableLabels: string[];
   currentUser: ActorIdentity;
+  showCover: boolean;
+  showBody: boolean;
   onCreateLabel: (label: string) => Promise<void>;
   restoringTaskId: string | null;
   deletingTaskId: string | null;
@@ -128,6 +130,8 @@ export function OtherTasksPanel({
   contextMenuTaskId,
   availableLabels,
   currentUser,
+  showCover,
+  showBody,
   onCreateLabel,
   restoringTaskId,
   deletingTaskId,
@@ -287,6 +291,8 @@ export function OtherTasksPanel({
               isContextMenuOpen={contextMenuTaskId === task.id}
               availableLabels={availableLabels}
               currentUser={currentUser}
+              showCover={showCover}
+              showBody={showBody}
               onCreateLabel={onCreateLabel}
               onEdit={onEdit}
               onUpdate={onUpdate}

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -1,4 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import remarkGfm from "remark-gfm";
+import remarkParse from "remark-parse";
+import { unified } from "unified";
 import { attachmentContentUrl, resolvePersistedAttachmentUrl } from "../api";
 import {
   TASK_PRIORITIES,
@@ -46,6 +49,37 @@ interface TaskCardProps {
   onDragStart: (task: Task, height: number) => void;
   onDragEnd: () => void;
   onOpenConversation: (conversation: TaskConversationItem) => void;
+}
+
+interface TaskCardMarkdownNode {
+  type: string;
+  value?: string;
+  children?: TaskCardMarkdownNode[];
+}
+
+const taskCardMarkdownParser = unified().use(remarkParse).use(remarkGfm);
+
+function taskBodyText(value: string) {
+  function visibleText(node: TaskCardMarkdownNode): string {
+    if (node.type === "image" || node.type === "imageReference" || node.type === "definition") {
+      return "";
+    }
+    if (node.type === "break") return " ";
+    if (node.value !== undefined) return node.value;
+    const separator = node.type === "root"
+      || node.type === "blockquote"
+      || node.type === "list"
+      || node.type === "listItem"
+      || node.type === "table"
+      || node.type === "tableRow"
+      ? " "
+      : "";
+    return node.children?.map(visibleText).join(separator) ?? "";
+  }
+
+  return visibleText(taskCardMarkdownParser.parse(value) as TaskCardMarkdownNode)
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function calendarDate(value: string, locale: string) {
@@ -392,12 +426,10 @@ export function TaskCard({
   const showsInlineParticipants = variant === "main"
     && task.participants.length > 0;
   const image = showCover ? firstTaskImage(task) : null;
-  const body = showBody
-    ? task.description
-        .replace(/!\[[^\]]*\]\((?:<[^>]+>|[^\s)]+)(?:\s+["'][^)]*["'])?\)/g, " ")
-        .replace(/\s+/g, " ")
-        .trim()
-    : "";
+  const body = useMemo(
+    () => showBody ? taskBodyText(task.description) : "",
+    [showBody, task.description],
+  );
   const hasProperties = task.priority !== "none" || task.labels.length > 0 || task.dueDate;
   const showsProperties = !processingCard
     && (hasProperties || showsInlineParticipants || showsConversation);

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -36,6 +36,8 @@ interface TaskCardProps {
   isContextMenuOpen: boolean;
   availableLabels: string[];
   currentUser: ActorIdentity;
+  showCover: boolean;
+  showBody: boolean;
   onCreateLabel: (label: string) => Promise<void>;
   onEdit: (task: Task) => void;
   onUpdate: (task: Task, changes: Partial<TaskDraft>) => Promise<Task>;
@@ -304,12 +306,16 @@ function AssigneeControl({
   participants,
   currentUser,
   disabled,
+  open,
+  onOpenChange,
   onChange,
 }: {
   task: Task;
   participants: ActorIdentity[];
   currentUser: ActorIdentity;
   disabled: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   onChange: (target: AssigneeTarget) => void;
 }) {
   const { text } = useTaskboardI18n();
@@ -319,25 +325,27 @@ function AssigneeControl({
       actors.findIndex((candidate) => actorKey(candidate) === actorKey(actor)) === index
     ));
   return (
-    <label className="task-participants-control card-property-control" title={text(`负责人：${task.assignee.name}`, `Assignee: ${task.assignee.name}`)}>
-      <ParticipantAvatars participants={participants} />
-      <select
-        aria-label={text(`${displayIdentifier} 负责人`, `${displayIdentifier} assignee`)}
-        value={actorKey(task.assignee)}
-        disabled={disabled}
-        onChange={(event) => {
-          const selected = options.find((actor) => actorKey(actor) === event.target.value);
-          const target = selected ? assigneeTargetForActor(selected, currentUser) : undefined;
-          if (target) onChange(target);
-        }}
-      >
-        {options.map((actor) => (
-          <option value={actorKey(actor)} key={actorKey(actor)}>
-            {actor.id === currentUser.id ? text(`${actor.name}（我）`, `${actor.name} (me)`) : actor.name}
-          </option>
-        ))}
-      </select>
-    </label>
+    <TaskPropertyPicker
+      value={actorKey(task.assignee)}
+      options={options.map((actor) => ({
+        value: actorKey(actor),
+        label: actor.id === currentUser.id ? text(`${actor.name}（我）`, `${actor.name} (me)`) : actor.name,
+        icon: <ActorAvatar actor={actor} className="task-property-assignee-avatar" />,
+      }))}
+      open={open}
+      disabled={disabled}
+      className="task-participants-control card-property-control"
+      triggerClassName="task-assignee-trigger"
+      triggerContent={<ParticipantAvatars participants={participants} />}
+      ariaLabel={text(`${displayIdentifier} 负责人`, `${displayIdentifier} assignee`)}
+      title={text(`负责人：${task.assignee.name}`, `Assignee: ${task.assignee.name}`)}
+      onOpenChange={onOpenChange}
+      onChange={(value) => {
+        const selected = options.find((actor) => actorKey(actor) === value);
+        const target = selected ? assigneeTargetForActor(selected, currentUser) : undefined;
+        if (target) onChange(target);
+      }}
+    />
   );
 }
 
@@ -353,6 +361,8 @@ export function TaskCard({
   isContextMenuOpen,
   availableLabels,
   currentUser,
+  showCover,
+  showBody,
   onCreateLabel,
   onEdit,
   onUpdate,
@@ -364,7 +374,7 @@ export function TaskCard({
 }: TaskCardProps) {
   const { locale, text } = useTaskboardI18n();
   const displayIdentifier = task.externalKey ?? task.identifier;
-  const [propertyMenu, setPropertyMenu] = useState<"priority" | "labels" | null>(null);
+  const [propertyMenu, setPropertyMenu] = useState<"priority" | "labels" | "assignee" | null>(null);
   const [savingProperty, setSavingProperty] = useState<"priority" | "labels" | "dueDate" | "assignee" | null>(null);
   const creator: ActorIdentity = {
     type: task.creatorType,
@@ -381,7 +391,13 @@ export function TaskCard({
   const showsConversation = supportsConversation && presentation.conversations.length > 0;
   const showsInlineParticipants = variant === "main"
     && task.participants.length > 0;
-  const image = firstTaskImage(task);
+  const image = showCover ? firstTaskImage(task) : null;
+  const body = showBody
+    ? task.description
+        .replace(/!\[[^\]]*\]\((?:<[^>]+>|[^\s)]+)(?:\s+["'][^)]*["'])?\)/g, " ")
+        .replace(/\s+/g, " ")
+        .trim()
+    : "";
   const hasProperties = task.priority !== "none" || task.labels.length > 0 || task.dueDate;
   const showsProperties = !processingCard
     && (hasProperties || showsInlineParticipants || showsConversation);
@@ -449,6 +465,8 @@ export function TaskCard({
               participants={task.participants.length ? task.participants : [creator]}
               currentUser={currentUser}
               disabled={propertyDisabled || task.source === "jira"}
+              open={propertyMenu === "assignee"}
+              onOpenChange={(open) => setPropertyMenu(open ? "assignee" : null)}
               onChange={(assigneeTarget) => updateProperty({ assigneeTarget }, "assignee")}
             />
             <span>{createdDate(task.createdAt, locale, text)}</span>
@@ -457,6 +475,8 @@ export function TaskCard({
       </div>
 
       <h3 id={`task-${task.id}-title`}>{task.title}</h3>
+
+      {body && <p className="task-card-description">{body}</p>}
 
       {image && (
         <TaskCardMedia key={image} src={image} />
@@ -501,6 +521,8 @@ export function TaskCard({
               participants={task.participants}
               currentUser={currentUser}
               disabled={propertyDisabled || task.source === "jira"}
+              open={propertyMenu === "assignee"}
+              onOpenChange={(open) => setPropertyMenu(open ? "assignee" : null)}
               onChange={(assigneeTarget) => updateProperty({ assigneeTarget }, "assignee")}
             />
           )}

--- a/web/src/components/TaskPropertyPicker.tsx
+++ b/web/src/components/TaskPropertyPicker.tsx
@@ -24,6 +24,7 @@ interface TaskPropertyPickerProps<Value extends string> {
   disabled?: boolean;
   className?: string;
   triggerClassName: string;
+  triggerContent?: ReactNode;
   ariaLabel: string;
   title?: string;
   onOpenChange: (open: boolean) => void;
@@ -37,6 +38,7 @@ export function TaskPropertyPicker<Value extends string>({
   disabled = false,
   className = "",
   triggerClassName,
+  triggerContent,
   ariaLabel,
   title,
   onOpenChange,
@@ -201,8 +203,12 @@ export function TaskPropertyPicker<Value extends string>({
           onOpenChange(true);
         }}
       >
-        <span className="task-property-trigger-icon">{selected.icon}</span>
-        <span className="task-property-trigger-label">{selected.label}</span>
+        {triggerContent ?? (
+          <>
+            <span className="task-property-trigger-icon">{selected.icon}</span>
+            <span className="task-property-trigger-label">{selected.label}</span>
+          </>
+        )}
       </button>
       {menu}
     </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1135,6 +1135,12 @@ kbd {
   background: transparent;
 }
 
+.board-card-display-trigger > svg {
+  width: 14px;
+  height: 14px;
+  color: var(--text-tertiary);
+}
+
 .task-filter-trigger.is-active {
   background: var(--accent-soft);
 }
@@ -2124,8 +2130,7 @@ kbd {
   pointer-events: auto;
 }
 
-.due-date-chip input,
-.task-participants-control select {
+.due-date-chip input {
   position: absolute;
   inset: 0;
   z-index: 1;
@@ -2139,7 +2144,7 @@ kbd {
 }
 
 .due-date-chip:has(input:focus-visible),
-.task-participants-control:has(select:focus-visible),
+.task-assignee-trigger:focus-visible,
 .card-label-trigger:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
@@ -2172,6 +2177,19 @@ kbd {
   display: inline-flex;
   align-items: center;
   flex: 0 0 auto;
+}
+
+.task-assignee-trigger {
+  display: inline-flex;
+  align-items: center;
+  min-width: 16px;
+  height: 20px;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
 }
 
 .card-topline {
@@ -2225,6 +2243,19 @@ kbd {
   font-size: 13px;
   font-weight: 500;
   line-height: 18px;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.task-card-description {
+  display: -webkit-box;
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 16px;
+  overflow-wrap: anywhere;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
 }


### PR DESCRIPTION
## Summary

- LOCAL-185: replace the issue-card assignee avatar's native select with the existing custom property picker while preserving the avatar-group trigger, assignee choices, save path, and Jira/save disabled states.
- LOCAL-216: add the Linear-style card display settings entry to the issue board with “封面” and “正文” switches. The switches control cover images and two-line body summaries on issue-entry cards.
- Persist the card display preference in `taskboard.board-card-display.v1` so it survives refresh. Defaults keep the prior UI: cover on, body off.

## Scope

The changes stay in the issue-board card path. List view, Gantt, Dashboard, detail pages, and the other dropdown work from PR #164 are unchanged.

## Verification

- Real Chrome: custom assignee listbox opened from the avatar group; no native card `select` remained.
- Real Chrome: assignee change returned `PATCH /api/tasks/:id` 200, survived refresh, and the original assignee was restored.
- Real Chrome: cover off/body on removed card media, showed body summaries, and remained active after refresh.
- Browser console: 0 errors, 0 warnings.
- `npm run typecheck`
- `npm run build:web`
- `git diff --check`

No test suite was added or run, per task scope.

Taskboard: LOCAL-185
Taskboard: LOCAL-216

Closes #165