### PR TITLE
Use short project issue identifiers

### DIFF
--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -340,9 +340,15 @@ function validateProjectId(value) {
   return id;
 }
 
-function projectPrefix(projectId) {
-  const prefix = projectId.toUpperCase().replace(/[^A-Z0-9]+/g, "");
-  return (prefix || "TASK").slice(0, 12);
+function projectPrefix(project) {
+  const idPrefix = project.id.toUpperCase().replace(/[^A-Z0-9]+/g, "").slice(0, 12) || "TASK";
+  const existingPrefix = project.first_identifier?.replace(/-\d+$/, "");
+  if (existingPrefix && existingPrefix !== idPrefix) return existingPrefix;
+  if (idPrefix.length <= 5) return idPrefix;
+  const namePrefix = [...project.name.toUpperCase().replace(/[^\p{L}\p{N}]+/gu, "")]
+    .slice(0, 3)
+    .join("");
+  return namePrefix || idPrefix.slice(0, 3);
 }
 
 function now() {
@@ -1521,6 +1527,7 @@ async function createTask(env, input, actor) {
   const project = await env.DB.prepare(`
     SELECT
       projects.id,
+      projects.name,
       (
         SELECT tasks.identifier
         FROM tasks
@@ -1534,9 +1541,7 @@ async function createTask(env, input, actor) {
   if (!project) {
     throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${input.projectId}' does not exist`);
   }
-  const prefix = project.first_identifier
-    ? project.first_identifier.replace(/-\d+$/, "")
-    : projectPrefix(project.id);
+  const prefix = projectPrefix(project);
   const suffixStart = prefix.length + 2;
   let sortOrder = input.sortOrder;
   if (sortOrder === undefined) {

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -391,9 +391,15 @@ function aiChatEventFromRow(row) {
   };
 }
 
-function projectPrefix(projectId) {
-  const prefix = projectId.toUpperCase().replace(/[^A-Z0-9]+/g, "");
-  return (prefix || "TASK").slice(0, 12);
+function projectPrefix(project) {
+  const idPrefix = project.id.toUpperCase().replace(/[^A-Z0-9]+/g, "").slice(0, 12) || "TASK";
+  const existingPrefix = project.first_identifier?.replace(/-\d+$/, "");
+  if (existingPrefix && existingPrefix !== idPrefix) return existingPrefix;
+  if (idPrefix.length <= 5) return idPrefix;
+  const namePrefix = [...project.name.toUpperCase().replace(/[^\p{L}\p{N}]+/gu, "")]
+    .slice(0, 3)
+    .join("");
+  return namePrefix || idPrefix.slice(0, 3);
 }
 
 export class TaskboardDatabase {
@@ -1733,6 +1739,7 @@ export class TaskboardDatabase {
       const project = this.database.prepare(`
         SELECT
           projects.id,
+          projects.name,
           projects.labels,
           projects.next_task_number,
           (
@@ -1749,9 +1756,7 @@ export class TaskboardDatabase {
         throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${input.projectId}' does not exist`);
       }
 
-      const prefix = project.first_identifier
-        ? project.first_identifier.replace(/-\d+$/, "")
-        : projectPrefix(project.id);
+      const prefix = projectPrefix(project);
       const maximum = this.database.prepare(`
         SELECT MAX(CAST(substr(identifier, ?) AS INTEGER)) AS number
         FROM tasks

--- a/test/cloud-shared-worker.test.mjs
+++ b/test/cloud-shared-worker.test.mjs
@@ -449,7 +449,7 @@ test("a failed task insert rolls back its reserved project identifier", async ()
 
   const succeeded = await createTask("atomic-counter", "First real issue");
   assert.equal(succeeded.response.status, 201);
-  assert.equal(succeeded.body.task.identifier, "ATOMICCOUNTE-1");
+  assert.equal(succeeded.body.task.identifier, "ATO-1");
 });
 
 test("archived tasks are excluded from project issue counts", async () => {

--- a/test/server.test.mjs
+++ b/test/server.test.mjs
@@ -1151,7 +1151,7 @@ test("project and task CRUD flow", async () => {
   });
   assert.equal(createResult.response.status, 201);
   const created = createResult.body.task;
-  assert.equal(created.identifier, "WEBSITE-1");
+  assert.equal(created.identifier, "WEB-1");
   assert.equal(created.version, 1);
   assert.equal(created.sortOrder, 1000);
   assert.equal(created.archivedAt, null);


### PR DESCRIPTION
## Summary

- Generate a short project prefix from the project name when a project still uses the legacy ID-derived prefix.
- Preserve established project prefixes such as `LOCAL`.
- Keep existing issue identifiers unchanged; only new issues use the new prefix.

## Root cause

Issue creation derived the prefix from the internal project ID. UUID project IDs therefore produced identifiers such as `266E8B346BD6-1`, and the first issue then locked that prefix for later issues.

## Verification

- `npm run typecheck`
- `npm run build:web`
- `npm run cloud:deploy:dry-run`
- Isolated real UI path: created an issue in the existing `metai 官网` project and confirmed `MET-2` on the board and detail view.
- Installed `taskctl issue get MET-2 --json` returned the same stored identifier.
