### PR TITLE
LOCAL-254: Open issues in new Codex threads

### DIFF
--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -992,14 +992,17 @@
   }
 
   async function resolveNativeProject(requestedProjectId, workspacePath) {
-    if (workspacePath) {
-      return normalizeNativeRootPath(workspacePath) ? { targetRoot: workspacePath } : null;
-    }
     const context = await nativeProjectContext();
-    const project = context.projects.find((candidate) => candidate.id === requestedProjectId) ?? null;
-    const targetRoot = project?.rootPaths[0];
-    return typeof targetRoot === "string" && normalizeNativeRootPath(targetRoot)
-      ? { targetRoot }
+    const normalizedWorkspacePath = normalizeNativeRootPath(workspacePath);
+    const project = context.projects.find((candidate) => (
+      candidate.id === requestedProjectId
+      || candidate.rootPaths.some((root) => (
+        normalizeNativeRootPath(root) === normalizedWorkspacePath
+      ))
+    )) ?? null;
+    const targetRoot = normalizedWorkspacePath ? workspacePath : project?.rootPaths[0];
+    return project && typeof targetRoot === "string" && normalizeNativeRootPath(targetRoot)
+      ? { projectId: project.id, targetRoot }
       : null;
   }
 
@@ -1018,18 +1021,18 @@
     }
   }
 
-  async function waitForNativeProject(targetRoot) {
+  async function waitForNativeProject(projectId, targetRoot) {
     const deadline = Date.now() + 8_000;
     const normalizedTargetRoot = normalizeNativeRootPath(targetRoot);
     while (Date.now() < deadline) {
-      const [projectId, activeRoots] = await Promise.all([
+      const [selectedProjectId, activeRoots] = await Promise.all([
         selectedNativeProjectId(),
         activeNativeWorkspaceRoots(),
       ]);
       if (
-        projectId
+        selectedProjectId === projectId
         && normalizeNativeRootPath(activeRoots[0]) === normalizedTargetRoot
-      ) return projectId;
+      ) return selectedProjectId;
       await new Promise((resolve) => window.setTimeout(resolve, 80));
     }
     throw new Error(hostText(
@@ -1046,6 +1049,7 @@
     const workspacePath = typeof payload?.workspacePath === "string"
       ? payload.workspacePath.trim()
       : "";
+    const projectless = payload?.projectless === true;
     const codexProjectKind = payload?.codexProjectKind === "remote" ? "remote" : "local";
     const requestedProjectId = typeof payload?.codexProjectId === "string"
       ? payload.codexProjectId.trim()
@@ -1077,7 +1081,9 @@
       );
       let codexHostId = "local";
       let targetRoot;
-      if (codexProjectKind === "remote") {
+      if (projectless) {
+        targetRoot = "";
+      } else if (codexProjectKind === "remote") {
         codexHostId = typeof payload?.codexHostId === "string"
           ? payload.codexHostId.trim()
           : "";
@@ -1095,10 +1101,9 @@
           ));
         }
         targetRoot = target.targetRoot;
-        const switched = await requestNativeFetch("add-workspace-root-option", {
-          root: targetRoot,
-          setActive: true,
-          origin: window.location.origin,
+        const switched = await requestNativeFetch("set-global-state", {
+          key: "selected-project",
+          value: { type: "local", projectId: target.projectId },
         });
         if (switched?.success !== true) {
           throw new Error(hostText(
@@ -1106,7 +1111,7 @@
             "Codex did not switch to the target project or worktree in time",
           ));
         }
-        lastNativeProjectId = await waitForNativeProject(targetRoot);
+        lastNativeProjectId = await waitForNativeProject(target.projectId, targetRoot);
       }
 
       closeTaskboard(false);
@@ -1117,12 +1122,14 @@
         state: {
           focusComposerNonce,
           prefillPrompt: instruction,
+          ...(projectless ? { project: null } : {}),
         },
       });
       const started = await requestHostTaskConversationStart({
         taskId,
         previousThreadId,
         codexHostId,
+        projectless,
         targetRoot,
         instruction,
         title,
@@ -1580,6 +1587,7 @@
     taskId,
     previousThreadId,
     codexHostId,
+    projectless,
     targetRoot,
     instruction,
     title,
@@ -1588,6 +1596,7 @@
       taskId,
       previousThreadId,
       codexHostId,
+      projectless,
       targetRoot,
       instruction,
       title,

--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -1146,6 +1146,14 @@
       lastNativeThreadId = startedThreadId;
       postToFrame({ type: "taskboard:thread-prepared", payload: { taskId, threadId: started.threadId } });
     } catch (error) {
+      const createdThreadId = normalizeThreadId(error?.threadId);
+      if (createdThreadId) {
+        await dispatchHostMessage({
+          type: "navigate-to-route",
+          path: routeForThread(createdThreadId),
+        });
+        lastNativeThreadId = createdThreadId;
+      }
       postToFrame({
         type: "taskboard:thread-create-error",
         payload: {

--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -1147,7 +1147,7 @@
       postToFrame({ type: "taskboard:thread-prepared", payload: { taskId, threadId: started.threadId } });
     } catch (error) {
       const createdThreadId = normalizeThreadId(error?.threadId);
-      if (createdThreadId) {
+      if (createdThreadId && codexProjectKind !== "remote") {
         await dispatchHostMessage({
           type: "navigate-to-route",
           path: routeForThread(createdThreadId),

--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -1021,18 +1021,18 @@
     }
   }
 
-  async function waitForNativeProject(projectId, targetRoot) {
+  async function waitForNativeProject(targetRoot) {
     const deadline = Date.now() + 8_000;
     const normalizedTargetRoot = normalizeNativeRootPath(targetRoot);
     while (Date.now() < deadline) {
-      const [selectedProjectId, activeRoots] = await Promise.all([
+      const [projectId, activeRoots] = await Promise.all([
         selectedNativeProjectId(),
         activeNativeWorkspaceRoots(),
       ]);
       if (
-        selectedProjectId === projectId
+        projectId
         && normalizeNativeRootPath(activeRoots[0]) === normalizedTargetRoot
-      ) return selectedProjectId;
+      ) return projectId;
       await new Promise((resolve) => window.setTimeout(resolve, 80));
     }
     throw new Error(hostText(
@@ -1101,17 +1101,11 @@
           ));
         }
         targetRoot = target.targetRoot;
-        const switched = await requestNativeFetch("set-global-state", {
-          key: "selected-project",
-          value: { type: "local", projectId: target.projectId },
+        bridge.sendMessageFromView({
+          type: "electron-add-new-workspace-root-option",
+          root: targetRoot,
         });
-        if (switched?.success !== true) {
-          throw new Error(hostText(
-            "Codex 未在限定时间内切换到目标项目或 worktree",
-            "Codex did not switch to the target project or worktree in time",
-          ));
-        }
-        lastNativeProjectId = await waitForNativeProject(target.projectId, targetRoot);
+        lastNativeProjectId = await waitForNativeProject(targetRoot);
       }
 
       closeTaskboard(false);

--- a/scripts/codex-injector-runtime.mjs
+++ b/scripts/codex-injector-runtime.mjs
@@ -69,9 +69,15 @@ function parseHostRequest(payload, parseAutomationRequest) {
     && request.codexHostId.length > 0
     && request.codexHostId.length <= 240
     && !/[\u0000-\u001f\u007f]/.test(request.codexHostId)
-    && typeof request.targetRoot === "string"
-    && request.targetRoot.length > 0
-    && request.targetRoot.length <= 4_096
+    && typeof request.projectless === "boolean"
+    && (
+      request.projectless
+      || (
+        typeof request.targetRoot === "string"
+        && request.targetRoot.length > 0
+        && request.targetRoot.length <= 4_096
+      )
+    )
     && typeof request.instruction === "string"
     && request.instruction.length > 0
     && request.instruction.length <= 4_000_000

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -88,6 +88,7 @@ const codexAutomationMethods = new Set([
 let codexAutomationRequestSequence = 0;
 let codexAppServerRequestSequence = 0;
 const taskConversationOperations = new Map();
+const taskConversationFailureTtlMs = 120_000;
 const quotaPolicyTimers = new Map();
 const quotaPolicyRecords = new Map();
 const quotaPolicyQueues = new Map();
@@ -1576,7 +1577,21 @@ function getOrStartTaskConversation(cdp, executionContextId, request) {
       taskConversationOperations.delete(request.taskId);
     }
   };
-  void promise.then(clearSettledOperation, clearSettledOperation);
+  const retainCreatedOrUncertainFailure = (error) => {
+    if (!(
+      error
+      && typeof error === "object"
+      && (typeof error.threadId === "string" || error.uncertain === true)
+    )) {
+      clearSettledOperation();
+      return;
+    }
+    const timer = setTimeout(() => {
+      clearSettledOperation();
+    }, taskConversationFailureTtlMs);
+    timer.unref?.();
+  };
+  void promise.then(clearSettledOperation, retainCreatedOrUncertainFailure);
   return promise;
 }
 

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -88,7 +88,6 @@ const codexAutomationMethods = new Set([
 let codexAutomationRequestSequence = 0;
 let codexAppServerRequestSequence = 0;
 const taskConversationOperations = new Map();
-const taskConversationOperationTtlMs = 120_000;
 const quotaPolicyTimers = new Map();
 const quotaPolicyRecords = new Map();
 const quotaPolicyQueues = new Map();
@@ -1572,15 +1571,12 @@ function getOrStartTaskConversation(cdp, executionContextId, request) {
   ));
   operation.promise = promise;
   taskConversationOperations.set(request.taskId, operation);
-  const retainSettledOperation = () => {
-    const timer = setTimeout(() => {
-      if (taskConversationOperations.get(request.taskId) === operation) {
-        taskConversationOperations.delete(request.taskId);
-      }
-    }, taskConversationOperationTtlMs);
-    timer.unref?.();
+  const clearSettledOperation = () => {
+    if (taskConversationOperations.get(request.taskId) === operation) {
+      taskConversationOperations.delete(request.taskId);
+    }
   };
-  void promise.then(retainSettledOperation, retainSettledOperation);
+  void promise.then(clearSettledOperation, clearSettledOperation);
   return promise;
 }
 

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -1385,7 +1385,14 @@ async function restoreQuotaPolicies(cdp) {
 }
 
 async function startTaskConversationViaCdp(cdp, executionContextId, request) {
-  const { codexHostId, instruction, previousThreadId, targetRoot, title } = request;
+  const {
+    codexHostId,
+    instruction,
+    previousThreadId,
+    projectless,
+    targetRoot,
+    title,
+  } = request;
   const normalizeWorkspaceRoot = (value) => {
     const root = String(value || "").trim();
     if (!root) return "";
@@ -1416,7 +1423,7 @@ async function startTaskConversationViaCdp(cdp, executionContextId, request) {
           !root
           || conversationId
           || !editor
-          || (editor.textContent || "") !== ${JSON.stringify(instruction)}
+          || (editor.innerText || "") !== ${JSON.stringify(instruction)}
         ) return false;
         editor.focus();
         return true;
@@ -1482,7 +1489,10 @@ async function startTaskConversationViaCdp(cdp, executionContextId, request) {
             );
             if (
               result?.thread?.id === threadId
-              && normalizeWorkspaceRoot(result.thread.cwd) === normalizedTargetRoot
+              && (
+                projectless
+                || normalizeWorkspaceRoot(result.thread.cwd) === normalizedTargetRoot
+              )
             ) {
               ready = true;
               break;
@@ -1490,7 +1500,11 @@ async function startTaskConversationViaCdp(cdp, executionContextId, request) {
           } catch {}
           await new Promise((resolve) => setTimeout(resolve, 80));
         }
-        if (!ready) throw new Error("Codex did not confirm the task conversation workspace root");
+        if (!ready) {
+          throw new Error(projectless
+            ? "Codex did not confirm the projectless task conversation"
+            : "Codex did not confirm the task conversation workspace root");
+        }
 
         try {
           await requestCodexAppServerViaCdp(

--- a/test/board-interactions.test.mjs
+++ b/test/board-interactions.test.mjs
@@ -141,7 +141,7 @@ test("common issue mutations enter a Linear-style undo queue", () => {
 });
 
 test("issues expose processing conversations without manual binding", () => {
-  assert.match(detailSource, /在对话中打开/);
+  assert.match(detailSource, /在新对话打开/);
   assert.match(detailSource, /onOpenInThread\(currentTask\)/);
   assert.doesNotMatch(appSource, /detail-thread-button/);
   assert.doesNotMatch(detailSource, /输入对话 ID|解除 Codex 对话绑定|>绑定</);

--- a/test/inject.test.mjs
+++ b/test/inject.test.mjs
@@ -266,20 +266,20 @@ test("issues start a native Codex conversation in the confirmed project with the
   assert.match(source, /requestNativeFetch\("active-workspace-roots", \{\}\)/);
   assert.match(source, /function normalizeNativeRootPath\(value\)/);
   assert.match(source, /async function resolveNativeProject\(requestedProjectId, workspacePath\)/);
-  assert.match(source, /workspacePath\) \{\s*return normalizeNativeRootPath\(workspacePath\) \? \{ targetRoot: workspacePath \} : null/);
-  assert.match(source, /const targetRoot = project\?\.rootPaths\[0\]/);
-  assert.match(source, /async function waitForNativeProject\(targetRoot\)/);
+  assert.match(source, /candidate\.id === requestedProjectId\s*\|\|\s*candidate\.rootPaths\.some/);
+  assert.match(source, /const targetRoot = normalizedWorkspacePath \? workspacePath : project\?\.rootPaths\[0\]/);
+  assert.match(source, /async function waitForNativeProject\(projectId, targetRoot\)/);
   const waitStart = source.indexOf("async function waitForNativeProject");
   const waitSource = source.slice(waitStart, source.indexOf("async function createThreadForTask", waitStart));
   assert.match(waitSource, /selectedNativeProjectId\(\)/);
   assert.match(waitSource, /activeNativeWorkspaceRoots\(\)/);
-  assert.match(waitSource, /projectId\s*&&\s*normalizeNativeRootPath\(activeRoots\[0\]\) === normalizedTargetRoot/);
+  assert.match(waitSource, /selectedProjectId === projectId\s*&&\s*normalizeNativeRootPath\(activeRoots\[0\]\) === normalizedTargetRoot/);
   assert.match(
     source,
-    /requestNativeFetch\("add-workspace-root-option", \{\s*root: targetRoot,\s*setActive: true,\s*origin: window\.location\.origin,/,
+    /requestNativeFetch\("set-global-state", \{\s*key: "selected-project",\s*value: \{ type: "local", projectId: target\.projectId \},/,
   );
   assert.match(source, /if \(switched\?\.success !== true\)/);
-  assert.match(source, /await waitForNativeProject\(targetRoot\)/);
+  assert.match(source, /await waitForNativeProject\(target\.projectId, targetRoot\)/);
   assert.match(
     createThreadSource,
     /if \(codexProjectKind === "remote"\) \{[\s\S]*?codexHostId = typeof payload\?\.codexHostId[\s\S]*?codexProjectWorkspacePath[\s\S]*?await waitForRemoteProject\(requestedProjectId, codexHostId, codexProjectWorkspacePath\);\s*targetRoot = codexProjectWorkspacePath;/,
@@ -290,10 +290,10 @@ test("issues start a native Codex conversation in the confirmed project with the
   assert.match(source, /const HOST_REQUEST_TIMEOUT_MS = 12_000/);
   assert.match(source, /const TASK_CONVERSATION_REQUEST_TIMEOUT_MS = 75_000/);
   assert.match(source, /function requestHost\(action, payload = \{\}, timeoutMs = HOST_REQUEST_TIMEOUT_MS\)/);
-  assert.match(source, /requestHostTaskConversationStart\(\{\s*taskId,\s*previousThreadId,\s*codexHostId,\s*targetRoot,\s*instruction,\s*title,/);
+  assert.match(source, /requestHostTaskConversationStart\(\{\s*taskId,\s*previousThreadId,\s*codexHostId,\s*projectless,\s*targetRoot,\s*instruction,\s*title,/);
   assert.match(
     source,
-    /requestHost\("start-task-conversation", \{\s*taskId,\s*previousThreadId,\s*codexHostId,\s*targetRoot,\s*instruction,\s*title,\s*\}, TASK_CONVERSATION_REQUEST_TIMEOUT_MS\)/,
+    /requestHost\("start-task-conversation", \{\s*taskId,\s*previousThreadId,\s*codexHostId,\s*projectless,\s*targetRoot,\s*instruction,\s*title,\s*\}, TASK_CONVERSATION_REQUEST_TIMEOUT_MS\)/,
   );
   assert.match(source, /lastNativeThreadId = startedThreadId/);
   assert.match(source, /type: "taskboard:thread-prepared", payload: \{ taskId, threadId: started\.threadId \}/);
@@ -370,11 +370,11 @@ test("host navigation follows Codex's renderer message bus", () => {
 test("the standalone web page reports that new Codex conversations require the embedded Taskboard", () => {
   assert.match(
     webApp,
-    /setActionError\(\[\s*"在对话中打开仅可在 Codex 内嵌任务面板中使用。请从 Codex 侧栏打开任务面板后重试。",/,
+    /setActionError\(\[\s*"在新对话打开仅可在 Codex 内嵌任务面板中使用。请从 Codex 侧栏打开任务面板后重试。",/,
   );
   assert.match(
     webApp,
-    /"Open in conversation is available only in the embedded Codex Taskboard\. Open Taskboard from the Codex sidebar and try again\.",/,
+    /"Open in new conversation is available only in the embedded Codex Taskboard\. Open Taskboard from the Codex sidebar and try again\.",/,
   );
   assert.doesNotMatch(webApp, /codex:\/\/new/);
 });

--- a/test/inject.test.mjs
+++ b/test/inject.test.mjs
@@ -268,18 +268,17 @@ test("issues start a native Codex conversation in the confirmed project with the
   assert.match(source, /async function resolveNativeProject\(requestedProjectId, workspacePath\)/);
   assert.match(source, /candidate\.id === requestedProjectId\s*\|\|\s*candidate\.rootPaths\.some/);
   assert.match(source, /const targetRoot = normalizedWorkspacePath \? workspacePath : project\?\.rootPaths\[0\]/);
-  assert.match(source, /async function waitForNativeProject\(projectId, targetRoot\)/);
+  assert.match(source, /async function waitForNativeProject\(targetRoot\)/);
   const waitStart = source.indexOf("async function waitForNativeProject");
   const waitSource = source.slice(waitStart, source.indexOf("async function createThreadForTask", waitStart));
   assert.match(waitSource, /selectedNativeProjectId\(\)/);
   assert.match(waitSource, /activeNativeWorkspaceRoots\(\)/);
-  assert.match(waitSource, /selectedProjectId === projectId\s*&&\s*normalizeNativeRootPath\(activeRoots\[0\]\) === normalizedTargetRoot/);
+  assert.match(waitSource, /projectId\s*&&\s*normalizeNativeRootPath\(activeRoots\[0\]\) === normalizedTargetRoot/);
   assert.match(
     source,
-    /requestNativeFetch\("set-global-state", \{\s*key: "selected-project",\s*value: \{ type: "local", projectId: target\.projectId \},/,
+    /bridge\.sendMessageFromView\(\{\s*type: "electron-add-new-workspace-root-option",\s*root: targetRoot,/,
   );
-  assert.match(source, /if \(switched\?\.success !== true\)/);
-  assert.match(source, /await waitForNativeProject\(target\.projectId, targetRoot\)/);
+  assert.match(source, /await waitForNativeProject\(targetRoot\)/);
   assert.match(
     createThreadSource,
     /if \(codexProjectKind === "remote"\) \{[\s\S]*?codexHostId = typeof payload\?\.codexHostId[\s\S]*?codexProjectWorkspacePath[\s\S]*?await waitForRemoteProject\(requestedProjectId, codexHostId, codexProjectWorkspacePath\);\s*targetRoot = codexProjectWorkspacePath;/,

--- a/test/injector.test.mjs
+++ b/test/injector.test.mjs
@@ -48,7 +48,7 @@ test("the CDP bridge accepts service ensure and native task conversation start a
   assert.match(runtimeSource, /request\.title\.length <= 240/);
   assert.match(source, /async function startTaskConversationViaCdp/);
   assert.match(source, /data-composer-placement="home"/);
-  assert.match(source, /\(editor\.textContent \|\| ""\) !== \$\{JSON\.stringify\(instruction\)\}/);
+  assert.match(source, /\(editor\.innerText \|\| ""\) !== \$\{JSON\.stringify\(instruction\)\}/);
   assert.doesNotMatch(source, /cdp\.send\("Input\.insertText", \{ text: instruction \}\)/);
   assert.match(
     source,

--- a/test/issue-composer-wiring.test.mjs
+++ b/test/issue-composer-wiring.test.mjs
@@ -86,11 +86,11 @@ test("task composer document converts only durable references and keeps slash an
   });
 });
 
-test("open in conversation rebinds durable references and hydrates only a fresh composer document", () => {
+test("open in new conversation bypasses AI chat while its durable reference rebind stays internal", () => {
   assert.match(apiSource, /"\/api\/local\/ai\/composer\/rebind"/);
-  assert.match(appSource, /inlineMediaComposerReferences\(descriptionSegments\)\.length === 0/);
-  assert.match(appSource, /await rebindAiChatComposerReferences\(\{/);
-  assert.match(appSource, /document: rebound\.ready \? rebound\.document : persistedDocument/);
+  assert.doesNotMatch(appSource, /rebindAiChatComposerReferences/);
+  assert.match(appSource, /type: "taskboard:create-thread"/);
+  assert.match(chatSource, /await rebindAiChatComposerReferences\(\{/);
   assert.match(chatSource, /if \(!unavailable\) tokenElement\.dataset\.composerCandidateRef = node\.candidateRef/);
   assert.match(chatSource, /setComposerRevision\(composerDraft\.revision\)/);
   assert.match(chatSource, /\|\| composerRebindBlocked/);

--- a/test/project-automation-settings.test.mjs
+++ b/test/project-automation-settings.test.mjs
@@ -75,18 +75,18 @@ test("project mapping is based on exact ids and workspace paths, never project n
   assert.doesNotMatch(appSource, /project\.name === selectedProject\.name/);
 });
 
-test("global tasks resolve thread metadata from the active Codex project", () => {
+test("global tasks open a projectless conversation", () => {
   const openTaskSource = appSource.slice(
     appSource.indexOf("function codexProjectContextForTaskProject"),
     appSource.indexOf("function changeProject"),
   );
   assert.match(
     openTaskSource,
-    /const effectiveCodexProjectId = taskboardProjectId === GLOBAL_PROJECT_ID\s*\? hostContext\?\.projectId\s*: taskboardProjectId/,
+    /if \(taskboardProjectId === GLOBAL_PROJECT_ID\) return null/,
   );
   assert.match(
     openTaskSource,
-    /hostContext\?\.projects\?\.find\(\s*\(project\) => project\.id === effectiveCodexProjectId/,
+    /const projectless = task\.projectId === GLOBAL_PROJECT_ID/,
   );
   assert.match(openTaskSource, /codexProjectId: codexProject\.id,\s*codexProjectKind: codexProject\.projectKind/);
   assert.match(openTaskSource, /const savedRemoteIdentity = projectCodexIdentities\[task\.projectId\]/);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2971,9 +2971,11 @@ export function App() {
     }
     const workspacePath = projectless
       ? undefined
-      : codexProjectContext?.workspacePath
-        ?? deviceWorkspacePaths[task.projectId]
-        ?? taskboardProject?.workspacePath;
+      : task.developmentContext?.type === "worktree"
+        ? task.developmentContext.path
+        : codexProjectContext?.workspacePath
+          ?? deviceWorkspacePaths[task.projectId]
+          ?? taskboardProject?.workspacePath;
     const instruction = `e-taskboard 处理任务面板任务 ${task.identifier}，并同步进度状态。`;
 
     if (!embedded || window.parent === window) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -46,7 +46,6 @@ import {
   listTasks,
   moveTask as moveTaskRequest,
   publishHostRuntime,
-  rebindAiChatComposerReferences,
   removeTaskRelation,
   resolveTaskboardUrl,
   restoreTask as restoreTaskRequest,
@@ -69,8 +68,6 @@ import { IssueListView } from "./components/IssueListView";
 import { JiraConnectionDialog } from "./components/JiraConnectionDialog";
 import { OtherTasksPanel } from "./components/OtherTasksPanel";
 import {
-  createInlineMediaSegments,
-  inlineMediaComposerReferences,
   resolveInlineMediaMarkdown,
   type PendingInlineImage,
 } from "./components/InlineMediaComposer";
@@ -103,7 +100,6 @@ import {
   type OtherTaskTab,
 } from "./issueBoardStatuses";
 import {
-  buildPersistedTaskComposerDocument,
   normalizeCodexThreadId,
   taskCardPresentation,
   type TaskCardPresentation,
@@ -118,7 +114,6 @@ import {
   writeTaskFilters,
 } from "./taskFilters";
 import {
-  COMPOSER_CONTRACT_VERSION,
   TASK_STATUSES,
   type ActorIdentity,
   type AiChatThread,
@@ -2620,6 +2615,7 @@ export function App() {
   }
 
   function codexProjectContextForTaskProject(taskboardProjectId: string) {
+    if (taskboardProjectId === GLOBAL_PROJECT_ID) return null;
     const taskboardProject = projects.find((project) => project.id === taskboardProjectId);
     const savedIdentity = projectCodexIdentities[taskboardProjectId];
     if (savedIdentity?.codexProjectKind === "remote") {
@@ -2632,17 +2628,12 @@ export function App() {
         ? savedIdentity
         : null;
     }
-    const effectiveCodexProjectId = taskboardProjectId === GLOBAL_PROJECT_ID
-      ? hostContext?.projectId
-      : taskboardProjectId;
     const directCodexProject = hostContext?.projects?.find(
-      (project) => project.id === effectiveCodexProjectId,
+      (project) => project.id === taskboardProjectId,
     );
-    const mappedWorkspacePath = taskboardProjectId === GLOBAL_PROJECT_ID
-      ? directCodexProject?.workspacePath ?? hostContext?.workspacePath
-      : deviceWorkspacePaths[taskboardProjectId]
-        ?? taskboardProject?.workspacePath
-        ?? directCodexProject?.workspacePath;
+    const mappedWorkspacePath = deviceWorkspacePaths[taskboardProjectId]
+      ?? taskboardProject?.workspacePath
+      ?? directCodexProject?.workspacePath;
     const codexProject = directCodexProject ?? hostContext?.projects?.find(
       (project) => project.workspacePath === mappedWorkspacePath,
     );
@@ -2945,6 +2936,7 @@ export function App() {
           codexHostId: identity.codexHostId,
           codexProjectWorkspacePath: identity.workspacePath,
           workspacePath: identity.workspacePath,
+          projectless: false,
         },
       });
     } catch (error) {
@@ -2960,9 +2952,8 @@ export function App() {
   }
 
   async function openTaskInThread(task: Task) {
-    const worktreePath = task.developmentContext?.type === "worktree"
-      ? task.developmentContext.path
-      : null;
+    const projectless = task.projectId === GLOBAL_PROJECT_ID;
+    const taskboardProject = projects.find((project) => project.id === task.projectId);
     const savedRemoteIdentity = projectCodexIdentities[task.projectId]?.codexProjectKind === "remote"
       ? projectCodexIdentities[task.projectId]
       : null;
@@ -2978,22 +2969,17 @@ export function App() {
       ));
       return;
     }
-    const workspacePath = worktreePath
-      ?? codexProjectContext?.workspacePath
-      ?? selectedDeviceWorkspacePath
-      ?? selectedProject?.workspacePath
-      ?? (
-        selectedProject?.id === GLOBAL_PROJECT_ID
-        || hostContext?.projectId === selectedProject?.id
-          ? hostContext?.workspacePath
-          : undefined
-      );
+    const workspacePath = projectless
+      ? undefined
+      : codexProjectContext?.workspacePath
+        ?? deviceWorkspacePaths[task.projectId]
+        ?? taskboardProject?.workspacePath;
     const instruction = `e-taskboard 处理任务面板任务 ${task.identifier}，并同步进度状态。`;
 
     if (!embedded || window.parent === window) {
       setActionError([
-        "在对话中打开仅可在 Codex 内嵌任务面板中使用。请从 Codex 侧栏打开任务面板后重试。",
-        "Open in conversation is available only in the embedded Codex Taskboard. Open Taskboard from the Codex sidebar and try again.",
+        "在新对话打开仅可在 Codex 内嵌任务面板中使用。请从 Codex 侧栏打开任务面板后重试。",
+        "Open in new conversation is available only in the embedded Codex Taskboard. Open Taskboard from the Codex sidebar and try again.",
       ]);
       return;
     }
@@ -3041,47 +3027,6 @@ export function App() {
         )).join("\n")
       : "（无）"}`;
     const embeddedInstruction = `${beforeDescription}${task.description}${afterDescription}`;
-    if (localAiChatAvailable) {
-      setActionError(null);
-      const descriptionSegments = createInlineMediaSegments(task.description, referenceTasks);
-      if (inlineMediaComposerReferences(descriptionSegments).length === 0) {
-        setAiOpenThreadRequest((current) => ({
-          projectId: task.projectId,
-          issueId: task.id,
-          composerText: embeddedInstruction,
-          requestId: (current?.requestId ?? 0) + 1,
-        }));
-        return;
-      }
-      const persistedDocument = buildPersistedTaskComposerDocument(
-        beforeDescription,
-        descriptionSegments,
-        afterDescription,
-      );
-      setOpeningThreadTaskId(task.id);
-      try {
-        const rebound = await rebindAiChatComposerReferences({
-          contractVersion: COMPOSER_CONTRACT_VERSION,
-          projectId: task.projectId,
-          document: persistedDocument,
-        });
-        setAiOpenThreadRequest((current) => ({
-          projectId: task.projectId,
-          issueId: task.id,
-          composerDraft: {
-            ready: rebound.ready,
-            revision: rebound.revision,
-            document: rebound.ready ? rebound.document : persistedDocument,
-          },
-          requestId: (current?.requestId ?? 0) + 1,
-        }));
-      } catch (error) {
-        setActionError(errorMessage(error));
-      } finally {
-        setOpeningThreadTaskId(null);
-      }
-      return;
-    }
     setOpeningThreadTaskId(task.id);
     setActionError(null);
     if (codexProjectContext?.codexProjectKind === "remote" && codexProjectContext.workspacePath) {
@@ -3100,7 +3045,8 @@ export function App() {
         description: task.description,
         canonicalReferences,
         instruction: embeddedInstruction,
-        projectName: selectedProject?.name,
+        projectName: taskboardProject?.name,
+        projectless,
         codexProjectId: codexProjectContext?.codexProjectId,
         codexProjectKind: codexProjectContext?.codexProjectKind ?? "local",
         codexHostId: codexProjectContext?.codexHostId ?? "local",

--- a/web/src/components/TaskContextMenu.tsx
+++ b/web/src/components/TaskContextMenu.tsx
@@ -415,7 +415,7 @@ export function TaskContextMenu({
           )}
         </MenuItem>
         <MenuItem
-          label={text("在对话中打开", "Open in conversation")}
+          label={text("在新对话打开", "Open in new conversation")}
           icon={<LinearIcon name="link" />}
           onPointerEnter={closeSubmenu}
           onClick={() => closeThen(() => onOpenInThread(task))}

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -1585,7 +1585,7 @@ export function TaskDetail({
                 <ActorAvatar actor={CODEX_AGENT_ACTOR} className="detail-thread-avatar" />
                 <span>{openingThread
                   ? text("正在打开…", "Opening…")
-                  : text("在对话中打开", "Open in conversation")}</span>
+                  : text("在新对话打开", "Open in new conversation")}</span>
               </button>
               {currentTask.externalUrl && (
                 <a


### PR DESCRIPTION
## Summary

- rename the task action to "Open in new conversation"
- create a native Codex thread instead of opening the Taskboard AI chat
- resolve and select the issue's Codex project, while global issues create projectless threads
- keep the issue title and prompt traceable in the created thread

## Verification

- real injected Codex: project issue created thread `01a01dac-a069-7352-8b85-e75019f2dad6` under the mapped `codex-taskboard` project and exact workspace root
- real injected Codex: global issue created distinct projectless thread `01a01daf-b322-7723-96ae-262d1fb3fdfb` under Recents
- `npm run typecheck`
- `npm run build:web`
- syntax checks for the injection and injector scripts

No tests were added.