### PR TITLE
LOCAL-248: allow issue creation from all projects

### DIFF
--- a/test/issue-composer-wiring.test.mjs
+++ b/test/issue-composer-wiring.test.mjs
@@ -22,14 +22,14 @@ const editorSource = await readFile(
 test("all four issue composers request candidates with the owning project and surface", () => {
   assert.match(
     editorSource,
-    /completionContext=\{\{ projectId, surface: "issue-description" \}\}/,
+    /completionContext=\{projectId \? \{ projectId, surface: "issue-description" \} : undefined\}/,
   );
   assert.equal(
     detailSource.match(/surface: "issue-description"/g)?.length,
     1,
   );
   assert.equal(detailSource.match(/surface: "comment"/g)?.length, 2);
-  assert.match(appSource, /projectId=\{selectedProjectId\}/);
+  assert.match(appSource, /projectId=\{editorProjectId\}/);
 });
 
 test("task composer document converts only durable references and keeps slash and legacy syntax as text", () => {

--- a/test/project-home.test.mjs
+++ b/test/project-home.test.mjs
@@ -82,11 +82,11 @@ test("the issue composer includes Linear-style labels and scheduling", () => {
   assert.match(editorSource, /developmentScan\.contexts/);
 });
 
-test("the current project is shown only in navigation, not in issue creation or detail properties", () => {
-  assert.doesNotMatch(editorSource, /property-project|dialog-project-icon|project\?\.name/);
+test("issue creation selects a project only from all projects and keeps the current project otherwise", () => {
+  assert.match(editorSource, /\{!task && projectOptions && \([\s\S]*?ariaLabel=\{text\("项目", "Project"\)\}/);
   assert.doesNotMatch(detailSource, /detail-property-label">项目|project-property-icon|project\.name/);
-  assert.doesNotMatch(styles, /\.property-project|\.dialog-project-icon|\.project-property-icon/);
-  assert.match(appSource, /createTaskRequest\(selectedProjectId, draft\)/);
+  assert.match(appSource, /projectOptions=\{!editor\.task && isAllProjects \? createTargetProjects : undefined\}/);
+  assert.match(appSource, /const targetProjectId = editorProjectId \?\? selectedProjectId;[\s\S]*?createTaskRequest\(targetProjectId, draft\)/);
   assert.match(appSource, /className="header-project-switcher"/);
 });
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -177,6 +177,7 @@ const GanttView = lazy(() => import("./components/GanttView").then((module) => (
 interface EditorState {
   task: Task | null;
   status: TaskStatus;
+  projectId?: string | null;
 }
 
 interface ContextMenuState {
@@ -760,6 +761,7 @@ export function App() {
   const [editor, setEditor] = useState<EditorState | null>(null);
   const [newTaskDraft, setNewTaskDraft] = useState<{
     projectId: string;
+    targetProjectId: string | null;
     draft: NewTaskEditorDraft;
   } | null>(null);
   const [detailTaskIdentifier, setDetailTaskIdentifier] = useState<string | null>(
@@ -1094,6 +1096,16 @@ export function App() {
   }, [hostContext?.projects, projectCodexIdentities, projects, recentProjectIds, text]);
   const firstEmptyProjectId = projectChoices.find((project) => project.issueCount === 0)?.id ?? null;
   const hasProjectsWithIssues = projectChoices.some((project) => project.issueCount > 0);
+  const editorProjectId = editor?.task?.projectId
+    ?? editor?.projectId
+    ?? (newTaskDraft?.projectId === selectedProjectId ? newTaskDraft.targetProjectId : undefined)
+    ?? (isAllProjects ? null : selectedProjectId);
+  const createTargetProjects = projectChoices.flatMap((choice) => {
+    const project = projects.find((candidate) => candidate.id === choice.id);
+    return project && project.source !== "jira"
+      ? [{ id: choice.id, name: choice.name }]
+      : [];
+  });
   const closeContextMenu = useCallback(() => setContextMenu(null), []);
   const issueReadStorageKey = selectedProjectId
     ? `${ISSUE_READ_KEY_PREFIX}:${taskboardMetadata?.mode ?? "local"}:${selectedProjectId}`
@@ -2181,13 +2193,14 @@ export function App() {
     createOptions?: NewTaskCreateOptions,
   ) {
     if (!selectedProjectId || !editor) return;
+    const targetProjectId = editorProjectId ?? selectedProjectId;
     setActionError(null);
     const creating = editor.task === null;
     let saved: Task;
     try {
       saved = editor.task
         ? await updateTaskRequest(editor.task, draft)
-        : await createTaskRequest(selectedProjectId, draft);
+        : await createTaskRequest(targetProjectId, draft);
     } catch (error) {
       if (error instanceof ApiError && error.code === "VERSION_CONFLICT") {
         void refreshTasks(selectedProjectId, { quiet: true });
@@ -2196,7 +2209,7 @@ export function App() {
     }
     if (creating) {
       setProjects((current) => current.map((project) => (
-        project.id === selectedProjectId
+        project.id === targetProjectId
           ? { ...project, issueCount: project.issueCount + 1 }
           : project
       )));
@@ -3514,7 +3527,7 @@ export function App() {
                 <LinearIcon name="recurrence" />
               </button>
             )}
-            {selectedProject && !isJiraProject && boardView !== "workflow" && (
+            {selectedProjectId && !isJiraProject && boardView !== "workflow" && (
               <button
                 className="icon-button header-create-button"
                 type="button"
@@ -4117,22 +4130,30 @@ export function App() {
       {editor && (
         <TaskEditor
           key={editor.task?.id ?? `new-${selectedProjectId}-${editor.status}`}
-          projectId={selectedProjectId}
+          projectId={editorProjectId}
+          projectOptions={!editor.task && isAllProjects ? createTargetProjects : undefined}
+          onProjectChange={(projectId) => setEditor((current) => (
+            current ? { ...current, projectId } : current
+          ))}
           task={editor.task}
-          tasks={tasks.filter((task) => task.projectId === selectedProjectId)}
-          referenceTasks={referenceTasks.filter((task) => task.projectId === selectedProjectId)}
+          tasks={tasks.filter((task) => task.projectId === editorProjectId)}
+          referenceTasks={referenceTasks.filter((task) => task.projectId === editorProjectId)}
           initialStatus={editor.status}
           initialDraft={editor.task || newTaskDraft?.projectId !== selectedProjectId
             ? null
             : newTaskDraft.draft}
-          labels={availableLabels}
+          labels={projects.find((project) => project.id === editorProjectId)?.labels ?? []}
           currentUser={currentUser}
           developmentScan={developmentScan}
           developmentScanLoading={developmentScanLoading}
-          onCreateLabel={persistProjectLabel}
+          onCreateLabel={(label) => persistProjectLabel(label, editorProjectId ?? selectedProjectId)}
           onCancel={(draft) => {
             if (!editor.task) {
-              setNewTaskDraft(draft ? { projectId: selectedProjectId, draft } : null);
+              setNewTaskDraft(draft ? {
+                projectId: selectedProjectId,
+                targetProjectId: editorProjectId,
+                draft,
+              } : null);
             }
             setEditor(null);
           }}

--- a/web/src/components/TaskEditor.tsx
+++ b/web/src/components/TaskEditor.tsx
@@ -44,6 +44,7 @@ import {
   type PendingInlineImage,
 } from "./InlineMediaComposer";
 import { TaskPropertyPicker } from "./TaskPropertyPicker";
+import { TaskboardIcon } from "./TaskboardIcon";
 
 const RECURRENCE_UNITS: Record<TaskboardLanguage, Record<Recurrence["unit"], string>> = {
   zh: {
@@ -90,7 +91,9 @@ export interface NewTaskEditorDraft {
 }
 
 interface TaskEditorProps {
-  projectId: string;
+  projectId: string | null;
+  projectOptions?: Array<{ id: string; name: string }>;
+  onProjectChange?: (projectId: string | null) => void;
   task: Task | null;
   tasks: Task[];
   referenceTasks: Task[];
@@ -148,6 +151,8 @@ function contextLabel(
 
 export function TaskEditor({
   projectId,
+  projectOptions,
+  onProjectChange,
   task,
   tasks,
   referenceTasks,
@@ -186,7 +191,7 @@ export function TaskEditor({
   const [relatedIds, setRelatedIds] = useState<string[]>(initialDraft?.relations.relatedIds ?? []);
   const [subIssueIds, setSubIssueIds] = useState<string[]>(initialDraft?.relations.subIssueIds ?? []);
   const [createMore, setCreateMore] = useState(false);
-  const [menu, setMenu] = useState<"status" | "priority" | "assignee" | "labels" | "development" | "more" | "due" | "recurrence" | null>(null);
+  const [menu, setMenu] = useState<"project" | "status" | "priority" | "assignee" | "labels" | "development" | "more" | "due" | "recurrence" | null>(null);
   const [relationMenu, setRelationMenu] = useState<DraftRelationMenu | null>(null);
   const [moreMenuPosition, setMoreMenuPosition] = useState<{ right: number; bottom: number } | null>(null);
   const [expanded, setExpanded] = useState(false);
@@ -345,6 +350,10 @@ export function TaskEditor({
     if (!task) {
       if (!createSubmitIntentRef.current) return;
       createSubmitIntentRef.current = false;
+      if (projectOptions && !projectId) {
+        setError(["请选择项目。", "Select a project."]);
+        return;
+      }
     }
     const cleanTitle = title.trim();
     if (!cleanTitle) {
@@ -541,7 +550,7 @@ export function TaskEditor({
               segments={descriptionSegments}
               mentionTasks={tasks}
               referenceTasks={referenceTasks}
-              completionContext={{ projectId, surface: "issue-description" }}
+              completionContext={projectId ? { projectId, surface: "issue-description" } : undefined}
               placeholder={text("添加描述…", "Add description…")}
               ariaLabel={text("描述", "Description")}
               disabled={saving}
@@ -564,6 +573,28 @@ export function TaskEditor({
 
         <div className="task-form-dock">
           <div className="property-row">
+            {!task && projectOptions && (
+              <TaskPropertyPicker
+                value={projectId ?? ""}
+                options={[
+                  {
+                    value: "",
+                    label: text("项目", "Project"),
+                    icon: <TaskboardIcon name="projectFolder" />,
+                  },
+                  ...projectOptions.map((project) => ({
+                    value: project.id,
+                    label: project.name,
+                    icon: <TaskboardIcon name="projectFolder" />,
+                  })),
+                ]}
+                open={menu === "project"}
+                triggerClassName="property-control property-project"
+                ariaLabel={text("项目", "Project")}
+                onOpenChange={(open) => setMenu(open ? "project" : null)}
+                onChange={(value) => onProjectChange?.(value || null)}
+              />
+            )}
             <TaskPropertyPicker
               value={status}
               options={TASK_STATUSES.map((value) => ({


### PR DESCRIPTION
## Summary
- show the existing create issue entry in the All projects view
- add the existing project picker as the first create-modal property only in All projects
- submit the selected real projectId while preserving the concrete-project create flow

## Direct-path verification
- All projects -> Create issue -> first property is Project -> select Alpha -> POST /api/tasks used projectId alpha -> ALPHA-1 remained visible in All projects
- Alpha project -> Create issue -> first property remained Status with no Project field -> POST /api/tasks used projectId alpha -> ALPHA-2 appeared in Alpha
- npm run typecheck
- npm run build:web

No tests were added or run, per the current repository validation budget.