### PR TITLE
fix: exclude closed issues from dashboard percentages

### DIFF
--- a/web/src/components/DashboardView.tsx
+++ b/web/src/components/DashboardView.tsx
@@ -503,7 +503,7 @@ export function DashboardView({
 
         <div className="dashboard-metrics">
           {metrics.map((metric) => {
-            const percent = tasks.length ? Math.round((metric.value / tasks.length) * 100) : 0;
+            const percent = activeTasks.length ? Math.round((metric.value / activeTasks.length) * 100) : 0;
             return (
               <article className={`dashboard-metric tone-${metric.tone}`} key={metric.label}>
                 <span className="dashboard-metric-label">{metric.label}</span>


### PR DESCRIPTION
## Summary
- exclude completed and canceled issues from the denominator used by the five Dashboard status-card percentages
- keep card counts, project completion, other statistics, layout, and interactions unchanged

## Direct verification
- used the installed Taskboard active runtime with the real codex-taskboard project data
- real scope: 311 issues, 253 completed, 25 canceled, 33 active
- after LOCAL-256 moved to in progress, the cards showed: In progress 11 / 33 = 33%, In review 3 / 33 = 9%, Blocked 0%, Overdue 0%, Backlog 19 / 33 = 58%
- project completion stayed 81% with 253 completed and 33 remaining; priority, label, and navigation displays stayed unchanged

Tests were not run per the task instructions; verification used the direct browser path and real runtime data.