### PR TITLE
Recover stalled Codex heartbeat connections

### DIFF
--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -552,6 +552,7 @@ class CdpConnection {
   }
 
   close() {
+    this.closed = true;
     this.socket.close();
   }
 }
@@ -1673,17 +1674,32 @@ function installTaskboardHostBinding(cdp, supervisor, startupToken) {
   }
 
   async function publishHeartbeat() {
-    const executionContextId = await install();
-    await cdp.send("Runtime.evaluate", {
-      contextId: executionContextId,
-      expression: `window.postMessage({
-        type: ${JSON.stringify(hostHeartbeatMessage)},
-        capability: ${JSON.stringify(hostCapability)},
-        at: Date.now(),
-        startupToken: ${JSON.stringify(startupToken)}
-      }, window.location.origin)`,
-      returnByValue: true,
-    });
+    let timeout;
+    try {
+      await Promise.race([
+        (async () => {
+          const executionContextId = await install();
+          await cdp.send("Runtime.evaluate", {
+            contextId: executionContextId,
+            expression: `window.postMessage({
+              type: ${JSON.stringify(hostHeartbeatMessage)},
+              capability: ${JSON.stringify(hostCapability)},
+              at: Date.now(),
+              startupToken: ${JSON.stringify(startupToken)}
+            }, window.location.origin)`,
+            returnByValue: true,
+          });
+        })(),
+        new Promise((_, reject) => {
+          timeout = setTimeout(() => {
+            cdp.close();
+            reject(new Error("Timed out publishing the Taskboard host heartbeat"));
+          }, 3_000);
+        }),
+      ]);
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 
   return { install, publishHeartbeat };


### PR DESCRIPTION
## What changed

- Add a 3-second deadline to the launcher heartbeat CDP operation.
- Mark a timed-out CDP connection closed so the existing watch loop reconnects the same Codex target.

## Root cause

A Codex CDP WebSocket can remain TCP-established while it no longer sends heartbeat events or handles host requests. The launcher only treated an explicit WebSocket close as disconnected, so the watch loop could wait forever and the automation panel reported that the launcher was unavailable.

## Impact

The automation panel can recover its Codex input capability after a stalled CDP session instead of remaining blocked until the launcher is restarted.

## Verification

- `node --check scripts/codex-injector.mjs`
- `git diff --check origin/main...HEAD`
- Real disposable Codex/Taskboard instance:
  - confirmed live heartbeat and host `ensure` response
  - paused the disposable Codex process for 8 seconds
  - confirmed the injector reconnected and reinjected the same target after resume
  - confirmed the recovered heartbeat and host response
  - opened the automation panel with real mouse input and confirmed the old launcher warning was absent
