### PR TITLE
fix: 仅用正文图片作为任务封面

### DIFF
--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -933,14 +933,7 @@ async function hydrateTask(env, row, activityComments = null, activityChanges = 
       WHERE attachments.task_id = ?
         AND attachments.comment_id IS NULL
         AND attachments.content_type LIKE 'image/%'
-        AND (
-          instr(tasks.description, 'api/attachments/' || attachments.id || '/content') > 0
-          OR EXISTS (
-            SELECT 1 FROM comments
-            WHERE comments.task_id = attachments.task_id
-              AND instr(comments.body, 'api/attachments/' || attachments.id || '/content') > 0
-          )
-        )
+        AND instr(tasks.description, 'api/attachments/' || attachments.id || '/content') > 0
       ORDER BY attachments.created_at, attachments.id
       LIMIT 1
     `).bind(task.id).first(),

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -2436,14 +2436,7 @@ export class TaskboardDatabase {
         WHERE attachments.task_id IN (${placeholders})
           AND attachments.comment_id IS NULL
           AND attachments.content_type LIKE 'image/%'
-          AND (
-            instr(tasks.description, 'api/attachments/' || attachments.id || '/content') > 0
-            OR EXISTS (
-              SELECT 1 FROM comments
-              WHERE comments.task_id = attachments.task_id
-                AND instr(comments.body, 'api/attachments/' || attachments.id || '/content') > 0
-            )
-          )
+          AND instr(tasks.description, 'api/attachments/' || attachments.id || '/content') > 0
         ORDER BY attachments.task_id, attachments.created_at, attachments.id
       `).all(...chunk);
       for (const row of rows) {


### PR DESCRIPTION
## 摘要
- `previewImage` 只从任务正文实际引用的 task-owned 图片产生
- 排除评论正文引用的图片
- SQLite 与 Cloud D1 使用同义查询

## 正式路径验证
- LOCAL-165：普通未引用附件，卡片 media=0
- LOCAL-258：孤立 task inline，卡片 media=0
- LOCAL-253：评论引用 task inline，卡片 media=0；评论图片仍完整加载
- LOCAL-219：正文引用图片，卡片 media=1，naturalWidth=1482

## 本地检查
- `node --check server/database.mjs`
- `node --check cloud/src/index.mjs`
- `npm run build:web`

未新增测试、护栏、兼容层或数据清理。