### PR TITLE
明确 UI 样式确认门槛

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ Make the smallest root-cause change. Do not add unrelated refactors, abstraction
 ## 5. Implement, verify, and report
 
 - Keep the issue `in_progress` during implementation.
-- Verify the direct user path. For UI work, use the real browser/App surface and provide visual evidence for user confirmation.
+- Verify the direct user path. For changes on a UI surface, use the real browser/App surface. Capture visual evidence when the result has visual impact; this evidence supports review and does not by itself require a separate user UI confirmation.
 - Report changed files, commit, exact head SHA, direct verification, PR, CI state, and remaining limitations in the issue.
 - Show ongoing status in the Taskboard opened through the injected Codex App.
 - Execution conversations do not merge, release, mark `done`, or claim user acceptance.
@@ -70,15 +70,20 @@ Make the smallest root-cause change. Do not add unrelated refactors, abstraction
 - Wait for the complete Pro answer. Do not use an instant-answer result. Check at approximately five-minute intervals when necessary; a complete review can take more than 30 minutes.
 - Simple mechanical changes, documentation, README updates, version-only changes, and already-approved code followed only by trivial edits can skip Pro review.
 - Fix actionable blockers in the same PR. Repeat Pro review only when the new implementation complexity warrants it.
-- For UI work, complete the full function and its direct verification first. Run any complexity-based Pro review before asking the user to confirm the final visual style.
+- Decide the UI confirmation gate from the actual visual impact and risk. Do not trigger it mechanically because code is in a UI component or changes a UI file.
+- Logic-only changes on a UI surface do not need separate user UI confirmation when they do not cause a meaningful visual change. This includes interaction logic, data behavior, toggle behavior, popover close conditions, and copy-and-paste behavior.
+- Small, low-risk, and visually unambiguous changes can skip user UI confirmation after the coordinator checks the real path and visual evidence. Examples include a local font-size, spacing, alignment, or color adjustment.
+- Require user UI confirmation before merge when the change adds UI, meaningfully changes layout, information hierarchy, or the presentation of a core interaction, has multiple reasonable visual choices, or the user explicitly asks to confirm the style.
+- For work that requires user UI confirmation, complete the full function and its direct verification first. Run any complexity-based Pro review before asking the user to confirm the final visual style.
 - After Pro approval, visual-only adjustments made for the user's final UI confirmation do not require another Pro review. The coordinator still checks that the delta is limited to the requested UI and reruns the relevant direct verification.
 - Close temporary review browser tabs after review finishes.
 
 ## 7. Acceptance and issue status
 
 - Reviewer approval means ready for user inspection, not user acceptance.
-- For UI work, put the complete reviewed function into the Taskboard-launched Codex App and ask the user to confirm the final visual style only after implementation and any required Pro review are complete.
-- Do not merge UI work until the user confirms its style. After visual-only feedback is applied and directly verified, the change can proceed without repeating Pro review.
+- When work meets the UI confirmation gate, put the complete reviewed function into the Taskboard-launched Codex App and ask the user to confirm the final visual style only after implementation and any required Pro review are complete.
+- Do not merge work that meets the UI confirmation gate until the user confirms its style. After visual-only feedback is applied and directly verified, the change can proceed without repeating Pro review.
+- UI-surface work that does not meet the confirmation gate can proceed after the coordinator verifies the real path, visual impact, scope, and required review without a separate user UI pause.
 - After implementation and required review pass, move the issue to `in_review`.
 - Never move an issue to `done` unless the user explicitly accepts it or asks for completion.
 - If the user explicitly authorizes finishing and releasing the whole batch without another pause, that instruction authorizes the remaining review, merge, and release steps, but still does not authorize marking issues `done`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,8 +74,8 @@ Make the smallest root-cause change. Do not add unrelated refactors, abstraction
 - Logic-only changes on a UI surface do not need separate user UI confirmation when they do not cause a meaningful visual change. This includes interaction logic, data behavior, toggle behavior, popover close conditions, and copy-and-paste behavior.
 - Small, low-risk, and visually unambiguous changes can skip user UI confirmation after the coordinator checks the real path and visual evidence. Examples include a local font-size, spacing, alignment, or color adjustment.
 - Require user UI confirmation before merge when the change adds UI, meaningfully changes layout, information hierarchy, or the presentation of a core interaction, has multiple reasonable visual choices, or the user explicitly asks to confirm the style.
-- For work that requires user UI confirmation, complete the full function and its direct verification first. Run any complexity-based Pro review before asking the user to confirm the final visual style.
-- After Pro approval, visual-only adjustments made for the user's final UI confirmation do not require another Pro review. The coordinator still checks that the delta is limited to the requested UI and reruns the relevant direct verification.
+- User UI confirmation is a final acceptance gate, not an intermediate development checkpoint. For work that requires it, ask only after the full function is complete, direct verification passes, and any complexity-based Pro review passes. Never ask the user to confirm a partially implemented UI.
+- After Pro approval, visual-only adjustments made from the user's final UI feedback do not require another Pro review. The coordinator checks that the delta is limited to the requested visual change, reruns the real path, and can then proceed to merge. If the adjustment changes functional logic or introduces new complex risk, reassess whether code review or Pro review is required.
 - Close temporary review browser tabs after review finishes.
 
 ## 7. Acceptance and issue status


### PR DESCRIPTION
## 变更

- 按实际视觉影响和风险判断是否需要用户确认 UI，不再按 UI 组件或文件机械触发。
- 只改变交互或数据逻辑、且无显著视觉变化的工作，不单独暂停等待 UI 确认。
- 局部字号、间距、对齐和颜色等低风险且结果明确的微调，可由协调者检查真实路径和截图后直接判断。
- 新增 UI、明显改变布局或信息层级、改变核心交互呈现、存在多种合理视觉方案，或用户明确要求时，合并前必须确认样式。
- UI 用户确认是最终验收门槛，不能发生在中间开发阶段。需要确认的 UI 必须先完整实现、完成直接验证，并通过按复杂度需要的 Pro 审核。
- Pro 通过后，根据用户反馈所做的纯视觉收尾不重复 Pro；协调者完成差量检查和真实路径验证后可继续合并。若调整改变功能逻辑或引入新的复杂风险，再重新判断代码或 Pro 复审。

## 本批判断

- LOCAL-211、LOCAL-216、LOCAL-217、LOCAL-218、LOCAL-219 属于逻辑调整，无需单独确认 UI。
- LOCAL-220 仅为局部字号微调，视觉风险很小，也跳过单独 UI 确认。
- 对应 PR #170 和 PR #172 已完成代码审核与 CI，处于最终阶段；本批变化不满足必须暂停等待用户 UI 确认的门槛。

## 检查

- `git diff --check`
- 变更仅包含 `AGENTS.md`
- 文档规则调整按现有风险标准跳过 Pro 审核