### PR TITLE
LOCAL-243: 新建议题复用可搜索关系选择器

### DIFF
--- a/web/src/components/IssueRelations.tsx
+++ b/web/src/components/IssueRelations.tsx
@@ -22,6 +22,121 @@ export interface RelationMutationResult {
   relatedTask: Task;
 }
 
+export function IssuePickerContent({
+  candidates,
+  selectedIds,
+  disabled,
+  onSelect,
+  onEscape,
+}: {
+  candidates: Task[];
+  selectedIds?: ReadonlySet<string>;
+  disabled?: boolean;
+  onSelect: (task: Task) => void | Promise<void>;
+  onEscape: () => void;
+}) {
+  const { text } = useTaskboardI18n();
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [savingId, setSavingId] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const results = useMemo(() => {
+    const normalized = query.trim().toLocaleLowerCase();
+    if (!normalized) return candidates;
+    return candidates.filter((task) => (
+      (task.externalKey ?? task.identifier).toLocaleLowerCase().includes(normalized)
+      || task.title.toLocaleLowerCase().includes(normalized)
+    ));
+  }, [candidates, query]);
+
+  useEffect(() => {
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, []);
+
+  async function choose(task: Task) {
+    setSavingId(task.id);
+    try {
+      await onSelect(task);
+    } catch {
+    } finally {
+      setSavingId(null);
+    }
+  }
+
+  return (
+    <>
+      <div className="issue-relation-search">
+        <LinearIcon name="search" />
+        <input
+          ref={inputRef}
+          value={query}
+          role="combobox"
+          aria-expanded="true"
+          aria-controls="issue-relation-results"
+          aria-activedescendant={results[activeIndex] ? `relation-option-${results[activeIndex].id}` : undefined}
+          placeholder={text("搜索议题…", "Search issues…")}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setActiveIndex(0);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              event.preventDefault();
+              onEscape();
+            } else if (event.key === "ArrowDown" && results.length > 0) {
+              event.preventDefault();
+              setActiveIndex((index) => (index + 1) % results.length);
+            } else if (event.key === "ArrowUp" && results.length > 0) {
+              event.preventDefault();
+              setActiveIndex((index) => (index - 1 + results.length) % results.length);
+            } else if (event.key === "Enter" && results[activeIndex]) {
+              event.preventDefault();
+              void choose(results[activeIndex]);
+            }
+          }}
+        />
+      </div>
+      <div
+        className={`issue-relation-results${selectedIds ? " has-selections" : ""}`}
+        id="issue-relation-results"
+        role="listbox"
+      >
+        {results.length > 0 ? results.map((candidate, index) => {
+          const selected = selectedIds?.has(candidate.id) ?? false;
+          const className = [
+            index === activeIndex ? "is-active" : "",
+            selected ? "is-selected" : "",
+          ].filter(Boolean).join(" ");
+          return (
+            <button
+              id={`relation-option-${candidate.id}`}
+              className={className}
+              type="button"
+              role="option"
+              aria-selected={selectedIds ? selected : index === activeIndex}
+              disabled={disabled || savingId !== null}
+              key={candidate.id}
+              onMouseEnter={() => setActiveIndex(index)}
+              onClick={() => void choose(candidate)}
+            >
+              <StatusIcon status={candidate.status} />
+              <span className="issue-relation-option-id">{candidate.externalKey ?? candidate.identifier}</span>
+              <span className="issue-relation-option-title">{candidate.title}</span>
+              {selectedIds && (
+                <span className="issue-relation-option-check">
+                  {selected && <LinearIcon name="check" />}
+                </span>
+              )}
+            </button>
+          );
+        }) : (
+          <p className="issue-relation-empty">{text("没有匹配的议题", "No matching issues")}</p>
+        )}
+      </div>
+    </>
+  );
+}
+
 interface RelationActions {
   task: Task;
   tasks: Task[];
@@ -49,44 +164,17 @@ export function IssuePicker({
   disabled?: boolean;
   onSelect: (task: Task) => Promise<void>;
 }) {
-  const { text } = useTaskboardI18n();
   const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState("");
-  const [activeIndex, setActiveIndex] = useState(0);
-  const [savingId, setSavingId] = useState<string | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const results = useMemo(() => {
-    const normalized = query.trim().toLocaleLowerCase();
-    if (!normalized) return candidates;
-    return candidates.filter((task) => (
-      (task.externalKey ?? task.identifier).toLocaleLowerCase().includes(normalized)
-      || task.title.toLocaleLowerCase().includes(normalized)
-    ));
-  }, [candidates, query]);
 
   useEffect(() => {
     if (!open) return;
-    setActiveIndex(0);
-    requestAnimationFrame(() => inputRef.current?.focus());
     const close = (event: PointerEvent) => {
       if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
     };
     window.addEventListener("pointerdown", close);
     return () => window.removeEventListener("pointerdown", close);
   }, [open]);
-
-  async function choose(task: Task) {
-    setSavingId(task.id);
-    try {
-      await onSelect(task);
-      setOpen(false);
-      setQuery("");
-    } catch {
-    } finally {
-      setSavingId(null);
-    }
-  }
 
   return (
     <div className="issue-relation-picker" ref={rootRef}>
@@ -103,58 +191,15 @@ export function IssuePicker({
       </button>
       {open && (
         <div className="issue-relation-popover">
-          <div className="issue-relation-search">
-            <LinearIcon name="search" />
-            <input
-              ref={inputRef}
-              value={query}
-              role="combobox"
-              aria-expanded="true"
-              aria-controls="issue-relation-results"
-              aria-activedescendant={results[activeIndex] ? `relation-option-${results[activeIndex].id}` : undefined}
-              placeholder={text("搜索议题…", "Search issues…")}
-              onChange={(event) => {
-                setQuery(event.target.value);
-                setActiveIndex(0);
-              }}
-              onKeyDown={(event) => {
-                if (event.key === "Escape") {
-                  event.preventDefault();
-                  setOpen(false);
-                } else if (event.key === "ArrowDown" && results.length > 0) {
-                  event.preventDefault();
-                  setActiveIndex((index) => (index + 1) % results.length);
-                } else if (event.key === "ArrowUp" && results.length > 0) {
-                  event.preventDefault();
-                  setActiveIndex((index) => (index - 1 + results.length) % results.length);
-                } else if (event.key === "Enter" && results[activeIndex]) {
-                  event.preventDefault();
-                  void choose(results[activeIndex]);
-                }
-              }}
-            />
-          </div>
-          <div className="issue-relation-results" id="issue-relation-results" role="listbox">
-            {results.length > 0 ? results.map((candidate, index) => (
-              <button
-                id={`relation-option-${candidate.id}`}
-                className={index === activeIndex ? "is-active" : ""}
-                type="button"
-                role="option"
-                aria-selected={index === activeIndex}
-                disabled={savingId !== null}
-                key={candidate.id}
-                onMouseEnter={() => setActiveIndex(index)}
-                onClick={() => void choose(candidate)}
-              >
-                <StatusIcon status={candidate.status} />
-                <span className="issue-relation-option-id">{candidate.externalKey ?? candidate.identifier}</span>
-                <span className="issue-relation-option-title">{candidate.title}</span>
-              </button>
-            )) : (
-              <p className="issue-relation-empty">{text("没有匹配的议题", "No matching issues")}</p>
-            )}
-          </div>
+          <IssuePickerContent
+            candidates={candidates}
+            disabled={disabled}
+            onEscape={() => setOpen(false)}
+            onSelect={async (task) => {
+              await onSelect(task);
+              setOpen(false);
+            }}
+          />
         </div>
       )}
     </div>

--- a/web/src/components/IssueRelations.tsx
+++ b/web/src/components/IssueRelations.tsx
@@ -40,6 +40,7 @@ export function IssuePickerContent({
   const [activeIndex, setActiveIndex] = useState(0);
   const [savingId, setSavingId] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const results = useMemo(() => {
     const normalized = query.trim().toLocaleLowerCase();
     if (!normalized) return candidates;
@@ -52,6 +53,10 @@ export function IssuePickerContent({
   useEffect(() => {
     requestAnimationFrame(() => inputRef.current?.focus());
   }, []);
+
+  useEffect(() => {
+    optionRefs.current[activeIndex]?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex]);
 
   async function choose(task: Task) {
     setSavingId(task.id);
@@ -80,7 +85,13 @@ export function IssuePickerContent({
             setActiveIndex(0);
           }}
           onKeyDown={(event) => {
-            if (event.key === "Escape") {
+            if (event.nativeEvent.isComposing || event.keyCode === 229) return;
+            if (event.key === "Enter") {
+              if (event.metaKey || event.ctrlKey) return;
+              event.preventDefault();
+              const activeResult = results[activeIndex];
+              if (activeResult) void choose(activeResult);
+            } else if (event.key === "Escape") {
               event.preventDefault();
               onEscape();
             } else if (event.key === "ArrowDown" && results.length > 0) {
@@ -89,9 +100,6 @@ export function IssuePickerContent({
             } else if (event.key === "ArrowUp" && results.length > 0) {
               event.preventDefault();
               setActiveIndex((index) => (index - 1 + results.length) % results.length);
-            } else if (event.key === "Enter" && results[activeIndex]) {
-              event.preventDefault();
-              void choose(results[activeIndex]);
             }
           }}
         />
@@ -109,6 +117,9 @@ export function IssuePickerContent({
           ].filter(Boolean).join(" ");
           return (
             <button
+              ref={(element) => {
+                optionRefs.current[index] = element;
+              }}
               id={`relation-option-${candidate.id}`}
               className={className}
               type="button"

--- a/web/src/components/TaskEditor.tsx
+++ b/web/src/components/TaskEditor.tsx
@@ -27,6 +27,7 @@ import {
 import { ActorAvatar } from "./ActorAvatar";
 import { STATUS_DETAILS, StatusIcon } from "./BoardColumn";
 import { LabelPicker } from "./LabelPicker";
+import { IssuePickerContent } from "./IssueRelations";
 import { LinearIcon, LinearPriorityIcon } from "./LinearIcon";
 import {
   fileKey,
@@ -716,20 +717,14 @@ export function TaskEditor({
                       <button className={relationMenu === "parent" ? "is-open" : undefined} type="button" role="menuitem" aria-haspopup="menu" aria-expanded={relationMenu === "parent"} onClick={() => setRelationMenu("parent")}><span><LinearIcon name="plus" /></span><strong>{text("添加父议题", "Add parent issue")}</strong>{selectedParent && <small>{selectedParent.externalKey ?? selectedParent.identifier}</small>}<b><LinearIcon name="chevronRight" /></b></button>
                       <button className={relationMenu === "related" ? "is-open" : undefined} type="button" role="menuitem" aria-haspopup="menu" aria-expanded={relationMenu === "related"} onClick={() => setRelationMenu("related")}><span><LinearIcon name="link" /></span><strong>{text("添加关联议题", "Add related issue")}</strong>{selectedRelated.length > 0 && <small>{text(`${selectedRelated.length} 个已选`, `${selectedRelated.length} selected`)}</small>}<b><LinearIcon name="chevronRight" /></b></button>
                       {relationMenu && (
-                        <div className="task-create-relation-submenu" role="menu" aria-label={text("选择关系议题", "Select relation issue")}>
-                          {relationCandidates.length > 0 ? relationCandidates.map((candidate) => {
-                            const selected = selectedRelationIds.has(candidate.id);
-                            return (
-                              <button className={selected ? "is-selected" : undefined} type="button" role="menuitemcheckbox" aria-checked={selected} key={candidate.id} onClick={() => toggleDraftRelation(candidate)}>
-                                <StatusIcon status={candidate.status} />
-                                <span className="issue-relation-option-id">{candidate.externalKey ?? candidate.identifier}</span>
-                                <span className="issue-relation-option-title">{candidate.title}</span>
-                                <span className="task-create-relation-check">{selected && <LinearIcon name="check" />}</span>
-                              </button>
-                            );
-                          }) : (
-                            <p className="issue-relation-empty">{text("没有可选议题", "No issues available")}</p>
-                          )}
+                        <div className="issue-relation-popover task-create-relation-submenu" aria-label={text("选择关系议题", "Select relation issue")}>
+                          <IssuePickerContent
+                            key={relationMenu}
+                            candidates={relationCandidates}
+                            selectedIds={selectedRelationIds}
+                            onEscape={() => setRelationMenu(null)}
+                            onSelect={toggleDraftRelation}
+                          />
                         </div>
                       )}
                     </>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3266,9 +3266,14 @@ kbd {
 }
 
 .issue-relation-results > button:hover,
-.issue-relation-results > button.is-active {
+.issue-relation-results > button.is-active,
+.issue-relation-results > button.is-selected {
   background: var(--surface-hover);
   color: var(--text-primary);
+}
+
+.issue-relation-results.has-selections > button {
+  grid-template-columns: 16px max-content minmax(0, 1fr) 16px;
 }
 
 .issue-relation-results > button > svg {
@@ -3293,6 +3298,19 @@ kbd {
   font-size: 12px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.issue-relation-option-check {
+  display: grid;
+  place-items: center;
+  width: 16px;
+  height: 16px;
+  color: var(--text-tertiary);
+}
+
+.issue-relation-option-check svg {
+  width: 12px;
+  height: 12px;
 }
 
 .issue-relation-empty {
@@ -7094,58 +7112,8 @@ kbd {
 }
 
 .task-create-relation-submenu {
-  position: absolute;
-  z-index: 1;
   top: 0;
   left: calc(100% + 4px);
-  width: min(360px, calc(100vw - 16px));
-  max-height: min(360px, calc(100vh - 16px));
-  padding: 6px;
-  overflow-y: auto;
-  border: var(--border-hairline) solid var(--border-strong);
-  border-radius: 12px;
-  background: var(--surface-raised);
-  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.14), 0 4px 12px rgba(0, 0, 0, 0.08);
-}
-
-.task-create-relation-submenu > button {
-  display: grid;
-  grid-template-columns: 16px max-content minmax(0, 1fr) 16px;
-  align-items: center;
-  width: 100%;
-  min-height: 36px;
-  gap: 8px;
-  padding: 0 8px;
-  border: 0;
-  border-radius: 7px;
-  background: transparent;
-  color: var(--text-secondary);
-  text-align: left;
-}
-
-.task-create-relation-submenu > button:hover,
-.task-create-relation-submenu > button.is-selected {
-  background: var(--surface-hover);
-  color: var(--text-primary);
-}
-
-.task-create-relation-submenu > button > svg,
-.task-create-relation-submenu > button > .taskboard-icon {
-  width: 14px;
-  height: 14px;
-}
-
-.task-create-relation-check {
-  display: grid;
-  place-items: center;
-  width: 16px;
-  height: 16px;
-  color: var(--text-tertiary);
-}
-
-.task-create-relation-check svg {
-  width: 12px;
-  height: 12px;
 }
 
 .due-popover {


### PR DESCRIPTION
## 变更
- 从详情页 IssuePicker 提取最小可复用内容层
- 新建议题的子议题、父议题、关联议题子菜单复用搜索、结果和键盘导航
- 保留父议题单选、子议题与关联议题多选、已选状态、移除和创建后写入语义

## 验证
- npm run typecheck
- npm run build:web
- git diff --check
- 127.0.0.1:5175 真实浏览器：搜索、ArrowUp/ArrowDown、Enter、三类选择、移除
- 隔离后端：创建议题后在详情页确认父、子、关联三类关系已持久化

未新增测试、护栏或兼容层。