### PR TITLE
Fix task property icon and picker behavior

### DIFF
--- a/web/src/components/BoardColumn.tsx
+++ b/web/src/components/BoardColumn.tsx
@@ -155,7 +155,7 @@ export function BoardColumn({
       <header className="column-header">
         <div className="column-heading">
           <span className={`column-status-icon status-icon-${details.tone}`}>
-            <StatusIcon status={status} size={14} />
+            <StatusIcon status={status} color="var(--column-status-color)" size={14} />
           </span>
           <h2 id={`column-${status}`}>
             {label}{tasks.length > 0 && (

--- a/web/src/components/BoardColumn.tsx
+++ b/web/src/components/BoardColumn.tsx
@@ -19,13 +19,6 @@ export const STATUS_DETAILS: Record<
   canceled: { label: "取消", tone: "canceled" },
 };
 
-const COLUMN_ADD_COLORS: Partial<Record<TaskStatus, string>> = {
-  todo: "var(--status-todo)",
-  in_progress: "var(--status-progress)",
-  in_review: "var(--status-review)",
-  blocked: "var(--status-blocked)",
-};
-
 interface BoardColumnProps {
   scrollRef: (element: HTMLDivElement | null) => void;
   status: TaskStatus;
@@ -172,7 +165,7 @@ export function BoardColumn({
               aria-label={text(`在${label}中新建议题`, `Create issue in ${label}`)}
               title={text(`添加到${label}`, `Add to ${label}`)}
             >
-              <PlusIcon color={COLUMN_ADD_COLORS[status] ?? "var(--text-quaternary)"} size={12} />
+              <PlusIcon color="var(--column-status-color)" size={12} />
             </button>
           </div>
         )}

--- a/web/src/components/GanttView.tsx
+++ b/web/src/components/GanttView.tsx
@@ -5,7 +5,7 @@ import type { Task, TaskDraft } from "../types";
 import type { TaskCardPresentation } from "../taskConversations";
 import { useTaskboardI18n } from "../i18n";
 import { LinearIcon } from "./LinearIcon";
-import { StartDateIcon } from "./SemanticIcons";
+import { DueDateIcon } from "./SemanticIcons";
 import { taskboardIconSource } from "./TaskboardIcon";
 
 type GanttZoom = "day" | "week" | "month";
@@ -518,7 +518,7 @@ export function GanttView({ tasks, presentations, hasActiveFilters, zoom, hideCo
         </button>
         {!visibleTasks.length && (
           <div className="gantt-empty-overlay">
-            <StartDateIcon color="currentColor" />
+            <DueDateIcon color="currentColor" />
             <span>{hasActiveFilters || hideCompleted
               ? text("当前条件下没有议题", "No issues match the current conditions")
               : text("创建议题后，可在这里安排时间线", "Create an issue to schedule it on the timeline")}</span>

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -975,7 +975,7 @@ function IssueReferenceChip({
       <span className="issue-reference-identity">
         {task && (
           <span className={`status-icon issue-reference-status status-icon-${STATUS_DETAILS[task.status].tone}`}>
-            <StatusIcon status={task.status} size={15} />
+            <StatusIcon status={task.status} color="var(--column-status-color)" size={15} />
           </span>
         )}
         <span className="issue-reference-id">{displayIdentifier}</span>

--- a/web/src/components/IssueListView.tsx
+++ b/web/src/components/IssueListView.tsx
@@ -70,7 +70,7 @@ export function IssueListView({
             <section className={`issue-list-group status-${status}`} key={status}>
               <button className="issue-list-group-header" type="button" onClick={() => toggleStatus(status)} aria-expanded={!isCollapsed}>
                 <LinearIcon name={isCollapsed ? "chevronRight" : "chevronDown"} />
-                <span className="issue-list-status-icon"><StatusIcon status={status} size={14} /></span>
+                <span className="issue-list-status-icon"><StatusIcon status={status} color="currentColor" size={14} /></span>
                 <strong>{statusLabel}</strong>
                 <span>{statusTasks.length}</span>
               </button>

--- a/web/src/components/SemanticIcons.tsx
+++ b/web/src/components/SemanticIcons.tsx
@@ -1,5 +1,4 @@
 import type { CSSProperties, HTMLAttributes, ReactNode, SVGProps } from "react";
-import calendarSource from "../assets/figma-taskboard/calendar.svg";
 import conversationSource from "../assets/figma-taskboard/conversation.svg";
 import prioritySource from "../assets/figma-taskboard/priority.svg";
 import priorityHighSource from "../assets/figma-taskboard/priority-high.svg";
@@ -207,10 +206,6 @@ export function BlockingRelationIcon({ type, ...props }: Omit<MaskIconProps, "so
   type: "blocked_by" | "blocks";
 }) {
   return <MaskIcon {...props} source={type === "blocked_by" ? relationBlockedBySource : relationBlocksSource} />;
-}
-
-export function StartDateIcon(props: Omit<MaskIconProps, "source">) {
-  return <MaskIcon {...props} source={calendarSource} />;
 }
 
 export function DueDateIcon(props: BasicIconProps) {

--- a/web/src/components/TaskContextMenu.tsx
+++ b/web/src/components/TaskContextMenu.tsx
@@ -183,7 +183,8 @@ export function TaskContextMenu({
     function closeFromOutside(event: PointerEvent) {
       if (!menuRef.current?.contains(event.target as Node)) onClose();
     }
-    function closeFromViewportChange() {
+    function closeFromViewportChange(event: Event) {
+      if (event.type === "scroll" && menuRef.current?.contains(event.target as Node)) return;
       onClose();
     }
 

--- a/web/src/components/TaskContextMenu.tsx
+++ b/web/src/components/TaskContextMenu.tsx
@@ -272,7 +272,7 @@ export function TaskContextMenu({
       <div className="context-menu-group">
         <MenuItem
           label={text("状态", "Status")}
-          icon={<StatusIcon status={task.status} />}
+          icon={<StatusIcon status={task.status} color="currentColor" />}
           shortcut="S"
           submenu="status"
           submenuOpen={submenu === "status"}
@@ -286,7 +286,7 @@ export function TaskContextMenu({
                 <MenuItem
                   key={status}
                   label={taskStatusLabel(language, status)}
-                  icon={<StatusIcon status={status} />}
+                  icon={<StatusIcon status={status} color="currentColor" />}
                   shortcut={String(index + 1)}
                   checked={task.status === status}
                   onClick={() => closeThen(() => onStatusChange(task, status))}

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -67,7 +67,6 @@ import {
   ProjectIcon,
   RecurrenceIcon,
   RelationIcon,
-  StartDateIcon,
   StatusIcon,
 } from "./SemanticIcons";
 import {
@@ -331,7 +330,7 @@ function ActivityChangeIcon({ field, before, after }: {
   if (field === "labels") return <LabelIcon color="currentColor" size={14} />;
   if (field === "assignee") return <LinearIcon name="myIssues" />;
   if (field === "developmentContext") return <BranchIcon color="currentColor" size={14} />;
-  if (field === "startDate") return <StartDateIcon color="currentColor" size={14} />;
+  if (field === "startDate") return <DueDateIcon color="currentColor" size={14} />;
   if (field === "dueDate") return <DueDateIcon color="currentColor" size={14} />;
   if (field === "recurrence") return <RecurrenceIcon color="currentColor" size={14} />;
   if (field === "archivedAt") return <DeleteIcon color="currentColor" size={14} />;
@@ -1657,8 +1656,7 @@ export function TaskDetail({
                 options={TASK_STATUSES.map((status) => ({
                   value: status,
                   label: taskStatusLabel(language, status),
-                  icon: <StatusIcon status={status} size={14} />,
-                  className: `status-icon-${STATUS_DETAILS[status].tone}`,
+                  icon: <StatusIcon status={status} color="currentColor" size={14} />,
                 }))}
                 open={propertyMenu === "status"}
                 disabled={savingProperty === "status"}
@@ -1786,7 +1784,7 @@ export function TaskDetail({
                 }
               }}
             >
-              <span className="detail-property-icon" aria-hidden="true"><StartDateIcon color="currentColor" size={14} /></span>
+              <span className="detail-property-icon" aria-hidden="true"><DueDateIcon color="currentColor" size={14} /></span>
               <span className="detail-property-label">{text("开始日期", "Start date")}</span>
               <input
                 type="date"

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -408,7 +408,7 @@ function DescriptionDocument({
           <span className={`issue-reference-inline issue-reference-status-${task.status}`}>
             <span className="issue-reference-identity">
               <span className={`status-icon issue-reference-status status-icon-${STATUS_DETAILS[task.status].tone}`}>
-                <StatusIcon status={task.status} size={15} />
+                <StatusIcon status={task.status} color="var(--column-status-color)" size={15} />
               </span>
               <span className="issue-reference-id">{task.externalKey ?? task.identifier}</span>
             </span>

--- a/web/src/components/TaskEditor.tsx
+++ b/web/src/components/TaskEditor.tsx
@@ -25,7 +25,6 @@ import {
   assigneeTargetForActor,
 } from "../actors";
 import { ActorAvatar } from "./ActorAvatar";
-import { STATUS_DETAILS } from "./BoardColumn";
 import { LabelPicker } from "./LabelPicker";
 import { IssuePickerContent } from "./IssueRelations";
 import { LinearIcon } from "./LinearIcon";
@@ -611,8 +610,7 @@ export function TaskEditor({
               options={TASK_STATUSES.map((value) => ({
                 value,
                 label: taskStatusLabel(language, value),
-                icon: <StatusIcon status={value} size={14} />,
-                className: `status-icon-${STATUS_DETAILS[value].tone}`,
+                icon: <StatusIcon status={value} color="currentColor" size={14} />,
               }))}
               open={menu === "status"}
               triggerClassName="property-control property-status"

--- a/web/src/components/TaskFilterMenu.tsx
+++ b/web/src/components/TaskFilterMenu.tsx
@@ -149,7 +149,7 @@ export function TaskFilterMenu({ tasks, search, labels, filters, onChange }: Tas
     keywords: status,
     count: countFor("statuses", (task) => task.status === status),
     selected: filters.statuses.includes(status),
-    icon: <span className={`filter-status-icon status-${status}`}><StatusIcon status={status} /></span>,
+    icon: <span className="filter-status-icon"><StatusIcon status={status} color="currentColor" /></span>,
     toggle: () => toggleStatus(status),
   })), [filters, language, search, tasks, text]);
 

--- a/web/src/components/TaskPropertyPicker.tsx
+++ b/web/src/components/TaskPropertyPicker.tsx
@@ -87,6 +87,7 @@ export function TaskPropertyPicker<Value extends string>({
   }
 
   function closeFromFocusLeave(event: FocusEvent<HTMLElement>) {
+    if (menuRef.current?.matches(":active")) return;
     const next = event.relatedTarget as Node | null;
     if (!next || (!rootRef.current?.contains(next) && !menuRef.current?.contains(next))) {
       onOpenChange(false);
@@ -135,7 +136,8 @@ export function TaskPropertyPicker<Value extends string>({
       triggerRef.current?.focus();
     }
 
-    function closeFromViewportChange() {
+    function closeFromViewportChange(event: Event) {
+      if (event.type === "scroll" && menuRef.current?.contains(event.target as Node)) return;
       onOpenChange(false);
     }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -29,8 +29,8 @@
   --success: #43bc58;
   --priority-urgent: #ff7236;
   --priority-high: #ff7236;
-  --priority-medium: var(--warning);
-  --priority-low: var(--accent);
+  --priority-medium: var(--text-tertiary);
+  --priority-low: var(--text-tertiary);
   --priority-none: var(--text-tertiary);
   --status-backlog: #9e9ea1;
   --status-todo: #9e9ea1;
@@ -1709,11 +1709,6 @@ kbd {
   color: var(--text-tertiary);
 }
 
-.filter-status-icon.status-in_progress { color: var(--status-progress); }
-.filter-status-icon.status-in_review { color: var(--status-review); }
-.filter-status-icon.status-blocked { color: var(--status-blocked); }
-.filter-status-icon.status-done { color: var(--status-done); }
-.filter-status-icon.status-canceled { color: var(--status-canceled); }
 .filter-status-icon svg { width: 15px; height: 15px; }
 
 .filter-label-glyph {
@@ -4402,7 +4397,7 @@ kbd {
   place-items: center;
   width: 16px;
   height: 16px;
-  color: var(--text-tertiary);
+  color: var(--text-secondary);
   grid-column: 2;
   grid-row: 1;
   justify-self: start;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4469,6 +4469,13 @@ kbd {
   display: none;
 }
 
+.detail-date-property-row input:focus::-webkit-datetime-edit-year-field,
+.detail-date-property-row input:focus::-webkit-datetime-edit-month-field,
+.detail-date-property-row input:focus::-webkit-datetime-edit-day-field {
+  background-color: transparent;
+  color: inherit;
+}
+
 .detail-property-picker {
   grid-column: 2;
   grid-row: 1;


### PR DESCRIPTION
## Summary
- correct board status icon colors and keep task status selectors/list headers neutral
- use the shared due-date icon for both start and due dates, and remove Chromium date-field focus highlighting
- keep branch/worktree property menus open during internal wheel and scrollbar scrolling

## Direct-path verification
- headed Chrome: exact board column colors, neutral create/detail/list status icons, identical start/due glyphs
- native date picker: focused internal year/month/day backgrounds are transparent; keyboard selection PATCH saved 2026-08-23; keyboard clear PATCH saved dueDate=null and recurrence=null
- create/detail development menus: wheel and real scrollbar drag retained the menu; selection closed it and POST/PATCH saved the exact worktree path and branch
- npm run typecheck
- npm run build:web
- git diff --check

Taskboard: LOCAL-165, LOCAL-259, LOCAL-263