### PR TITLE
Fix toolbar focus and thinking content truncation

### DIFF
--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -838,7 +838,10 @@ function ThinkingSteps({
                           {eventStatus === "running" && <span aria-hidden="true">…</span>}
                         </span>
                         {content && (
-                          <span className="ai-chat-thinking-step-description">
+                          <span
+                            className="ai-chat-thinking-step-description"
+                            title={content}
+                          >
                             {content}
                           </span>
                         )}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1026,8 +1026,6 @@ kbd {
   background: var(--surface-hover);
 }
 
-.task-filter-trigger:focus-visible,
-.task-filter-trigger.is-open,
 .other-tasks-trigger:focus-visible,
 .other-tasks-trigger.is-open {
   border-color: var(--border-strong);
@@ -1152,6 +1150,14 @@ kbd {
 
 .task-filter-trigger.is-active .filter-icon {
   stroke: var(--accent);
+}
+
+.task-filter-trigger:focus-visible,
+.task-filter-trigger.is-open {
+  border-color: transparent;
+  outline: 0;
+  background: var(--surface-active);
+  box-shadow: none;
 }
 
 .task-filter-active-dot {
@@ -7920,12 +7926,15 @@ kbd {
 
 .ai-chat-thinking-step-description {
   display: block;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
   color: var(--text-tertiary);
   font-size: 13px;
   font-weight: 400;
   line-height: 1.35;
-  overflow-wrap: anywhere;
-  white-space: pre-wrap;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .ai-chat-thinking-step.is-failed .ai-chat-thinking-step-label {


### PR DESCRIPTION
## Summary
- make the filter and card-display triggers use the existing gray active surface when focused or open, without the blue outline or shadow
- keep thinking-step content to one ellipsized line and expose the complete content through the native hover title
- scope truncation to ThinkingSteps so normal final assistant replies remain unchanged

## Root cause
- `.task-filter-trigger` inherited both the global blue `button:focus-visible` outline and its own blue focus/open shadow
- thinking-step descriptions used wrapping text and did not expose their complete content on hover

## Verification
- `npm run typecheck`
- `npm run build:web`
- `git diff --check`
- real headed Chromium against the current installed Taskboard runtime:
  - filter and card-display open/focus states render with gray fill, transparent border, no outline, and no shadow
  - all 7 visible thinking descriptions remain one line; warning and command content truncate with ellipsis and expose complete matching titles on hover
  - normal final assistant content remains multiline

Closes LOCAL-222
Closes LOCAL-223