### PR TITLE
LOCAL-259: Make date rows fully clickable

### DIFF
--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -1747,7 +1747,16 @@ export function TaskDetail({
                 }, "developmentContext")}
               />
             </div>
-            <label className="detail-property-row">
+            <label
+              className="detail-property-row detail-date-property-row"
+              onClick={(event) => {
+                const input = event.currentTarget.querySelector("input");
+                if (input && !input.disabled) {
+                  event.preventDefault();
+                  input.showPicker();
+                }
+              }}
+            >
               <span className="detail-property-icon" aria-hidden="true"><LinearIcon name="calendar" /></span>
               <span className="detail-property-label">{text("开始日期", "Start date")}</span>
               <input
@@ -1759,7 +1768,16 @@ export function TaskDetail({
                 }, "startDate")}
               />
             </label>
-            <label className="detail-property-row">
+            <label
+              className="detail-property-row detail-date-property-row"
+              onClick={(event) => {
+                const input = event.currentTarget.querySelector("input");
+                if (input && !input.disabled) {
+                  event.preventDefault();
+                  input.showPicker();
+                }
+              }}
+            >
               <span className="detail-property-icon" aria-hidden="true"><LinearIcon name="calendar" /></span>
               <span className="detail-property-label">{text("截止日期", "Due date")}</span>
               <input

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4460,6 +4460,15 @@ kbd {
   appearance: none;
 }
 
+.detail-date-property-row,
+.detail-date-property-row input {
+  cursor: pointer;
+}
+
+.detail-date-property-row input::-webkit-calendar-picker-indicator {
+  display: none;
+}
+
 .detail-property-picker {
   grid-column: 2;
   grid-row: 1;


### PR DESCRIPTION
## Summary
- Make the start-date and due-date property rows open the existing native date picker from any point in the row.
- Hide the duplicate native calendar indicator while keeping the existing left-side icon.
- Keep the existing date save and clear chain unchanged.

## Verification
- npm run typecheck
- npm run build:web
- Isolated real UI: clicked the left side of the start-date row and the far-right side of the due-date row; each opened the picker once.
- Selected and cleared both dates; all four PATCH requests returned 200 and the persisted values returned to null.
- Agent self-review: low complexity, no actionable findings.

No automated tests were added per task scope.