### PR TITLE
Fix LOCAL-216 settings popover behavior

### DIFF
--- a/web/src/components/BoardCardDisplayMenu.tsx
+++ b/web/src/components/BoardCardDisplayMenu.tsx
@@ -38,9 +38,6 @@ export function BoardCardDisplayMenu({
         setOpen(false);
       }
     }
-    function closeFromViewportChange() {
-      setOpen(false);
-    }
     function closeFromEscape(event: KeyboardEvent) {
       if (event.key !== "Escape") return;
       setOpen(false);
@@ -48,13 +45,9 @@ export function BoardCardDisplayMenu({
     }
     document.addEventListener("pointerdown", closeFromOutside);
     document.addEventListener("keydown", closeFromEscape);
-    window.addEventListener("resize", closeFromViewportChange);
-    window.addEventListener("scroll", closeFromViewportChange, true);
     return () => {
       document.removeEventListener("pointerdown", closeFromOutside);
       document.removeEventListener("keydown", closeFromEscape);
-      window.removeEventListener("resize", closeFromViewportChange);
-      window.removeEventListener("scroll", closeFromViewportChange, true);
     };
   }, [open]);
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1135,10 +1135,15 @@ kbd {
   background: transparent;
 }
 
+.task-filter-trigger.board-card-display-trigger {
+  justify-content: center;
+  color: var(--text-primary);
+}
+
 .board-card-display-trigger > svg {
   width: 14px;
   height: 14px;
-  color: var(--text-tertiary);
+  color: inherit;
 }
 
 .task-filter-trigger.is-active {


### PR DESCRIPTION
## Summary

- Center the existing Linear display-options icon and match the adjacent toolbar icon color.
- Keep the card display popover open while changing Cover or Body.
- Keep the existing outside-click, trigger-toggle, and Escape close paths.
- Preserve the existing cover/body persistence, card rendering, and Markdown summary filtering.

## Root cause

The Linear SVG was a normal flex child without horizontal centering and had a tertiary-color override. The popover also captured every window scroll event; changing card height could produce a descendant scroll and close the popover.

## Validation

- Real Chromium: icon center delta 0 px and final color `rgb(27, 27, 27)`.
- Real Chromium: two consecutive switch changes kept the popover open.
- Real Chromium: outside click, Escape, and a second trigger click closed it; board scrolling did not.
- Real Chromium: changed values survived reload; the original Cover on / Body off preference was restored afterward.
- Browser console: 0 errors, 0 warnings.
- `npm run typecheck`
- `npm run build:web`
- `git diff --check`

No tests were added or run, per the task scope.