### PR TITLE
Fix mixed-content clipboard and long issue references

### DIFF
--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -105,6 +105,22 @@ let segmentSequence = 0;
 const inlineMediaMarkdownParser = unified().use(remarkParse).use(remarkGfm);
 const EMPTY_MENTION_TASKS: readonly Task[] = [];
 const INLINE_MEDIA_CLIPBOARD_MIME = "application/x-taskboard-inline-media";
+const INLINE_MEDIA_HTML_BLOCKS = new Set([
+  "ADDRESS",
+  "BLOCKQUOTE",
+  "DIV",
+  "H1",
+  "H2",
+  "H3",
+  "H4",
+  "H5",
+  "H6",
+  "LI",
+  "OL",
+  "P",
+  "PRE",
+  "UL",
+]);
 let inlineMediaClipboard: { id: string; segments: InlineMediaSegment[] } | null = null;
 
 function segmentId(prefix: string): string {
@@ -318,6 +334,144 @@ function inlineMediaClipboardText(segments: InlineMediaSegment[]): string {
     if (segment.type === "persisted-image") return segment.alt;
     return segment.identifier;
   }).join("");
+}
+
+function inlineMediaClipboardHtml(
+  segments: InlineMediaSegment[],
+  clipboardId: string,
+  ownerDocument: Document,
+): string {
+  const wrapper = ownerDocument.createElement("div");
+  wrapper.dataset.taskboardInlineMediaClipboard = clipboardId;
+
+  for (const segment of segments) {
+    if (segment.type === "text") {
+      const text = ownerDocument.createElement("span");
+      text.style.whiteSpace = "pre-wrap";
+      text.textContent = segment.text;
+      wrapper.append(text);
+      continue;
+    }
+    if (segment.type === "issue-reference") {
+      const link = ownerDocument.createElement("a");
+      const href = /\]\(([^)]+)\)$/.exec(segment.markdown)?.[1];
+      if (href) link.setAttribute("href", href);
+      link.dataset.taskboardInlineMediaMarkdown = segment.markdown;
+      link.textContent = segment.identifier;
+      wrapper.append(link);
+      continue;
+    }
+    if (segment.type === "persisted-image") {
+      const image = ownerDocument.createElement("img");
+      image.src = resolvePersistedAttachmentUrl(segment.url);
+      image.alt = segment.alt;
+      image.dataset.taskboardInlineMediaMarkdown = segment.markdown;
+      wrapper.append(image);
+      continue;
+    }
+    const pendingImage = ownerDocument.createElement("span");
+    pendingImage.dataset.taskboardInlineMediaPendingImage = segment.id;
+    pendingImage.textContent = segment.file.name;
+    wrapper.append(pendingImage);
+  }
+
+  return wrapper.outerHTML;
+}
+
+export function writeInlineMediaClipboard(
+  clipboardData: DataTransfer,
+  segments: InlineMediaSegment[],
+  ownerDocument: Document,
+) {
+  const clipboardId = segmentId("clipboard");
+  inlineMediaClipboard = { id: clipboardId, segments };
+  clipboardData.setData(INLINE_MEDIA_CLIPBOARD_MIME, clipboardId);
+  clipboardData.setData("text/plain", inlineMediaClipboardText(segments));
+  clipboardData.setData(
+    "text/html",
+    inlineMediaClipboardHtml(segments, clipboardId, ownerDocument),
+  );
+}
+
+function inlineMediaClipboardIdFromHtml(html: string): string {
+  if (!html) return "";
+  const document = new DOMParser().parseFromString(html, "text/html");
+  return document.body
+    .querySelector<HTMLElement>("[data-taskboard-inline-media-clipboard]")
+    ?.dataset.taskboardInlineMediaClipboard ?? "";
+}
+
+export function createInlineMediaSegmentsFromHtml(
+  html: string,
+  referenceTasks: readonly Task[],
+): InlineMediaSegment[] | null {
+  if (!html) return null;
+  const document = new DOMParser().parseFromString(html, "text/html");
+  let markdown = "";
+  let structured = false;
+
+  const visit = (node: Node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      markdown += node.textContent ?? "";
+      return;
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) return;
+    const element = node as HTMLElement;
+    if (["BUTTON", "SCRIPT", "STYLE"].includes(element.tagName)) return;
+
+    const inlineMarkdown = element.dataset.taskboardInlineMediaMarkdown;
+    if (inlineMarkdown) {
+      markdown += inlineMarkdown;
+      structured = true;
+      return;
+    }
+    if (element.tagName === "A") {
+      const href = element.getAttribute("href") ?? "";
+      const queryIndex = href.indexOf("?");
+      const search = queryIndex >= 0 ? href.slice(queryIndex) : "";
+      const identifier = readIssueIdentifier(search);
+      const projectId = new URLSearchParams(search).get("project");
+      if (identifier && projectId) {
+        const task = referenceTasks.find((candidate) => (
+          candidate.projectId === projectId && candidate.identifier === identifier
+        ));
+        const displayIdentifier = task?.externalKey ?? identifier;
+        const route = new URLSearchParams({ project: projectId, issue: identifier });
+        markdown += `[@${displayIdentifier}](?${route})`;
+        structured = true;
+        return;
+      }
+    }
+    if (element.tagName === "IMG") {
+      const source = element.getAttribute("src");
+      if (source) {
+        let url = source;
+        try {
+          const parsed = new URL(source);
+          const attachment = parsed.pathname.match(/\/api\/attachments\/([^/]+)\/content$/);
+          if (parsed.protocol === "http:" && parsed.hostname === "127.0.0.1" && attachment) {
+            url = `api/attachments/${attachment[1]}/content`;
+          }
+        } catch {}
+        const alt = (element.getAttribute("alt") ?? "").replace(/[\\[\]]/g, "\\$&");
+        markdown += `![${alt}](${url})`;
+        structured = true;
+      }
+      return;
+    }
+    if (element.tagName === "BR") {
+      markdown += "\n";
+      return;
+    }
+
+    const block = INLINE_MEDIA_HTML_BLOCKS.has(element.tagName);
+    if (block && markdown && !markdown.endsWith("\n")) markdown += "\n";
+    for (const child of element.childNodes) visit(child);
+    if (block && element.nextSibling && !markdown.endsWith("\n")) markdown += "\n";
+  };
+
+  for (const child of document.body.childNodes) visit(child);
+  return structured ? createInlineMediaSegments(markdown, referenceTasks) : null;
 }
 
 function cloneInlineMediaSegments(segments: InlineMediaSegment[]): InlineMediaSegment[] {
@@ -703,13 +857,19 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
     }
 
     function currentLogicalRange(): { start: number; end: number } | null {
+      const root = rootRef.current;
       const selection = window.getSelection();
-      if (!selection || selection.rangeCount === 0) return null;
+      if (!root || !selection || selection.rangeCount === 0) return null;
       const range = selection.getRangeAt(0);
-      const start = logicalOffsetForPoint(range.startContainer, range.startOffset, "start");
+      if (!range.intersectsNode(root)) return null;
+      const start = root.contains(range.startContainer)
+        ? logicalOffsetForPoint(range.startContainer, range.startOffset, "start")
+        : 0;
       if (start === null) return null;
       if (range.collapsed) return { start, end: start };
-      const end = logicalOffsetForPoint(range.endContainer, range.endOffset, "end");
+      const end = root.contains(range.endContainer)
+        ? logicalOffsetForPoint(range.endContainer, range.endOffset, "end")
+        : segmentsLength(segments);
       return end === null ? null : { start, end };
     }
 
@@ -1009,7 +1169,9 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
     function pasteContent(event: ClipboardEvent<HTMLDivElement>) {
       const range = currentLogicalRange();
       if (!range) return;
-      const clipboardId = event.clipboardData.getData(INLINE_MEDIA_CLIPBOARD_MIME);
+      const clipboardHtml = event.clipboardData.getData("text/html");
+      const clipboardId = event.clipboardData.getData(INLINE_MEDIA_CLIPBOARD_MIME)
+        || inlineMediaClipboardIdFromHtml(clipboardHtml);
       if (clipboardId && inlineMediaClipboard?.id === clipboardId) {
         event.preventDefault();
         applyRangeReplacement(
@@ -1018,6 +1180,12 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
           cloneInlineMediaSegments(inlineMediaClipboard.segments),
           false,
         );
+        return;
+      }
+      const htmlSegments = createInlineMediaSegmentsFromHtml(clipboardHtml, referenceTasks);
+      if (htmlSegments) {
+        event.preventDefault();
+        applyRangeReplacement(range.start, range.end, htmlSegments, false);
         return;
       }
       const clipboardFiles = clipboardImages(event.clipboardData);
@@ -1158,11 +1326,12 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
             const range = currentLogicalRange();
             if (!range || range.start === range.end) return;
             const copiedSegments = inlineMediaRangeSegments(segments, range.start, range.end);
-            const clipboardId = segmentId("clipboard");
-            inlineMediaClipboard = { id: clipboardId, segments: copiedSegments };
             event.preventDefault();
-            event.clipboardData.setData(INLINE_MEDIA_CLIPBOARD_MIME, clipboardId);
-            event.clipboardData.setData("text/plain", inlineMediaClipboardText(copiedSegments));
+            writeInlineMediaClipboard(
+              event.clipboardData,
+              copiedSegments,
+              event.currentTarget.ownerDocument,
+            );
           }}
           onKeyUp={(event) => {
             if (event.key !== "Escape") updateMentionFromSelection();

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -417,7 +417,7 @@ export function createInlineMediaSegmentsFromHtml(
     }
     if (node.nodeType !== Node.ELEMENT_NODE) return;
     const element = node as HTMLElement;
-    if (["BUTTON", "SCRIPT", "STYLE"].includes(element.tagName)) return;
+    if (["SCRIPT", "STYLE"].includes(element.tagName)) return;
 
     const inlineMarkdown = element.dataset.taskboardInlineMediaMarkdown;
     if (inlineMarkdown) {
@@ -425,22 +425,29 @@ export function createInlineMediaSegmentsFromHtml(
       structured = true;
       return;
     }
+    if (element.tagName === "BUTTON") return;
     if (element.tagName === "A") {
       const href = element.getAttribute("href") ?? "";
-      const queryIndex = href.indexOf("?");
-      const search = queryIndex >= 0 ? href.slice(queryIndex) : "";
-      const identifier = readIssueIdentifier(search);
-      const projectId = new URLSearchParams(search).get("project");
-      if (identifier && projectId) {
-        const task = referenceTasks.find((candidate) => (
-          candidate.projectId === projectId && candidate.identifier === identifier
-        ));
-        const displayIdentifier = task?.externalKey ?? identifier;
-        const route = new URLSearchParams({ project: projectId, issue: identifier });
-        markdown += `[@${displayIdentifier}](?${route})`;
-        structured = true;
-        return;
-      }
+      try {
+        const base = new URL(window.document.baseURI);
+        base.search = "";
+        base.hash = "";
+        const url = new URL(href, base);
+        if (url.origin === base.origin && url.pathname === base.pathname) {
+          const identifier = readIssueIdentifier(url.search);
+          const projectId = url.searchParams.get("project");
+          if (identifier && projectId) {
+            const task = referenceTasks.find((candidate) => (
+              candidate.projectId === projectId && candidate.identifier === identifier
+            ));
+            const displayIdentifier = task?.externalKey ?? identifier;
+            const route = new URLSearchParams({ project: projectId, issue: identifier });
+            markdown += `[@${displayIdentifier}](?${route})`;
+            structured = true;
+            return;
+          }
+        }
+      } catch {}
     }
     if (element.tagName === "IMG") {
       const source = element.getAttribute("src");
@@ -605,6 +612,7 @@ function IssueReferenceChip({
       className={`issue-reference-inline inline-media-issue-reference${task ? ` issue-reference-status-${task.status}` : ""}`}
       contentEditable={false}
       data-inline-media-segment={segment.id}
+      data-taskboard-inline-media-markdown={segment.markdown}
       disabled={disabled}
       aria-label={task
         ? text(
@@ -698,7 +706,8 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
           element.className = segment.type === "issue-reference"
             ? "inline-media-atom"
             : "inline-media-atom inline-media-image-atom";
-          element.contentEditable = "false";
+          if (segment.type === "pending-image") element.contentEditable = "false";
+          else element.dataset.taskboardInlineMediaMarkdown = segment.markdown;
           nextAtomHosts.set(segment.id, element);
         }
         fragment.append(element);
@@ -1182,11 +1191,15 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
         );
         return;
       }
-      const htmlSegments = createInlineMediaSegmentsFromHtml(clipboardHtml, referenceTasks);
-      if (htmlSegments) {
-        event.preventDefault();
-        applyRangeReplacement(range.start, range.end, htmlSegments, false);
-        return;
+      const taskboardHtml = clipboardId
+        || clipboardHtml.includes("data-taskboard-inline-media-markdown");
+      if (taskboardHtml) {
+        const htmlSegments = createInlineMediaSegmentsFromHtml(clipboardHtml, referenceTasks);
+        if (htmlSegments) {
+          event.preventDefault();
+          applyRangeReplacement(range.start, range.end, htmlSegments, false);
+          return;
+        }
       }
       const clipboardFiles = clipboardImages(event.clipboardData);
       if (clipboardFiles.length > 0) {
@@ -1194,6 +1207,12 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
         const images = insertableImages(clipboardFiles);
         if (!images || images.length === 0) return;
         applyRangeReplacement(range.start, range.end, images.map(imageSegment), false);
+        return;
+      }
+      const htmlSegments = createInlineMediaSegmentsFromHtml(clipboardHtml, referenceTasks);
+      if (htmlSegments) {
+        event.preventDefault();
+        applyRangeReplacement(range.start, range.end, htmlSegments, false);
         return;
       }
 
@@ -1323,6 +1342,13 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
           onDrop={dropContent}
           onPaste={pasteContent}
           onCopy={(event) => {
+            const selection = event.currentTarget.ownerDocument.getSelection();
+            if (!selection || selection.rangeCount === 0) return;
+            const selectedRange = selection.getRangeAt(0);
+            if (
+              !event.currentTarget.contains(selectedRange.startContainer)
+              || !event.currentTarget.contains(selectedRange.endContainer)
+            ) return;
             const range = currentLogicalRange();
             if (!range || range.start === range.end) return;
             const copiedSegments = inlineMediaRangeSegments(segments, range.start, range.end);

--- a/web/src/components/MarkdownDocument.tsx
+++ b/web/src/components/MarkdownDocument.tsx
@@ -5,6 +5,7 @@ import {
   useId,
   useState,
   type ComponentPropsWithoutRef,
+  type ClipboardEventHandler,
   type MouseEvent,
   type ReactElement,
   type ReactNode,
@@ -469,26 +470,34 @@ function MarkdownPre({ children, ...props }: ComponentPropsWithoutRef<"pre">) {
 
 export function MarkdownDocument({
   value,
+  onCopy,
   onLinkClick,
   renderLink,
 }: {
   value: string;
+  onCopy?: ClipboardEventHandler<HTMLDivElement>;
   onLinkClick?: (event: MouseEvent<HTMLAnchorElement>, href?: string) => void;
   renderLink?: (href: string | undefined, children: ReactNode) => ReactNode | null;
 }) {
   return (
-    <div className="issue-description-document">
+    <div className="issue-description-document" onCopy={onCopy}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkStripMarkdownComments, remarkBreaks]}
         urlTransform={(url) => defaultUrlTransform(resolvePersistedAttachmentUrl(url))}
         components={{
-          a: ({ node: _node, href, children, className, ...props }) => {
+          a: ({ node, href, children, className, ...props }) => {
             const renderedLink = renderLink?.(href, children);
             const isRenderedLink = renderedLink !== null && renderedLink !== undefined;
+            const start = node?.position?.start.offset;
+            const end = node?.position?.end.offset;
+            const markdown = typeof start === "number" && typeof end === "number"
+              ? value.slice(start, end)
+              : undefined;
             return (
               <a
                 {...props}
                 className={[className, isRenderedLink ? "issue-reference-link" : ""].filter(Boolean).join(" ") || undefined}
+                data-taskboard-inline-media-markdown={isRenderedLink ? markdown : undefined}
                 href={href}
                 target="_blank"
                 rel="noreferrer"
@@ -497,6 +506,14 @@ export function MarkdownDocument({
                 {isRenderedLink ? renderedLink : children}
               </a>
             );
+          },
+          img: ({ node, ...props }) => {
+            const start = node?.position?.start.offset;
+            const end = node?.position?.end.offset;
+            const markdown = typeof start === "number" && typeof end === "number"
+              ? value.slice(start, end)
+              : undefined;
+            return <img {...props} data-taskboard-inline-media-markdown={markdown} />;
           },
           pre: MarkdownPre,
         }}

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useRef, useState, type KeyboardEvent, type MouseEvent } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ClipboardEvent,
+  type KeyboardEvent,
+  type MouseEvent,
+} from "react";
 import { taskboardStorage } from "../storage";
 import {
   ApiError,
@@ -54,11 +61,13 @@ import {
 } from "./PendingAttachments";
 import {
   createInlineMediaSegments,
+  createInlineMediaSegmentsFromHtml,
   InlineMediaComposer,
   inlineMediaImages,
   inlineMediaText,
   resolveInlineMediaMarkdown,
   serializeInlineMedia,
+  writeInlineMediaClipboard,
   type InlineMediaComposerHandle,
   type InlineMediaSegment,
 } from "./InlineMediaComposer";
@@ -346,6 +355,29 @@ function DescriptionDocument({
   return (
     <MarkdownDocument
       value={value}
+      onCopy={(event: ClipboardEvent<HTMLDivElement>) => {
+        const selection = event.currentTarget.ownerDocument.getSelection();
+        if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
+        const range = selection.getRangeAt(0);
+        if (!range.intersectsNode(event.currentTarget)) return;
+        const selectedRange = range.cloneRange();
+        if (!event.currentTarget.contains(selectedRange.startContainer)) {
+          selectedRange.setStart(event.currentTarget, 0);
+        }
+        if (!event.currentTarget.contains(selectedRange.endContainer)) {
+          selectedRange.setEnd(event.currentTarget, event.currentTarget.childNodes.length);
+        }
+        const wrapper = event.currentTarget.ownerDocument.createElement("div");
+        wrapper.append(selectedRange.cloneContents());
+        const segments = createInlineMediaSegmentsFromHtml(wrapper.innerHTML, referenceTasks);
+        if (!segments) return;
+        event.preventDefault();
+        writeInlineMediaClipboard(
+          event.clipboardData,
+          segments,
+          event.currentTarget.ownerDocument,
+        );
+      }}
       renderLink={(href) => {
         const reference = href ? referencedTask(href, referenceTasks) : null;
         if (!reference) return null;

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -359,14 +359,11 @@ function DescriptionDocument({
         const selection = event.currentTarget.ownerDocument.getSelection();
         if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
         const range = selection.getRangeAt(0);
-        if (!range.intersectsNode(event.currentTarget)) return;
+        if (
+          !event.currentTarget.contains(range.startContainer)
+          || !event.currentTarget.contains(range.endContainer)
+        ) return;
         const selectedRange = range.cloneRange();
-        if (!event.currentTarget.contains(selectedRange.startContainer)) {
-          selectedRange.setStart(event.currentTarget, 0);
-        }
-        if (!event.currentTarget.contains(selectedRange.endContainer)) {
-          selectedRange.setEnd(event.currentTarget, event.currentTarget.childNodes.length);
-        }
         const wrapper = event.currentTarget.ownerDocument.createElement("div");
         wrapper.append(selectedRange.cloneContents());
         const segments = createInlineMediaSegmentsFromHtml(wrapper.innerHTML, referenceTasks);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2716,6 +2716,8 @@ kbd {
 
 .issue-description-document a.issue-reference-link {
   display: inline-flex;
+  min-width: 0;
+  max-width: 100%;
   color: inherit;
   vertical-align: middle;
 }
@@ -2727,6 +2729,8 @@ kbd {
 .issue-reference-inline {
   display: inline-flex;
   align-items: center;
+  min-width: 0;
+  max-width: 100%;
   min-height: 22px;
   gap: 5px;
   padding: 0 6px 0 4px;
@@ -2736,7 +2740,7 @@ kbd {
   color: var(--text-secondary);
   font-size: 0.94em;
   line-height: 22px;
-  white-space: nowrap;
+  white-space: normal;
 }
 
 .issue-reference-link:hover .issue-reference-inline {
@@ -2766,9 +2770,11 @@ kbd {
 }
 
 .issue-reference-title {
-  flex: 0 0 auto;
+  flex: 1 1 auto;
+  min-width: 0;
   color: var(--text-primary);
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .issue-description-document ul,


### PR DESCRIPTION
## Summary

- preserve text, issue references, and images when mixed content is copied from saved Markdown or any inline-media editor
- make the structured clipboard self-describing through custom MIME and HTML while keeping the existing attachment save path
- keep long issue-reference titles inside the content column and wrap the full title in read and edit states

## Verification

- `npm run typecheck`
- `npm run build:web`
- real headed Chrome on the installed Taskboard endpoint, using final bundle `index-Bj7l2Pi8.js`: all 8 LOCAL-219 copy/paste paths retained text, issue references, and images; paths 2-5 stayed green
- LOCAL-224 read and edit states: 484 px reference inside a 484 px container, two title lines, no horizontal scroll; status icon, ID, full title, link behavior, and editor atom semantics retained

No automated tests were added under the confirmed issue workflow; the direct product paths were verified instead.
