### PR TITLE
fix(ai-chat): 用步骤标题展开思考详情

### DIFF
--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -821,8 +821,14 @@ function MarkdownMessage({
 
 function ThinkingStepDetail({
   detail,
+  label,
+  content,
+  running,
 }: {
   detail: ThinkingActivityDetail;
+  label: string;
+  content: string;
+  running: boolean;
 }) {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -832,9 +838,23 @@ function ThinkingStepDetail({
         aria-expanded={isOpen}
         className="ai-chat-thinking-detail-trigger"
         onClick={() => setIsOpen((open) => !open)}
+        onKeyDown={(event) => {
+          if (event.key !== "Enter") return;
+          event.preventDefault();
+          setIsOpen((open) => !open);
+        }}
+        title={content}
         type="button"
       >
-        <span>{detail.summary}</span>
+        <span className="ai-chat-thinking-step-label">
+          {label}
+          {running && <span aria-hidden="true">…</span>}
+        </span>
+        {content && (
+          <span className="ai-chat-thinking-step-description">
+            {content}
+          </span>
+        )}
         <LinearIcon name="chevronRight" />
       </button>
       <div
@@ -909,6 +929,9 @@ function ThinkingSteps({
               const activityLabel = event.type === "error" && event.data?.status === "warning"
                 ? WARNING_ACTIVITY_LABEL
                 : ACTIVITY_LABELS[event.type];
+              const label = activityLabel
+                ? text(...activityLabel)
+                : text("执行活动", "Activity");
               const content = detail?.kind === "lines"
                 && (event.type === "file" || event.type === "file_change")
                 ? text(
@@ -940,24 +963,28 @@ function ThinkingSteps({
                       )}
                     </span>
                     <div className="ai-chat-thinking-step-content">
-                      <div className="ai-chat-thinking-step-heading">
-                        <span className="ai-chat-thinking-step-label">
-                          {activityLabel
-                            ? text(...activityLabel)
-                            : text("执行活动", "Activity")}
-                          {eventStatus === "running" && <span aria-hidden="true">…</span>}
-                        </span>
-                        {content && (
-                          <span
-                            className="ai-chat-thinking-step-description"
-                            title={content}
-                          >
-                            {content}
+                      {detail ? (
+                        <ThinkingStepDetail
+                          content={content}
+                          detail={detail}
+                          label={label}
+                          running={eventStatus === "running"}
+                        />
+                      ) : (
+                        <div className="ai-chat-thinking-step-heading">
+                          <span className="ai-chat-thinking-step-label">
+                            {label}
+                            {eventStatus === "running" && <span aria-hidden="true">…</span>}
                           </span>
-                        )}
-                      </div>
-                      {detail && (
-                        <ThinkingStepDetail detail={detail} />
+                          {content && (
+                            <span
+                              className="ai-chat-thinking-step-description"
+                              title={content}
+                            >
+                              {content}
+                            </span>
+                          )}
+                        </div>
                       )}
                     </div>
                   </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8003,15 +8003,16 @@ kbd {
 }
 
 .ai-chat-thinking-detail {
-  margin-top: 4px;
   margin-left: -12px;
   color: var(--text-tertiary);
   font-size: 13px;
 }
 
 .ai-chat-thinking-detail-trigger {
-  display: inline-flex;
+  display: flex;
   align-items: center;
+  width: 100%;
+  min-width: 0;
   min-height: 26px;
   gap: 6px;
   padding: 4px 12px;
@@ -8023,6 +8024,15 @@ kbd {
   font: inherit;
   text-align: left;
   transition: background-color 80ms ease, color 80ms ease;
+}
+
+.ai-chat-thinking-detail-trigger .ai-chat-thinking-step-label {
+  flex: 0 0 auto;
+  white-space: nowrap;
+}
+
+.ai-chat-thinking-detail-trigger .ai-chat-thinking-step-description {
+  flex: 1 1 auto;
 }
 
 .ai-chat-thinking-detail-trigger:hover {
@@ -8038,9 +8048,17 @@ kbd {
 
 .ai-chat-thinking-detail-trigger svg {
   order: 2;
+  flex: 0 0 auto;
   width: 12px;
   height: 12px;
-  transition: transform 140ms ease;
+  opacity: 0;
+  transition: opacity 80ms ease, transform 140ms ease;
+}
+
+.ai-chat-thinking-detail-trigger:hover svg,
+.ai-chat-thinking-detail-trigger:focus-visible svg,
+.ai-chat-thinking-detail.is-open .ai-chat-thinking-detail-trigger svg {
+  opacity: 1;
 }
 
 .ai-chat-thinking-detail.is-open .ai-chat-thinking-detail-trigger svg {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8041,9 +8041,7 @@ kbd {
 }
 
 .ai-chat-thinking-detail-trigger:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
-  outline-offset: 2px;
-  border-radius: 4px;
+  outline: 0;
 }
 
 .ai-chat-thinking-detail-trigger svg {


### PR DESCRIPTION
## 变更
- 有 detail 的思考步骤直接使用整条标题作为展开/收起按钮
- 默认保持单行省略，hover、focus 或展开时显示箭头
- 保留现有输出 panel；无 detail 步骤、普通消息和最终回答不变

## 验证
- 5177 真实 Taskboard AI 对话：collapsed、hover、expanded、再次收起、focus/Enter、输出滚动均通过
- npm run typecheck
- npm run build:web
- git diff --check

关联：LOCAL-223