### PR TITLE
Fix inline media editor regressions

### DIFF
--- a/cloud/migrations/0010_task_relation_origin.sql
+++ b/cloud/migrations/0010_task_relation_origin.sql
@@ -1,0 +1,3 @@
+ALTER TABLE task_relations
+ADD COLUMN origin TEXT NOT NULL DEFAULT 'manual'
+CHECK (origin IN ('manual', 'mention'));

--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -1157,6 +1157,25 @@ function parseVersionMutation(body) {
   };
 }
 
+function parseRelationOrigin(value) {
+  if (value === undefined) return undefined;
+  if (value !== "manual" && value !== "mention") {
+    throw new ApiError(400, "INVALID_FIELD", "'origin' must be manual or mention");
+  }
+  return value;
+}
+
+function parseRelationMutation(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["version", "threadId", "threadBinding", "origin"]));
+  return {
+    version: parseVersion(body.version),
+    threadId: parseThreadId(body.threadId),
+    threadBinding: parseThreadBinding(body.threadBinding),
+    origin: parseRelationOrigin(body.origin),
+  };
+}
+
 function parseCommentCreate(body) {
   assertPlainObject(body);
   assertAllowedKeys(body, new Set(["body", "threadId", "threadBinding"]));
@@ -2051,9 +2070,9 @@ async function addRelation(env, taskId, type, relatedTaskId, input, actor) {
   statements.push(
     env.DB.prepare(`
       INSERT INTO task_relations (
-        relation_type, source_task_id, target_task_id, created_at
+        relation_type, source_task_id, target_task_id, origin, created_at
       )
-      SELECT ?, ?, ?, ?
+      SELECT ?, ?, ?, ?, ?
       WHERE EXISTS (
         SELECT 1 FROM tasks WHERE id = ? AND version = ?
       )
@@ -2061,6 +2080,7 @@ async function addRelation(env, taskId, type, relatedTaskId, input, actor) {
       endpoints.relationType,
       endpoints.sourceTaskId,
       endpoints.targetTaskId,
+      input.origin ?? "manual",
       timestamp,
       task.id,
       input.version,
@@ -2133,8 +2153,8 @@ async function removeRelation(env, taskId, type, relatedTaskId, input, actor) {
     input.version,
   );
   const endpoints = relationEndpoints(type, task.id, relatedTask.id);
-  const exists = await env.DB.prepare(`
-    SELECT 1 AS found
+  const relation = await env.DB.prepare(`
+    SELECT origin
     FROM task_relations
     WHERE relation_type = ? AND source_task_id = ? AND target_task_id = ?
   `).bind(
@@ -2142,8 +2162,14 @@ async function removeRelation(env, taskId, type, relatedTaskId, input, actor) {
     endpoints.sourceTaskId,
     endpoints.targetTaskId,
   ).first();
-  if (!exists) {
+  if (!relation) {
     throw new ApiError(404, "RELATION_NOT_FOUND", "This issue relation does not exist");
+  }
+  if (input.origin && relation.origin !== input.origin) {
+    return {
+      task: await getTask(env, task.id),
+      relatedTask: await getTask(env, relatedTask.id),
+    };
   }
   const timestamp = now();
   const storedBinding = storedThreadBinding(input.threadBinding, input.threadId);
@@ -2712,7 +2738,7 @@ async function routeApi(request, env, actor, url) {
     const taskId = decodePathPart(relationMatch[1], "Task id");
     const type = decodePathPart(relationMatch[2], "Relation type");
     const relatedTaskId = decodePathPart(relationMatch[3], "Related task id");
-    const input = parseVersionMutation(await readJson(request));
+    const input = parseRelationMutation(await readJson(request));
     if (request.method === "POST") {
       return json(200, await addRelation(env, taskId, type, relatedTaskId, input, actor));
     }

--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -2177,8 +2177,54 @@ async function removeRelation(env, taskId, type, relatedTaskId, input, actor) {
     ? `thread_id = ?, thread_codex_project_id = ?, thread_codex_project_kind = ?,
       thread_codex_host_id = ?, thread_workspace_path = ?,`
     : "";
-  const results = await env.DB.batch([
-    env.DB.prepare(`
+  const mentionRemoval = input.origin === "mention"
+    && endpoints.relationType === "related";
+  const taskReference = `](?${new URLSearchParams({
+    project: task.project_id,
+    issue: relatedTask.identifier,
+  })})`;
+  const relatedTaskReference = `](?${new URLSearchParams({
+    project: task.project_id,
+    issue: task.identifier,
+  })})`;
+  const deleteStatement = mentionRemoval
+    ? env.DB.prepare(`
+      DELETE FROM task_relations
+      WHERE relation_type = ?
+        AND source_task_id = ?
+        AND target_task_id = ?
+        AND origin = 'mention'
+        AND EXISTS (
+          SELECT 1 FROM tasks WHERE id = ? AND version = ?
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM tasks
+          WHERE (id = ? AND instr(description, ?) > 0)
+            OR (id = ? AND instr(description, ?) > 0)
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM comments
+          WHERE (task_id = ? AND instr(body, ?) > 0)
+            OR (task_id = ? AND instr(body, ?) > 0)
+        )
+    `).bind(
+      endpoints.relationType,
+      endpoints.sourceTaskId,
+      endpoints.targetTaskId,
+      task.id,
+      input.version,
+      task.id,
+      taskReference,
+      relatedTask.id,
+      relatedTaskReference,
+      task.id,
+      taskReference,
+      relatedTask.id,
+      relatedTaskReference,
+    )
+    : env.DB.prepare(`
       DELETE FROM task_relations
       WHERE relation_type = ?
         AND source_task_id = ?
@@ -2192,14 +2238,16 @@ async function removeRelation(env, taskId, type, relatedTaskId, input, actor) {
       endpoints.targetTaskId,
       task.id,
       input.version,
-    ),
+    );
+  const results = await env.DB.batch([
+    deleteStatement,
     env.DB.prepare(`
       UPDATE tasks
       SET
         ${threadAssignment}
         version = version + 1,
         updated_at = ?
-      WHERE id = ? AND version = ?
+      WHERE id = ? AND version = ?${mentionRemoval ? " AND changes() = 1" : ""}
     `).bind(...(storedBinding ?? []), timestamp, task.id, input.version),
     taskActivityStatement(
       env,
@@ -2216,6 +2264,12 @@ async function removeRelation(env, taskId, type, relatedTaskId, input, actor) {
   ]);
   if (!changed(results[1])) {
     const latest = await requireTaskRow(env, task.id);
+    if (mentionRemoval && latest.version === input.version) {
+      return {
+        task: await getTask(env, task.id),
+        relatedTask: await getTask(env, relatedTask.id),
+      };
+    }
     throw new ApiError(
       409,
       "VERSION_CONFLICT",

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -639,6 +639,25 @@ function parseArchive(body) {
   };
 }
 
+function parseRelationOrigin(value) {
+  if (value === undefined) return undefined;
+  if (value !== "manual" && value !== "mention") {
+    throw new ApiError(400, "INVALID_FIELD", "'origin' must be manual or mention");
+  }
+  return value;
+}
+
+function parseRelationMutation(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["version", "threadId", "threadBinding", "origin"]));
+  return {
+    version: parseVersion(body.version),
+    threadId: parseThreadId(body.threadId),
+    threadBinding: parseThreadBinding(body.threadBinding),
+    origin: parseRelationOrigin(body.origin),
+  };
+}
+
 function parseIssueRelationType(value) {
   if (!["parent", "blocks", "blocked_by", "related"].includes(value)) {
     throw new ApiError(
@@ -2554,8 +2573,8 @@ export function createTaskboardServer(options = {}) {
         }
         const relationType = parseIssueRelationType(type);
         if (request.method === "POST") {
-          const { version, threadId, threadBinding } = resolveInputThreadBinding(
-            parseArchive(await readJson(request)),
+          const { version, threadId, threadBinding, origin } = resolveInputThreadBinding(
+            parseRelationMutation(await readJson(request)),
           );
           const result = database.addTaskRelation(
             taskId,
@@ -2565,13 +2584,14 @@ export function createTaskboardServer(options = {}) {
             threadId,
             threadBinding,
             actorFromRequest(request),
+            origin,
           );
           events.emit("task.relation.updated", result);
           return sendJson(response, 200, result);
         }
         if (request.method === "DELETE") {
-          const { version, threadId, threadBinding } = resolveInputThreadBinding(
-            parseArchive(await readJson(request)),
+          const { version, threadId, threadBinding, origin } = resolveInputThreadBinding(
+            parseRelationMutation(await readJson(request)),
           );
           const result = database.removeTaskRelation(
             taskId,
@@ -2581,6 +2601,7 @@ export function createTaskboardServer(options = {}) {
             threadId,
             threadBinding,
             actorFromRequest(request),
+            origin,
           );
           events.emit("task.relation.updated", result);
           return sendJson(response, 200, result);

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -2225,10 +2225,58 @@ export class TaskboardDatabase {
           relatedTask: this.getTask(relatedTask.id),
         };
       }
-      this.database.prepare(`
-        DELETE FROM task_relations
-        WHERE relation_type = ? AND source_task_id = ? AND target_task_id = ?
-      `).run(relationType, sourceTaskId, targetTaskId);
+      let deleted;
+      if (origin === "mention" && relationType === "related") {
+        const taskReference = `](?${new URLSearchParams({
+          project: task.projectId,
+          issue: relatedTask.identifier,
+        })})`;
+        const relatedTaskReference = `](?${new URLSearchParams({
+          project: task.projectId,
+          issue: task.identifier,
+        })})`;
+        deleted = this.database.prepare(`
+          DELETE FROM task_relations
+          WHERE relation_type = ? AND source_task_id = ? AND target_task_id = ?
+            AND origin = 'mention'
+            AND NOT EXISTS (
+              SELECT 1
+              FROM tasks
+              WHERE (id = ? AND instr(description, ?) > 0)
+                OR (id = ? AND instr(description, ?) > 0)
+            )
+            AND NOT EXISTS (
+              SELECT 1
+              FROM comments
+              WHERE (task_id = ? AND instr(body, ?) > 0)
+                OR (task_id = ? AND instr(body, ?) > 0)
+            )
+        `).run(
+          relationType,
+          sourceTaskId,
+          targetTaskId,
+          task.id,
+          taskReference,
+          relatedTask.id,
+          relatedTaskReference,
+          task.id,
+          taskReference,
+          relatedTask.id,
+          relatedTaskReference,
+        );
+      } else {
+        deleted = this.database.prepare(`
+          DELETE FROM task_relations
+          WHERE relation_type = ? AND source_task_id = ? AND target_task_id = ?
+        `).run(relationType, sourceTaskId, targetTaskId);
+      }
+      if (origin === "mention" && relationType === "related" && deleted.changes === 0) {
+        this.database.exec("COMMIT");
+        return {
+          task: this.getTask(task.id),
+          relatedTask: this.getTask(relatedTask.id),
+        };
+      }
       const timestamp = now();
       this.#touchTask(task.id, version, threadId, threadBinding, timestamp);
       this.#recordTaskActivity(task.id, actor, [{

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -749,6 +749,7 @@ export class TaskboardDatabase {
         relation_type TEXT NOT NULL CHECK (relation_type IN ('parent', 'blocks', 'related')),
         source_task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
         target_task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+        origin TEXT NOT NULL DEFAULT 'manual' CHECK (origin IN ('manual', 'mention')),
         created_at TEXT NOT NULL,
         CHECK (source_task_id <> target_task_id),
         CHECK (relation_type <> 'related' OR source_task_id < target_task_id),
@@ -762,6 +763,15 @@ export class TaskboardDatabase {
         ON task_relations(target_task_id)
         WHERE relation_type = 'parent';
     `);
+
+    const taskRelationColumns = this.database.prepare("PRAGMA table_info(task_relations)").all();
+    if (!taskRelationColumns.some((column) => column.name === "origin")) {
+      this.database.exec(`
+        ALTER TABLE task_relations
+        ADD COLUMN origin TEXT NOT NULL DEFAULT 'manual'
+          CHECK (origin IN ('manual', 'mention'))
+      `);
+    }
 
     const commentColumns = this.database.prepare("PRAGMA table_info(comments)").all();
     if (!commentColumns.some((column) => column.name === "thread_id")) {
@@ -2122,7 +2132,7 @@ export class TaskboardDatabase {
     }
   }
 
-  addTaskRelation(id, version, type, relatedId, threadId, threadBinding, actor) {
+  addTaskRelation(id, version, type, relatedId, threadId, threadBinding, actor, origin = "manual") {
     this.database.exec("BEGIN IMMEDIATE");
     try {
       const task = this.#requireTask(id);
@@ -2168,9 +2178,9 @@ export class TaskboardDatabase {
         : null;
       this.database.prepare(`
         INSERT INTO task_relations (
-          relation_type, source_task_id, target_task_id, created_at
-        ) VALUES (?, ?, ?, ?)
-      `).run(relationType, sourceTaskId, targetTaskId, timestamp);
+          relation_type, source_task_id, target_task_id, origin, created_at
+        ) VALUES (?, ?, ?, ?, ?)
+      `).run(relationType, sourceTaskId, targetTaskId, origin, timestamp);
       this.#touchTask(task.id, version, threadId, threadBinding, timestamp);
       this.#recordTaskActivity(task.id, actor, [{
         field: "relation",
@@ -2188,7 +2198,7 @@ export class TaskboardDatabase {
     }
   }
 
-  removeTaskRelation(id, version, type, relatedId, threadId, threadBinding, actor) {
+  removeTaskRelation(id, version, type, relatedId, threadId, threadBinding, actor, origin) {
     this.database.exec("BEGIN IMMEDIATE");
     try {
       const task = this.#requireTask(id);
@@ -2200,13 +2210,25 @@ export class TaskboardDatabase {
         task.id,
         relatedTask.id,
       );
-      const removed = this.database.prepare(`
+      const relation = this.database.prepare(`
+        SELECT origin
+        FROM task_relations
+        WHERE relation_type = ? AND source_task_id = ? AND target_task_id = ?
+      `).get(relationType, sourceTaskId, targetTaskId);
+      if (!relation) {
+        throw new ApiError(404, "RELATION_NOT_FOUND", "This issue relation does not exist");
+      }
+      if (origin && relation.origin !== origin) {
+        this.database.exec("COMMIT");
+        return {
+          task: this.getTask(task.id),
+          relatedTask: this.getTask(relatedTask.id),
+        };
+      }
+      this.database.prepare(`
         DELETE FROM task_relations
         WHERE relation_type = ? AND source_task_id = ? AND target_task_id = ?
       `).run(relationType, sourceTaskId, targetTaskId);
-      if (removed.changes !== 1) {
-        throw new ApiError(404, "RELATION_NOT_FOUND", "This issue relation does not exist");
-      }
       const timestamp = now();
       this.#touchTask(task.id, version, threadId, threadBinding, timestamp);
       this.#recordTaskActivity(task.id, actor, [{

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -130,6 +130,7 @@ import {
   type CodexThreadBinding,
   type DevelopmentScan,
   type HostContext,
+  type IssueRelationOrigin,
   type IssueRelationType,
   type JiraConnection,
   type Project,
@@ -2514,12 +2515,13 @@ export function App() {
     task: Task,
     type: IssueRelationType,
     relatedTaskId: string,
+    origin?: IssueRelationOrigin,
   ) {
     setActionError(null);
     try {
       const result = action === "add"
-        ? await addTaskRelation(task, type, relatedTaskId)
-        : await removeTaskRelation(task, type, relatedTaskId);
+        ? await addTaskRelation(task, type, relatedTaskId, undefined, origin)
+        : await removeTaskRelation(task, type, relatedTaskId, undefined, origin);
       setTasks((current) => sortTasks(current.map((candidate) => {
         if (candidate.id === result.task.id) return result.task;
         if (candidate.id === result.relatedTask.id) return result.relatedTask;
@@ -3686,11 +3688,11 @@ export function App() {
             onDeleteLabel={removeProjectLabel}
             onUpdate={(current, changes) => updateTaskProperties(current, changes)}
             onOpenTask={openTaskDetail}
-            onAddRelation={(current, type, relatedTaskId) => (
-              mutateTaskRelation("add", current, type, relatedTaskId)
+            onAddRelation={(current, type, relatedTaskId, origin) => (
+              mutateTaskRelation("add", current, type, relatedTaskId, origin)
             )}
-            onRemoveRelation={(current, type, relatedTaskId) => (
-              mutateTaskRelation("remove", current, type, relatedTaskId)
+            onRemoveRelation={(current, type, relatedTaskId, origin) => (
+              mutateTaskRelation("remove", current, type, relatedTaskId, origin)
             )}
             onOpenThread={openThread}
             onOpenLegacyLocalThread={openLegacyLocalThread}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -16,6 +16,7 @@ import type {
   CodexThreadBinding,
   DevelopmentScan,
   HostContext,
+  IssueRelationOrigin,
   IssueRelationType,
   JiraConnection,
   Project,
@@ -612,12 +613,17 @@ export async function addTaskRelation(
   type: IssueRelationType,
   relatedTaskId: string,
   threadId?: string,
+  origin?: IssueRelationOrigin,
 ): Promise<{ task: Task; relatedTask: Task }> {
   return request<{ task: Task; relatedTask: Task }>(
     `/api/tasks/${encodeURIComponent(task.id)}/relations/${type}/${encodeURIComponent(relatedTaskId)}`,
     {
       method: "POST",
-      body: JSON.stringify({ version: task.version, ...(threadId ? { threadId } : {}) }),
+      body: JSON.stringify({
+        version: task.version,
+        ...(origin ? { origin } : {}),
+        ...(threadId ? { threadId } : {}),
+      }),
     },
   );
 }
@@ -627,12 +633,17 @@ export async function removeTaskRelation(
   type: IssueRelationType,
   relatedTaskId: string,
   threadId?: string,
+  origin?: IssueRelationOrigin,
 ): Promise<{ task: Task; relatedTask: Task }> {
   return request<{ task: Task; relatedTask: Task }>(
     `/api/tasks/${encodeURIComponent(task.id)}/relations/${type}/${encodeURIComponent(relatedTaskId)}`,
     {
       method: "DELETE",
-      body: JSON.stringify({ version: task.version, ...(threadId ? { threadId } : {}) }),
+      body: JSON.stringify({
+        version: task.version,
+        ...(origin ? { origin } : {}),
+        ...(threadId ? { threadId } : {}),
+      }),
     },
   );
 }

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -56,6 +56,7 @@ interface InlineImageSegment {
   token: string;
   file: File;
   dataUrl: string | null;
+  dataUrlReady: Promise<void>;
 }
 
 interface PersistedImageSegment {
@@ -200,11 +201,16 @@ function imageSegment(file: File, dataUrl: string | null = null): InlineImageSeg
     token: `<!--taskboard-inline-image:${id}-->`,
     file,
     dataUrl,
+    dataUrlReady: Promise.resolve(),
   };
   if (!dataUrl) {
     const reader = new FileReader();
-    reader.addEventListener("load", () => {
-      if (typeof reader.result === "string") segment.dataUrl = reader.result;
+    segment.dataUrlReady = new Promise((resolve, reject) => {
+      reader.addEventListener("load", () => {
+        segment.dataUrl = reader.result as string;
+        resolve();
+      });
+      reader.addEventListener("error", () => reject(reader.error));
     });
     reader.readAsDataURL(file);
   }
@@ -1802,16 +1808,18 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       applyRangeReplacement(start, end, insertion);
     }
 
-    function copyContent(event: ClipboardEvent<HTMLDivElement>): {
+    async function copyContent(event: ClipboardEvent<HTMLDivElement>): Promise<{
       range: { start: number; end: number };
       segments: InlineMediaSegment[];
-    } | null {
-      const selection = event.currentTarget.ownerDocument.getSelection();
+    } | null> {
+      const currentTarget = event.currentTarget;
+      const ownerDocument = currentTarget.ownerDocument;
+      const selection = ownerDocument.getSelection();
       if (!selection || selection.rangeCount === 0) return null;
       const selectedRange = selection.getRangeAt(0);
       if (
-        !event.currentTarget.contains(selectedRange.startContainer)
-        || !event.currentTarget.contains(selectedRange.endContainer)
+        !currentTarget.contains(selectedRange.startContainer)
+        || !currentTarget.contains(selectedRange.endContainer)
       ) return null;
       const range = currentLogicalRange();
       if (!range || range.start === range.end) return null;
@@ -1821,11 +1829,14 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
         segment.type === "pending-image" && segment.file.type === "image/png"
       ));
       if (image) {
+        await Promise.all(copiedSegments.flatMap((segment) => (
+          segment.type === "pending-image" ? [segment.dataUrlReady] : []
+        )));
         const payload = inlineMediaClipboardPayload(
           copiedSegments,
-          event.currentTarget.ownerDocument,
+          ownerDocument,
         );
-        void navigator.clipboard.write([new ClipboardItem({
+        await navigator.clipboard.write([new ClipboardItem({
           "image/png": image.file,
           "text/html": new Blob([payload.html], { type: "text/html" }),
           "text/plain": new Blob([payload.plainText], { type: "text/plain" }),
@@ -1834,7 +1845,7 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
         writeInlineMediaClipboard(
           event.clipboardData,
           copiedSegments,
-          event.currentTarget.ownerDocument,
+          ownerDocument,
         );
       }
       return { range, segments: copiedSegments };
@@ -2049,9 +2060,10 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
           onPaste={pasteContent}
           onCopy={copyContent}
           onCut={(event) => {
-            const copied = copyContent(event);
-            if (!copied) return;
-            applyRangeReplacement(copied.range.start, copied.range.end, [], false);
+            void copyContent(event).then((copied) => {
+              if (!copied) return;
+              applyRangeReplacement(copied.range.start, copied.range.end, [], false);
+            });
           }}
           onKeyUp={(event) => {
             if (event.key !== "Escape") updateCompletionFromSelection();

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -163,6 +163,7 @@ function completionSelectionId(selection: CompletionSelection): string {
 let segmentSequence = 0;
 const inlineMediaMarkdownParser = unified().use(remarkParse).use(remarkGfm);
 const EMPTY_MENTION_TASKS: readonly Task[] = [];
+const EMPTY_TEXT_CARET = "\uFEFF";
 const INLINE_MEDIA_CLIPBOARD_MIME = "application/x-taskboard-inline-media";
 const INLINE_MEDIA_HTML_BLOCKS = new Set([
   "ADDRESS",
@@ -691,6 +692,18 @@ function inlineMediaClipboardHtml(
       wrapper.append(text);
       continue;
     }
+    if (segment.type === "issue-reference") {
+      const route = new URLSearchParams({
+        project: segment.projectId,
+        issue: segment.issueIdentifier,
+      });
+      const issue = ownerDocument.createElement("a");
+      issue.dataset.taskboardInlineMediaMarkdown = segment.markdown;
+      issue.href = new URL(`?${route}`, ownerDocument.baseURI).toString();
+      issue.textContent = `@${segment.identifier}`;
+      wrapper.append(issue);
+      continue;
+    }
     if (isInlineReference(segment) || segment.type === "persisted-image") {
       const markdown = ownerDocument.createElement("span");
       markdown.dataset.taskboardInlineMediaMarkdown = segment.markdown;
@@ -701,6 +714,7 @@ function inlineMediaClipboardHtml(
     if (segment.dataUrl) {
       const pendingImage = ownerDocument.createElement("img");
       pendingImage.dataset.taskboardInlineMediaPendingImage = segment.id;
+      pendingImage.dataset.taskboardInlineMediaMarkdown = pendingImageClipboardMarkdown(segment) ?? "";
       pendingImage.src = segment.dataUrl;
       pendingImage.alt = segment.file.name;
       wrapper.append(pendingImage);
@@ -715,21 +729,30 @@ function inlineMediaClipboardHtml(
   return wrapper.outerHTML;
 }
 
+function inlineMediaClipboardPayload(
+  segments: InlineMediaSegment[],
+  ownerDocument: Document,
+): { id: string; plainText: string; html: string } {
+  const id = segmentId("clipboard");
+  const clipboardSegments = selfContainedClipboardSegments(segments);
+  const exportedSegments = stableClipboardSegments(clipboardSegments);
+  inlineMediaClipboard = { id, segments: clipboardSegments };
+  return {
+    id,
+    plainText: inlineMediaClipboardText(exportedSegments),
+    html: inlineMediaClipboardHtml(exportedSegments, id, ownerDocument),
+  };
+}
+
 export function writeInlineMediaClipboard(
   clipboardData: DataTransfer,
   segments: InlineMediaSegment[],
   ownerDocument: Document,
 ) {
-  const clipboardId = segmentId("clipboard");
-  const clipboardSegments = selfContainedClipboardSegments(segments);
-  const exportedSegments = stableClipboardSegments(clipboardSegments);
-  inlineMediaClipboard = { id: clipboardId, segments: clipboardSegments };
-  clipboardData.setData(INLINE_MEDIA_CLIPBOARD_MIME, clipboardId);
-  clipboardData.setData("text/plain", inlineMediaClipboardText(exportedSegments));
-  clipboardData.setData(
-    "text/html",
-    inlineMediaClipboardHtml(exportedSegments, clipboardId, ownerDocument),
-  );
+  const payload = inlineMediaClipboardPayload(segments, ownerDocument);
+  clipboardData.setData(INLINE_MEDIA_CLIPBOARD_MIME, payload.id);
+  clipboardData.setData("text/plain", payload.plainText);
+  clipboardData.setData("text/html", payload.html);
 }
 
 function inlineMediaClipboardIdFromHtml(html: string): string {
@@ -1167,7 +1190,8 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
             element.textContent = segment.text;
             if (segment.text.endsWith("\n")) element.append(document.createElement("br"));
           } else {
-            element.append(document.createTextNode(""), document.createElement("br"));
+            element.dataset.inlineMediaEmptyText = "true";
+            element.append(document.createTextNode(EMPTY_TEXT_CARET), document.createElement("br"));
           }
         } else {
           element.className = isInlineReference(segment)
@@ -1514,7 +1538,7 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       if (!element || !(textNode instanceof Text)) return query.anchorRect;
       const anchorRange = document.createRange();
       anchorRange.setStart(textNode, Math.min(query.start, textNode.length));
-      anchorRange.collapse(true);
+      anchorRange.setEnd(textNode, Math.min(query.start + 1, textNode.length));
       return anchorRange.getBoundingClientRect();
     }
 
@@ -1588,7 +1612,7 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       const textNode = element?.firstChild;
       if (textNode instanceof Text) {
         anchorRange.setStart(textNode, Math.min(start, textNode.length));
-        anchorRange.collapse(true);
+        anchorRange.setEnd(textNode, Math.min(start + 1, textNode.length));
       } else {
         anchorRange.setStart(range.startContainer, range.startOffset);
         anchorRange.collapse(true);
@@ -1793,11 +1817,26 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       if (!range || range.start === range.end) return null;
       const copiedSegments = inlineMediaRangeSegments(segments, range.start, range.end);
       event.preventDefault();
-      writeInlineMediaClipboard(
-        event.clipboardData,
-        copiedSegments,
-        event.currentTarget.ownerDocument,
-      );
+      const image = copiedSegments.find((segment): segment is InlineImageSegment => (
+        segment.type === "pending-image" && segment.file.type === "image/png"
+      ));
+      if (image) {
+        const payload = inlineMediaClipboardPayload(
+          copiedSegments,
+          event.currentTarget.ownerDocument,
+        );
+        void navigator.clipboard.write([new ClipboardItem({
+          "image/png": image.file,
+          "text/html": new Blob([payload.html], { type: "text/html" }),
+          "text/plain": new Blob([payload.plainText], { type: "text/plain" }),
+        })]);
+      } else {
+        writeInlineMediaClipboard(
+          event.clipboardData,
+          copiedSegments,
+          event.currentTarget.ownerDocument,
+        );
+      }
       return { range, segments: copiedSegments };
     }
 
@@ -1822,7 +1861,7 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       const pendingImageHtml = clipboardHtml.includes(
         "data-taskboard-inline-media-pending-image",
       );
-      if (taskboardHtml && !pendingImageHtml) {
+      if (taskboardHtml) {
         const htmlSegments = createInlineMediaSegmentsFromHtml(clipboardHtml, referenceTasks);
         if (htmlSegments) {
           event.preventDefault();
@@ -1902,7 +1941,21 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
         const id = child.dataset.inlineMediaSegment;
         const segment = id ? existing.get(id) : null;
         if (segment?.type === "text") {
-          next.push({ ...segment, text: child.textContent ?? "" });
+          let text = child.textContent ?? "";
+          if (child.dataset.inlineMediaEmptyText) {
+            const textNode = child.firstChild;
+            const placeholderOffset = textNode instanceof Text
+              ? textNode.data.indexOf(EMPTY_TEXT_CARET)
+              : -1;
+            text = text.replace(EMPTY_TEXT_CARET, "");
+            if (text) {
+              if (textNode instanceof Text && placeholderOffset >= 0) {
+                textNode.deleteData(placeholderOffset, 1);
+              }
+              delete child.dataset.inlineMediaEmptyText;
+            }
+          }
+          next.push({ ...segment, text });
         } else if (segment) {
           next.push(segment);
           nextAtomHosts.set(segment.id, child);
@@ -1986,7 +2039,7 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
           }}
           onCompositionEnd={(event) => {
             composing.current = false;
-            if (isEmpty && !event.currentTarget.textContent) {
+            if (isEmpty && !event.currentTarget.textContent?.replace(EMPTY_TEXT_CARET, "")) {
               event.currentTarget.dataset.empty = "true";
             }
             syncSegmentsFromDom();
@@ -1998,18 +2051,6 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
           onCut={(event) => {
             const copied = copyContent(event);
             if (!copied) return;
-            const image = copied.segments.find((segment): segment is InlineImageSegment => (
-              segment.type === "pending-image" && segment.file.type === "image/png"
-            ));
-            if (image) {
-              const plainText = event.clipboardData.getData("text/plain");
-              const html = event.clipboardData.getData("text/html");
-              void navigator.clipboard.write([new ClipboardItem({
-                "image/png": image.file,
-                "text/html": new Blob([html], { type: "text/html" }),
-                "text/plain": new Blob([plainText], { type: "text/plain" }),
-              })]);
-            }
             applyRangeReplacement(copied.range.start, copied.range.end, [], false);
           }}
           onKeyUp={(event) => {

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -1081,6 +1081,8 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
   }, ref) {
     const { text } = useTaskboardI18n();
     const rootRef = useRef<HTMLDivElement>(null);
+    const latestSegments = useRef(segments);
+    latestSegments.current = segments;
     const atomHosts = useRef(new Map<string, HTMLElement>());
     const nativeSegments = useRef(new Map<string, InlineMediaSegment>());
     const pendingSelection = useRef<number | null>(null);
@@ -1538,14 +1540,25 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
       applyRangeReplacement(start, start + segmentLength(segments[index]), [], false);
     }
 
+    function completionRangeFromCaret(caretRange: Range, triggerLength: number): Range | null {
+      const root = rootRef.current;
+      if (!root || !caretRange.collapsed || !root.contains(caretRange.startContainer)) return null;
+      const textNode = caretRange.startContainer;
+      if (!(textNode instanceof Text) || caretRange.startOffset < triggerLength) return null;
+      const range = document.createRange();
+      const triggerOffset = caretRange.startOffset - triggerLength;
+      range.setStart(textNode, triggerOffset);
+      range.setEnd(textNode, triggerOffset + 1);
+      return range;
+    }
+
     function completionAnchorRect(query: ComposerQuery): DOMRect {
-      const element = elementForSegment(query.segmentId);
-      const textNode = element?.firstChild;
-      if (!element || !(textNode instanceof Text)) return query.anchorRect;
-      const anchorRange = document.createRange();
-      anchorRange.setStart(textNode, Math.min(query.start, textNode.length));
-      anchorRange.setEnd(textNode, Math.min(query.start + 1, textNode.length));
-      return anchorRange.getBoundingClientRect();
+      const root = rootRef.current;
+      const selection = window.getSelection();
+      if (!root || !selection || selection.rangeCount === 0) return query.anchorRect;
+      const caretRange = selection.getRangeAt(0);
+      return completionRangeFromCaret(caretRange, query.end - query.start)
+        ?.getBoundingClientRect() ?? query.anchorRect;
     }
 
     function updateCompletionFromSelection() {
@@ -1613,13 +1626,10 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
         return;
       }
       const start = prefix.lastIndexOf(trigger);
-      const anchorRange = document.createRange();
-      const element = elementForSegment(segment.id);
-      const textNode = element?.firstChild;
-      if (textNode instanceof Text) {
-        anchorRange.setStart(textNode, Math.min(start, textNode.length));
-        anchorRange.setEnd(textNode, Math.min(start + 1, textNode.length));
-      } else {
+      const triggerLength = end - start;
+      let anchorRange = completionRangeFromCaret(range, triggerLength);
+      if (!anchorRange) {
+        anchorRange = range.cloneRange();
         anchorRange.setStart(range.startContainer, range.startOffset);
         anchorRange.collapse(true);
       }
@@ -1836,8 +1846,15 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
           copiedSegments,
           ownerDocument,
         );
-        await navigator.clipboard.write([new ClipboardItem({
+        const imageOnly = copiedSegments.every((segment) => (
+          segment.type === "pending-image"
+          || (segment.type === "text" && segment.text.length === 0)
+        ));
+        await navigator.clipboard.write([new ClipboardItem(imageOnly ? {
           "image/png": image.file,
+          "text/html": new Blob([payload.html], { type: "text/html" }),
+          "text/plain": new Blob([payload.plainText], { type: "text/plain" }),
+        } : {
           "text/html": new Blob([payload.html], { type: "text/html" }),
           "text/plain": new Blob([payload.plainText], { type: "text/plain" }),
         })]);
@@ -2062,7 +2079,33 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
           onCut={(event) => {
             void copyContent(event).then((copied) => {
               if (!copied) return;
-              applyRangeReplacement(copied.range.start, copied.range.end, [], false);
+              const currentSegments = latestSegments.current;
+              const currentCut = inlineMediaRangeSegments(
+                currentSegments,
+                copied.range.start,
+                copied.range.end,
+              );
+              const unchanged = currentCut.length === copied.segments.length
+                && currentCut.every((segment, index) => {
+                  const snapshot = copied.segments[index];
+                  return segment.id === snapshot.id
+                    && segment.type === snapshot.type
+                    && (
+                      segment.type !== "text"
+                      || (snapshot.type === "text" && segment.text === snapshot.text)
+                    );
+                });
+              if (!unchanged) return;
+              const replacement = replaceInlineMediaRange(
+                currentSegments,
+                copied.range.start,
+                copied.range.end,
+                [],
+              );
+              pendingSelection.current = replacement.caret;
+              pendingMentionUpdate.current = false;
+              setCompletionQuery(null);
+              onChange(replacement.segments);
             });
           }}
           onKeyUp={(event) => {

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -13,6 +13,7 @@ import {
   createComment,
   deleteAttachment,
   deleteComment,
+  getTask,
   listAttachments,
   listComments,
   listTaskActivities,
@@ -744,6 +745,15 @@ export function TaskDetail({
         referencedIds.has(relatedTaskId)
         || !current.relations.related.some((relation) => relation.id === relatedTaskId)
       ) continue;
+      const relatedTask = await getTask(relatedTaskId);
+      if (
+        mentionTaskIds(createInlineMediaSegments(relatedTask.description, referenceTasks))
+          .has(anchor.id)
+      ) continue;
+      const relatedComments = await listComments(relatedTaskId);
+      if (relatedComments.some((comment) => (
+        mentionTaskIds(createInlineMediaSegments(comment.body, referenceTasks)).has(anchor.id)
+      ))) continue;
       const result = await applyRelationMutation(
         () => onRemoveRelation(current, "related", relatedTaskId, "mention"),
       );

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -35,6 +35,7 @@ import type {
   CodexThreadBinding,
   DevelopmentContext,
   DevelopmentScan,
+  IssueRelationOrigin,
   IssueRelationType,
   Recurrence,
   Task,
@@ -119,11 +120,13 @@ interface TaskDetailProps {
     task: Task,
     type: IssueRelationType,
     relatedTaskId: string,
+    origin?: IssueRelationOrigin,
   ) => Promise<RelationMutationResult>;
   onRemoveRelation: (
     task: Task,
     type: IssueRelationType,
     relatedTaskId: string,
+    origin?: IssueRelationOrigin,
   ) => Promise<RelationMutationResult>;
   onOpenThread: (binding: CodexThreadBinding) => void;
   onOpenLegacyLocalThread: (threadId: string) => void;
@@ -700,10 +703,51 @@ export function TaskDetail({
         || relatedIds.has(relatedTaskId)
       ) continue;
       const result = await applyRelationMutation(
-        () => onAddRelation(current, "related", relatedTaskId),
+        () => onAddRelation(current, "related", relatedTaskId, "mention"),
       );
       current = result.task;
       relatedIds.add(relatedTaskId);
+    }
+    return current;
+  }
+
+  function mentionTaskIds(segments: InlineMediaSegment[]): Set<string> {
+    return new Set(segments.flatMap((segment) => (
+      segment.type === "issue-reference" && segment.taskId ? [segment.taskId] : []
+    )));
+  }
+
+  function removedMentionTaskIds(
+    previous: InlineMediaSegment[],
+    next: InlineMediaSegment[],
+  ): Set<string> {
+    const nextIds = mentionTaskIds(next);
+    return new Set([...mentionTaskIds(previous)].filter((taskId) => !nextIds.has(taskId)));
+  }
+
+  async function removeUnreferencedMentionRelations(
+    anchor: Task,
+    candidates: Set<string>,
+  ): Promise<Task> {
+    if (candidates.size === 0) return anchor;
+    const savedComments = await listComments(anchor.id);
+    const referencedIds = mentionTaskIds(createInlineMediaSegments(anchor.description, referenceTasks));
+    for (const comment of savedComments) {
+      for (const taskId of mentionTaskIds(createInlineMediaSegments(comment.body, referenceTasks))) {
+        referencedIds.add(taskId);
+      }
+    }
+
+    let current = anchor;
+    for (const relatedTaskId of candidates) {
+      if (
+        referencedIds.has(relatedTaskId)
+        || !current.relations.related.some((relation) => relation.id === relatedTaskId)
+      ) continue;
+      const result = await applyRelationMutation(
+        () => onRemoveRelation(current, "related", relatedTaskId, "mention"),
+      );
+      current = result.task;
     }
     return current;
   }
@@ -741,6 +785,10 @@ export function TaskDetail({
       setEditingDescription(false);
       return;
     }
+    const removedMentionIds = removedMentionTaskIds(
+      createInlineMediaSegments(currentTask.description, referenceTasks),
+      descriptionSegments,
+    );
 
     setSavingProperty("description");
     onError(null);
@@ -758,7 +806,11 @@ export function TaskDetail({
         return null;
       });
       if (!saved) return;
-      const savedWithRelations = await addMentionRelations(saved, descriptionSegments);
+      const savedWithAddedRelations = await addMentionRelations(saved, descriptionSegments);
+      const savedWithRelations = await removeUnreferencedMentionRelations(
+        savedWithAddedRelations,
+        removedMentionIds,
+      );
       setCurrentTask(savedWithRelations);
       setDescription(savedWithRelations.description);
       setDescriptionSegments(createInlineMediaSegments(savedWithRelations.description, referenceTasks));
@@ -866,6 +918,10 @@ export function TaskDetail({
       if (body === comment.body) endCommentEdit();
       return;
     }
+    const removedMentionIds = removedMentionTaskIds(
+      createInlineMediaSegments(comment.body, referenceTasks),
+      editingSegments,
+    );
     setSavingCommentId(comment.id);
     setCommentsError(null);
     try {
@@ -883,7 +939,11 @@ export function TaskDetail({
         resolveInlineMediaMarkdown(body, editingInlineImages, uploaded).trim(),
       );
       setComments((current) => current.map((item) => item.id === updated.id ? updated : item));
-      const savedWithRelations = await addMentionRelations(currentTask, editingSegments);
+      const savedWithAddedRelations = await addMentionRelations(currentTask, editingSegments);
+      const savedWithRelations = await removeUnreferencedMentionRelations(
+        savedWithAddedRelations,
+        removedMentionIds,
+      );
       setCurrentTask(savedWithRelations);
       endCommentEdit();
     } catch (error) {
@@ -895,12 +955,20 @@ export function TaskDetail({
 
   async function confirmDelete() {
     if (!pendingDelete || deleting) return;
+    const removedMentionIds = mentionTaskIds(
+      createInlineMediaSegments(pendingDelete.body, referenceTasks),
+    );
     setDeleting(true);
     setCommentsError(null);
     try {
       await deleteComment(pendingDelete);
       setComments((current) => current.filter((comment) => comment.id !== pendingDelete.id));
       setPendingDelete(null);
+      const savedWithRelations = await removeUnreferencedMentionRelations(
+        currentTask,
+        removedMentionIds,
+      );
+      setCurrentTask(savedWithRelations);
     } catch (error) {
       setCommentsError(messageFor(error));
     } finally {

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -862,9 +862,9 @@ export function TaskDetail({
       setCommentSegments(createInlineMediaSegments());
       setPendingCommentFiles([]);
       if (commentAttachmentInputRef.current) commentAttachmentInputRef.current.value = "";
-      let relationAnchor = currentTask;
+      let relationAnchor = await getTask(currentTask.id);
       if (changeStatusToTodo) {
-        const saved = await onUpdate(currentTask, { status: "todo" });
+        const saved = await onUpdate(relationAnchor, { status: "todo" });
         setCurrentTask(saved);
         relationAnchor = saved;
         setChangeStatusToTodo(false);
@@ -949,7 +949,8 @@ export function TaskDetail({
         resolveInlineMediaMarkdown(body, editingInlineImages, uploaded).trim(),
       );
       setComments((current) => current.map((item) => item.id === updated.id ? updated : item));
-      const savedWithAddedRelations = await addMentionRelations(currentTask, editingSegments);
+      const relationAnchor = await getTask(currentTask.id);
+      const savedWithAddedRelations = await addMentionRelations(relationAnchor, editingSegments);
       const savedWithRelations = await removeUnreferencedMentionRelations(
         savedWithAddedRelations,
         removedMentionIds,

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -14,6 +14,7 @@ export type TaskPriority = (typeof TASK_PRIORITIES)[number];
 export type ActorType = "user" | "agent";
 export type AssigneeTarget = "current-user" | "codex-agent";
 export type IssueRelationType = "parent" | "blocks" | "blocked_by" | "related";
+export type IssueRelationOrigin = "manual" | "mention";
 
 export interface ActorIdentity {
   type: ActorType;


### PR DESCRIPTION
## Summary

- Preserve unsubmitted mixed text, issue references, and PNG images across copy and cut.
- Give Chrome IME a real layout caret after an image without persisting the DOM placeholder.
- Track `related` relation origin and remove mention-created relations only after their last saved reference disappears.
- Anchor the issue mention menu to the actual trigger character instead of a collapsed range.

## E3 paths

- LOCAL-219: unsubmitted composer selection -> one system clipboard item -> Taskboard or external paste.
- LOCAL-262: image -> DOM-only caret text -> real Chrome composition starts on the first key.
- LOCAL-265: saved mention diff -> persisted `origin` -> conditional relation removal.
- LOCAL-268: `@` trigger -> non-collapsed character range -> portal menu coordinates.

## Verification

- `npm run typecheck`
- `npm run build:web`
- Isolated local API and SQLite: mention relation adds/removes; manual relation ignores mention removal without version or activity change.
- Independent Agent implementation review passed after the FEFF offset blocker was fixed.

Direct Chrome clipboard, IME, and positioning evidence will be added before handoff.
