### PR TITLE
Preserve stable clipboard references

### DIFF
--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -65,6 +65,8 @@ interface IssueReferenceSegment {
   type: "issue-reference";
   markdown: string;
   identifier: string;
+  projectId: string;
+  issueIdentifier: string;
   taskId: string | null;
 }
 
@@ -195,25 +197,59 @@ function imageSegment(file: File): InlineImageSegment {
 
 const COMPOSER_REFERENCE_URL = /^taskboard:\/\/composer-reference\/v1\/(skill|agent)\/([A-Za-z0-9_-]+)$/;
 const COMPOSER_REFERENCE_NAMESPACE_URL = /^taskboard:\/\/composer-reference\/([^/]+)\/([^/]+)\/([A-Za-z0-9_-]+)$/;
+const ISSUE_COMPOSER_REFERENCE_URL = /^taskboard:\/\/composer-reference\/v1\/issue\/([A-Za-z0-9_-]+)$/;
+const IMAGE_COMPOSER_REFERENCE_URL = /^taskboard:\/\/composer-reference\/v1\/image\/([A-Za-z0-9_-]+)$/;
 
-function base64UrlReferenceKey(
-  value: string,
-  requireNfc: boolean,
-): string | null {
+function encodedComposerReferenceKey(value: string): string {
+  return btoa(String.fromCharCode(...new TextEncoder().encode(value)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function decodedComposerReferenceKey(value: string): string | null {
   if (!value || value.length % 4 === 1) return null;
   try {
     const padded = `${value.replace(/-/g, "+").replace(/_/g, "/")}${"=".repeat((4 - value.length % 4) % 4)}`;
     const bytes = Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
     const decoded = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-    if (!decoded || (requireNfc && decoded !== decoded.normalize("NFC"))) return null;
-    const canonical = btoa(String.fromCharCode(...new TextEncoder().encode(decoded)))
-      .replace(/\+/g, "-")
-      .replace(/\//g, "_")
-      .replace(/=+$/, "");
-    return canonical === value ? value : null;
+    return decoded && encodedComposerReferenceKey(decoded) === value ? decoded : null;
   } catch {
     return null;
   }
+}
+
+function base64UrlReferenceKey(
+  value: string,
+  requireNfc: boolean,
+): string | null {
+  const decoded = decodedComposerReferenceKey(value);
+  return decoded && (!requireNfc || decoded === decoded.normalize("NFC")) ? value : null;
+}
+
+function issueComposerReference(url: string) {
+  const match = ISSUE_COMPOSER_REFERENCE_URL.exec(url);
+  const value = match ? decodedComposerReferenceKey(match[1]) : null;
+  if (!value) return null;
+  const route = new URLSearchParams(value);
+  const projectId = route.get("project")?.trim();
+  const identifier = readIssueIdentifier(value);
+  return projectId && identifier ? { projectId, identifier } : null;
+}
+
+function attachmentIdFromUrl(url: string): string | null {
+  try {
+    const path = new URL(url, "http://taskboard.local").pathname;
+    return path.match(/\/api\/attachments\/([A-Za-z0-9_-]+)\/content$/)?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function imageComposerReference(url: string): string | null {
+  const match = IMAGE_COMPOSER_REFERENCE_URL.exec(url);
+  const attachmentId = match ? decodedComposerReferenceKey(match[1]) : null;
+  return attachmentId && /^[A-Za-z0-9_-]+$/.test(attachmentId) ? attachmentId : null;
 }
 
 function markdownNodeText(node: MarkdownAstNode): string | null {
@@ -274,13 +310,23 @@ export function createInlineMediaSegments(
 ): InlineMediaSegment[] {
   const segments: InlineMediaSegment[] = [];
   const items: Array<
-    | { type: "persisted-image"; start: number; end: number; alt: string; url: string }
+    | {
+        type: "persisted-image";
+        start: number;
+        end: number;
+        alt: string;
+        url: string;
+        markdown?: string;
+      }
     | {
         type: "issue-reference";
         start: number;
         end: number;
         identifier: string;
+        projectId: string;
+        issueIdentifier: string;
         taskId: string | null;
+        markdown?: string;
       }
     | (Omit<InlineComposerReferenceSegment, "id"> & { start: number; end: number })
     | (Omit<InlineUnsupportedComposerReferenceSegment, "id"> & { start: number; end: number })
@@ -292,12 +338,18 @@ export function createInlineMediaSegments(
   while (nodes.length > 0) {
     const node = nodes.pop()!;
     if (node.type === "image") {
+      const attachmentId = imageComposerReference(node.url!);
+      const url = attachmentId ? `api/attachments/${attachmentId}/content` : node.url!;
+      const alt = node.alt ?? "";
       items.push({
         type: "persisted-image",
         start: node.position.start.offset,
         end: node.position.end.offset,
-        alt: node.alt ?? "",
-        url: node.url!,
+        alt,
+        url,
+        markdown: attachmentId
+          ? `![${alt.replace(/[\\[\]]/g, "\\$&")}](${url})`
+          : undefined,
       });
     }
     if (node.type === "imageReference") {
@@ -312,9 +364,13 @@ export function createInlineMediaSegments(
         });
       }
     }
-    if (node.type === "link" && node.url?.startsWith("?")) {
-      const projectId = new URLSearchParams(node.url).get("project");
-      const identifier = readIssueIdentifier(node.url);
+    let handledIssueReference = false;
+    if (node.type === "link" && node.url) {
+      const stableIssue = issueComposerReference(node.url);
+      const projectId = stableIssue?.projectId
+        ?? (node.url.startsWith("?") ? new URLSearchParams(node.url).get("project") : null);
+      const identifier = stableIssue?.identifier
+        ?? (node.url.startsWith("?") ? readIssueIdentifier(node.url) : null);
       const task = projectId && identifier
         ? referenceTasks.find((candidate) => (
             candidate.projectId === projectId && candidate.identifier === identifier
@@ -326,11 +382,17 @@ export function createInlineMediaSegments(
           start: node.position.start.offset,
           end: node.position.end.offset,
           identifier: task?.externalKey ?? identifier,
+          projectId,
+          issueIdentifier: identifier,
           taskId: task?.id ?? null,
+          markdown: stableIssue
+            ? `[@${task?.externalKey ?? identifier}](?${new URLSearchParams({ project: projectId, issue: identifier })})`
+            : undefined,
         });
+        handledIssueReference = true;
       }
     }
-    const composerReference = composerReferenceFromNode(node, text);
+    const composerReference = handledIssueReference ? null : composerReferenceFromNode(node, text);
     if (composerReference) items.push(composerReference);
     if (node.children) nodes.push(...node.children);
   }
@@ -344,7 +406,7 @@ export function createInlineMediaSegments(
       segments.push({
         id: segmentId("image"),
         type: "persisted-image",
-        markdown: text.slice(item.start, item.end),
+        markdown: item.markdown ?? text.slice(item.start, item.end),
         alt: item.alt,
         url: item.url,
       });
@@ -352,8 +414,10 @@ export function createInlineMediaSegments(
       segments.push({
         id: segmentId("issue"),
         type: "issue-reference",
-        markdown: text.slice(item.start, item.end),
+        markdown: item.markdown ?? text.slice(item.start, item.end),
         identifier: item.identifier,
+        projectId: item.projectId,
+        issueIdentifier: item.issueIdentifier,
         taskId: item.taskId,
       });
     } else if (item.type === "unsupported-reference") {
@@ -515,6 +579,35 @@ function selfContainedClipboardSegments(
   });
 }
 
+function stableClipboardSegments(
+  segments: InlineMediaSegment[],
+): InlineMediaSegment[] {
+  return segments.map((segment) => {
+    if (segment.type === "issue-reference") {
+      const route = new URLSearchParams({
+        project: segment.projectId,
+        issue: segment.issueIdentifier,
+      });
+      const referenceKey = encodedComposerReferenceKey(route.toString());
+      return {
+        ...segment,
+        markdown: `[@${segment.identifier}](taskboard://composer-reference/v1/issue/${referenceKey})`,
+      };
+    }
+    if (segment.type === "persisted-image") {
+      const attachmentId = attachmentIdFromUrl(segment.url);
+      if (!attachmentId) return segment;
+      const alt = segment.alt.replace(/[\\[\]]/g, "\\$&");
+      const referenceKey = encodedComposerReferenceKey(attachmentId);
+      return {
+        ...segment,
+        markdown: `![${alt}](taskboard://composer-reference/v1/image/${referenceKey})`,
+      };
+    }
+    return segment;
+  });
+}
+
 function inlineMediaClipboardHtml(
   segments: InlineMediaSegment[],
   clipboardId: string,
@@ -554,12 +647,13 @@ export function writeInlineMediaClipboard(
 ) {
   const clipboardId = segmentId("clipboard");
   const clipboardSegments = selfContainedClipboardSegments(segments);
+  const exportedSegments = stableClipboardSegments(clipboardSegments);
   inlineMediaClipboard = { id: clipboardId, segments: clipboardSegments };
   clipboardData.setData(INLINE_MEDIA_CLIPBOARD_MIME, clipboardId);
-  clipboardData.setData("text/plain", inlineMediaClipboardText(clipboardSegments));
+  clipboardData.setData("text/plain", inlineMediaClipboardText(exportedSegments));
   clipboardData.setData(
     "text/html",
-    inlineMediaClipboardHtml(clipboardSegments, clipboardId, ownerDocument),
+    inlineMediaClipboardHtml(exportedSegments, clipboardId, ownerDocument),
   );
 }
 
@@ -1453,6 +1547,8 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
           type: "issue-reference",
           markdown: `[@${displayIdentifier}](?${route})`,
           identifier: displayIdentifier,
+          projectId: task.projectId,
+          issueIdentifier: task.identifier,
           taskId: task.id,
         };
         applyRangeReplacement(


### PR DESCRIPTION
## Summary

- export issue references and persisted Taskboard images with stable typed `taskboard://composer-reference/v1/...` Markdown
- parse those issue/image references back into the existing Taskboard composer segments
- keep the current internal structured clipboard path and existing saved Markdown formats unchanged

## Direct verification

- reading-state real selection + Meta+C produced stable issue/image metadata in external textarea and contenteditable targets
- editing-state Meta+A + Meta+C produced the same stable metadata
- full Taskboard clipboard paste restored one issue atom and two loaded persisted images
- copying the external textarea back, without Taskboard's private MIME, still restored one issue atom and two loaded persisted images in the Taskboard comment composer
- ordinary text order stayed unchanged; verification content was cleared without saving

## Checks

- `npm run typecheck`
- `npm run build:web`
- `git diff --check`

No tests were added or run. The change does not alter the attachment API, saved Markdown format, editor architecture, or UI.
