### PR TITLE
Preserve pending images across clipboard boundaries

### DIFF
--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -50,6 +50,7 @@ interface InlineImageSegment {
   type: "pending-image";
   token: string;
   file: File;
+  dataUrl: string | null;
 }
 
 interface PersistedImageSegment {
@@ -185,20 +186,30 @@ function textSegment(text = ""): InlineTextSegment {
   return { id: segmentId("text"), type: "text", text };
 }
 
-function imageSegment(file: File): InlineImageSegment {
+function imageSegment(file: File, dataUrl: string | null = null): InlineImageSegment {
   const id = segmentId("image");
-  return {
+  const segment: InlineImageSegment = {
     id,
     type: "pending-image",
     token: `<!--taskboard-inline-image:${id}-->`,
     file,
+    dataUrl,
   };
+  if (!dataUrl) {
+    const reader = new FileReader();
+    reader.addEventListener("load", () => {
+      if (typeof reader.result === "string") segment.dataUrl = reader.result;
+    });
+    reader.readAsDataURL(file);
+  }
+  return segment;
 }
 
 const COMPOSER_REFERENCE_URL = /^taskboard:\/\/composer-reference\/v1\/(skill|agent)\/([A-Za-z0-9_-]+)$/;
 const COMPOSER_REFERENCE_NAMESPACE_URL = /^taskboard:\/\/composer-reference\/([^/]+)\/([^/]+)\/([A-Za-z0-9_-]+)$/;
 const ISSUE_COMPOSER_REFERENCE_URL = /^taskboard:\/\/composer-reference\/v1\/issue\/([A-Za-z0-9_-]+)$/;
 const IMAGE_COMPOSER_REFERENCE_URL = /^taskboard:\/\/composer-reference\/v1\/image\/([A-Za-z0-9_-]+)$/;
+const PENDING_IMAGE_COMPOSER_REFERENCE_URL = /^taskboard:\/\/composer-reference\/v1\/pending-image\/([A-Za-z0-9_-]+)\.([A-Za-z0-9_-]+)$/;
 
 function encodedComposerReferenceKey(value: string): string {
   return btoa(String.fromCharCode(...new TextEncoder().encode(value)))
@@ -250,6 +261,27 @@ function imageComposerReference(url: string): string | null {
   const match = IMAGE_COMPOSER_REFERENCE_URL.exec(url);
   const attachmentId = match ? decodedComposerReferenceKey(match[1]) : null;
   return attachmentId && /^[A-Za-z0-9_-]+$/.test(attachmentId) ? attachmentId : null;
+}
+
+function pendingImageComposerReference(
+  url: string,
+  name: string,
+): { file: File; dataUrl: string } | null {
+  const match = PENDING_IMAGE_COMPOSER_REFERENCE_URL.exec(url);
+  const type = match ? decodedComposerReferenceKey(match[1]) : null;
+  if (!match || !type?.startsWith("image/")) return null;
+  try {
+    const base64 = `${match[2].replace(/-/g, "+").replace(/_/g, "/")}${"=".repeat((4 - match[2].length % 4) % 4)}`;
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+    return {
+      file: new File([bytes], name || "image", { type }),
+      dataUrl: `data:${type};base64,${base64}`,
+    };
+  } catch {
+    return null;
+  }
 }
 
 function markdownNodeText(node: MarkdownAstNode): string | null {
@@ -328,6 +360,13 @@ export function createInlineMediaSegments(
         taskId: string | null;
         markdown?: string;
       }
+    | {
+        type: "pending-image";
+        start: number;
+        end: number;
+        file: File;
+        dataUrl: string;
+      }
     | (Omit<InlineComposerReferenceSegment, "id"> & { start: number; end: number })
     | (Omit<InlineUnsupportedComposerReferenceSegment, "id"> & { start: number; end: number })
   > = [];
@@ -338,19 +377,29 @@ export function createInlineMediaSegments(
   while (nodes.length > 0) {
     const node = nodes.pop()!;
     if (node.type === "image") {
-      const attachmentId = imageComposerReference(node.url!);
-      const url = attachmentId ? `api/attachments/${attachmentId}/content` : node.url!;
       const alt = node.alt ?? "";
-      items.push({
-        type: "persisted-image",
-        start: node.position.start.offset,
-        end: node.position.end.offset,
-        alt,
-        url,
-        markdown: attachmentId
-          ? `![${alt.replace(/[\\[\]]/g, "\\$&")}](${url})`
-          : undefined,
-      });
+      const pendingImage = pendingImageComposerReference(node.url!, alt);
+      if (pendingImage) {
+        items.push({
+          type: "pending-image",
+          start: node.position.start.offset,
+          end: node.position.end.offset,
+          ...pendingImage,
+        });
+      } else {
+        const attachmentId = imageComposerReference(node.url!);
+        const url = attachmentId ? `api/attachments/${attachmentId}/content` : node.url!;
+        items.push({
+          type: "persisted-image",
+          start: node.position.start.offset,
+          end: node.position.end.offset,
+          alt,
+          url,
+          markdown: attachmentId
+            ? `![${alt.replace(/[\\[\]]/g, "\\$&")}](${url})`
+            : undefined,
+        });
+      }
     }
     if (node.type === "imageReference") {
       const definition = getDefinition(node.identifier);
@@ -402,7 +451,9 @@ export function createInlineMediaSegments(
 
   for (const item of items) {
     if (item.start > offset) segments.push(textSegment(text.slice(offset, item.start)));
-    if (item.type === "persisted-image") {
+    if (item.type === "pending-image") {
+      segments.push(imageSegment(item.file, item.dataUrl));
+    } else if (item.type === "persisted-image") {
       segments.push({
         id: segmentId("image"),
         type: "persisted-image",
@@ -561,9 +612,20 @@ function inlineMediaRangeSegments(
 function inlineMediaClipboardText(segments: InlineMediaSegment[]): string {
   return segments.map((segment) => {
     if (segment.type === "text") return segment.text;
-    if (segment.type === "pending-image") return segment.file.name;
+    if (segment.type === "pending-image") {
+      return pendingImageClipboardMarkdown(segment) ?? segment.file.name;
+    }
     return segment.markdown;
   }).join("");
+}
+
+function pendingImageClipboardMarkdown(segment: InlineImageSegment): string | null {
+  const match = segment.dataUrl?.match(/^data:([^;,]+);base64,(.+)$/);
+  if (!match) return null;
+  const typeKey = encodedComposerReferenceKey(match[1]);
+  const dataKey = match[2].replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  const alt = segment.file.name.replace(/[\\[\]]/g, "\\$&");
+  return `![${alt}](taskboard://composer-reference/v1/pending-image/${typeKey}.${dataKey})`;
 }
 
 function selfContainedClipboardSegments(
@@ -632,8 +694,14 @@ function inlineMediaClipboardHtml(
       continue;
     }
     const pendingImage = ownerDocument.createElement("span");
-    pendingImage.dataset.taskboardInlineMediaPendingImage = segment.id;
-    pendingImage.textContent = segment.file.name;
+    const markdown = pendingImageClipboardMarkdown(segment);
+    if (markdown) {
+      pendingImage.dataset.taskboardInlineMediaMarkdown = markdown;
+      pendingImage.textContent = markdown;
+    } else {
+      pendingImage.dataset.taskboardInlineMediaPendingImage = segment.id;
+      pendingImage.textContent = segment.file.name;
+    }
     wrapper.append(pendingImage);
   }
 
@@ -748,7 +816,7 @@ export function createInlineMediaSegmentsFromHtml(
 function cloneInlineMediaSegments(segments: InlineMediaSegment[]): InlineMediaSegment[] {
   return segments.map((segment) => {
     if (segment.type === "text") return textSegment(segment.text);
-    if (segment.type === "pending-image") return imageSegment(segment.file);
+    if (segment.type === "pending-image") return imageSegment(segment.file, segment.dataUrl);
     const prefix = segment.type === "persisted-image"
       ? "image"
       : segment.type === "issue-reference"
@@ -1225,7 +1293,7 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       addImages(files) {
         const images = insertableImages(files);
         if (!images || images.length === 0) return;
-        onChange(normalizeSegments([...segments, ...images.map(imageSegment)]));
+        onChange(normalizeSegments([...segments, ...images.map((file) => imageSegment(file))]));
       },
     }), [onChange, onError, segments]);
 
@@ -1732,7 +1800,12 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
         event.preventDefault();
         const images = insertableImages(clipboardFiles);
         if (!images || images.length === 0) return;
-        applyRangeReplacement(range.start, range.end, images.map(imageSegment), false);
+        applyRangeReplacement(
+          range.start,
+          range.end,
+          images.map((file) => imageSegment(file)),
+          false,
+        );
         return;
       }
       const htmlSegments = createInlineMediaSegmentsFromHtml(clipboardHtml, referenceTasks);
@@ -1765,7 +1838,12 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
         ? logicalOffsetForPoint(caretRange.startContainer, caretRange.startOffset, "start")
         : null;
       const insertionOffset = offset ?? currentLogicalRange()?.end ?? segmentsLength(segments);
-      applyRangeReplacement(insertionOffset, insertionOffset, images.map(imageSegment), false);
+      applyRangeReplacement(
+        insertionOffset,
+        insertionOffset,
+        images.map((file) => imageSegment(file)),
+        false,
+      );
     }
 
     function syncSegmentsFromDom() {


### PR DESCRIPTION
## What changed

- serialize unsaved inline comment images as self-contained `taskboard://composer-reference/v1/pending-image/...` Markdown when copied outside Taskboard
- parse that metadata back into the existing pending-image File segment
- keep the existing private clipboard fast path, persisted attachment-ID format, save format, and upload API unchanged

## Direct verification

- current main reproduced the failure in the 5173 Demo: pending PNG copied through an external textarea became only `image.png`; copying it back restored 0 images
- this branch: the same real Meta+C/Meta+V path emitted one pending-image reference and restored one loaded image
- mixed text + pending image + LOCAL-219 reference preserved order and restored 1 image + 1 issue atom
- saved description still restored 2 loaded images + 1 issue
- existing comment edit mode still restored 1 loaded image + 1 issue; edit was canceled
- `npm run typecheck`
- `npm run build:web`
- `git diff --check`

No tests, guardrails, compatibility layer, or unrelated refactor were added.
