### PR TITLE
Fix all-project temporary task creation

### DIFF
--- a/test/project-home.test.mjs
+++ b/test/project-home.test.mjs
@@ -16,7 +16,7 @@ test("the project switcher merges live Codex projects with persisted Taskboard p
   assert.match(appSource, /persistedById/);
   assert.match(appSource, /name: project\.id === GLOBAL_PROJECT_ID\s*\? text\("临时任务", "Temporary tasks"\)\s*: persistedById\.get\(project\.id\)\?\.name \?\? project\.name/);
   assert.match(appSource, /for \(const project of projects\) \{[\s\S]*?inCodex: false,[\s\S]*?persisted: true/);
-  assert.match(appSource, /projectChoices\.map\(\(project\) => \(/);
+  assert.match(appSource, /projectMenuChoices\.map\(\(project\) => \(/);
   assert.match(appSource, /createProjectRequest/);
   assert.match(apiSource, /export async function createProject/);
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1090,12 +1090,15 @@ export function App() {
       ...sortedChoices.filter((project) => project.issueCount === 0),
     ];
   }, [hostContext?.projects, projectCodexIdentities, projects, recentProjectIds, text]);
-  const firstEmptyProjectId = projectChoices.find((project) => project.issueCount === 0)?.id ?? null;
-  const hasProjectsWithIssues = projectChoices.some((project) => project.issueCount > 0);
+  const projectMenuChoices = projectChoices.filter(
+    (project) => project.id !== GLOBAL_PROJECT_ID || project.issueCount > 0,
+  );
+  const firstEmptyProjectId = projectMenuChoices.find((project) => project.issueCount === 0)?.id ?? null;
+  const hasProjectsWithIssues = projectMenuChoices.some((project) => project.issueCount > 0);
   const editorProjectId = editor?.task?.projectId
     ?? editor?.projectId
     ?? (newTaskDraft?.projectId === selectedProjectId ? newTaskDraft.targetProjectId : undefined)
-    ?? (isAllProjects ? null : selectedProjectId);
+    ?? (isAllProjects ? GLOBAL_PROJECT_ID : selectedProjectId);
   const createTargetProjects = projectChoices.flatMap((choice) => {
     const project = projects.find((candidate) => candidate.id === choice.id);
     return project && project.source !== "jira"
@@ -2028,7 +2031,6 @@ export function App() {
         && !event.metaKey
         && !event.ctrlKey
         && selectedProjectId
-        && !isAllProjects
         && !isJiraProject
       ) {
         event.preventDefault();
@@ -2050,7 +2052,7 @@ export function App() {
 
     window.addEventListener("keydown", handleShortcut);
     return () => window.removeEventListener("keydown", handleShortcut);
-  }, [boardView, contextMenu, detailTaskId, editor, isAllProjects, isJiraProject, projectMenuOpen, selectedProjectId]);
+  }, [boardView, contextMenu, detailTaskId, editor, isJiraProject, projectMenuOpen, selectedProjectId]);
 
   const filteredTasks = useMemo(() => {
     return tasks.filter(
@@ -3419,7 +3421,7 @@ export function App() {
                       {isAllProjects && <span className="project-menu-check" aria-hidden="true"><LinearIcon name="check" /></span>}
                     </button>
                     <div className="project-menu-divider" role="separator" />
-                    {projectChoices.map((project) => (
+                    {projectMenuChoices.map((project) => (
                       <Fragment key={project.id}>
                         {hasProjectsWithIssues && project.id === firstEmptyProjectId && (
                           <div className="project-menu-divider" role="separator" />


### PR DESCRIPTION
## Summary
- default All projects issue creation to Temporary tasks
- hide Temporary tasks from the header project menu while it has no active issues
- restore the C create shortcut in All projects

## Direct verification
- isolated headed Chromium: empty Temporary tasks was absent from the header menu
- pressing C opened the issue editor with Temporary tasks selected
- creating the issue produced LOCAL-1 in All projects
- reopening the header menu showed Temporary tasks after its issue count became 1
- the header create button also opened the editor with Temporary tasks selected
- npm run typecheck
- npm run build:web
- node --test test/project-home.test.mjs: 13/13 passed after aligning one existing source assertion exposed by CI

No new tests, guardrails, compatibility layers, or unrelated refactors were added.