### PR TITLE
Fix IME caret placement after inline images

### DIFF
--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -1424,7 +1424,7 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
         if (segment.type !== "text" && offset <= current) {
           return { node: root, offset: Math.max(childIndex, 0) };
         }
-        if (segment.type !== "text" && offset <= current + length) {
+        if (segment.type !== "text" && offset < current + length) {
           return { node: root, offset: Math.max(childIndex + 1, 0) };
         }
         current += length;


### PR DESCRIPTION
Summary
- Keep a collapsed caret at the following text segment when it lands exactly on an inline image right boundary.
- Fix the shared InlineMediaComposer path used by new comments, edited comments, issue descriptions, and new-issue descriptions.
- Audit LOCAL-261 image sizing without adding a speculative CSS change: pending and persisted images share the same renderer and style, and the formal app kept a 6000 x 900 PNG within the composer.

Direct verification
- Formal installed app before the change: after pasting an image first, selection was the composer root at offset 2 with three children.
- Source preview after the change: the same path selected the trailing inline-media-text span at offset 0.
- Shared issue-description path also selected the trailing inline-media-text span at offset 0.
- LOCAL-261: 6000 x 900 PNG loaded at 6000 x 900 and rendered within the comment composer; clientWidth equaled scrollWidth. No overflow was reproduced.
- npm run typecheck
- npm run build:web -- --configLoader runner
- git diff --check

Scope
- One comparison operator changed in InlineMediaComposer.tsx.
- No tests, guardrails, compatibility layer, style sweep, or unrelated refactor.
- The in-app browser key interface does not enter the macOS IME. The original macOS failure screenshot and the real before/after DOM selection path are the direct evidence; no synthetic composition event was used.