### PR TITLE
Preserve Taskboard metadata in rich-text clipboard

### DIFF
--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -531,21 +531,11 @@ function inlineMediaClipboardHtml(
       wrapper.append(text);
       continue;
     }
-    if (isInlineReference(segment)) {
-      const link = ownerDocument.createElement("a");
-      const href = /\]\(([^)]+)\)$/.exec(segment.markdown)?.[1];
-      if (href) link.setAttribute("href", href);
-      link.dataset.taskboardInlineMediaMarkdown = segment.markdown;
-      link.textContent = segment.type === "issue-reference" ? segment.identifier : segment.label;
-      wrapper.append(link);
-      continue;
-    }
-    if (segment.type === "persisted-image") {
-      const image = ownerDocument.createElement("img");
-      image.src = resolvePersistedAttachmentUrl(segment.url);
-      image.alt = segment.alt;
-      image.dataset.taskboardInlineMediaMarkdown = segment.markdown;
-      wrapper.append(image);
+    if (isInlineReference(segment) || segment.type === "persisted-image") {
+      const markdown = ownerDocument.createElement("span");
+      markdown.dataset.taskboardInlineMediaMarkdown = segment.markdown;
+      markdown.textContent = segment.markdown;
+      wrapper.append(markdown);
       continue;
     }
     const pendingImage = ownerDocument.createElement("span");


### PR DESCRIPTION
## 产品路径

从议题正文或评论复制混合内容时，Taskboard 继续写内部结构化剪贴板；外部富文本软件现在也能看到完整的议题、图片、Skill 和 Agent Markdown 元数据。

## 实现

- 只调整 InlineMediaComposer 的 HTML 剪贴板表示。
- 已持久化引用和图片使用现有 segment.markdown 作为可见内容。
- 保留内部 MIME、Taskboard data 属性、text/plain、保存格式和 API。

## 验证

- 阅读态复制到外部 textarea：完整 Markdown。
- 阅读态复制到外部 contenteditable：完整 Markdown。
- 编辑态 Cmd+A 复制到外部 contenteditable：完整 Markdown。
- 粘回 Taskboard：恢复 1 个议题原子和 3 张真实图片，3 张均加载成功。
- npm run typecheck、npm run build:web、git diff --check 通过。

## 审核

低复杂度，自审通过。只检查实现正确性、直接路径、范围和真实 bug；未增加测试、护栏、兼容层或无关重构。