### PR TITLE
Fix Taskboard launcher panel actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Keep existing Codex windows open and run:
 CODEX_TASKBOARD_HOST=127.0.0.1 npm run codex
 ```
 
-This starts the local Taskboard service when needed, launches the official macOS Codex app with an independent profile and loopback-only port `9231`, waits for the main renderer and sidebar, injects a native-looking Taskboard entry after Plugins, and keeps watching both the service and replacement renderers. Existing Codex windows remain unchanged. Keep this command running while using the embedded panel. The launcher does not modify `ChatGPT.app` or its `app.asar`.
+This starts the local Taskboard service when needed. It reuses an open Codex with a reachable CDP renderer, or launches the official macOS Codex app with an independent profile and loopback-only port `9231` when no Codex is open. If only an ordinary Codex without a CDP endpoint is open, the launcher waits and does not start a second instance. It injects a native-looking Taskboard entry after Plugins and keeps watching both the service and replacement renderers. Keep this command running while using the embedded panel. The launcher does not modify `ChatGPT.app` or its `app.asar`.
 
 The source launcher writes its authenticated endpoint to `.data/launcher-runtime.json`. A `taskctl` command installed with `npm link` reads this file by default, so a normal shell and a Codex task opened from the panel use the same Taskboard service without an extra environment variable.
 
@@ -111,7 +111,7 @@ npm run app:build
 
 Open `src-tauri/target/universal-apple-darwin/release/bundle/macos/Codex Taskboard.app` from Finder. The DMG is in `src-tauri/target/universal-apple-darwin/release/bundle/dmg/`. If you only want the stable App, download the current DMG from [GitHub Releases](https://github.com/chuspeeism/dashi-taskboard/releases/latest).
 
-The App contains its own Node runtime, Taskboard service, built web UI, Skill, CLI wrapper, and injection script. It starts the service, launches the official Codex app, waits for the renderer, injects the sidebar entry, and opens the panel without showing a terminal window. The App can be copied away from this checkout; the target Mac only needs the official Codex app and does not need this repository, a system Node installation, or a separate Codex CLI installation. Taskboard data is stored in `~/Library/Application Support/Codex Taskboard`, and launcher output is written to `~/Library/Logs/Codex Taskboard/codex-taskboard-launcher.log`.
+The App contains its own Node runtime, Taskboard service, built web UI, Skill, CLI wrapper, and injection script. It starts the service, reuses an open Codex with a reachable CDP renderer, or launches the official Codex app when no Codex is open. If only an ordinary Codex without a CDP endpoint is open, it reports that the current platform cannot inject into that instance and does not start a second one. It waits for the renderer, injects the sidebar entry, and opens the panel without showing a terminal window. The App can be copied away from this checkout; the target Mac only needs the official Codex app and does not need this repository, a system Node installation, or a separate Codex CLI installation. Taskboard data is stored in `~/Library/Application Support/Codex Taskboard`, and launcher output is written to `~/Library/Logs/Codex Taskboard/codex-taskboard-launcher.log`.
 
 ### Windows code signing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -90,7 +90,7 @@ npm run codex:inject -- --port 9231 --open
 CODEX_TASKBOARD_HOST=127.0.0.1 npm run codex
 ```
 
-该命令会在需要时启动本地 Taskboard 服务，使用独立配置文件和仅限回环访问的端口 `9231` 启动官方 macOS Codex App，等待主渲染器和侧边栏，在 Plugins 后注入一个原生外观的 Taskboard 入口，并持续监视服务和替换后的渲染器。现有 Codex 窗口不会变化。使用嵌入式面板时，请让该命令保持运行。启动器不会修改 `ChatGPT.app` 或其 `app.asar`。
+该命令会在需要时启动本地 Taskboard 服务。它会复用已打开且有可用 CDP 渲染器的 Codex；如果没有打开 Codex，它会使用独立配置文件和仅限回环访问的端口 `9231` 启动官方 macOS Codex App。如果只打开了没有 CDP 入口的普通 Codex，启动器会等待，并且不会启动第二个实例。它会在 Plugins 后注入一个原生外观的 Taskboard 入口，并持续监视服务和替换后的渲染器。使用嵌入式面板时，请让该命令保持运行。启动器不会修改 `ChatGPT.app` 或其 `app.asar`。
 
 源码启动器会把带身份信息的服务地址写入 `.data/launcher-runtime.json`。通过 `npm link` 安装的 `taskctl` 默认读取此文件。因此，普通 shell 和从面板打开的 Codex 任务无需设置额外环境变量，即可使用同一个 Taskboard 服务。
 
@@ -111,7 +111,7 @@ npm run app:build
 
 从 Finder 打开 `src-tauri/target/universal-apple-darwin/release/bundle/macos/Codex Taskboard.app`。DMG 位于 `src-tauri/target/universal-apple-darwin/release/bundle/dmg/`。如果只需安装稳定版，请从 [GitHub Releases](https://github.com/chuspeeism/dashi-taskboard/releases/latest) 下载当前 DMG。
 
-该 App 包含自己的 Node 运行时、Taskboard 服务、构建后的 Web UI、Skill、CLI 包装器和注入脚本。它会启动服务，启动官方 Codex App，等待渲染器，注入侧边栏入口，并在不显示终端窗口的情况下打开面板。该 App 可以复制到本检出目录之外；目标 Mac 只需安装官方 Codex App，不需要此仓库、系统 Node 安装或单独的 Codex CLI 安装。Taskboard 数据存储在 `~/Library/Application Support/Codex Taskboard`，启动器输出写入 `~/Library/Logs/Codex Taskboard/codex-taskboard-launcher.log`。
+该 App 包含自己的 Node 运行时、Taskboard 服务、构建后的 Web UI、Skill、CLI 包装器和注入脚本。它会启动服务，复用已打开且有可用 CDP 渲染器的 Codex；如果没有打开 Codex，它会启动官方 Codex App。如果只打开了没有 CDP 入口的普通 Codex，它会说明当前平台无法向该实例注入，并且不会启动第二个实例。它会等待渲染器，注入侧边栏入口，并在不显示终端窗口的情况下打开面板。该 App 可以复制到本检出目录之外；目标 Mac 只需安装官方 Codex App，不需要此仓库、系统 Node 安装或单独的 Codex CLI 安装。Taskboard 数据存储在 `~/Library/Application Support/Codex Taskboard`，启动器输出写入 `~/Library/Logs/Codex Taskboard/codex-taskboard-launcher.log`。
 
 本地构建使用 ad-hoc 代码签名进行直接验证。公开的 macOS 下载仍需要 Developer ID 签名和 Apple 公证。
 

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -302,7 +302,7 @@ function codexExecutablePath(appPath) {
   );
 }
 
-function managedCodexProcesses(appPath) {
+function codexAppProcesses(appPath) {
   const processes = spawnSync("/bin/ps", ["-ww", "-axo", "pid=,command="], {
     encoding: "utf8",
     env: withoutTaskboardLauncherEnvironment(process.env),
@@ -311,14 +311,12 @@ function managedCodexProcesses(appPath) {
   if (processes.status !== 0) throw new Error("Unable to inspect the launched Codex process");
 
   const executable = codexExecutablePath(appPath);
-  const profileArgument = `--user-data-dir=${independentCodexProfilePath}`;
   const matches = [];
   for (const line of processes.stdout.split("\n")) {
     const match = line.match(/^\s*(\d+)\s+(.+)$/);
     if (
       match
-      && match[2].startsWith(`${executable} `)
-      && match[2].includes(` ${profileArgument} `)
+      && (match[2] === executable || match[2].startsWith(`${executable} `))
     ) {
       matches.push({ pid: Number(match[1]), command: match[2] });
     }
@@ -326,10 +324,24 @@ function managedCodexProcesses(appPath) {
   return matches;
 }
 
+function managedCodexProcesses(appPath) {
+  const profileArgument = `--user-data-dir=${independentCodexProfilePath}`;
+  return codexAppProcesses(appPath).filter((record) => (
+    record.command.includes(` ${profileArgument} `)
+  ));
+}
+
 function managedCodexProcess(appPath) {
   const processes = managedCodexProcesses(appPath);
   if (processes.length > 1) throw new Error("Multiple managed Codex processes are running");
   return processes[0] ?? null;
+}
+
+function codexProcessDebuggingPort(record) {
+  const match = record.command.match(/ --remote-debugging-port=(\d+)(?: |$)/);
+  if (!match) return null;
+  const port = Number(match[1]);
+  return Number.isInteger(port) && port > 0 && port <= 65_535 ? port : null;
 }
 
 function managedCodexUsesPort(record, port) {
@@ -420,6 +432,20 @@ async function stopManagedCodex(record) {
   if (isManagedCodexRunning(record)) {
     throw new Error("Unable to stop the managed Codex process");
   }
+}
+
+function activateCodexApp(pid) {
+  if (process.platform !== "darwin") return;
+  const activation = spawnSync("/usr/bin/osascript", [
+    "-l",
+    "JavaScript",
+    "-e",
+    `ObjC.import("AppKit"); const app = $.NSRunningApplication.runningApplicationWithProcessIdentifier(${pid}); if (!app || !app.activateWithOptions(1)) throw new Error("Unable to activate Codex");`,
+  ], {
+    env: withoutTaskboardLauncherEnvironment(process.env),
+    stdio: "ignore",
+  });
+  if (activation.status !== 0) throw new Error("Unable to activate the Codex app");
 }
 
 async function launchCodexWithPipe(appPath) {
@@ -1991,8 +2017,10 @@ async function main() {
   let managedCodex = null;
   let pendingCodexLaunch = null;
   let cdpRuntime = null;
+  let codexAppPid = null;
   let runtimePublishPromise = null;
   const injectedTargets = new Map();
+  let idleAfterNormalExit = false;
   let openRequestGeneration = options.open ? 1 : 0;
   let openedRequestGeneration = 0;
   const hasOpenPending = () => openedRequestGeneration < openRequestGeneration;
@@ -2020,6 +2048,7 @@ async function main() {
         throw new Error("Taskboard injection is not ready");
       }
       await connection.send("Page.bringToFront");
+      activateCodexApp(codexAppPid);
       openedRequestGeneration = Math.max(openedRequestGeneration, generation);
       return true;
     } catch (error) {
@@ -2077,7 +2106,34 @@ async function main() {
   };
 
   const startManagedCodex = async () => {
-    if (stopping) return;
+    if (stopping) return false;
+    if (!options.cdpPipe) {
+      const runningCodex = codexAppProcesses(options.appPath);
+      for (const record of runningCodex) {
+        const port = codexProcessDebuggingPort(record);
+        if (!port || !(await isReachable(`http://127.0.0.1:${port}/json/version`))) continue;
+        try {
+          if ((await codexTargets(port)).length === 0) continue;
+        } catch {
+          continue;
+        }
+        cdpRuntime = tcpCdpRuntime(port);
+        codexAppPid = record.pid;
+        options.attachExisting = true;
+        console.log(JSON.stringify({ reusedCodexPid: record.pid, cdpPort: port }));
+        return true;
+      }
+      if (runningCodex.length > 0) {
+        console.error(
+          "Waiting for Codex: the running Codex instance has no debuggable renderer; no second instance will be started.",
+        );
+        return false;
+      }
+    }
+    if (options.launch) {
+      await importCodexBrowserProfile();
+      if (stopping) return false;
+    }
     if (options.cdpPipe) {
       const launchPromise = (async () => {
         const launched = await launchCodexWithPipe(options.appPath);
@@ -2092,7 +2148,7 @@ async function main() {
       } finally {
         if (pendingCodexLaunch === launchPromise) pendingCodexLaunch = null;
       }
-      return;
+      return true;
     }
     const launchPromise = launchCodexWithLaunchServices(
       options.appPath,
@@ -2102,19 +2158,21 @@ async function main() {
     pendingCodexLaunch = launchPromise;
     try {
       managedCodex = await launchPromise;
+      codexAppPid = managedCodex.pid;
     } catch (error) {
       if (!stopping) throw error;
     } finally {
       if (pendingCodexLaunch === launchPromise) pendingCodexLaunch = null;
     }
-    if (stopping) return;
+    if (stopping) return false;
     try {
       await waitUntilReachable(cdpVersionUrl, 30_000, () => stopping);
     } catch (error) {
-      if (stopping) return;
+      if (stopping) return false;
       throw error;
     }
     if (!stopping) cdpRuntime = tcpCdpRuntime(options.port);
+    return !stopping;
   };
 
   let cleanupPromise = null;
@@ -2207,19 +2265,19 @@ async function main() {
     if (stopping) return;
     await publishRuntime();
     if (stopping) return;
-    if (options.launch) {
-      await importCodexBrowserProfile();
-      if (stopping) return;
-    }
 
     if (options.cdpPipe || !cdpReachable) {
-      await startManagedCodex();
+      idleAfterNormalExit = !(await startManagedCodex());
     } else {
       if (options.launch) {
         managedCodex = managedCodexProcess(options.appPath);
         if (!managedCodex || !managedCodexUsesPort(managedCodex, options.port)) {
           throw new Error(`Codex CDP port ${options.port} belongs to another process`);
         }
+        codexAppPid = managedCodex.pid;
+      } else {
+        codexAppPid = codexAppProcesses(options.appPath)
+          .find((record) => codexProcessDebuggingPort(record) === options.port)?.pid ?? null;
       }
       cdpRuntime = tcpCdpRuntime(options.port);
     }
@@ -2230,35 +2288,36 @@ async function main() {
     let firstResults = [];
     const firstOpenGeneration = openRequestGeneration;
     const shouldOpenFirstTarget = firstOpenGeneration > openedRequestGeneration;
-    try {
-      firstResults = await injectAll(
-        cdpRuntime,
-        source,
-        sourceHash,
-        shouldOpenFirstTarget,
-        options.screenshot,
-        injectedTargets,
-        options.watch,
-        supervisor,
-        options.attachExisting,
-        options.startupToken,
-      );
-    } catch (error) {
-      if (!options.watch) throw error;
-      console.error(`Waiting for Codex renderer: ${error.message}`);
+    if (!idleAfterNormalExit) {
+      try {
+        firstResults = await injectAll(
+          cdpRuntime,
+          source,
+          sourceHash,
+          shouldOpenFirstTarget,
+          options.screenshot,
+          injectedTargets,
+          options.watch,
+          supervisor,
+          options.attachExisting,
+          options.startupToken,
+        );
+      } catch (error) {
+        if (!options.watch) throw error;
+        console.error(`Waiting for Codex renderer: ${error.message}`);
+      }
     }
     if (stopping) return;
     if (firstResults.length > 0) {
       if (shouldOpenFirstTarget) {
         openedRequestGeneration = Math.max(openedRequestGeneration, firstOpenGeneration);
+        activateCodexApp(codexAppPid);
       }
       console.log(JSON.stringify({ injected: firstResults }, null, 2));
     }
     if (hasOpenPending() && injectedTargets.size > 0) {
       await requestTaskboardOpen();
     }
-    let idleAfterNormalExit = false;
-
     if (!options.watch) {
       if (options.cdpPipe) codexProcess?.unref();
       return;
@@ -2285,7 +2344,7 @@ async function main() {
       if (idleAfterNormalExit) {
         if (!hasOpenPending()) continue;
         try {
-          await startManagedCodex();
+          if (!(await startManagedCodex())) continue;
           idleAfterNormalExit = false;
         } catch (restartError) {
           console.error(`Waiting to restart Codex: ${restartError.message}`);

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -1839,16 +1839,23 @@ async function injectTarget(
         await hostBridge.publishHeartbeat();
       });
       await hostBridge.publishHeartbeat();
+      if (shouldOpen && !reconciled.shouldRemainOpen) {
+        await cdp.send("Runtime.evaluate", {
+          expression: "window.__codexTaskboardInjection__?.open()",
+          returnByValue: true,
+        });
+      }
+      const shouldRemainOpen = shouldOpen || reconciled.shouldRemainOpen;
       const status = await waitForInjectionStatus(
         cdp,
-        reconciled.shouldRemainOpen,
+        shouldRemainOpen,
         sourceHash,
         15_000,
       );
       const frameLoaded = status.frameUrl
         ? await waitForFrame(cdp, status.frameUrl, 15_000)
         : false;
-      if (reconciled.shouldRemainOpen && (!status.frameReady || !frameLoaded)) {
+      if (shouldRemainOpen && (!status.frameReady || !frameLoaded)) {
         throw new Error("Taskboard frame did not report ready in the Codex renderer");
       }
       retained = true;

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -2277,11 +2277,18 @@ async function main() {
       idleAfterNormalExit = !(await startManagedCodex());
     } else {
       if (options.launch) {
-        managedCodex = managedCodexProcess(options.appPath);
-        if (!managedCodex || !managedCodexUsesPort(managedCodex, options.port)) {
+        const runningCodex = codexAppProcesses(options.appPath)
+          .find((record) => codexProcessDebuggingPort(record) === options.port);
+        if (!runningCodex || (await codexTargets(options.port)).length === 0) {
           throw new Error(`Codex CDP port ${options.port} belongs to another process`);
         }
-        codexAppPid = managedCodex.pid;
+        managedCodex = managedCodexProcesses(options.appPath)
+          .find((record) => record.pid === runningCodex.pid) ?? null;
+        codexAppPid = runningCodex.pid;
+        if (!managedCodex) {
+          options.attachExisting = true;
+          console.log(JSON.stringify({ reusedCodexPid: runningCodex.pid, cdpPort: options.port }));
+        }
       } else {
         codexAppPid = codexAppProcesses(options.appPath)
           .find((record) => codexProcessDebuggingPort(record) === options.port)?.pid ?? null;
@@ -2416,7 +2423,8 @@ async function main() {
         const launchedCodexExited = options.cdpPipe
           ? codexProcess
             && (codexProcess.exitCode !== null || codexProcess.signalCode !== null)
-          : managedCodex && !isManagedCodexRunning(managedCodex);
+          : codexAppPid && !codexAppProcesses(options.appPath)
+            .some((record) => record.pid === codexAppPid);
         if (launchedCodexExited) {
           injectedTargets.forEach((connection) => {
             unregisterQuotaPolicyCdp(connection);
@@ -2445,6 +2453,7 @@ async function main() {
             continue;
           }
           managedCodex = null;
+          codexAppPid = null;
           idleAfterNormalExit = true;
           console.error(
             "Waiting for Codex after exit; open Codex Taskboard again to restart it.",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -784,7 +784,7 @@ fn watch_launcher_output<R: std::io::Read + Send + 'static>(
                     {
                         snapshot.phase = "starting".into();
                         snapshot.message =
-                            "已打开的 Codex 不提供注入入口；不会启动第二个实例。".into();
+                            "当前平台无法向已打开的普通 Codex 注入；不会启动第二个实例。".into();
                     }
                 });
             } else if is_stderr && line.contains("Waiting for Codex") {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -82,6 +82,11 @@ struct LauncherPidRecord {
     injector_path: PathBuf,
 }
 
+#[derive(Deserialize)]
+struct LauncherRuntimeDescriptor {
+    url: String,
+}
+
 struct LauncherState {
     child: Mutex<Option<u32>>,
     snapshot: Mutex<LauncherSnapshot>,
@@ -772,7 +777,17 @@ fn watch_launcher_output<R: std::io::Read + Send + 'static>(
     thread::spawn(move || {
         for line in BufReader::new(reader).lines().map_while(Result::ok) {
             append_log(&state, &line);
-            if is_stderr && line.contains("Waiting for Codex") {
+            if is_stderr && line.contains("running Codex instance has no debuggable renderer") {
+                update_snapshot(&app, &state, |snapshot| {
+                    if state.generation.load(Ordering::SeqCst) == generation
+                        && snapshot.child_pid == Some(pid)
+                    {
+                        snapshot.phase = "starting".into();
+                        snapshot.message =
+                            "已打开的 Codex 不提供注入入口；不会启动第二个实例。".into();
+                    }
+                });
+            } else if is_stderr && line.contains("Waiting for Codex") {
                 update_snapshot(&app, &state, |snapshot| {
                     if state.generation.load(Ordering::SeqCst) == generation
                         && snapshot.child_pid == Some(pid)
@@ -1126,6 +1141,28 @@ fn restart_launcher(
 fn open_taskboard(state: &LauncherState) -> Result<(), String> {
     state.snapshot.lock().unwrap().open_request_pending = true;
     signal_pending_taskboard_open(state)
+}
+
+fn open_taskboard_in_browser(state: &LauncherState) -> Result<(), String> {
+    let descriptor = fs::read_to_string(state.data_directory.join("launcher-runtime.json"))
+        .map_err(|error| error.to_string())?;
+    let descriptor: LauncherRuntimeDescriptor =
+        serde_json::from_str(&descriptor).map_err(|error| error.to_string())?;
+    let url = format!("{}/", descriptor.url.trim_end_matches('/'));
+    #[cfg(target_os = "macos")]
+    let status = StdCommand::new("/usr/bin/open")
+        .arg(&url)
+        .status()
+        .map_err(|error| error.to_string())?;
+    #[cfg(target_os = "windows")]
+    let status = StdCommand::new("rundll32.exe")
+        .args(["url.dll,FileProtocolHandler", &url])
+        .status()
+        .map_err(|error| error.to_string())?;
+    status
+        .success()
+        .then_some(())
+        .ok_or_else(|| "系统默认浏览器没有打开任务面板".to_string())
 }
 
 async fn check_for_startup_update(
@@ -1582,6 +1619,13 @@ fn main() {
             *state.status_menu.lock().unwrap() = Some(launcher_status.clone());
             let open_taskboard_item =
                 MenuItem::with_id(app, "open-taskboard", "打开任务面板", true, None::<&str>)?;
+            let open_taskboard_web = MenuItem::with_id(
+                app,
+                "open-taskboard-web",
+                "在网页打开任务面板",
+                true,
+                None::<&str>,
+            )?;
             let check_update =
                 MenuItem::with_id(app, "check-update", "检查更新", false, None::<&str>)?;
             let restart_codex =
@@ -1602,6 +1646,7 @@ fn main() {
                     &app_info,
                     &launcher_status,
                     &open_taskboard_item,
+                    &open_taskboard_web,
                     &restart_codex,
                     &check_update,
                     &autostart,
@@ -1644,6 +1689,22 @@ fn main() {
                                     "Codex Taskboard 打开失败",
                                     &format!("{error}\n\n请确认 Codex 正在运行。"),
                                 );
+                            }
+                        });
+                    }
+                    "open-taskboard-web" => {
+                        let Some(state) = app.try_state::<Arc<LauncherState>>() else {
+                            return;
+                        };
+                        let state = Arc::clone(state.inner());
+                        let app = app.clone();
+                        tauri::async_runtime::spawn_blocking(move || {
+                            if let Err(error) = open_taskboard_in_browser(&state) {
+                                append_log(
+                                    &state,
+                                    &format!("Launcher menu browser open failed: {error}"),
+                                );
+                                show_error_dialog(&app, "Codex Taskboard 网页打开失败", &error);
                             }
                         });
                     }


### PR DESCRIPTION
## 功能

- 复用已有可调试 Codex 时按启动请求直接打开任务面板
- 状态栏打开动作激活实际注入的 Codex 进程
- 状态栏增加「在网页打开任务面板」入口

## 验证

- 复用既有 Codex，未创建第二个实例，面板直接打开
- Chrome 前台时触发打开动作，前台切换到准确的注入 PID
- 网页入口在默认浏览器打开当前有效 Taskboard 页面
- JavaScript 语法、cargo fmt、cargo check、git diff --check 通过

未新增测试、护栏、兼容层或无关重构。