### PR TITLE
Release v1.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-taskboard",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-taskboard",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "dependencies": {
         "@lobehub/icons-static-svg": "^1.94.0",
         "@xyflow/react": "^12.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-taskboard",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "codex-taskboard-launcher"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "base64 0.22.1",
  "dispatch2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-taskboard-launcher"
-version = "1.0.6"
+version = "1.0.7"
 description = "Codex Taskboard macOS launcher"
 edition = "2021"
 rust-version = "1.88"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex Taskboard",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "identifier": "com.chuspeeism.codex-taskboard",
   "app": {
     "windows": []


### PR DESCRIPTION
## What changed

- Bump the application version from `1.0.6` to `1.0.7` in the five existing version files.
- Keep release workflows and product code unchanged.

## Validation

- Confirmed `package.json`, `package-lock.json`, `Cargo.toml`, the launcher entry in `Cargo.lock`, and `tauri.conf.json` all report `1.0.7`.
- Confirmed unrelated Rust dependencies that also use version `1.0.6` were not changed.
- `git diff --check` passed.

This is a mechanical version-only PR. Complexity-based Pro review is not required.