### PR TITLE
Release v1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-taskboard",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-taskboard",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@lobehub/icons-static-svg": "^1.94.0",
         "@xyflow/react": "^12.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-taskboard",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "codex-taskboard-launcher"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "base64 0.22.1",
  "dispatch2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-taskboard-launcher"
-version = "1.1.0"
+version = "1.1.1"
 description = "Codex Taskboard macOS launcher"
 edition = "2021"
 rust-version = "1.88"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex Taskboard",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "identifier": "com.chuspeeism.codex-taskboard",
   "app": {
     "windows": []


### PR DESCRIPTION
## 产品更新
- 对话中的思考步骤默认保持单行，悬停可查看完整内容
- 新建议题时可搜索子议题、父议题和关联议题
- 复制粘贴时保留议题、Skill 和 Agent 引用，并让长标题引用在正文区域内折行

## 版本
- package.json / package-lock.json: 1.1.1
- Tauri Cargo.toml / Cargo.lock / tauri.conf.json: 1.1.1

## 验证
- Cargo metadata 读取版本 1.1.1
- JSON 版本字段一致
- git diff --check

本 PR 仅包含机械版本更新，按项目规则跳过 Pro 审核。