### PR TITLE
LOCAL-260: Keep inline previews visible in details

### DIFF
--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -935,11 +935,22 @@ async function hydrateTask(env, row, activityComments = null, activityChanges = 
       ORDER BY tasks.sort_order, tasks.created_at, tasks.id
     `).bind(task.id, task.id, task.id)),
     env.DB.prepare(`
-      SELECT * FROM attachments
-      WHERE task_id = ?
-        AND comment_id IS NULL
-        AND content_type LIKE 'image/%'
-      ORDER BY created_at, id
+      SELECT attachments.*
+      FROM attachments
+      JOIN tasks ON tasks.id = attachments.task_id
+      WHERE attachments.task_id = ?
+        AND attachments.comment_id IS NULL
+        AND attachments.content_type LIKE 'image/%'
+        AND (
+          attachments.kind = 'attachment'
+          OR instr(tasks.description, 'api/attachments/' || attachments.id || '/content') > 0
+          OR EXISTS (
+            SELECT 1 FROM comments
+            WHERE comments.task_id = attachments.task_id
+              AND instr(comments.body, 'api/attachments/' || attachments.id || '/content') > 0
+          )
+        )
+      ORDER BY attachments.created_at, attachments.id
       LIMIT 1
     `).bind(task.id).first(),
   ]);

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -2424,11 +2424,22 @@ export class TaskboardDatabase {
       if (chunk.length === 0) continue;
       const placeholders = chunk.map(() => "?").join(", ");
       const rows = this.database.prepare(`
-        SELECT * FROM attachments
-        WHERE task_id IN (${placeholders})
-          AND comment_id IS NULL
-          AND content_type LIKE 'image/%'
-        ORDER BY task_id, created_at, id
+        SELECT attachments.*
+        FROM attachments
+        JOIN tasks ON tasks.id = attachments.task_id
+        WHERE attachments.task_id IN (${placeholders})
+          AND attachments.comment_id IS NULL
+          AND attachments.content_type LIKE 'image/%'
+          AND (
+            attachments.kind = 'attachment'
+            OR instr(tasks.description, 'api/attachments/' || attachments.id || '/content') > 0
+            OR EXISTS (
+              SELECT 1 FROM comments
+              WHERE comments.task_id = attachments.task_id
+                AND instr(comments.body, 'api/attachments/' || attachments.id || '/content') > 0
+            )
+          )
+        ORDER BY attachments.task_id, attachments.created_at, attachments.id
       `).all(...chunk);
       for (const row of rows) {
         if (!imagesByTask.has(row.task_id)) imagesByTask.set(row.task_id, attachmentFromRow(row));


### PR DESCRIPTION
## Summary
- exclude unreferenced task-level inline images from card preview candidates
- keep normal image attachments and inline images referenced by the task or a comment eligible
- apply the same selection rule to local and Cloud data paths

## Verification
- npm run build:web
- node --check server/database.mjs
- node --check cloud/src/index.mjs
- headed browser: orphan inline task has no card cover and no detail attachment
- headed browser: referenced inline image is loaded in the card and description, with no duplicate attachment row