### PR TITLE
Require complete Taskboard thread bindings

### DIFF
--- a/skills/manage-taskboard/SKILL.md
+++ b/skills/manage-taskboard/SKILL.md
@@ -35,6 +35,8 @@ When writing Chinese, keep the English word or use **本地 companion** / **本�
 
 - Preserve existing issue scope when adding requirements or acceptance details.
 - Add only relations that the work requires. Use parent for contained work, blocks or blocked_by for dependencies, and related for close association.
-- Let `taskctl` read `CODEX_THREAD_ID` for writes. Outside Codex, pass the exact conversation ID with `--thread-id`.
+- Let `taskctl` read `CODEX_THREAD_ID` for controller attribution. Outside Codex, pass the exact conversation ID with `--thread-id`. This value alone is not a complete task binding.
+- Any issue that the current conversation claims or continues must store a complete `threadBinding`: `threadId`, `codexProjectId`, `codexProjectKind`, `codexHostId`, and `workspacePath`. For an unbound local issue launched with injected Taskboard context, use the current `CODEX_THREAD_ID`, the injected project id and workspace path, `local` project kind, and `local` host id. Pass all five explicit `--binding-*` options on the claim and every later `issue move` that retains ownership. If any identity field is unavailable, stop before moving the issue to `in_progress`; never create a legacy binding containing only `threadId`.
+- When an issue already has a complete `threadBinding`, preserve its exact five saved values on every status write. Do not rebuild or replace it from the current context, and never take over a binding owned by another conversation.
 - Use the latest returned `version` with `--if-version` for concurrent updates. On conflict, read the issue again and reconcile before retrying.
 - Download and inspect an inline `![alt](api/attachments/<id>/content)` image only when it is needed to understand the requirement.

--- a/skills/manage-taskboard/references/cli.md
+++ b/skills/manage-taskboard/references/cli.md
@@ -98,11 +98,11 @@ taskctl issue update ID \
 taskctl issue move ID --status STATUS \
   [--thread-id ID] \
   [--binding-thread-id ID \
-   --binding-codex-project-id PROJECT_ID \
-   --binding-codex-project-kind local|remote \
-   --binding-codex-host-id HOST_ID \
-   --binding-workspace-path PATH] \
-  [--clear-binding-thread] \
+    [--binding-codex-project-id PROJECT_ID \
+     --binding-codex-project-kind local|remote \
+     --binding-codex-host-id HOST_ID \
+     --binding-workspace-path PATH] \
+   | --clear-binding-thread] \
   [--if-version N] [--json]
 taskctl issue archive ID [--thread-id ID] [--if-version N] [--json]
 taskctl issue restore ID [--thread-id ID] [--if-version N] [--json]
@@ -110,7 +110,7 @@ taskctl issue restore ID [--thread-id ID] [--if-version N] [--json]
 
 Use `issue move` to set `in_progress` before implementation and `in_review` after implementation and self-verification. Codex must not move work directly from `in_progress` to `done`; use `done` only after the user explicitly confirms acceptance or explicitly asks to mark the issue complete. Use `blocked` when work cannot continue and `canceled` when it will not continue. On a version conflict, fetch the issue again and reconcile before retrying.
 
-`--thread-id` records the conversation performing the mutation; it does not create a complete task binding. A conversation that claims or continues an issue must pass all five `--binding-*` options together. Reuse an existing complete binding exactly. For an unbound local issue launched with injected Taskboard context, use the current conversation id, injected project id and workspace path, `local` project kind, and `local` host id. Never leave an active issue with only a legacy local `threadId`. Use `--clear-binding-thread` only when the workflow explicitly requires an unbound issue.
+`--thread-id` records the conversation performing the mutation; it does not create a complete task binding. `--binding-thread-id` can stand alone to preserve a legacy local binding. If any binding identity option is present, all four identity options are required. `--clear-binding-thread` conflicts with every `--binding-*` option. A conversation that claims or continues an issue must pass all five `--binding-*` options together. Reuse an existing complete binding exactly. For an unbound local issue launched with injected Taskboard context, use the current conversation id, injected project id and workspace path, `local` project kind, and `local` host id. Never leave an active issue with only a legacy local `threadId`. Use `--clear-binding-thread` only when the workflow explicitly requires an unbound issue.
 
 Use either `--git-branch` or `--worktree-path`/`--worktree-branch`; an issue has only one development context. Issue JSON stores it as `developmentContext`, either `{ "type": "branch", "branch": "..." }` or `{ "type": "worktree", "path": "...", "branch": "..." }`. Its singular `threadId` is the Codex conversation that most recently created or changed the issue itself. Recurrence requires a due date.
 

--- a/skills/manage-taskboard/references/cli.md
+++ b/skills/manage-taskboard/references/cli.md
@@ -95,12 +95,22 @@ taskctl issue update ID \
   [--if-version N] \
   [--json]
 
-taskctl issue move ID --status STATUS [--thread-id ID] [--if-version N] [--json]
+taskctl issue move ID --status STATUS \
+  [--thread-id ID] \
+  [--binding-thread-id ID \
+   --binding-codex-project-id PROJECT_ID \
+   --binding-codex-project-kind local|remote \
+   --binding-codex-host-id HOST_ID \
+   --binding-workspace-path PATH] \
+  [--clear-binding-thread] \
+  [--if-version N] [--json]
 taskctl issue archive ID [--thread-id ID] [--if-version N] [--json]
 taskctl issue restore ID [--thread-id ID] [--if-version N] [--json]
 ```
 
 Use `issue move` to set `in_progress` before implementation and `in_review` after implementation and self-verification. Codex must not move work directly from `in_progress` to `done`; use `done` only after the user explicitly confirms acceptance or explicitly asks to mark the issue complete. Use `blocked` when work cannot continue and `canceled` when it will not continue. On a version conflict, fetch the issue again and reconcile before retrying.
+
+`--thread-id` records the conversation performing the mutation; it does not create a complete task binding. A conversation that claims or continues an issue must pass all five `--binding-*` options together. Reuse an existing complete binding exactly. For an unbound local issue launched with injected Taskboard context, use the current conversation id, injected project id and workspace path, `local` project kind, and `local` host id. Never leave an active issue with only a legacy local `threadId`. Use `--clear-binding-thread` only when the workflow explicitly requires an unbound issue.
 
 Use either `--git-branch` or `--worktree-path`/`--worktree-branch`; an issue has only one development context. Issue JSON stores it as `developmentContext`, either `{ "type": "branch", "branch": "..." }` or `{ "type": "worktree", "path": "...", "branch": "..." }`. Its singular `threadId` is the Codex conversation that most recently created or changed the issue itself. Recurrence requires a due date.
 

--- a/test/manage-taskboard-skill.test.mjs
+++ b/test/manage-taskboard-skill.test.mjs
@@ -44,3 +44,32 @@ test("the taskboard skill coordinates safe issue execution and review handoff", 
     /Verify the requested operation path[\s\S]*Add a comment with the changes, verification result, outcome, and remaining risks[\s\S]*Read the issue again, then move it to `in_review` with its current `version`/i,
   );
 });
+
+test("the taskboard skill requires complete thread bindings for claimed work", () => {
+  assert.match(
+    skillSource,
+    /This value alone is not a complete task binding/i,
+  );
+  assert.match(
+    skillSource,
+    /must store a complete `threadBinding`:[\s\S]*`threadId`[\s\S]*`codexProjectId`[\s\S]*`codexProjectKind`[\s\S]*`codexHostId`[\s\S]*`workspacePath`/i,
+  );
+  assert.match(
+    skillSource,
+    /Pass all five explicit `--binding-\*` options[\s\S]*never create a legacy binding containing only `threadId`/i,
+  );
+  assert.match(
+    skillSource,
+    /preserve its exact five saved values on every status write[\s\S]*never take over a binding owned by another conversation/i,
+  );
+
+  assert.match(cliReference, /--binding-thread-id ID/i);
+  assert.match(cliReference, /--binding-codex-project-id PROJECT_ID/i);
+  assert.match(cliReference, /--binding-codex-project-kind local\|remote/i);
+  assert.match(cliReference, /--binding-codex-host-id HOST_ID/i);
+  assert.match(cliReference, /--binding-workspace-path PATH/i);
+  assert.match(
+    cliReference,
+    /`--thread-id` records the conversation performing the mutation; it does not create a complete task binding/i,
+  );
+});


### PR DESCRIPTION
## Summary
- distinguish controller attribution from a complete task thread binding
- require all five binding identity fields when an Agent claims or continues work
- document the existing taskctl binding flags and add a targeted regression test

## Root cause
The manage-taskboard skill told Agents to rely on CODEX_THREAD_ID. taskctl correctly used that only as mutation attribution, so status writes omitted threadBinding and became legacy local bindings. Auto Claim then blocked the issue because project and host identity could not be verified.

## Verification
- node --test test/manage-taskboard-skill.test.mjs test/cli.test.mjs
- npm test: 451/452 Node tests passed on the first full run; the single injection fixture timeout passed when rerun independently
- git diff --check