### PR TITLE
Quote packaged taskctl command in Skill

### DIFF
--- a/skills/manage-taskboard/SKILL.md
+++ b/skills/manage-taskboard/SKILL.md
@@ -12,7 +12,7 @@ Open only the relevant section of [references/cli.md](references/cli.md) when co
 ## Select the CLI and active service
 
 - Use the exact `taskctl` binary and Taskboard URL supplied by the task or injected runtime. Do not replace them with a global CLI, the default port, or another board.
-- On macOS, when no binary is injected and the desktop app is installed, check the fixed packaged wrapper at `/Applications/Codex Taskboard.app/Contents/Resources/bin/taskctl` and use it directly. It reads the active launcher runtime; do not search the filesystem for another CLI or reconstruct the tokenized URL.
+- On macOS, when no binary is injected and the desktop app is installed, use `'/Applications/Codex Taskboard.app/Contents/Resources/bin/taskctl' issue get ID --json`. Keep the single quotes because the path contains a space. The packaged wrapper reads the active launcher runtime; do not search the filesystem for another CLI or reconstruct the tokenized URL.
 - If that exact command reaches a sandbox restriction on the loopback service, retry the same command with the required permission. Do not switch binaries or endpoints.
 
 ## Terminology: local companion


### PR DESCRIPTION
## Summary

- add a copy-ready macOS packaged taskctl command
- require the single quotes around the path with a space
- leave CLI, runtime routing, runner, app-server, and cwd unchanged because diagnostics did not prove defects there

## Verification

- quoted installed taskctl command read LOCAL-227 from project 1655e734-40ab-4f63-8b45-ca8a8fa930de
- npm run typecheck
- npm run build:web
- git diff --check

A real Taskboard AI turn and an ephemeral Codex turn were attempted. Both stopped before command execution with 401 invalid_issuer from the current Codex authentication. No automated tests were added or run.