### PR TITLE
Fix inline media cut and issue mention relations

### DIFF
--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -698,10 +698,18 @@ function inlineMediaClipboardHtml(
       wrapper.append(markdown);
       continue;
     }
-    const pendingImage = ownerDocument.createElement("span");
-    pendingImage.dataset.taskboardInlineMediaPendingImage = segment.id;
-    pendingImage.textContent = segment.file.name;
-    wrapper.append(pendingImage);
+    if (segment.dataUrl) {
+      const pendingImage = ownerDocument.createElement("img");
+      pendingImage.dataset.taskboardInlineMediaPendingImage = segment.id;
+      pendingImage.src = segment.dataUrl;
+      pendingImage.alt = segment.file.name;
+      wrapper.append(pendingImage);
+    } else {
+      const pendingImage = ownerDocument.createElement("span");
+      pendingImage.dataset.taskboardInlineMediaPendingImage = segment.id;
+      pendingImage.textContent = segment.file.name;
+      wrapper.append(pendingImage);
+    }
   }
 
   return wrapper.outerHTML;
@@ -1159,7 +1167,7 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
             element.textContent = segment.text;
             if (segment.text.endsWith("\n")) element.append(document.createElement("br"));
           } else {
-            element.append(document.createElement("br"));
+            element.append(document.createTextNode(""), document.createElement("br"));
           }
         } else {
           element.className = isInlineReference(segment)
@@ -1770,6 +1778,29 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       applyRangeReplacement(start, end, insertion);
     }
 
+    function copyContent(event: ClipboardEvent<HTMLDivElement>): {
+      range: { start: number; end: number };
+      segments: InlineMediaSegment[];
+    } | null {
+      const selection = event.currentTarget.ownerDocument.getSelection();
+      if (!selection || selection.rangeCount === 0) return null;
+      const selectedRange = selection.getRangeAt(0);
+      if (
+        !event.currentTarget.contains(selectedRange.startContainer)
+        || !event.currentTarget.contains(selectedRange.endContainer)
+      ) return null;
+      const range = currentLogicalRange();
+      if (!range || range.start === range.end) return null;
+      const copiedSegments = inlineMediaRangeSegments(segments, range.start, range.end);
+      event.preventDefault();
+      writeInlineMediaClipboard(
+        event.clipboardData,
+        copiedSegments,
+        event.currentTarget.ownerDocument,
+      );
+      return { range, segments: copiedSegments };
+    }
+
     function pasteContent(event: ClipboardEvent<HTMLDivElement>) {
       const range = currentLogicalRange();
       if (!range) return;
@@ -1963,23 +1994,23 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
           onDragOver={dragContent}
           onDrop={dropContent}
           onPaste={pasteContent}
-          onCopy={(event) => {
-            const selection = event.currentTarget.ownerDocument.getSelection();
-            if (!selection || selection.rangeCount === 0) return;
-            const selectedRange = selection.getRangeAt(0);
-            if (
-              !event.currentTarget.contains(selectedRange.startContainer)
-              || !event.currentTarget.contains(selectedRange.endContainer)
-            ) return;
-            const range = currentLogicalRange();
-            if (!range || range.start === range.end) return;
-            const copiedSegments = inlineMediaRangeSegments(segments, range.start, range.end);
-            event.preventDefault();
-            writeInlineMediaClipboard(
-              event.clipboardData,
-              copiedSegments,
-              event.currentTarget.ownerDocument,
-            );
+          onCopy={copyContent}
+          onCut={(event) => {
+            const copied = copyContent(event);
+            if (!copied) return;
+            const image = copied.segments.find((segment): segment is InlineImageSegment => (
+              segment.type === "pending-image" && segment.file.type === "image/png"
+            ));
+            if (image) {
+              const plainText = event.clipboardData.getData("text/plain");
+              const html = event.clipboardData.getData("text/html");
+              void navigator.clipboard.write([new ClipboardItem({
+                "image/png": image.file,
+                "text/html": new Blob([html], { type: "text/html" }),
+                "text/plain": new Blob([plainText], { type: "text/plain" }),
+              })]);
+            }
+            applyRangeReplacement(copied.range.start, copied.range.end, [], false);
           }}
           onKeyUp={(event) => {
             if (event.key !== "Escape") updateCompletionFromSelection();

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -686,6 +686,29 @@ export function TaskDetail({
     }
   }
 
+  async function addMentionRelations(
+    anchor: Task,
+    segments: InlineMediaSegment[],
+  ): Promise<Task> {
+    let current = anchor;
+    const relatedIds = new Set(current.relations.related.map((relation) => relation.id));
+    for (const segment of segments) {
+      if (segment.type !== "issue-reference" || !segment.taskId) continue;
+      const relatedTaskId = segment.taskId;
+      if (
+        relatedTaskId === current.id
+        || segment.projectId !== current.projectId
+        || relatedIds.has(relatedTaskId)
+      ) continue;
+      const result = await applyRelationMutation(
+        () => onAddRelation(current, "related", relatedTaskId),
+      );
+      current = result.task;
+      relatedIds.add(relatedTaskId);
+    }
+    return current;
+  }
+
   function handleTitleKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
     if (event.key === "Enter" && !event.shiftKey) {
       event.preventDefault();
@@ -736,9 +759,10 @@ export function TaskDetail({
         return null;
       });
       if (!saved) return;
-      setCurrentTask(saved);
-      setDescription(saved.description);
-      setDescriptionSegments(createInlineMediaSegments(saved.description, referenceTasks));
+      const savedWithRelations = await addMentionRelations(saved, descriptionSegments);
+      setCurrentTask(savedWithRelations);
+      setDescription(savedWithRelations.description);
+      setDescriptionSegments(createInlineMediaSegments(savedWithRelations.description, referenceTasks));
       setAttachments((current) => [
         ...current,
         ...uploaded.filter((attachment) => !current.some((item) => item.id === attachment.id)),
@@ -777,11 +801,15 @@ export function TaskDetail({
       setCommentSegments(createInlineMediaSegments());
       setPendingCommentFiles([]);
       if (commentAttachmentInputRef.current) commentAttachmentInputRef.current.value = "";
+      let relationAnchor = currentTask;
       if (changeStatusToTodo) {
         const saved = await onUpdate(currentTask, { status: "todo" });
         setCurrentTask(saved);
+        relationAnchor = saved;
         setChangeStatusToTodo(false);
       }
+      const savedWithRelations = await addMentionRelations(relationAnchor, commentSegments);
+      setCurrentTask(savedWithRelations);
       const failed = results.length - uploaded.length;
       if (failed > 0) setCommentsError([
         `评论已发布，但有 ${failed} 个附件上传失败。`,
@@ -856,6 +884,8 @@ export function TaskDetail({
         resolveInlineMediaMarkdown(body, editingInlineImages, uploaded).trim(),
       );
       setComments((current) => current.map((item) => item.id === updated.id ? updated : item));
+      const savedWithRelations = await addMentionRelations(currentTask, editingSegments);
+      setCurrentTask(savedWithRelations);
       endCommentEdit();
     } catch (error) {
       setCommentsError(messageFor(error));


### PR DESCRIPTION
## Summary
- preserve text, issue references, and pending PNG images across cut and paste, including external macOS apps
- give the empty text segment after an image a real IME editing host
- add related issue relations after saving mentions in descriptions, new comments, and edited comments

## Product semantics
Removing a mention does not remove an existing related relation. The relation model has no source provenance, so it may also come from another comment or a manual relation.

## Direct verification
- real Chrome plus macOS system clipboard: add comment, edit comment, and edit description; Cmd+A and mouse-drag cut/paste
- real TextEdit paste: text, issue reference, and image are present
- real Safari plus WeType Pinyin: image followed by physical n, i, Space commits 你 without a stray Latin letter
- real Taskboard UI: description, new-comment, and edit-comment mentions add related items; deleting a mention retains the relation
- npm run typecheck
- npm run build:web
- git diff --check

No regression tests were added or run, per repository delivery order.