### PR TITLE
fix(ai-chat): hide console window on Windows when spawning AI turn process

### DIFF
--- a/server/ai-chat-catalog.mjs
+++ b/server/ai-chat-catalog.mjs
@@ -142,6 +142,7 @@ function listSkills(codexExecutable, workspacePath, processEnv) {
       cwd: workspacePath,
       env: processEnv,
       stdio: ["pipe", "pipe", "ignore"],
+      windowsHide: true,
     });
     let buffer = "";
     let settled = false;
@@ -264,6 +265,7 @@ export async function discoverAiCatalog({
       encoding: "utf8",
       timeout: CATALOG_TIMEOUT_MS,
       maxBuffer: CATALOG_MAX_BUFFER,
+      windowsHide: true,
     }),
     listSkills(codexExecutable, workspacePath, environment),
   ]);

--- a/server/ai-chat-process.mjs
+++ b/server/ai-chat-process.mjs
@@ -347,6 +347,7 @@ export function spawnCodexTurn({
     detached: true,
     env: withoutTaskboardLauncherEnvironment(env),
     stdio: ["pipe", "pipe", "pipe", "pipe"],
+    windowsHide: true,
   });
 
   let stdoutChunks = [];

--- a/server/ai-turn-owner.mjs
+++ b/server/ai-turn-owner.mjs
@@ -11,6 +11,7 @@ const command = executableCommand(executable, JSON.parse(encodedArgs));
 const child = spawn(command.executable, command.args, {
   env: process.env,
   stdio: "inherit",
+  windowsHide: true,
 });
 
 const control = new Socket({ fd: 3, readable: true, writable: false });


### PR DESCRIPTION
## What
Add `windowsHide: true` to child process spawn options in `ai-turn-owner.mjs` and `ai-chat-process.mjs` to prevent Windows 0x800700e8 console errors and error dialog popups when launching AI chat turns.

## Why
This change resolves the target issue or improvement.

## How to test
Verify that the project builds/runs correctly and the specific bug/improvement is addressed.

Fixes #161