### PR TITLE
fix: 任务封面只使用正文图片

### DIFF
--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import { unified } from "unified";
-import { attachmentContentUrl, resolvePersistedAttachmentUrl } from "../api";
+import { resolvePersistedAttachmentUrl } from "../api";
 import {
   TASK_PRIORITIES,
   type ActorIdentity,
@@ -109,8 +109,7 @@ function firstTaskImage(task: Task) {
     /!\[[^\]]*\]\((?:<([^>]+)>|([^\s)]+))(?:\s+["'][^)]*["'])?\)/,
   );
   const source = markdownImage?.[1]
-    ?? markdownImage?.[2]
-    ?? (task.previewImage ? attachmentContentUrl(task.previewImage) : null);
+    ?? markdownImage?.[2];
   return source ? resolvePersistedAttachmentUrl(source) : null;
 }
 


### PR DESCRIPTION
## 结果

- 任务卡片封面只从任务正文的 Markdown 图片产生。
- 不再回退到服务端 `previewImage`。
- SQLite 与 Cloud D1 保持现有相同的正文限定查询。

## 根因

当前正式安装版 1.1.2 仍会向任务列表返回普通附件、孤立 inline 和评论引用图片作为 `previewImage`。最新前端继续信任该字段，因此正文没有图片的卡片仍会显示封面。

## 直接验证

最新前端连接当前正式 Taskboard 运行时和正式数据：

- LOCAL-165：0 个封面媒体。
- LOCAL-253：0 个封面媒体。
- LOCAL-258：0 个封面媒体。
- LOCAL-264：1 个正文封面，图片完成加载，尺寸为 1070 × 1076。
- `npm run build:web` 通过。

按要求没有新增测试、护栏、兼容层或无关改动。