### PR TITLE
Fix temporary project visibility and Project Docs labels

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1742,10 +1742,11 @@ export function App() {
       current?.operation === "initial" ? { ...current, requestId } : current
     ));
     try {
-      const [nextProjects, metadata, workspaces] = await Promise.all([
+      const [nextProjects, metadata, workspaces, nextTemporaryTasks] = await Promise.all([
         listProjects(signal),
         getTaskboardMetadata(signal),
         listDeviceWorkspaces(signal),
+        listTasks(GLOBAL_PROJECT_ID, signal),
       ]);
       if (requestId !== projectsRequestRef.current) return;
       const nextJiraConnection = await getJiraConnection(signal);
@@ -1769,7 +1770,14 @@ export function App() {
         taskboardStorage.setItem(DEVICE_WORKSPACE_PATHS_KEY, JSON.stringify(next));
         return next;
       });
-      setProjects(nextProjects);
+      setProjects(nextProjects.map((project) => project.id === GLOBAL_PROJECT_ID
+        ? {
+            ...project,
+            issueCount: nextTemporaryTasks.filter((task) => (
+              MAIN_STATUSES.some((status) => status === task.status)
+            )).length,
+          }
+        : project));
       setJiraConnection(nextJiraConnection);
       setSelectedProjectId((current) => {
         const fromQuery = new URLSearchParams(window.location.search).get("project");
@@ -1808,9 +1816,19 @@ export function App() {
       current?.operation === "refresh" ? { ...current, requestId } : current
     ));
     try {
-      const nextProjects = await listProjects();
+      const [nextProjects, nextTemporaryTasks] = await Promise.all([
+        listProjects(),
+        listTasks(GLOBAL_PROJECT_ID),
+      ]);
       if (requestId !== projectsRequestRef.current) return;
-      setProjects(nextProjects);
+      setProjects(nextProjects.map((project) => project.id === GLOBAL_PROJECT_ID
+        ? {
+            ...project,
+            issueCount: nextTemporaryTasks.filter((task) => (
+              MAIN_STATUSES.some((status) => status === task.status)
+            )).length,
+          }
+        : project));
       setProjectLoadError((current) => (
         current?.operation === "refresh" && current.requestId === requestId ? null : current
       ));
@@ -3561,7 +3579,7 @@ export function App() {
                 aria-pressed={boardView === "readme"}
                 onClick={() => selectBoardView("readme")}
               >
-                Readme
+                {text("项目文档", "Project Docs")}
               </button>
             )}
           </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1742,14 +1742,16 @@ export function App() {
       current?.operation === "initial" ? { ...current, requestId } : current
     ));
     try {
-      const [nextProjects, metadata, workspaces, nextTemporaryTasks] = await Promise.all([
+      const [nextProjects, metadata, workspaces] = await Promise.all([
         listProjects(signal),
         getTaskboardMetadata(signal),
         listDeviceWorkspaces(signal),
-        listTasks(GLOBAL_PROJECT_ID, signal),
       ]);
       if (requestId !== projectsRequestRef.current) return;
-      const nextJiraConnection = await getJiraConnection(signal);
+      const [nextJiraConnection, nextTemporaryTasks] = await Promise.all([
+        getJiraConnection(signal),
+        listTasks(GLOBAL_PROJECT_ID, signal),
+      ]);
       if (requestId !== projectsRequestRef.current) return;
       setTaskboardMetadata((current) => (
         current

--- a/web/src/components/ProjectReadmeView.tsx
+++ b/web/src/components/ProjectReadmeView.tsx
@@ -93,8 +93,8 @@ export function ProjectReadmeView({
       if (err instanceof ApiError && err.code === "VERSION_CONFLICT") {
         setSaveError(
           text(
-            "项目说明已被其他协作者或 Agent 更新，请刷新后重试。",
-            "Project README was modified elsewhere. Please refresh and try again.",
+            "项目文档已被其他协作者或 Agent 更新，请刷新后重试。",
+            "Project Docs were modified elsewhere. Please refresh and try again.",
           ),
         );
       } else {
@@ -113,7 +113,7 @@ export function ProjectReadmeView({
     return (
       <div className="project-readme-loading">
         <div className="project-readme-spinner" />
-        <p>{text("正在加载 Readme…", "Loading Readme…")}</p>
+        <p>{text("正在加载项目文档…", "Loading Project Docs…")}</p>
       </div>
     );
   }
@@ -145,7 +145,7 @@ export function ProjectReadmeView({
           </span>
           <div className="project-readme-title-info">
             <h1 className="project-readme-heading">
-              Readme
+              {text("项目文档", "Project Docs")}
             </h1>
             <div className="project-readme-meta">
               <span className="project-readme-project-badge">{project.name}</span>
@@ -175,7 +175,7 @@ export function ProjectReadmeView({
               onClick={handleStartEditing}
             >
               <EditIcon color="currentColor" />
-              <span>{hasContent ? text("编辑 Readme", "Edit Readme") : text("编写 Readme", "Write Readme")}</span>
+              <span>{hasContent ? text("编辑项目文档", "Edit Project Docs") : text("编写项目文档", "Write Project Docs")}</span>
             </button>
           ) : (
             <div className="project-readme-edit-actions">
@@ -258,10 +258,10 @@ export function ProjectReadmeView({
                 value={draftContent}
                 onChange={(e) => setDraftContent(e.target.value)}
                 placeholder={text(
-                  "输入项目 Readme 内容，支持 Markdown 语法…",
-                  "Enter project Readme content in Markdown…",
+                  "输入项目文档内容，支持 Markdown 语法…",
+                  "Enter Project Docs content in Markdown…",
                 )}
-                aria-label={text("项目 Readme 内容", "Project Readme content")}
+                aria-label={text("项目文档内容", "Project Docs content")}
                 rows={24}
               />
               <div className="project-readme-editor-footer">
@@ -295,12 +295,12 @@ export function ProjectReadmeView({
             <LinearIcon name="file" />
           </div>
           <h2 className="project-readme-empty-title">
-            {text("项目暂无 Readme", "No Readme for this project yet")}
+            {text("暂无项目文档", "No Project Docs for this project yet")}
           </h2>
           <p className="project-readme-empty-desc">
             {text(
-              "为项目撰写全局 Readme，记录项目目标、技术栈、架构与规范，方便团队协作者与 Agent 快速上手。",
-              "Create a project Readme to document goals, architecture, tech stack, and conventions for collaborators and AI agents.",
+              "创建项目文档，记录项目目标、技术栈、架构与规范，方便团队协作者与 Agent 快速上手。",
+              "Create Project Docs to document goals, architecture, tech stack, and conventions for collaborators and AI agents.",
             )}
           </p>
           <button
@@ -309,7 +309,7 @@ export function ProjectReadmeView({
             onClick={handleStartEditing}
           >
             <PlusIcon color="currentColor" size={16} />
-            <span>{text("开始编写 Readme", "Create Project Readme")}</span>
+            <span>{text("开始编写项目文档", "Create Project Docs")}</span>
           </button>
         </div>
       )}


### PR DESCRIPTION
## Summary

- LOCAL-248：项目列表加载与刷新时读取 local 未归档议题，只把 todo、in_progress、blocked、in_review 计入临时任务的菜单计数；其他项目计数、排序、创建和跨项目返回逻辑不变。
- LOCAL-269：顶部入口和 ProjectReadmeView 的直接可见字段统一为中文“项目文档”、英文“Project Docs”；内部 readme key、组件/API/类型/存储/路由和正文保持不变。

## Verification

- `npm run typecheck`
- `npm run build:web`
- `node --test test/project-home.test.mjs`（13/13；针对首轮 CI 证实的已有源码形状断言）
- 浏览器直接验证（安装版正式 SQLite 即时快照）：
  - local 只有 3 条 backlog、主状态为 0 时，项目下拉不显示“临时任务”。
  - 同一真实议题在一次性验证副本切到 todo 后，项目下拉显示且只显示一个“临时任务”。
  - 中文和英文的顶部入口、页面标题、空状态、编写/编辑按钮、placeholder、aria-label、已有正文只读路径均通过；未保存正文。
  - 1280×720 页面无横向或纵向溢出，浏览器控制台无 error。
- Agent review：exact commit `8ceecdd3c22d9b8f7754a5b9fe981b358f060ddc` 通过，风险低，无阻断问题。

Taskboard: LOCAL-248, LOCAL-269