### PR TITLE
清理旧版重复 Taskboard Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Copy or symlink `skills/manage-taskboard` into the Codex skills directory, then 
 
 ```bash
 ln -s /absolute/path/to/codex-taskboard/skills/manage-taskboard \
-  ~/.codex/skills/manage-taskboard
+  ~/.agents/skills/manage-taskboard
 ```
 
-The Skill teaches Codex to inspect an issue, move it to `in_progress`, use optimistic versions, verify the work, and then move it to `in_review`; it moves the issue to `done` only after the user explicitly confirms acceptance or asks to mark it complete.
+The desktop app keeps this same directory synchronized with its bundled Skill. The Skill teaches Codex to inspect an issue, move it to `in_progress`, use optimistic versions, verify the work, and then move it to `in_review`; it moves the issue to `done` only after the user explicitly confirms acceptance or asks to mark it complete.
 
 ## Embed in Codex
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -56,10 +56,10 @@ npm run taskctl -- issue create \
 
 ```bash
 ln -s /absolute/path/to/codex-taskboard/skills/manage-taskboard \
-  ~/.codex/skills/manage-taskboard
+  ~/.agents/skills/manage-taskboard
 ```
 
-该 Skill 会指导 Codex 检查议题，将其移到 `in_progress`，使用乐观版本控制，验证工作，然后将其移到 `in_review`；只有在用户明确确认接受或要求将议题标记为完成后，才会将议题移到 `done`。
+桌面 App 会让该目录与内置 Skill 保持同步。该 Skill 会指导 Codex 检查议题，将其移到 `in_progress`，使用乐观版本控制，验证工作，然后将其移到 `in_review`；只有在用户明确确认接受或要求将议题标记为完成后，才会将议题移到 `done`。
 
 ## 嵌入 Codex
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -356,6 +356,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-autostart",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ minisign-verify = "0.2"
 reqwest = { version = "0.13", default-features = false, features = ["stream", "rustls-no-provider"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 tauri = { version = "2.11.5", features = ["tray-icon"] }
 tauri-plugin-autostart = "2.5.1"
 tauri-plugin-dialog = "2.7.2"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -20,6 +20,7 @@ use objc2_app_kit::{
 use objc2_foundation::{NSObject, NSSize, NSString};
 use reqwest::header::{HeaderValue, ACCEPT};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 #[cfg(target_os = "macos")]
 use std::cell::RefCell;
 #[cfg(target_os = "macos")]
@@ -57,6 +58,15 @@ const STOP_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(target_os = "macos")]
 const LAUNCHER_STOP_TIMEOUT: Duration = Duration::from_secs(36);
 const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(30 * 60);
+// Unique whole-directory snapshots shipped from app-v0.2.0 through v1.1.2.
+const KNOWN_TASKBOARD_SKILL_DIGESTS: [&str; 6] = [
+    "eeaaa5d71a2c47688bf62a5eb9f45e9138fe49eb636a46cfd6af8a0f8853e2e0",
+    "c4ce3257bbf3efed1bb4d2d9f26436be8ba835d4ab4adf6fed38f5abbedafa59",
+    "6f1b1bb3a731aa154018c97b0779442f6c461cb5dd3ea91ca49da4bb3b8a8ea0",
+    "8ab19649d29cad0a39b0ab202b909bf03de07e37837b05cd5c3df5a4da0119f8",
+    "27131c82ac63c2884c1fcb7dd22a4e1c75975c7d79eb3fa3483a7949dd5f284d",
+    "ae74aec793decf6d9013c36f4b53e01723796a45567b77e9e9f22b4a168d3fbe",
+];
 #[cfg(target_os = "macos")]
 const TASKBOARD_LISTEN_FD: i32 = 5;
 
@@ -415,6 +425,113 @@ fn copy_directory(source: &Path, destination: &Path) -> Result<(), std::io::Erro
         }
     }
     Ok(())
+}
+
+fn collect_skill_files(
+    root: &Path,
+    directory: &Path,
+    files: &mut Vec<PathBuf>,
+) -> Result<bool, std::io::Error> {
+    for entry in fs::read_dir(directory)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            return Ok(false);
+        }
+        if file_type.is_dir() {
+            let file_count = files.len();
+            if !collect_skill_files(root, &entry.path(), files)? {
+                return Ok(false);
+            }
+            if files.len() == file_count {
+                return Ok(false);
+            }
+        } else if file_type.is_file() {
+            files.push(entry.path().strip_prefix(root).unwrap().to_path_buf());
+        } else {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn skill_directory_digest(directory: &Path) -> Result<Option<String>, std::io::Error> {
+    let mut files = Vec::new();
+    if !collect_skill_files(directory, directory, &mut files)? {
+        return Ok(None);
+    }
+    files.sort();
+    let mut digest = Sha256::new();
+    for relative_path in files {
+        let contents = fs::read(directory.join(&relative_path))?;
+        digest.update(relative_path.to_string_lossy().replace('\\', "/"));
+        digest.update([0]);
+        digest.update((contents.len() as u64).to_le_bytes());
+        digest.update(contents);
+    }
+    Ok(Some(format!("{:x}", digest.finalize())))
+}
+
+fn reconcile_legacy_skill(
+    home_directory: &Path,
+    bundled_skill: &Path,
+) -> Result<Option<(PathBuf, PathBuf)>, std::io::Error> {
+    let legacy_skill = home_directory.join(".codex/skills/manage-taskboard");
+    let metadata = match fs::symlink_metadata(&legacy_skill) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+
+    if metadata.file_type().is_symlink() {
+        fs::remove_dir_all(legacy_skill)?;
+        return Ok(None);
+    }
+
+    if metadata.is_dir() {
+        let legacy_digest = skill_directory_digest(&legacy_skill)?;
+        let bundled_digest = skill_directory_digest(bundled_skill)?;
+        let known_copy = legacy_digest.as_ref().is_some_and(|digest| {
+            bundled_digest.as_ref() == Some(digest)
+                || KNOWN_TASKBOARD_SKILL_DIGESTS.contains(&digest.as_str())
+        });
+        if known_copy {
+            fs::remove_dir_all(legacy_skill)?;
+            return Ok(None);
+        }
+    }
+
+    let backup_path = home_directory
+        .join(".codex/taskboard-skill-backups")
+        .join(format!("manage-taskboard-{}", Uuid::new_v4()));
+    Ok(Some((legacy_skill, backup_path)))
+}
+
+fn resolve_legacy_skill_conflict(
+    app: &AppHandle,
+    legacy_skill: &Path,
+    backup_path: &Path,
+) -> Result<bool, std::io::Error> {
+    let proceed = app
+        .dialog()
+        .message(format!(
+            "检测到旧位置中的 manage-taskboard Skill 与当前 App 内置版本不同，可能包含你的修改。\n\n为避免 Codex 同时发现两个版本，Taskboard 会把旧副本完整保留到：\n\n{}\n\n选择退出不会改动旧副本，也不会启动 Codex。",
+            backup_path.display()
+        ))
+        .title("Codex Taskboard Skill 冲突")
+        .kind(MessageDialogKind::Warning)
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "保留备份并继续".into(),
+            "退出".into(),
+        ))
+        .blocking_show();
+    if !proceed {
+        return Ok(false);
+    }
+
+    fs::create_dir_all(backup_path.parent().unwrap())?;
+    fs::rename(legacy_skill, backup_path)?;
+    Ok(true)
 }
 
 fn loopback_listener() -> Result<TcpListener, String> {
@@ -1567,6 +1684,7 @@ fn main() {
                 .path()
                 .resource_dir()?
                 .join("app/skills/manage-taskboard");
+            let legacy_skill_conflict = reconcile_legacy_skill(&home_directory, &bundled_skill)?;
             let global_skill = home_directory.join(".agents/skills/manage-taskboard");
             if global_skill.exists() {
                 fs::remove_dir_all(&global_skill)?;
@@ -1796,6 +1914,23 @@ fn main() {
             let startup_check_update = check_update.clone();
             let startup_quit = quit.clone();
             tauri::async_runtime::spawn(async move {
+                if let Some((legacy_skill, backup_path)) = legacy_skill_conflict {
+                    match resolve_legacy_skill_conflict(&app_handle, &legacy_skill, &backup_path) {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            app_handle.exit(0);
+                            return;
+                        }
+                        Err(error) => {
+                            show_error_dialog(
+                                &app_handle,
+                                "Codex Taskboard Skill 更新失败",
+                                &format!("无法保留旧 Skill：{error}"),
+                            );
+                            return;
+                        }
+                    }
+                }
                 if let Err(error) = start_launcher(&app_handle, &state) {
                     append_log(&state, &format!("Launcher startup failed: {error}"));
                     update_snapshot(&app_handle, &state, |snapshot| {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1927,6 +1927,7 @@ fn main() {
                                 "Codex Taskboard Skill 更新失败",
                                 &format!("无法保留旧 Skill：{error}"),
                             );
+                            app_handle.exit(1);
                             return;
                         }
                     }


### PR DESCRIPTION
## 变更

- 把中英文 README 的手动安装目录统一为 `~/.agents/skills/manage-taskboard`。
- Launcher 启动时识别旧 `~/.codex/skills/manage-taskboard`：旧 README 符号链接和已发布的官方目录副本会安全清理。
- 旧副本与官方版本不同时，使用现有原生对话框提示，并在用户同意后完整备份到 `~/.codex/taskboard-skill-backups`，然后才启动 Codex。
- 规范目录继续由 App 内置 Skill 刷新，避免 Codex 同时发现两个不同版本的同名 Skill。

## 真实路径

旧副本存在 → 启动或升级后重启 Codex Taskboard → Tauri setup 识别旧副本 → 自动清理已知副本，或提示并备份用户修改副本 → 刷新 `~/.agents` → 启动 Codex → Codex 只发现一个 `manage-taskboard`。

## 验证

- `cargo fmt --check`
- `cargo check`
- `npm run typecheck`
- `npm run build:web`
- 最终 x86_64 macOS App 构建成功。
- 最终构建 App 的隔离 HOME 路径：符号链接被移除但目标目录保留；已知 v0.2.0 目录被清理；两条路径的 `~/.agents` 都与 App 内置 Skill 完全一致。
- 用户修改副本进入原生提示路径；同意后原目录及新增文件完整保留在显示的备份目录。
- 官方 Codex `skills/list` 对最终隔离 HOME 只返回一个启用的 `manage-taskboard`，路径为 `~/.agents/skills/manage-taskboard/SKILL.md`。
- `npm run app:verify-packaged-taskctl` 在取得本地回环监听权限后通过，未更换 binary、endpoint 或命令。

按当前项目规则，本轮未新增测试。在线更新和发布签名验证需要包含修复的后续版本，本 PR 不发布。

Closes #209
