### PR TITLE
feat: 优化项目下拉框

### DIFF
--- a/server/app.mjs
+++ b/server/app.mjs
@@ -2743,7 +2743,7 @@ export function createTaskboardServer(options = {}) {
       if (pathname === "/api/tasks") {
         if (request.method === "GET") {
           const filters = parseTaskFilters(url.searchParams);
-          if (filters.projectId === JIRA_PROJECT_ID) await jira.sync();
+          if (!filters.projectId || filters.projectId === JIRA_PROJECT_ID) await jira.sync();
           return sendJson(response, 200, { tasks: database.listTasks(filters) });
         }
         if (request.method === "POST") {

--- a/test/ai-chat-ui.test.mjs
+++ b/test/ai-chat-ui.test.mjs
@@ -135,7 +135,7 @@ test("reasoning and raw JSONL events never enter the visible activity timeline",
 
 test("App wires the global panel outside project/detail branches and hides it without local capability", () => {
   assert.match(appSource, /const AiChat = lazy\(\(\) => import\("\.\/components\/AiChat"\)/);
-  assert.match(appSource, /localAiChatAvailable && \([\s\S]*?<Suspense fallback=\{null\}>[\s\S]*?<AiChat/);
+  assert.match(appSource, /localAiChatAvailable && !isAllProjects && \([\s\S]*?<Suspense fallback=\{null\}>[\s\S]*?<AiChat/);
   assert.doesNotMatch(appSource, /import \{ AiChat,/);
   assert.match(appSource, /<AiChat/);
   assert.match(appSource, /projectId=\{selectedProjectId \|\| null\}/);

--- a/test/board-interactions.test.mjs
+++ b/test/board-interactions.test.mjs
@@ -45,10 +45,11 @@ test("text selection is reserved for editable fields", () => {
 });
 
 test("main issue cards stay compact while sidebar cards show ownership and creation time", () => {
-  assert.doesNotMatch(cardSource, /projectName|project-chip/);
+  assert.match(cardSource, /projectName[\s\S]*?className="project-chip"/);
   assert.match(cardSource, /variant === "sidebar" && \([\s\S]*?className="sidebar-card-creator"/);
   assert.match(cardSource, /<AssigneeControl[\s\S]*?<span>\{createdDate\(task\.createdAt, locale, text\)\}<\/span>/);
-  assert.doesNotMatch(styles, /\.card-footer|\.created-at|\.project-chip/);
+  assert.doesNotMatch(styles, /\.card-footer|\.created-at/);
+  assert.match(styles, /\.project-chip/);
   assert.match(styles, /\.task-card \{[\s\S]*?min-height: 80px;[\s\S]*?gap: 6px;[\s\S]*?padding: 7px 8px/);
   assert.match(detailSource, /currentTask\.createdAt/);
 });

--- a/test/board-views.test.mjs
+++ b/test/board-views.test.mjs
@@ -31,7 +31,7 @@ test("the taskboard defaults to issues and exposes the current project views", (
   assert.match(appSource, /onClick=\{\(\) => selectBoardView\("issues"\)\}/);
   assert.match(appSource, /const SHOW_WORKFLOW_BOARD_ENTRY = false/);
   assert.match(appSource, /SHOW_WORKFLOW_BOARD_ENTRY && \([\s\S]*?>\s*\{text\("节点模式", "Workflow"\)\}\s*<\/button>/);
-  assert.match(appSource, /function changeProject[\s\S]*?setBoardView\(readProjectBoardView\(projectId\)\)/);
+  assert.match(appSource, /function changeProject[\s\S]*?setBoardView\(projectId === ALL_PROJECTS_ID \? "issues" : readProjectBoardView\(projectId\)\)/);
   assert.doesNotMatch(appSource, /<span>活跃<\/span>|<span>积压事项<\/span>|所有议题|add-view/);
 });
 

--- a/test/issue-detail-route.test.mjs
+++ b/test/issue-detail-route.test.mjs
@@ -48,7 +48,7 @@ test("the app restores issue detail from the URL and follows browser history", (
     appSource.indexOf("function openTaskDetail"),
     appSource.indexOf("function closeTaskDetail"),
   );
-  assert.match(openTaskSource, /buildIssueUrl\(window\.location\.href, task\.projectId, null\)/);
+  assert.match(openTaskSource, /buildIssueUrl\(window\.location\.href, selectedProjectId, null\)/);
   assert.match(openTaskSource, /window\.history\.replaceState/);
   assert.match(openTaskSource, /window\.history\.pushState/);
   assert.match(appSource, /function closeTaskDetail\(\)[\s\S]*?window\.history\.replaceState/);

--- a/test/project-home.test.mjs
+++ b/test/project-home.test.mjs
@@ -14,7 +14,7 @@ const labelsSource = await readFile(new URL("../web/src/labels.ts", import.meta.
 test("the project switcher merges live Codex projects with persisted Taskboard projects", () => {
   assert.match(appSource, /hostContext\?\.projects \?\? \[\]/);
   assert.match(appSource, /persistedById/);
-  assert.match(appSource, /name: project\.id === GLOBAL_PROJECT_ID\s*\? text\("全局", "Global"\)\s*: persistedById\.get\(project\.id\)\?\.name \?\? project\.name/);
+  assert.match(appSource, /name: project\.id === GLOBAL_PROJECT_ID\s*\? text\("临时任务", "Temporary tasks"\)\s*: persistedById\.get\(project\.id\)\?\.name \?\? project\.name/);
   assert.match(appSource, /for \(const project of projects\) \{[\s\S]*?inCodex: false,[\s\S]*?persisted: true/);
   assert.match(appSource, /projectChoices\.map\(\(project\) => \(/);
   assert.match(appSource, /createProjectRequest/);
@@ -99,7 +99,7 @@ test("the project header exposes project, automation, and create controls", () =
 });
 
 test("the project header keeps detail navigation separate from the project switcher", () => {
-  assert.match(appSource, /const headerProjectName = selectedProject\?\.id === GLOBAL_PROJECT_ID\s*\? text\("全局", "Global"\)\s*: selectedProject\?\.name \?\? text\("任务面板", "Taskboard"\)/);
+  assert.match(appSource, /const headerProjectName = isAllProjects\s*\? text\("所有项目", "All projects"\)\s*: selectedProject\?\.id === GLOBAL_PROJECT_ID\s*\? text\("临时任务", "Temporary tasks"\)\s*: selectedProject\?\.name \?\? text\("任务面板", "Taskboard"\)/);
   assert.match(appSource, /detailTask && \([\s\S]*?aria-label=\{text\("返回议题看板", "Back to issue board"\)\}[\s\S]*?<\/button>/);
   assert.match(appSource, /className="header-project-switcher"[\s\S]*?<span className="project-name">\{headerProjectName\}<\/span>/);
   assert.doesNotMatch(appSource, /className="issue-root-button"/);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1863,12 +1863,12 @@ export function App() {
   }, [refreshTasks, selectedProjectId]);
 
   useEffect(() => {
-    if (!isJiraProject || !selectedProjectId) return;
+    if ((!isJiraProject && !(isAllProjects && jiraConnection?.configured)) || !selectedProjectId) return;
     const timer = window.setInterval(() => {
       void refreshTasks(selectedProjectId, { quiet: true });
     }, 60_000);
     return () => window.clearInterval(timer);
-  }, [isJiraProject, refreshTasks, selectedProjectId]);
+  }, [isAllProjects, isJiraProject, jiraConnection?.configured, refreshTasks, selectedProjectId]);
 
   const refreshWorkflowOptions = useCallback(async (projectId: string, signal?: AbortSignal) => {
     const record = await getWorkflowWorkspace<unknown>(projectId, signal);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,5 @@
 import {
+  Fragment,
   lazy,
   Suspense,
   useCallback,
@@ -313,6 +314,7 @@ const DEFAULT_USER_ACTOR: ActorIdentity = {
 };
 
 const GLOBAL_PROJECT_ID = "local";
+const ALL_PROJECTS_ID = "__all_projects__";
 const RECENT_PROJECT_IDS_KEY = "taskboard.recentProjectIds.v1";
 const PROJECT_VIEW_KEY_PREFIX = "taskboard.project-view.v1.";
 const DEVICE_WORKSPACE_PATHS_KEY = "taskboard.deviceWorkspacePaths.v1";
@@ -625,7 +627,11 @@ function LocalRealtimeSync({
       }
       const eventProjectId = payload.projectId ?? payload.project?.id;
       const affectsSelectedProject = Boolean(selectedProjectId)
-        && (!eventProjectId || eventProjectId === selectedProjectId);
+        && (
+          selectedProjectId === ALL_PROJECTS_ID
+          || !eventProjectId
+          || eventProjectId === selectedProjectId
+        );
       if (event.type === "project.created") {
         scheduleRefresh({ projects: true });
         return;
@@ -640,7 +646,9 @@ function LocalRealtimeSync({
       }
       if (!affectsSelectedProject) return;
       if (event.type === "workflow.updated") {
-        if (selectedProjectId) void refreshWorkflowOptions(selectedProjectId);
+        if (selectedProjectId && selectedProjectId !== ALL_PROJECTS_ID) {
+          void refreshWorkflowOptions(selectedProjectId);
+        }
         return;
       }
       if (event.type.startsWith("comment.")) {
@@ -662,7 +670,9 @@ function LocalRealtimeSync({
     source.onopen = () => {
       setConnection("live");
       scheduleRefresh({ projects: true, tasks: Boolean(selectedProjectId) });
-      if (selectedProjectId) void refreshWorkflowOptions(selectedProjectId);
+      if (selectedProjectId && selectedProjectId !== ALL_PROJECTS_ID) {
+        void refreshWorkflowOptions(selectedProjectId);
+      }
       if (detailTaskId) {
         setCommentsRevision((current) => current + 1);
         setAttachmentsRevision((current) => current + 1);
@@ -863,6 +873,7 @@ export function App() {
   }, []);
 
   const selectedProject = projects.find((project) => project.id === selectedProjectId) ?? null;
+  const isAllProjects = selectedProjectId === ALL_PROJECTS_ID;
   const isJiraProject = selectedProject?.source === "jira";
   const aiImportProjectId = hasLoadedTasks
     && tasks.length === 0
@@ -890,7 +901,7 @@ export function App() {
     ...DEFAULT_USER_ACTOR,
     name: text("本地用户", "Local user"),
   };
-  const selectedDeviceWorkspacePath = selectedProjectId === GLOBAL_PROJECT_ID
+  const selectedDeviceWorkspacePath = selectedProjectId === GLOBAL_PROJECT_ID || isAllProjects
     ? undefined
     : deviceWorkspacePaths[selectedProjectId];
   const selectedProjectAutomation = projectAutomations[selectedProjectId];
@@ -1030,7 +1041,13 @@ export function App() {
   const contextMenuTask = contextMenu
     ? tasks.find((task) => task.id === contextMenu.taskId) ?? null
     : null;
-  const availableLabels = selectedProject?.labels ?? [];
+  const availableLabels = isAllProjects
+    ? [...new Set(projects.flatMap((project) => project.labels))]
+    : selectedProject?.labels ?? [];
+  const projectNames = useMemo(() => Object.fromEntries(projects.map((project) => [
+    project.id,
+    project.id === GLOBAL_PROJECT_ID ? text("临时任务", "Temporary tasks") : project.name,
+  ])), [projects, text]);
   const projectChoices = useMemo<ProjectChoice[]>(() => {
     const persistedById = new Map(projects.map((project) => [project.id, project]));
     const seen = new Set<string>();
@@ -1041,7 +1058,7 @@ export function App() {
       choices.push({
         id: project.id,
         name: project.id === GLOBAL_PROJECT_ID
-          ? text("全局", "Global")
+          ? text("临时任务", "Temporary tasks")
           : persistedById.get(project.id)?.name ?? project.name,
         issueCount: persistedById.get(project.id)?.issueCount ?? 0,
         inCodex: true,
@@ -1060,7 +1077,9 @@ export function App() {
       if (seen.has(project.id)) continue;
       choices.push({
         id: project.id,
-        name: project.id === GLOBAL_PROJECT_ID ? text("全局", "Global") : project.name,
+        name: project.id === GLOBAL_PROJECT_ID
+          ? text("临时任务", "Temporary tasks")
+          : project.name,
         issueCount: project.issueCount,
         inCodex: false,
         persisted: true,
@@ -1068,11 +1087,17 @@ export function App() {
       });
     }
     const recentOrder = new Map(recentProjectIds.map((projectId, index) => [projectId, index]));
-    return choices.sort((left, right) => (
+    const sortedChoices = choices.sort((left, right) => (
       (recentOrder.get(left.id) ?? recentProjectIds.length)
       - (recentOrder.get(right.id) ?? recentProjectIds.length)
     ));
+    return [
+      ...sortedChoices.filter((project) => project.issueCount > 0),
+      ...sortedChoices.filter((project) => project.issueCount === 0),
+    ];
   }, [hostContext?.projects, projectCodexIdentities, projects, recentProjectIds, text]);
+  const firstEmptyProjectId = projectChoices.find((project) => project.issueCount === 0)?.id ?? null;
+  const hasProjectsWithIssues = projectChoices.some((project) => project.issueCount > 0);
   const closeContextMenu = useCallback(() => setContextMenu(null), []);
   const issueReadStorageKey = selectedProjectId
     ? `${ISSUE_READ_KEY_PREFIX}:${taskboardMetadata?.mode ?? "local"}:${selectedProjectId}`
@@ -1380,6 +1405,7 @@ export function App() {
   function openTaskDetail(task: Pick<Task, "identifier" | "projectId">) {
     const fullTask = tasksRef.current.find((candidate) => candidate.identifier === task.identifier);
     if (fullTask) markTaskRead(fullTask);
+    if (isAllProjects) changeProject(task.projectId);
     if (boardView === "list" && issueListRef.current) {
       pendingDetailSourceScrollRef.current = {
         projectId: selectedProjectId,
@@ -1464,7 +1490,7 @@ export function App() {
       }
       setDetailTaskIdentifier(routeIssueIdentifier);
       if (routeProjectId === selectedProjectId) return;
-      setBoardView(readProjectBoardView(routeProjectId));
+      setBoardView(routeProjectId === ALL_PROJECTS_ID ? "issues" : readProjectBoardView(routeProjectId));
       setSelectedProjectId(routeProjectId);
     }
 
@@ -1480,7 +1506,9 @@ export function App() {
   }, [embedded, theme]);
 
   useEffect(() => {
-    if (selectedProjectId) setBoardView(readProjectBoardView(selectedProjectId));
+    if (selectedProjectId) {
+      setBoardView(selectedProjectId === ALL_PROJECTS_ID ? "issues" : readProjectBoardView(selectedProjectId));
+    }
   }, [selectedProjectId]);
 
   useEffect(() => {
@@ -1730,7 +1758,9 @@ export function App() {
       setJiraConnection(nextJiraConnection);
       setSelectedProjectId((current) => {
         const fromQuery = new URLSearchParams(window.location.search).get("project");
+        if (fromQuery === ALL_PROJECTS_ID) return fromQuery;
         if (fromQuery && nextProjects.some((project) => project.id === fromQuery)) return fromQuery;
+        if (current === ALL_PROJECTS_ID) return current;
         if (current && nextProjects.some((project) => project.id === current)) return current;
         return nextProjects.find((project) => project.id === GLOBAL_PROJECT_ID)?.id
           ?? nextProjects[0]?.id
@@ -1791,9 +1821,10 @@ export function App() {
       current ? { ...current, requestId } : current
     ));
     try {
+      const taskProjectId = projectId === ALL_PROJECTS_ID ? undefined : projectId;
       const [nextTasks, nextArchivedTasks] = await Promise.all([
-        listTasks(projectId, options.signal),
-        listArchivedTasks(projectId, options.signal),
+        listTasks(taskProjectId, options.signal),
+        listArchivedTasks(taskProjectId, options.signal),
       ]);
       if (requestId !== tasksRequestRef.current) return;
       setTasks(sortTasks(nextTasks));
@@ -1845,7 +1876,7 @@ export function App() {
   }, []);
 
   useEffect(() => {
-    if (!selectedProjectId) {
+    if (!selectedProjectId || isAllProjects) {
       setWorkflowOptions(DEFAULT_WORKFLOW_OPTIONS);
       return;
     }
@@ -1857,11 +1888,12 @@ export function App() {
       }
     });
     return () => controller.abort();
-  }, [refreshWorkflowOptions, selectedProjectId]);
+  }, [isAllProjects, refreshWorkflowOptions, selectedProjectId]);
 
   useEffect(() => {
-    if (!selectedProjectId) {
+    if (!selectedProjectId || isAllProjects) {
       setDevelopmentScan({ workspacePath: null, contexts: [] });
+      setDevelopmentScanLoading(false);
       return;
     }
     const controller = new AbortController();
@@ -1893,6 +1925,7 @@ export function App() {
     detailTask?.threadId,
     hostContext?.projectId,
     hostContext?.threadId,
+    isAllProjects,
     rememberDeviceWorkspacePath,
     selectedProjectId,
     selectedDeviceWorkspacePath,
@@ -1919,7 +1952,7 @@ export function App() {
         const projectId = selectedProjectIdRef.current;
         if (projectId) {
           void refreshTasks(projectId, { quiet: true });
-          void refreshWorkflowOptions(projectId).catch(() => {});
+          if (projectId !== ALL_PROJECTS_ID) void refreshWorkflowOptions(projectId).catch(() => {});
         }
         setWorkflowRevision((current) => current + 1);
         setCommentsRevision((current) => current + 1);
@@ -2004,6 +2037,7 @@ export function App() {
         && !event.metaKey
         && !event.ctrlKey
         && selectedProjectId
+        && !isAllProjects
         && !isJiraProject
         && boardView !== "workflow"
       ) {
@@ -2026,7 +2060,7 @@ export function App() {
 
     window.addEventListener("keydown", handleShortcut);
     return () => window.removeEventListener("keydown", handleShortcut);
-  }, [boardView, contextMenu, detailTaskId, editor, isJiraProject, projectMenuOpen, selectedProjectId]);
+  }, [boardView, contextMenu, detailTaskId, editor, isAllProjects, isJiraProject, projectMenuOpen, selectedProjectId]);
 
   const filteredTasks = useMemo(() => {
     return tasks.filter(
@@ -2312,7 +2346,11 @@ export function App() {
       return;
     }
 
-    const destination = tasks.filter((candidate) => candidate.status === status && candidate.id !== task.id);
+    const destination = tasks.filter((candidate) => (
+      candidate.projectId === task.projectId
+      && candidate.status === status
+      && candidate.id !== task.id
+    ));
     const statusChanged = task.status !== status;
     const insertionIndex = statusChanged && !useDropPosition
       ? 0
@@ -2322,7 +2360,9 @@ export function App() {
     const targetIndex = insertionIndex < 0 ? destination.length : insertionIndex;
     const desiredOrder = [...destination];
     desiredOrder.splice(targetIndex, 0, task);
-    const currentOrder = tasks.filter((candidate) => candidate.status === status);
+    const currentOrder = tasks.filter((candidate) => (
+      candidate.projectId === task.projectId && candidate.status === status
+    ));
     if (
       task.status === status
       && currentOrder.length === desiredOrder.length
@@ -2449,10 +2489,10 @@ export function App() {
     }
   }
 
-  async function persistProjectLabel(label: string) {
+  async function persistProjectLabel(label: string, projectId = selectedProjectId) {
     setActionError(null);
     try {
-      const project = await createProjectLabelRequest(selectedProjectId, label);
+      const project = await createProjectLabelRequest(projectId, label);
       setProjects((current) => current.map((candidate) => (
         candidate.id === project.id ? project : candidate
       )));
@@ -3115,8 +3155,8 @@ export function App() {
     setProjectContextMenu(null);
     setProjectMenuOpen(false);
     setDetailTaskIdentifier(null);
-    setBoardView(readProjectBoardView(projectId));
-    rememberProjectOpen(projectId);
+    setBoardView(projectId === ALL_PROJECTS_ID ? "issues" : readProjectBoardView(projectId));
+    if (projectId !== ALL_PROJECTS_ID) rememberProjectOpen(projectId);
     setSelectedProjectId(projectId);
     setSearch("");
     setFilters(EMPTY_TASK_FILTERS);
@@ -3308,9 +3348,11 @@ export function App() {
     }
   }
 
-  const headerProjectName = selectedProject?.id === GLOBAL_PROJECT_ID
-    ? text("全局", "Global")
-    : selectedProject?.name ?? text("任务面板", "Taskboard");
+  const headerProjectName = isAllProjects
+    ? text("所有项目", "All projects")
+    : selectedProject?.id === GLOBAL_PROJECT_ID
+      ? text("临时任务", "Temporary tasks")
+      : selectedProject?.name ?? text("任务面板", "Taskboard");
   const appShellStyle = embedded
     ? { "--codex-titlebar-left-inset": `${hostContext?.titlebarLeftInset ?? 0}px` } as CSSProperties
     : undefined;
@@ -3417,31 +3459,51 @@ export function App() {
                 {projectMenuOpen && (
                   <div className="header-project-menu" role="menu" aria-label={text("项目", "Projects")}>
                     <span>{text("切换项目", "Switch project")}</span>
+                    <button
+                      type="button"
+                      role="menuitemradio"
+                      aria-checked={isAllProjects}
+                      disabled={openingProjectId !== null}
+                      onClick={() => {
+                        if (isAllProjects) setProjectMenuOpen(false);
+                        else changeProject(ALL_PROJECTS_ID);
+                      }}
+                    >
+                      <LinearIcon className="project-avatar" name="myIssues" />
+                      <span>{text("所有项目", "All projects")}</span>
+                      {isAllProjects && <span className="project-menu-check" aria-hidden="true"><LinearIcon name="check" /></span>}
+                    </button>
+                    <div className="project-menu-divider" role="separator" />
                     {projectChoices.map((project) => (
-                      <button
-                        type="button"
-                        role="menuitemradio"
-                        aria-checked={project.id === selectedProjectId}
-                        disabled={openingProjectId !== null}
-                        key={project.id}
-                        onContextMenu={project.id.startsWith("temp-") ? (event) => {
-                          event.preventDefault();
-                          setProjectContextMenu({
-                            project,
-                            x: event.clientX,
-                            y: event.clientY,
-                          });
-                        } : undefined}
-                        onClick={() => {
-                          if (project.id === selectedProjectId) setProjectMenuOpen(false);
-                          else void selectProject(project);
-                        }}
-                      >
-                        <TaskboardIcon className="project-avatar" name="projectFolder" />
-                        <span>{project.name}</span>
-                        {project.id === selectedProjectId && <span className="project-menu-check" aria-hidden="true"><LinearIcon name="check" /></span>}
-                      </button>
+                      <Fragment key={project.id}>
+                        {hasProjectsWithIssues && project.id === firstEmptyProjectId && (
+                          <div className="project-menu-divider" role="separator" />
+                        )}
+                        <button
+                          type="button"
+                          role="menuitemradio"
+                          aria-checked={project.id === selectedProjectId}
+                          disabled={openingProjectId !== null}
+                          onContextMenu={project.id.startsWith("temp-") ? (event) => {
+                            event.preventDefault();
+                            setProjectContextMenu({
+                              project,
+                              x: event.clientX,
+                              y: event.clientY,
+                            });
+                          } : undefined}
+                          onClick={() => {
+                            if (project.id === selectedProjectId) setProjectMenuOpen(false);
+                            else void selectProject(project);
+                          }}
+                        >
+                          <TaskboardIcon className="project-avatar" name="projectFolder" />
+                          <span>{project.name}</span>
+                          {project.id === selectedProjectId && <span className="project-menu-check" aria-hidden="true"><LinearIcon name="check" /></span>}
+                        </button>
+                      </Fragment>
                     ))}
+                    <div className="project-menu-divider" role="separator" />
                     <button
                       type="button"
                       role="menuitem"
@@ -3473,7 +3535,7 @@ export function App() {
           <div ref={dragRegionRef} className="workspace-drag-region" aria-hidden="true" />
 
           <div className="header-actions">
-            {selectedProjectId && (
+            {selectedProject && (
               <ProjectAutomationMenu
                 automation={selectedProjectAutomation}
                 pending={automationPending}
@@ -3495,7 +3557,7 @@ export function App() {
                 <LinearIcon name="recurrence" />
               </button>
             )}
-            {selectedProjectId && !isJiraProject && boardView !== "workflow" && (
+            {selectedProject && !isJiraProject && boardView !== "workflow" && (
               <button
                 className="icon-button header-create-button"
                 type="button"
@@ -3511,14 +3573,16 @@ export function App() {
 
         {selectedProjectId && !detailTask && <div className="board-toolbar">
           <div className="view-tabs" aria-label={text("看板视图", "Board views")}>
-            <button
-              className={`view-tab${boardView === "dashboard" ? " active" : ""}`}
-              type="button"
-              aria-pressed={boardView === "dashboard"}
-              onClick={() => selectBoardView("dashboard")}
-            >
-              {text("仪表盘", "Dashboard")}
-            </button>
+            {!isAllProjects && (
+              <button
+                className={`view-tab${boardView === "dashboard" ? " active" : ""}`}
+                type="button"
+                aria-pressed={boardView === "dashboard"}
+                onClick={() => selectBoardView("dashboard")}
+              >
+                {text("仪表盘", "Dashboard")}
+              </button>
+            )}
             <button
               className={`view-tab${boardView === "issues" ? " active" : ""}`}
               type="button"
@@ -3723,7 +3787,7 @@ export function App() {
               </button>
             </div>
           </div>
-        ) : boardView === "dashboard" ? (
+        ) : boardView === "dashboard" && selectedProject ? (
           <DashboardView
             key={selectedProjectId}
             projectId={selectedProjectId}
@@ -3818,10 +3882,11 @@ export function App() {
                         settlingTaskId={settlingTaskId}
                         contextMenuTaskId={contextMenu?.taskId ?? null}
                         availableLabels={availableLabels}
+                        projectNames={isAllProjects ? projectNames : undefined}
                         currentUser={currentUser}
                         showCover={boardCardDisplay.cover}
                         showBody={boardCardDisplay.body}
-                        createEnabled={!isJiraProject}
+                        createEnabled={!isAllProjects && !isJiraProject}
                         onCreateLabel={persistProjectLabel}
                         onCreate={(initialStatus) => setEditor({ task: null, status: initialStatus })}
                         onEdit={openTaskDetail}
@@ -3853,6 +3918,7 @@ export function App() {
                     settlingTaskId={settlingTaskId}
                     contextMenuTaskId={contextMenu?.taskId ?? null}
                     availableLabels={availableLabels}
+                    projectNames={isAllProjects ? projectNames : undefined}
                     currentUser={currentUser}
                     showCover={boardCardDisplay.cover}
                     showBody={boardCardDisplay.body}
@@ -3860,7 +3926,7 @@ export function App() {
                     restoringTaskId={restoringTaskId}
                     deletingTaskId={deletingArchivedTaskId}
                     onTabChange={setOtherTasksTab}
-                    onCreate={isJiraProject
+                    onCreate={isJiraProject || isAllProjects
                       ? undefined
                       : (initialStatus) => setEditor({ task: null, status: initialStatus })}
                     onRestore={(task) => void restoreArchivedTask(task)}
@@ -4140,7 +4206,7 @@ export function App() {
         />
       )}
 
-      {localAiChatAvailable && (
+      {localAiChatAvailable && !isAllProjects && (
         <Suspense fallback={null}>
           <AiChat
             available

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -812,6 +812,7 @@ export function App() {
   const dragRegionRef = useRef<HTMLDivElement>(null);
   const issueListRef = useRef<HTMLDivElement>(null);
   const boardColumnScrollRefs = useRef<Partial<Record<TaskStatus, HTMLDivElement | null>>>({});
+  const detailSourceProjectIdRef = useRef<string | null>(null);
   const pendingDetailSourceScrollRef = useRef<DetailSourceScroll | null>(null);
   const selectedProjectIdRef = useRef(selectedProjectId);
   selectedProjectIdRef.current = selectedProjectId;
@@ -1405,7 +1406,9 @@ export function App() {
   function openTaskDetail(task: Pick<Task, "identifier" | "projectId">) {
     const fullTask = tasksRef.current.find((candidate) => candidate.identifier === task.identifier);
     if (fullTask) markTaskRead(fullTask);
-    if (isAllProjects) changeProject(task.projectId);
+    const currentIssue = readIssueIdentifier(window.location.search);
+    if (!currentIssue) detailSourceProjectIdRef.current = selectedProjectId;
+    if (isAllProjects) setSelectedProjectId(task.projectId);
     if (boardView === "list" && issueListRef.current) {
       pendingDetailSourceScrollRef.current = {
         projectId: selectedProjectId,
@@ -1426,8 +1429,7 @@ export function App() {
     closeContextMenu();
     setProjectMenuOpen(false);
     setDetailTaskIdentifier(task.identifier);
-    const currentIssue = readIssueIdentifier(window.location.search);
-    const boardUrl = buildIssueUrl(window.location.href, task.projectId, null);
+    const boardUrl = buildIssueUrl(window.location.href, selectedProjectId, null);
     if (!currentIssue) {
       window.history.replaceState(window.history.state, "", boardUrl);
     }
@@ -1440,8 +1442,14 @@ export function App() {
   }
 
   function closeTaskDetail() {
+    const sourceProjectId = detailSourceProjectIdRef.current ?? selectedProjectId;
+    detailSourceProjectIdRef.current = null;
     setDetailTaskIdentifier(null);
-    const url = buildIssueUrl(window.location.href, selectedProjectId || null, null);
+    if (sourceProjectId !== selectedProjectId) {
+      setSelectedProjectId(sourceProjectId);
+      setBoardView(sourceProjectId === ALL_PROJECTS_ID ? "issues" : readProjectBoardView(sourceProjectId));
+    }
+    const url = buildIssueUrl(window.location.href, sourceProjectId, null);
     window.history.replaceState(window.history.state, "", url);
   }
 
@@ -3154,6 +3162,7 @@ export function App() {
     closeContextMenu();
     setProjectContextMenu(null);
     setProjectMenuOpen(false);
+    detailSourceProjectIdRef.current = null;
     setDetailTaskIdentifier(null);
     setBoardView(projectId === ALL_PROJECTS_ID ? "issues" : readProjectBoardView(projectId));
     if (projectId !== ALL_PROJECTS_ID) rememberProjectOpen(projectId);
@@ -3469,7 +3478,7 @@ export function App() {
                         else changeProject(ALL_PROJECTS_ID);
                       }}
                     >
-                      <LinearIcon className="project-avatar" name="myIssues" />
+                      <TaskboardIcon className="project-avatar" name="projectFolder" />
                       <span>{text("所有项目", "All projects")}</span>
                       {isAllProjects && <span className="project-menu-check" aria-hidden="true"><LinearIcon name="check" /></span>}
                     </button>

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -524,16 +524,17 @@ export async function listDevelopmentContexts(
 }
 
 async function listTasksByArchive(
-  projectId: string,
+  projectId: string | undefined,
   archived: "true" | "false",
   signal?: AbortSignal,
 ): Promise<Task[]> {
-  const params = new URLSearchParams({ projectId, archived });
+  const params = new URLSearchParams({ archived });
+  if (projectId) params.set("projectId", projectId);
   const data = await request<{ tasks: Task[] }>(`/api/tasks?${params}`, { signal });
   return data.tasks;
 }
 
-export function listTasks(projectId: string, signal?: AbortSignal): Promise<Task[]> {
+export function listTasks(projectId?: string, signal?: AbortSignal): Promise<Task[]> {
   return listTasksByArchive(projectId, "false", signal);
 }
 
@@ -545,7 +546,7 @@ export async function getTask(taskId: string, signal?: AbortSignal): Promise<Tas
   return data.task;
 }
 
-export function listArchivedTasks(projectId: string, signal?: AbortSignal): Promise<Task[]> {
+export function listArchivedTasks(projectId?: string, signal?: AbortSignal): Promise<Task[]> {
   return listTasksByArchive(projectId, "true", signal);
 }
 

--- a/web/src/components/BoardColumn.tsx
+++ b/web/src/components/BoardColumn.tsx
@@ -76,11 +76,12 @@ interface BoardColumnProps {
   settlingTaskId: string | null;
   contextMenuTaskId: string | null;
   availableLabels: string[];
+  projectNames?: Record<string, string>;
   currentUser: ActorIdentity;
   showCover: boolean;
   showBody: boolean;
   createEnabled?: boolean;
-  onCreateLabel: (label: string) => Promise<void>;
+  onCreateLabel: (label: string, projectId?: string) => Promise<void>;
   onCreate: (status: TaskStatus) => void;
   onEdit: (task: Task) => void;
   onUpdate: (task: Task, changes: Partial<TaskDraft>) => Promise<Task>;
@@ -107,6 +108,7 @@ export function BoardColumn({
   settlingTaskId,
   contextMenuTaskId,
   availableLabels,
+  projectNames,
   currentUser,
   showCover,
   showBody,
@@ -227,10 +229,11 @@ export function BoardColumn({
               isSettling={settlingTaskId === task.id}
               isContextMenuOpen={contextMenuTaskId === task.id}
               availableLabels={availableLabels}
+              projectName={projectNames?.[task.projectId]}
               currentUser={currentUser}
               showCover={showCover}
               showBody={showBody}
-              onCreateLabel={onCreateLabel}
+              onCreateLabel={(label) => onCreateLabel(label, task.projectId)}
               onEdit={onEdit}
               onUpdate={onUpdate}
               onComplete={onComplete}

--- a/web/src/components/OtherTasksPanel.tsx
+++ b/web/src/components/OtherTasksPanel.tsx
@@ -94,10 +94,11 @@ interface OtherTasksPanelProps {
   settlingTaskId: string | null;
   contextMenuTaskId: string | null;
   availableLabels: string[];
+  projectNames?: Record<string, string>;
   currentUser: ActorIdentity;
   showCover: boolean;
   showBody: boolean;
-  onCreateLabel: (label: string) => Promise<void>;
+  onCreateLabel: (label: string, projectId?: string) => Promise<void>;
   restoringTaskId: string | null;
   deletingTaskId: string | null;
   onTabChange: (tab: OtherTaskTab) => void;
@@ -129,6 +130,7 @@ export function OtherTasksPanel({
   settlingTaskId,
   contextMenuTaskId,
   availableLabels,
+  projectNames,
   currentUser,
   showCover,
   showBody,
@@ -290,10 +292,11 @@ export function OtherTasksPanel({
               isSettling={settlingTaskId === task.id}
               isContextMenuOpen={contextMenuTaskId === task.id}
               availableLabels={availableLabels}
+              projectName={projectNames?.[task.projectId]}
               currentUser={currentUser}
               showCover={showCover}
               showBody={showBody}
-              onCreateLabel={onCreateLabel}
+              onCreateLabel={(label) => onCreateLabel(label, task.projectId)}
               onEdit={onEdit}
               onUpdate={onUpdate}
               onContextMenu={onContextMenu}

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -19,7 +19,7 @@ import type {
   TaskConversationItem,
 } from "../taskConversations";
 import { ActorAvatar } from "./ActorAvatar";
-import { LinearPriorityIcon } from "./LinearIcon";
+import { LinearIcon, LinearPriorityIcon } from "./LinearIcon";
 import { LabelPicker } from "./LabelPicker";
 import { TaskPropertyPicker } from "./TaskPropertyPicker";
 import { TaskConversationMenu } from "./TaskConversationMenu";
@@ -38,6 +38,7 @@ interface TaskCardProps {
   isSettling: boolean;
   isContextMenuOpen: boolean;
   availableLabels: string[];
+  projectName?: string;
   currentUser: ActorIdentity;
   showCover: boolean;
   showBody: boolean;
@@ -394,6 +395,7 @@ export function TaskCard({
   isSettling,
   isContextMenuOpen,
   availableLabels,
+  projectName,
   currentUser,
   showCover,
   showBody,
@@ -431,8 +433,8 @@ export function TaskCard({
     [showBody, task.description],
   );
   const hasProperties = task.priority !== "none" || task.labels.length > 0 || task.dueDate;
-  const showsProperties = !processingCard
-    && (hasProperties || showsInlineParticipants || showsConversation);
+  const showsProperties = Boolean(projectName)
+    || (!processingCard && (hasProperties || showsInlineParticipants || showsConversation));
   const propertyDisabled = savingProperty !== null;
 
   function updateProperty(changes: Partial<TaskDraft>, property: NonNullable<typeof savingProperty>) {
@@ -516,7 +518,13 @@ export function TaskCard({
 
       {showsProperties && (
         <div className="card-properties" aria-label={text("议题属性", "Issue properties")}>
-          {task.priority !== "none" && (
+          {projectName && (
+            <span className="project-chip" title={projectName}>
+              <LinearIcon name="project" />
+              <span>{projectName}</span>
+            </span>
+          )}
+          {!processingCard && task.priority !== "none" && (
             <PriorityControl
               task={task}
               disabled={propertyDisabled}
@@ -525,7 +533,7 @@ export function TaskCard({
               onChange={(priority) => updateProperty({ priority }, "priority")}
             />
           )}
-          {task.labels.length > 0 && (
+          {!processingCard && task.labels.length > 0 && (
             <LabelPicker
               availableLabels={availableLabels}
               selectedLabels={task.labels}
@@ -539,15 +547,17 @@ export function TaskCard({
               onCreateLabel={onCreateLabel}
             />
           )}
-          <DueDateControl
-            task={task}
-            disabled={propertyDisabled}
-            onChange={(dueDate) => updateProperty({
-              dueDate,
-              ...(dueDate ? {} : { recurrence: null }),
-            }, "dueDate")}
-          />
-          {showsInlineParticipants && (
+          {!processingCard && (
+            <DueDateControl
+              task={task}
+              disabled={propertyDisabled}
+              onChange={(dueDate) => updateProperty({
+                dueDate,
+                ...(dueDate ? {} : { recurrence: null }),
+              }, "dueDate")}
+            />
+          )}
+          {!processingCard && showsInlineParticipants && (
             <AssigneeControl
               task={task}
               participants={task.participants}
@@ -558,8 +568,8 @@ export function TaskCard({
               onChange={(assigneeTarget) => updateProperty({ assigneeTarget }, "assignee")}
             />
           )}
-          {showsConversation && <span className="card-properties-spacer" aria-hidden="true" />}
-          {showsConversation && (
+          {!processingCard && showsConversation && <span className="card-properties-spacer" aria-hidden="true" />}
+          {!processingCard && showsConversation && (
             <TaskConversationMenu
               conversations={presentation.conversations}
               onOpenConversation={onOpenConversation}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9903,7 +9903,7 @@ kbd {
   overflow: hidden;
   border: .5px solid var(--border);
   border-radius: 999px;
-  background: var(--surface-muted);
+  background: var(--surface);
   color: var(--text-secondary);
   font-size: 10px;
   font-weight: 450;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -832,6 +832,12 @@ kbd {
   height: 16px;
 }
 
+.project-menu-divider {
+  height: var(--border-hairline);
+  margin: 4px 3px;
+  background: var(--border);
+}
+
 .project-menu-check {
   color: var(--accent);
   font-size: 11px;
@@ -9884,6 +9890,37 @@ kbd {
   font-weight: 450;
   line-height: 18px;
   white-space: nowrap;
+}
+
+.project-chip {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 1 auto;
+  max-width: 132px;
+  height: 20px;
+  gap: 4px;
+  padding: 0 7px;
+  overflow: hidden;
+  border: .5px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface-muted);
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 450;
+  line-height: 18px;
+  white-space: nowrap;
+}
+
+.project-chip > svg {
+  flex: 0 0 auto;
+  width: 12px;
+  height: 12px;
+}
+
+.project-chip > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .priority-chip svg {


### PR DESCRIPTION
## 概要
- 将“全局”改名为“临时任务”
- 增加置顶“所有项目”视图，并聚合加载全部议题
- 在聚合看板卡片行首显示项目名称胶囊
- 按有议题和无议题项目分组，仅用分割线区分

## 验证
- npm run typecheck
- npm run build:web
- 真实 Chromium：项目菜单、所有项目聚合、项目胶囊、处理中卡片、卡片详情路径和请求参数