### PR TITLE
Fix packaged launcher dependency and release 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-taskboard",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-taskboard",
-      "version": "1.0.9",
+      "version": "1.1.0",
       "dependencies": {
         "@lobehub/icons-static-svg": "^1.94.0",
         "@xyflow/react": "^12.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-taskboard",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/prepare-tauri-app.mjs
+++ b/scripts/prepare-tauri-app.mjs
@@ -195,6 +195,11 @@ async function copyApplicationResources() {
   await Promise.all([
     cp(path.join(projectRoot, "server"), path.join(appResources, "server"), { recursive: true }),
     cp(path.join(projectRoot, "shared"), path.join(appResources, "shared"), { recursive: true }),
+    cp(
+      path.join(projectRoot, "node_modules", "smol-toml"),
+      path.join(appResources, "node_modules", "smol-toml"),
+      { recursive: true },
+    ),
     cp(path.join(projectRoot, "dist", "web"), path.join(appResources, "dist", "web"), {
       recursive: true,
     }),

--- a/scripts/verify-packaged-taskctl.mjs
+++ b/scripts/verify-packaged-taskctl.mjs
@@ -48,6 +48,7 @@ const runtimeFile = path.join(dataDirectory, "launcher-runtime.json");
 const nodePath = path.join(appPath, "Contents", "MacOS", "node");
 const appRoot = path.join(appPath, "Contents", "Resources", "app");
 const wrapperPath = path.join(appPath, "Contents", "Resources", "bin", "taskctl");
+await stat(path.join(appRoot, "node_modules", "smol-toml", "package.json"));
 const reservation = createServer();
 await new Promise((resolve, reject) => {
   reservation.once("error", reject);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "codex-taskboard-launcher"
-version = "1.0.9"
+version = "1.1.0"
 dependencies = [
  "base64 0.22.1",
  "dispatch2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-taskboard-launcher"
-version = "1.0.9"
+version = "1.1.0"
 description = "Codex Taskboard macOS launcher"
 edition = "2021"
 rust-version = "1.88"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex Taskboard",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "identifier": "com.chuspeeism.codex-taskboard",
   "app": {
     "windows": []


### PR DESCRIPTION
## What changed

- Package `smol-toml` inside `Resources/app/node_modules` for both macOS and Windows resource preparation.
- Make the existing packaged-App verification require that dependency in the final App bundle.
- Set the application version to 1.1.0.

## Root cause

v1.0.9 added a top-level `smol-toml` import, but the desktop packaging step copied application source without runtime `node_modules`. The installed Launcher therefore exited before the server listened, wrote its runtime descriptor, or became ready to open the Taskboard.

## User impact

The desktop service can start again after update, and the Taskboard can be opened from the Launcher.

## Validation

- `npm run app:prepare -- --target universal-apple-darwin`
- Imported the prepared `server/ai-chat-catalog.mjs` with the bundled ARM64 Node runtime
- Built an unsigned universal `Codex Taskboard.app` with Rust 1.88
- `npm run app:verify-packaged-taskctl -- ".../Codex Taskboard.app"`
- Verified the packaged service starts, writes its runtime descriptor, and supports packaged `taskctl` create/read/update/comment operations
- `node --check` for both changed scripts
- `git diff --check`

The local unsigned signature preflight still reports the same Node signature condition observed in the earlier 1.0.8 and 1.0.9 artifacts; the exact-head CI signing and preflight jobs remain authoritative for release.
