### PR TITLE
fix: keep task covers aligned with visible body images

### DIFF
--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -934,8 +934,7 @@ async function hydrateTask(env, row, activityComments = null, activityChanges = 
         AND attachments.comment_id IS NULL
         AND attachments.content_type LIKE 'image/%'
         AND (
-          attachments.kind = 'attachment'
-          OR instr(tasks.description, 'api/attachments/' || attachments.id || '/content') > 0
+          instr(tasks.description, 'api/attachments/' || attachments.id || '/content') > 0
           OR EXISTS (
             SELECT 1 FROM comments
             WHERE comments.task_id = attachments.task_id

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -2437,8 +2437,7 @@ export class TaskboardDatabase {
           AND attachments.comment_id IS NULL
           AND attachments.content_type LIKE 'image/%'
           AND (
-            attachments.kind = 'attachment'
-            OR instr(tasks.description, 'api/attachments/' || attachments.id || '/content') > 0
+            instr(tasks.description, 'api/attachments/' || attachments.id || '/content') > 0
             OR EXISTS (
               SELECT 1 FROM comments
               WHERE comments.task_id = attachments.task_id


### PR DESCRIPTION
## Summary

- Stop ordinary image attachments from becoming task-card covers when the body does not reference them.
- Keep task-level images referenced by the description or comments eligible in both SQLite and Cloud D1.

## Direct-path verification

- Formal LOCAL-165 data proved the old cover source was the ordinary attachment `local-165-permission-send.png`; its detail view exposed it only as a download row.
- With the same LOCAL-165 description and five ordinary attachments on the current source, `previewImage` is null, the card has no media, and all five attachments remain visible in detail.
- A task-level inline image referenced by Markdown remains the preview; the card and detail image load at 634×150, and the ordinary attachment section stays absent.

## Focused checks

- `node --check server/database.mjs`
- `node --check cloud/src/index.mjs`
- `npm run build:web`
- `npm run typecheck`
- `git diff --check`