### PR TITLE
Add issue button to empty project state

### DIFF
--- a/test/other-tasks-panel.test.mjs
+++ b/test/other-tasks-panel.test.mjs
@@ -96,7 +96,7 @@ test("panel cards reuse TaskCard and the existing ranked board drop path", () =>
 });
 
 test("global creation defaults to todo while per-column creation keeps the chosen status", () => {
-  assert.equal(appSource.match(/setEditor\(\{ task: null, status: "todo" \}\)/g)?.length, 2);
+  assert.equal(appSource.match(/setEditor\(\{ task: null, status: "todo" \}\)/g)?.length, 3);
   assert.doesNotMatch(appSource, /setEditor\(\{ task: null, status: "backlog" \}\)/);
   assert.match(appSource, /onCreate=\{\(initialStatus\) => setEditor\(\{ task: null, status: initialStatus \}\)\}/);
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3628,6 +3628,13 @@ export function App() {
             >
               {text("导入当前项目任务状态", "Import current project task status")}
             </button>
+            <button
+              className="button secondary"
+              type="button"
+              onClick={() => setEditor({ task: null, status: "todo" })}
+            >
+              {text("添加议题", "Add issue")}
+            </button>
           </div>
         ) : boardView === "dashboard" ? (
           <DashboardView

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3613,28 +3613,30 @@ export function App() {
               "让 Codex 检查当前项目目录对应的对话，并整理任务状态。",
               "Ask Codex to inspect conversations for this project directory and organize their task status.",
             )}</p>
-            <button
-              className="button primary"
-              type="button"
-              onClick={() => setAiOpenThreadRequest((current) => ({
-                projectId: selectedProject.id,
-                issueId: null,
-                composerText: text(
-                  "只检查当前项目目录对应的 Codex 对话。请将其中已完成、处理中和待执行的任务整理并导入当前项目的 Taskboard。",
-                  "Only inspect Codex conversations associated with the current project directory. Organize completed, in-progress, and pending tasks, then import them into this project's Taskboard.",
-                ),
-                requestId: (current?.requestId ?? 0) + 1,
-              }))}
-            >
-              {text("导入当前项目任务状态", "Import current project task status")}
-            </button>
-            <button
-              className="button secondary"
-              type="button"
-              onClick={() => setEditor({ task: null, status: "todo" })}
-            >
-              {text("添加议题", "Add issue")}
-            </button>
+            <div className="page-empty-actions">
+              <button
+                className="button primary"
+                type="button"
+                onClick={() => setAiOpenThreadRequest((current) => ({
+                  projectId: selectedProject.id,
+                  issueId: null,
+                  composerText: text(
+                    "只检查当前项目目录对应的 Codex 对话。请将其中已完成、处理中和待执行的任务整理并导入当前项目的 Taskboard。",
+                    "Only inspect Codex conversations associated with this project directory. Organize completed, in-progress, and pending tasks, then import them into this project's Taskboard.",
+                  ),
+                  requestId: (current?.requestId ?? 0) + 1,
+                }))}
+              >
+                {text("导入当前项目任务状态", "Import current project task status")}
+              </button>
+              <button
+                className="button secondary"
+                type="button"
+                onClick={() => setEditor({ task: null, status: "todo" })}
+              >
+                {text("添加议题", "Add issue")}
+              </button>
+            </div>
           </div>
         ) : boardView === "dashboard" ? (
           <DashboardView

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4924,6 +4924,12 @@ kbd {
   font-size: 11px;
 }
 
+.page-empty-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .page-empty code {
   margin-bottom: 12px;
   padding: 5px 7px;


### PR DESCRIPTION
## Summary
- add the white secondary “添加议题” action to the empty project state
- reuse the existing `setEditor({ task: null, status: "todo" })` path and `TaskEditor`

## Verification
- `npm run typecheck`
- `npm run build:web`
- `git diff --check`
- Real Chrome opened the existing “新建议题” editor, accepted temporary title input, and canceled without saving.