### PR TITLE
Fix single-Enter line breaks in inline editors

### DIFF
--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -700,8 +700,12 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
         element.dataset.inlineMediaSegment = segment.id;
         if (segment.type === "text") {
           element.className = "inline-media-text";
-          if (segment.text) element.textContent = segment.text;
-          else element.append(document.createElement("br"));
+          if (segment.text) {
+            element.textContent = segment.text;
+            if (segment.text.endsWith("\n")) element.append(document.createElement("br"));
+          } else {
+            element.append(document.createElement("br"));
+          }
         } else {
           element.className = segment.type === "issue-reference"
             ? "inline-media-atom"


### PR DESCRIPTION
## Summary

- render a browser-editable break after a text segment that ends in a newline
- keep the stored editor value as one exact newline while moving the caret to the visible next line
- fix the shared path used by issue descriptions, new comments, and existing comment edits

## Root cause

InlineMediaComposer converted Enter into a single newline in state, then rebuilt the contenteditable text segment with that newline at the end of a text node. Chromium kept the visible caret before that trailing newline, so the next input stayed on the first line. A second Enter was needed before the empty line became visible.

## Validation

- `npm run typecheck`
- `npm run build:web`
- `git diff --check`
- real browser: issue description, new comment, and existing comment edit each used one Enter and persisted exact newline-delimited content
- saved values confirmed through the supplied Taskboard dynamic endpoint
- browser console: 0 errors, 0 warnings

Taskboard: LOCAL-228
