### PR TITLE
fix: remove thinking-step hover background

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8003,7 +8003,6 @@ kbd {
 }
 
 .ai-chat-thinking-detail-trigger:hover {
-  background: var(--surface-muted);
   color: var(--text-secondary);
 }
 


### PR DESCRIPTION
## Summary

- Remove the gray hover background from AI thinking-step command rows.
- Keep the existing arrow and expand/collapse behavior unchanged.

## Verification

- Real Taskboard conversation: normal and hover backgrounds are transparent.
- Hover arrow remains visible; expand and collapse still work.
- npm run typecheck, npm run build:web, and git diff --check pass.

Review: low-complexity one-line CSS change; Agent self-review passed, so Pro review was skipped.

Tracks LOCAL-223.