### PR TITLE
fix: preserve pending images across editor copy paste

### DIFF
--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -694,14 +694,8 @@ function inlineMediaClipboardHtml(
       continue;
     }
     const pendingImage = ownerDocument.createElement("span");
-    const markdown = pendingImageClipboardMarkdown(segment);
-    if (markdown) {
-      pendingImage.dataset.taskboardInlineMediaMarkdown = markdown;
-      pendingImage.textContent = markdown;
-    } else {
-      pendingImage.dataset.taskboardInlineMediaPendingImage = segment.id;
-      pendingImage.textContent = segment.file.name;
-    }
+    pendingImage.dataset.taskboardInlineMediaPendingImage = segment.id;
+    pendingImage.textContent = segment.file.name;
     wrapper.append(pendingImage);
   }
 
@@ -1787,7 +1781,10 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       }
       const taskboardHtml = clipboardId
         || clipboardHtml.includes("data-taskboard-inline-media-markdown");
-      if (taskboardHtml) {
+      const pendingImageHtml = clipboardHtml.includes(
+        "data-taskboard-inline-media-pending-image",
+      );
+      if (taskboardHtml && !pendingImageHtml) {
         const htmlSegments = createInlineMediaSegmentsFromHtml(clipboardHtml, referenceTasks);
         if (htmlSegments) {
           event.preventDefault();
@@ -1808,7 +1805,9 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
         );
         return;
       }
-      const htmlSegments = createInlineMediaSegmentsFromHtml(clipboardHtml, referenceTasks);
+      const htmlSegments = pendingImageHtml
+        ? null
+        : createInlineMediaSegmentsFromHtml(clipboardHtml, referenceTasks);
       if (htmlSegments) {
         event.preventDefault();
         applyRangeReplacement(range.start, range.end, htmlSegments, false);


### PR DESCRIPTION
## Summary
- keep pending-image bytes in one clipboard flavor instead of duplicating the Base64 payload in HTML
- use a lightweight HTML marker for same-page File cloning
- fall back to clipboard image or plain-text data when the page-local File reference is unavailable

## Direct verification
- Task description, edit comment, and add comment: all six copy directions passed with real Cmd+C and Cmd+V
- repeated all six directions with real mouse drag selection
- every path preserved text, the LOCAL-197 issue atom, image, and trailing text in order
- every pasted image loaded at 753 by 327 pixels
- cross-page fallback also restored the issue atom and loaded image
- source edits were canceled and target drafts were cleared; no validation content was saved

## Checks
- git diff --check
- npm run typecheck
- npm run build:web

No UI, API, save-format, test, guardrail, or unrelated refactor changes.

Exact head: b5e1e4183bb3ea93cde77c084e8947acdfedb416