### PR TITLE
Fix InlineMediaComposer input spacing and IME placeholders

### DIFF
--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -1763,9 +1763,15 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
           onInput={() => {
             if (!composing.current) syncSegmentsFromDom();
           }}
-          onCompositionStart={() => { composing.current = true; }}
-          onCompositionEnd={() => {
+          onCompositionStart={(event) => {
+            composing.current = true;
+            event.currentTarget.removeAttribute("data-empty");
+          }}
+          onCompositionEnd={(event) => {
             composing.current = false;
+            if (isEmpty && !event.currentTarget.textContent) {
+              event.currentTarget.dataset.empty = "true";
+            }
             syncSegmentsFromDom();
           }}
           onDragOver={dragContent}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6348,6 +6348,7 @@ kbd {
   margin-top: 2px;
   padding: 6px 0 12px;
   font-size: 15px;
+  line-height: 27px;
 }
 
 .inline-media-description[data-empty="true"] {


### PR DESCRIPTION
## Summary

- align the new-issue description line height with the existing detail preview body
- hide InlineMediaComposer placeholders as soon as IME composition starts
- restore the placeholder when composition ends with an empty value

Tracks LOCAL-244 and LOCAL-245.

## Verification

- real Chromium preview on port 5176: new issue description, detail description, new comment, and edit comment
- compositionstart, confirmed compositionend, and canceled-empty compositionend paths
- computed line-height: new issue description 27px; detail preview body 27px
- npm run typecheck
- npm run build:web
- git diff --check

No automated tests were added, per the repository feature-work rule.