### PR TITLE
feat: 集成 DeepSeek Harness 插件

### DIFF
--- a/integrations/deepseek-harness/README.md
+++ b/integrations/deepseek-harness/README.md
@@ -1,0 +1,11 @@
+# DeepSeek Harness plugin
+
+This directory is an installable DeepSeek Harness bundle. It adds a Taskboard entry to the Harness sidebar and opens the active installed Codex Taskboard runtime.
+
+From a DeepSeek Harness source checkout, install it into the Web profile:
+
+```sh
+pnpm dsh plugin --profile web add /absolute/path/to/codex-taskboard/integrations/deepseek-harness
+```
+
+Start Codex Taskboard before opening the entry. The plugin reads the launcher-owned runtime file, so it does not depend on a fixed port.

--- a/integrations/deepseek-harness/client.js
+++ b/integrations/deepseek-harness/client.js
@@ -1,0 +1,162 @@
+window.__ModuleLoader__.load({
+  id: "dsh-codex-taskboard",
+  factory: (require) => {
+    const module = { exports: {} };
+    const exports = module.exports;
+    const React = require("react");
+    const { useEffect, useState } = React;
+
+    const ROUTE = "/integrations/codex-taskboard";
+    const PANEL_ID = "dsh-codex-taskboard-panel";
+    const STYLE_ID = "dsh-codex-taskboard-style";
+    const CSS = `
+.dsh-codex-taskboard-trigger{box-sizing:border-box;display:flex;align-items:center;gap:8px;width:calc(100% + 8px);height:34px;margin:4px -4px;padding:6px 2px 6px 10px;border:0;border-radius:12px;background:transparent;color:var(--dsw-alias-label-primary);cursor:pointer;font:inherit;overflow:hidden}
+.dsh-codex-taskboard-trigger:hover{background:var(--dsw-alias-interactive-bg-hover)}
+.dsh-codex-taskboard-trigger.rail{justify-content:center;width:36px;height:36px;margin:8px 0 10px;padding:0;border-radius:50%}
+.dsh-codex-taskboard-label{white-space:nowrap;overflow:hidden}
+.dsh-codex-taskboard-panel{position:fixed;z-index:900;display:flex;flex-direction:column;box-sizing:border-box;border-left:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-2);box-shadow:var(--dsw-shadow-lv3)}
+.dsh-codex-taskboard-header{display:flex;flex:none;align-items:center;justify-content:space-between;height:48px;padding:8px 14px 8px 18px;box-sizing:border-box;color:var(--dsw-alias-label-primary)}
+.dsh-codex-taskboard-actions{display:flex;gap:8px}
+.dsh-codex-taskboard-action{border:0;border-radius:8px;background:transparent;color:inherit;cursor:pointer;padding:5px 9px;font:inherit}
+.dsh-codex-taskboard-action:hover{background:var(--dsw-alias-interactive-bg-hover)}
+.dsh-codex-taskboard-frame{flex:1;min-height:0;border:0;background:#fff}
+`;
+
+    function centerColumnBox() {
+      for (const element of document.querySelectorAll("*")) {
+        for (const className of element.classList) {
+          if (!className.endsWith("_centerCol")) continue;
+          const rect = element.getBoundingClientRect();
+          return {
+            left: rect.left,
+            top: rect.top,
+            right: window.innerWidth - rect.right,
+            bottom: window.innerHeight - rect.bottom,
+          };
+        }
+      }
+      return { left: 0, top: 0, right: 0, bottom: 0 };
+    }
+
+    function useCenterColumnBox() {
+      const [box, setBox] = useState(centerColumnBox);
+      useEffect(() => {
+        const measure = () => setBox(centerColumnBox());
+        const observer = new ResizeObserver(measure);
+        const column = [...document.querySelectorAll("*")].find((element) =>
+          [...element.classList].some((className) => className.endsWith("_centerCol")),
+        );
+        if (column) observer.observe(column);
+        window.addEventListener("resize", measure);
+        return () => {
+          observer.disconnect();
+          window.removeEventListener("resize", measure);
+        };
+      }, []);
+      return box;
+    }
+
+    function ChecklistIcon() {
+      return React.createElement(
+        "svg",
+        { width: 18, height: 18, viewBox: "0 0 18 18", fill: "none", "aria-hidden": true },
+        React.createElement("path", {
+          d: "M3.5 4.5h1.2l.8.9 1.7-2M8 4.5h6.5M3.5 9h1.2l.8.9 1.7-2M8 9h6.5M3.5 13.5h1.2l.8.9 1.7-2M8 13.5h6.5",
+          stroke: "currentColor",
+          strokeWidth: 1.35,
+          strokeLinecap: "round",
+          strokeLinejoin: "round",
+        }),
+      );
+    }
+
+    function TaskboardPanel({ onClose }) {
+      const box = useCenterColumnBox();
+      const [generation, setGeneration] = useState(0);
+      return React.createElement(
+        "aside",
+        {
+          id: PANEL_ID,
+          className: "dsh-codex-taskboard-panel",
+          style: box,
+          "aria-label": "任务面板",
+        },
+        React.createElement(
+          "div",
+          { className: "dsh-codex-taskboard-header" },
+          React.createElement("strong", null, "任务面板"),
+          React.createElement(
+            "div",
+            { className: "dsh-codex-taskboard-actions" },
+            React.createElement(
+              "button",
+              {
+                type: "button",
+                className: "dsh-codex-taskboard-action",
+                onClick: () => setGeneration((value) => value + 1),
+              },
+              "刷新",
+            ),
+            React.createElement(
+              "button",
+              { type: "button", className: "dsh-codex-taskboard-action", onClick: onClose },
+              "关闭",
+            ),
+          ),
+        ),
+        React.createElement("iframe", {
+          key: generation,
+          className: "dsh-codex-taskboard-frame",
+          src: `${ROUTE}?refresh=${generation}`,
+          title: "Codex Taskboard",
+        }),
+      );
+    }
+
+    function TaskboardEntry({ wide }) {
+      const [open, setOpen] = useState(false);
+      return React.createElement(
+        React.Fragment,
+        null,
+        React.createElement(
+          "button",
+          {
+            type: "button",
+            className: `dsh-codex-taskboard-trigger${wide ? "" : " rail"}`,
+            title: "任务面板",
+            "aria-label": "任务面板",
+            "aria-expanded": open,
+            "aria-controls": PANEL_ID,
+            onClick: () => setOpen((value) => !value),
+          },
+          React.createElement(ChecklistIcon),
+          wide && React.createElement("span", { className: "dsh-codex-taskboard-label" }, "任务面板"),
+        ),
+        open && React.createElement(TaskboardPanel, { onClose: () => setOpen(false) }),
+      );
+    }
+
+    const inject = ["slots"];
+
+    function apply(ctx) {
+      ctx.effect(() => {
+        const style = document.createElement("style");
+        style.id = STYLE_ID;
+        style.dataset.plugin = "dsh-codex-taskboard";
+        style.textContent = CSS;
+        document.head.appendChild(style);
+        return () => style.remove();
+      }, "codex-taskboard: styles");
+
+      ctx.slots.inject("sidebar.footer.action", () => ctx.slots.register({
+        name: "sidebar.footer.action",
+        id: "codex-taskboard",
+        order: 0,
+      }, TaskboardEntry));
+    }
+
+    exports.apply = apply;
+    exports.inject = inject;
+    return module.exports;
+  },
+});

--- a/integrations/deepseek-harness/cordis.patch.yml
+++ b/integrations/deepseek-harness/cordis.patch.yml
@@ -1,0 +1,3 @@
+- insert:
+    - id: codex-taskboard
+      name: dsh-codex-taskboard

--- a/integrations/deepseek-harness/index.js
+++ b/integrations/deepseek-harness/index.js
@@ -1,0 +1,45 @@
+import { readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export const name = "codex-taskboard";
+export const inject = ["webServer"];
+
+const ROUTE = "/integrations/codex-taskboard";
+const RUNTIME_FILE = process.env.CODEX_TASKBOARD_RUNTIME_FILE
+  ?? path.join(os.homedir(), "Library/Application Support/Codex Taskboard/launcher-runtime.json");
+
+async function activeTaskboardUrl() {
+  const descriptor = JSON.parse(await readFile(RUNTIME_FILE, "utf8"));
+  if (descriptor?.version !== 1 || typeof descriptor.url !== "string") {
+    throw new Error("The active Codex Taskboard runtime is invalid");
+  }
+  const url = new URL(`${descriptor.url.replace(/\/$/, "")}/`);
+  url.searchParams.set("host", "deepseek-harness");
+  return url.href;
+}
+
+export function apply(ctx) {
+  ctx.effect(
+    () => ctx.webServer.register({
+      kind: "exact",
+      path: ROUTE,
+      handler: async (_request, response) => {
+        try {
+          response.writeHead(307, {
+            location: await activeTaskboardUrl(),
+            "cache-control": "no-store",
+          });
+          response.end();
+        } catch {
+          response.writeHead(503, {
+            "content-type": "text/plain; charset=utf-8",
+            "cache-control": "no-store",
+          });
+          response.end("Codex Taskboard is not running.");
+        }
+      },
+    }),
+    "codex-taskboard: active runtime route",
+  );
+}

--- a/integrations/deepseek-harness/package.json
+++ b/integrations/deepseek-harness/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "dsh-codex-taskboard",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./index.js",
+  "exports": {
+    ".": "./index.js",
+    "./client": "./client.js",
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "index.js",
+    "client.js",
+    "cordis.patch.yml"
+  ],
+  "dsh": {
+    "bundle": {
+      "patch": "./cordis.patch.yml"
+    },
+    "client": {
+      "platform": "web",
+      "inject": [
+        "@deepseek-ai/dsh-client-ui-sidebar"
+      ]
+    }
+  }
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1656,7 +1656,7 @@ export function App() {
   }, [embedded, host]);
 
   useEffect(() => {
-    if (host !== "workbuddy" && host !== "deepseek-harness") return;
+    if (host !== "workbuddy") return;
     let disposed = false;
     const syncRuntime = async () => {
       try {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -692,7 +692,7 @@ function LocalRealtimeSync({
 export function App() {
   const query = useMemo(() => new URL(document.baseURI).searchParams, []);
   const host = query.get("host");
-  const embedded = host === "codex" || host === "workbuddy";
+  const embedded = host === "codex" || host === "workbuddy" || host === "deepseek-harness";
   const undoShortcut = navigator.userAgent.includes("Macintosh") ? "⌘Z" : "Ctrl+Z";
   const [theme, setTheme] = useState<Theme>(getInitialTheme);
   const [hostContext, setHostContext] = useState<HostContext | null>(null);
@@ -1656,7 +1656,7 @@ export function App() {
   }, [embedded, host]);
 
   useEffect(() => {
-    if (host !== "workbuddy") return;
+    if (host !== "workbuddy" && host !== "deepseek-harness") return;
     let disposed = false;
     const syncRuntime = async () => {
       try {


### PR DESCRIPTION
## 变更

- 增加可由 `dsh plugin --profile web add` 安装的 Taskboard 插件子目录。
- 插件读取安装版 Taskboard 的活动运行时，不再固定使用 47823。
- 增加 `deepseek-harness` 嵌入模式，让 Taskboard 填满 Harness 主区域。

## 直接验证

- `node --check integrations/deepseek-harness/index.js`
- `node --check integrations/deepseek-harness/client.js`
- `npm run build:web`
- 用临时 DSH_HOME 运行官方 `pnpm dsh plugin --profile web add <plugin-path>`，确认 bundle 进入 profile 与启动图。
- 启动真实 Harness，确认插件 bundle 路由、活动运行时跳转和侧栏入口。
- 在 Chrome 点击新入口，确认当前活动看板可见 LOCAL-249；本分支前端确认专用嵌入布局。

未增加测试。按项目规则，只验证本次直接操作路径。