### PR TITLE
LOCAL-270: Reuse issue description editor for project docs

### DIFF
--- a/cloud/migrations/0010_project_readme_attachments.sql
+++ b/cloud/migrations/0010_project_readme_attachments.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS project_readme_attachments (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  filename TEXT NOT NULL,
+  content_type TEXT NOT NULL,
+  size INTEGER NOT NULL CHECK (size >= 0),
+  created_at TEXT NOT NULL
+);
+
+CREATE TRIGGER project_readme_attachments_revision_insert
+AFTER INSERT ON project_readme_attachments
+BEGIN
+  UPDATE global_revision SET revision = revision + 1 WHERE singleton = 1;
+END;
+
+CREATE TRIGGER project_readme_attachments_revision_delete
+AFTER DELETE ON project_readme_attachments
+BEGIN
+  UPDATE global_revision SET revision = revision + 1 WHERE singleton = 1;
+END;

--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -798,6 +798,18 @@ function attachmentFromRow(row) {
   };
 }
 
+function projectReadmeAttachmentFromRow(row) {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    kind: "inline",
+    filename: row.filename,
+    contentType: row.content_type,
+    size: row.size,
+    createdAt: row.created_at,
+  };
+}
+
 async function all(statement) {
   return (await statement.all()).results;
 }
@@ -2473,17 +2485,63 @@ async function uploadAttachment(env, ownerType, ownerId, request) {
   return attachmentFromRow(row);
 }
 
+async function uploadProjectReadmeAttachment(env, projectId, request) {
+  await requireProject(env, projectId);
+  const metadata = parseAttachmentHeaders(request);
+  if (metadata.kind !== "inline") {
+    throw new ApiError(
+      400,
+      "INVALID_ATTACHMENT_KIND",
+      "Project README attachments must be inline",
+    );
+  }
+  const body = await readAttachment(request);
+  const id = uuid();
+  await env.ATTACHMENTS.put(id, body, {
+    httpMetadata: { contentType: metadata.contentType },
+  });
+  try {
+    await env.DB.prepare(`
+      INSERT INTO project_readme_attachments (
+        id, project_id, filename, content_type, size, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?)
+    `).bind(
+      id,
+      projectId,
+      metadata.filename,
+      metadata.contentType,
+      body.byteLength,
+      now(),
+    ).run();
+  } catch (error) {
+    await env.ATTACHMENTS.delete(id);
+    throw error;
+  }
+  const row = await env.DB.prepare(
+    "SELECT * FROM project_readme_attachments WHERE id = ?",
+  ).bind(id).first();
+  return projectReadmeAttachmentFromRow(row);
+}
+
 async function requireAttachment(env, id) {
   const row = await env.DB.prepare("SELECT * FROM attachments WHERE id = ?").bind(id).first();
-  if (!row) {
-    throw new ApiError(404, "ATTACHMENT_NOT_FOUND", `Attachment '${id}' does not exist`);
-  }
-  return attachmentFromRow(row);
+  if (row) return attachmentFromRow(row);
+  const projectReadmeRow = await env.DB.prepare(
+    "SELECT * FROM project_readme_attachments WHERE id = ?",
+  ).bind(id).first();
+  if (projectReadmeRow) return projectReadmeAttachmentFromRow(projectReadmeRow);
+  throw new ApiError(404, "ATTACHMENT_NOT_FOUND", `Attachment '${id}' does not exist`);
 }
 
 async function deleteAttachment(env, id) {
   const attachment = await requireAttachment(env, id);
-  await env.DB.prepare("DELETE FROM attachments WHERE id = ?").bind(attachment.id).run();
+  if (attachment.projectId) {
+    await env.DB.prepare(
+      "DELETE FROM project_readme_attachments WHERE id = ?",
+    ).bind(attachment.id).run();
+  } else {
+    await env.DB.prepare("DELETE FROM attachments WHERE id = ?").bind(attachment.id).run();
+  }
   await env.ATTACHMENTS.delete(attachment.id);
   return attachment;
 }
@@ -2652,6 +2710,20 @@ async function routeApi(request, env, actor, url) {
       ? await addProjectLabel(env, projectId, label)
       : await deleteProjectLabel(env, projectId, label);
     return json(200, { project });
+  }
+
+  const projectReadmeAttachmentsMatch = pathname.match(
+    /^\/api\/projects\/([^/]+)\/readme\/attachments$/,
+  );
+  if (projectReadmeAttachmentsMatch) {
+    requireNoQuery(url, "Project README attachment routes");
+    const projectId = validateProjectId(
+      decodePathPart(projectReadmeAttachmentsMatch[1], "Project id"),
+    );
+    if (request.method !== "POST") methodNotAllowed(["POST"]);
+    return json(201, {
+      attachment: await uploadProjectReadmeAttachment(env, projectId, request),
+    });
   }
 
   const projectReadmeMatch = pathname.match(

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -2404,6 +2404,44 @@ export function createTaskboardServer(options = {}) {
         return sendJson(response, 200, { project });
       }
 
+      const projectReadmeAttachmentsRoute = pathname.match(
+        /^\/api\/projects\/([^/]+)\/readme\/attachments$/,
+      );
+      if (projectReadmeAttachmentsRoute) {
+        if ([...url.searchParams.keys()].length > 0) {
+          throw new ApiError(400, "UNKNOWN_QUERY_PARAMETER", "Project README attachment routes do not accept query parameters");
+        }
+        let projectId;
+        try {
+          projectId = decodeURIComponent(projectReadmeAttachmentsRoute[1]);
+        } catch {
+          throw new ApiError(400, "INVALID_PATH", "Project id contains invalid encoding");
+        }
+        validateProjectId(projectId);
+        if (request.method !== "POST") return methodNotAllowed(response, ["POST"]);
+        const metadata = parseAttachmentHeaders(request);
+        if (metadata.kind !== "inline") {
+          throw new ApiError(400, "INVALID_ATTACHMENT_KIND", "Project README attachments must be inline");
+        }
+        const body = await readBody(request, ATTACHMENT_BODY_LIMIT, "Attachment cannot exceed 25 MiB");
+        const id = randomUUID();
+        await mkdir(resolved.attachmentsDirectory, { recursive: true });
+        const storagePath = path.join(resolved.attachmentsDirectory, id);
+        await writeFile(storagePath, body, { flag: "wx" });
+        let attachment;
+        try {
+          attachment = database.createProjectReadmeAttachment(projectId, {
+            id,
+            ...metadata,
+            size: body.length,
+          });
+        } catch (error) {
+          await unlink(storagePath);
+          throw error;
+        }
+        return sendJson(response, 201, { attachment });
+      }
+
       const projectReadmeRoute = pathname.match(/^\/api\/projects\/([^/]+)\/readme$/);
       if (projectReadmeRoute) {
         if ([...url.searchParams.keys()].length > 0) {
@@ -2777,7 +2815,7 @@ export function createTaskboardServer(options = {}) {
         if (request.method !== "GET" && request.method !== "HEAD") {
           return methodNotAllowed(response, ["GET", "HEAD"]);
         }
-        const attachment = database.getAttachment(id);
+        const attachment = database.getAttachment(id) ?? database.getProjectReadmeAttachment(id);
         if (!attachment) throw new ApiError(404, "ATTACHMENT_NOT_FOUND", `Attachment '${id}' does not exist`);
         const body = await readFile(path.join(resolved.attachmentsDirectory, attachment.id));
         const encodedFilename = encodeURIComponent(attachment.filename).replace(/['()*]/g, (character) => (

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -343,6 +343,18 @@ function projectReadmeFromRow(row, projectId) {
   };
 }
 
+function projectReadmeAttachmentFromRow(row) {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    kind: "inline",
+    filename: row.filename,
+    contentType: row.content_type,
+    size: row.size,
+    createdAt: row.created_at,
+  };
+}
+
 function aiChatRunFromRow(row) {
   return {
     id: row.id,
@@ -524,6 +536,15 @@ export class TaskboardDatabase {
         version INTEGER NOT NULL DEFAULT 1 CHECK (version > 0),
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS project_readme_attachments (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        filename TEXT NOT NULL,
+        content_type TEXT NOT NULL,
+        size INTEGER NOT NULL CHECK (size >= 0),
+        created_at TEXT NOT NULL
       );
 
       CREATE TABLE IF NOT EXISTS project_summaries (
@@ -1408,6 +1429,32 @@ export class TaskboardDatabase {
       throw error;
     }
     return this.getProjectReadme(projectId);
+  }
+
+  createProjectReadmeAttachment(projectId, input) {
+    if (!this.database.prepare("SELECT 1 FROM projects WHERE id = ?").get(projectId)) {
+      throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${projectId}' does not exist`);
+    }
+    this.database.prepare(`
+      INSERT INTO project_readme_attachments (
+        id, project_id, filename, content_type, size, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?)
+    `).run(
+      input.id,
+      projectId,
+      input.filename,
+      input.contentType,
+      input.size,
+      now(),
+    );
+    return this.getProjectReadmeAttachment(input.id);
+  }
+
+  getProjectReadmeAttachment(id) {
+    const row = this.database.prepare(`
+      SELECT * FROM project_readme_attachments WHERE id = ?
+    `).get(id);
+    return row ? projectReadmeAttachmentFromRow(row) : null;
   }
 
   listAiChatThreads() {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3759,8 +3759,10 @@ export function App() {
           <ProjectReadmeView
             key={selectedProjectId}
             project={selectedProject}
-            currentUser={currentUser}
+            tasks={tasks.filter((task) => task.projectId === selectedProject.id)}
+            referenceTasks={referenceTasks.filter((task) => task.projectId === selectedProject.id)}
             revision={readmeRevision}
+            onOpenTask={openTaskDetail}
             onError={setActionError}
           />
         ) : boardView === "dashboard" && selectedProject ? (

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -20,6 +20,7 @@ import type {
   JiraConnection,
   Project,
   ProjectReadme,
+  ProjectReadmeAttachment,
   ProjectSummary,
   Task,
   TaskChangeActivity,
@@ -454,6 +455,25 @@ export async function saveProjectReadme(
   return data.readme;
 }
 
+export async function uploadProjectReadmeAttachment(
+  projectId: string,
+  file: File,
+): Promise<ProjectReadmeAttachment> {
+  const data = await request<{ attachment: ProjectReadmeAttachment }>(
+    `/api/projects/${encodeURIComponent(projectId)}/readme/attachments`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": file.type || "application/octet-stream",
+        "X-Taskboard-Filename": encodeURIComponent(file.name),
+        "X-Taskboard-Attachment-Kind": "inline",
+      },
+      body: file,
+    },
+  );
+  return data.attachment;
+}
+
 export async function createProject(input: {
   id: string;
   name: string;
@@ -748,7 +768,7 @@ export async function deleteAttachment(attachment: Attachment): Promise<void> {
   });
 }
 
-export function attachmentContentUrl(attachment: Attachment): string {
+export function attachmentContentUrl(attachment: { id: string }): string {
   return `api/attachments/${encodeURIComponent(attachment.id)}/content`;
 }
 

--- a/web/src/components/DescriptionDocument.tsx
+++ b/web/src/components/DescriptionDocument.tsx
@@ -1,0 +1,106 @@
+import type { ClipboardEvent } from "react";
+import { readIssueIdentifier } from "../issueRoute";
+import type { Task, TaskRelationSummary } from "../types";
+import { STATUS_DETAILS } from "./BoardColumn";
+import {
+  createInlineMediaSegmentsFromHtml,
+  writeInlineMediaClipboard,
+} from "./InlineMediaComposer";
+import { MarkdownDocument } from "./MarkdownDocument";
+import { StatusIcon } from "./SemanticIcons";
+
+function referencedTask(
+  href: string,
+  referenceTasks: Task[],
+): { identifier: string; task: Task | null } | null {
+  try {
+    const base = new URL(document.baseURI);
+    base.search = "";
+    base.hash = "";
+    const url = new URL(href, base);
+    if (url.origin !== base.origin || url.pathname !== base.pathname) return null;
+    const identifier = readIssueIdentifier(url.search);
+    const projectId = url.searchParams.get("project");
+    if (!identifier || !projectId) return null;
+    const task = referenceTasks.find((candidate) => (
+      candidate.projectId === projectId && candidate.identifier === identifier
+    )) ?? null;
+    return { identifier: task?.externalKey ?? identifier, task };
+  } catch {
+    return null;
+  }
+}
+
+export function DescriptionDocument({
+  value,
+  referenceTasks,
+  onOpenTask,
+}: {
+  value: string;
+  referenceTasks: Task[];
+  onOpenTask: (task: TaskRelationSummary) => void;
+}) {
+  return (
+    <MarkdownDocument
+      value={value}
+      onCopy={(event: ClipboardEvent<HTMLDivElement>) => {
+        const selection = event.currentTarget.ownerDocument.getSelection();
+        if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
+        const range = selection.getRangeAt(0);
+        if (
+          !event.currentTarget.contains(range.startContainer)
+          || !event.currentTarget.contains(range.endContainer)
+        ) return;
+        const selectedRange = range.cloneRange();
+        const wrapper = event.currentTarget.ownerDocument.createElement("div");
+        wrapper.append(selectedRange.cloneContents());
+        const segments = createInlineMediaSegmentsFromHtml(wrapper.innerHTML, referenceTasks);
+        if (!segments) return;
+        event.preventDefault();
+        writeInlineMediaClipboard(
+          event.clipboardData,
+          segments,
+          event.currentTarget.ownerDocument,
+        );
+      }}
+      renderLink={(href) => {
+        const reference = href ? referencedTask(href, referenceTasks) : null;
+        if (!reference) return null;
+        const { task } = reference;
+        if (!task) {
+          return (
+            <span className="issue-reference-inline">
+              <span className="issue-reference-identity">
+                <span className="issue-reference-id">{reference.identifier}</span>
+              </span>
+            </span>
+          );
+        }
+        return (
+          <span className={`issue-reference-inline issue-reference-status-${task.status}`}>
+            <span className="issue-reference-identity">
+              <span className={`status-icon issue-reference-status status-icon-${STATUS_DETAILS[task.status].tone}`}>
+                <StatusIcon status={task.status} color="var(--column-status-color)" size={15} />
+              </span>
+              <span className="issue-reference-id">{task.externalKey ?? task.identifier}</span>
+            </span>
+            <span className="issue-reference-title">{task.title}</span>
+          </span>
+        );
+      }}
+      onLinkClick={(event, href) => {
+        const reference = href ? referencedTask(href, referenceTasks) : null;
+        if (
+          !reference
+          || event.button !== 0
+          || event.metaKey
+          || event.ctrlKey
+          || event.shiftKey
+          || event.altKey
+        ) return;
+        event.preventDefault();
+        if (reference.task) onOpenTask(reference.task);
+      }}
+    />
+  );
+}

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -17,7 +17,6 @@ import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import { unified } from "unified";
 import type {
-  Attachment,
   ComposerCandidate,
   ComposerCandidatesResponse,
   ComposerSurface,
@@ -535,7 +534,7 @@ export function serializeInlineMedia(segments: InlineMediaSegment[]): string {
 export function resolveInlineMediaMarkdown(
   value: string,
   images: PendingInlineImage[],
-  attachments: Attachment[],
+  attachments: Array<{ id: string }>,
 ): string {
   return images.reduce((markdown, image, index) => {
     const attachment = attachments[index];

--- a/web/src/components/ProjectReadmeView.css
+++ b/web/src/components/ProjectReadmeView.css
@@ -1,18 +1,24 @@
 .project-readme-container {
-  display: flex;
-  flex-direction: column;
   flex: 1;
+  min-width: 0;
   min-height: 0;
-  overflow-y: auto;
-  width: 100%;
-  max-width: 1080px;
+  overflow: auto;
+  padding: 32px 40px 80px;
+  box-sizing: border-box;
+  -webkit-user-select: text;
+  user-select: text;
+}
+
+.project-readme-content {
+  width: min(781px, 100%);
   margin: 0 auto;
-  padding: 20px 28px 48px;
+  padding: 0 14px 34px;
   box-sizing: border-box;
 }
 
 .project-readme-loading {
   display: flex;
+  flex: 1;
   flex-direction: column;
   align-items: center;
   justify-content: center;
@@ -35,105 +41,6 @@
   to { transform: rotate(360deg); }
 }
 
-.project-readme-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding-bottom: 18px;
-  margin-bottom: 24px;
-  border-bottom: 1px solid var(--border);
-}
-
-.project-readme-title-group {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-}
-
-.project-readme-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: 8px;
-  background: var(--surface-hover, rgba(0, 0, 0, 0.04));
-  color: var(--text-primary);
-  font-size: 18px;
-}
-
-.project-readme-title-info {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.project-readme-heading {
-  margin: 0;
-  font-size: 20px;
-  font-weight: 600;
-  color: var(--text-primary);
-  letter-spacing: -0.015em;
-}
-
-.project-readme-meta {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 12px;
-  color: var(--text-tertiary);
-}
-
-.project-readme-project-badge {
-  padding: 1px 7px;
-  border-radius: 4px;
-  background: var(--surface-hover, rgba(0, 0, 0, 0.05));
-  color: var(--text-secondary);
-  font-weight: 500;
-}
-
-.project-readme-actions,
-.project-readme-edit-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.project-readme-tab-toggle {
-  display: inline-flex;
-  padding: 2px;
-  background: var(--surface-hover, rgba(0, 0, 0, 0.04));
-  border-radius: 6px;
-  border: 1px solid var(--border);
-  margin-right: 4px;
-}
-
-.project-readme-tab {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 4px 10px;
-  border: none;
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 12px;
-  font-weight: 500;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: all 0.15s ease;
-}
-
-.project-readme-tab:hover {
-  color: var(--text-primary);
-}
-
-.project-readme-tab.is-active {
-  background: var(--surface, #ffffff);
-  color: var(--text-primary);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
-}
-
 .project-readme-alert {
   display: flex;
   align-items: center;
@@ -145,113 +52,7 @@
 }
 
 .project-readme-alert.error {
+  border: 1px solid rgba(220, 38, 38, 0.2);
   background: rgba(220, 38, 38, 0.1);
   color: #dc2626;
-  border: 1px solid rgba(220, 38, 38, 0.2);
-}
-
-.project-readme-content-wrapper,
-.project-readme-preview-wrapper {
-  padding: 24px 28px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  min-height: 380px;
-}
-
-.project-readme-editor-wrapper {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.project-readme-textarea-wrapper {
-  display: flex;
-  flex-direction: column;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--surface);
-  overflow: hidden;
-}
-
-.project-readme-textarea {
-  width: 100%;
-  padding: 18px 20px;
-  box-sizing: border-box;
-  border: none;
-  outline: none;
-  background: transparent;
-  color: var(--text-primary);
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
-  font-size: 13.5px;
-  line-height: 1.6;
-  resize: vertical;
-  min-height: 380px;
-}
-
-.project-readme-editor-footer {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 8px 16px;
-  background: var(--surface-hover, rgba(0, 0, 0, 0.02));
-  border-top: 1px solid var(--border);
-  font-size: 11.5px;
-  color: var(--text-tertiary);
-}
-
-.project-readme-preview-empty {
-  color: var(--text-tertiary);
-  font-size: 13px;
-  text-align: center;
-  padding: 40px 0;
-}
-
-.project-readme-empty-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  padding: 56px 24px;
-  background: var(--surface);
-  border: 1px dashed var(--border);
-  border-radius: 8px;
-  margin-top: 12px;
-}
-
-.project-readme-empty-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 52px;
-  height: 52px;
-  border-radius: 12px;
-  background: var(--surface-hover, rgba(0, 0, 0, 0.04));
-  color: var(--text-secondary);
-  font-size: 24px;
-  margin-bottom: 16px;
-}
-
-.project-readme-empty-title {
-  margin: 0 0 8px;
-  font-size: 17px;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.project-readme-empty-desc {
-  margin: 0 0 24px;
-  max-width: 480px;
-  font-size: 13px;
-  line-height: 1.55;
-  color: var(--text-secondary);
-}
-
-.project-readme-create-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 9px 18px;
-  font-size: 13px;
 }

--- a/web/src/components/ProjectReadmeView.tsx
+++ b/web/src/components/ProjectReadmeView.tsx
@@ -100,7 +100,7 @@ export function ProjectReadmeView({
 
   async function save() {
     if (saving || !readme) return;
-    const draftContent = serializeInlineMedia(segments).trim();
+    const draftContent = serializeInlineMedia(segments);
     const inlineImages = inlineMediaImages(segments);
     if (draftContent === readme.content && inlineImages.length === 0) {
       setEditing(false);
@@ -119,7 +119,7 @@ export function ProjectReadmeView({
         draftContent,
         inlineImages,
         uploaded,
-      ).trim();
+      );
       const updated = await saveProjectReadme(project.id, resolvedContent, readme.version);
       setReadme(updated);
       setSegments(createInlineMediaSegments(updated.content, referenceTasks));

--- a/web/src/components/ProjectReadmeView.tsx
+++ b/web/src/components/ProjectReadmeView.tsx
@@ -1,36 +1,56 @@
 import { useEffect, useRef, useState } from "react";
-import { ApiError, getProjectReadme, saveProjectReadme } from "../api";
+import {
+  ApiError,
+  getProjectReadme,
+  saveProjectReadme,
+  uploadProjectReadmeAttachment,
+} from "../api";
 import { useTaskboardI18n } from "../i18n";
-import type { ActorIdentity, Project, ProjectReadme } from "../types";
+import type { Project, ProjectReadme, Task, TaskRelationSummary } from "../types";
+import { DescriptionDocument } from "./DescriptionDocument";
+import {
+  createInlineMediaSegments,
+  InlineMediaComposer,
+  inlineMediaImages,
+  resolveInlineMediaMarkdown,
+  serializeInlineMedia,
+  type InlineMediaComposerHandle,
+  type InlineMediaSegment,
+} from "./InlineMediaComposer";
 import { LinearIcon } from "./LinearIcon";
-import { MarkdownDocument } from "./MarkdownDocument";
-import { EditIcon, PlusIcon } from "./SemanticIcons";
 import "./ProjectReadmeView.css";
+
+type ProjectReadmeError = string | readonly [string, string];
 
 interface ProjectReadmeViewProps {
   project: Project;
-  currentUser: ActorIdentity;
+  tasks: Task[];
+  referenceTasks: Task[];
   revision: number;
-  onError?: (error: string) => void;
+  onOpenTask: (task: TaskRelationSummary) => void;
+  onError?: (error: ProjectReadmeError | null) => void;
 }
 
 export function ProjectReadmeView({
   project,
-  currentUser: _currentUser,
+  tasks,
+  referenceTasks,
   revision,
+  onOpenTask,
   onError,
 }: ProjectReadmeViewProps) {
-  const { language, text } = useTaskboardI18n();
+  const { text } = useTaskboardI18n();
   const [readme, setReadme] = useState<ProjectReadme | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [loadRequest, setLoadRequest] = useState(0);
   const [editing, setEditing] = useState(false);
-  const [draftContent, setDraftContent] = useState("");
-  const [editTab, setEditTab] = useState<"write" | "preview">("write");
+  const [segments, setSegments] = useState<InlineMediaSegment[]>(
+    () => createInlineMediaSegments("", referenceTasks),
+  );
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const composerRef = useRef<InlineMediaComposerHandle>(null);
 
   useEffect(() => {
     if (editing) return;
@@ -42,12 +62,12 @@ export function ProjectReadmeView({
       .then((data) => {
         if (!active) return;
         setReadme(data);
-        setDraftContent(data.content);
+        setSegments(createInlineMediaSegments(data.content, referenceTasks));
       })
       .catch((err) => {
         if (!active) return;
-        const msg = err instanceof Error ? err.message : String(err);
-        setLoadError(msg);
+        const message = err instanceof Error ? err.message : String(err);
+        setLoadError(message);
       })
       .finally(() => {
         if (active) setLoading(false);
@@ -58,56 +78,67 @@ export function ProjectReadmeView({
     };
   }, [editing, loadRequest, project.id, revision]);
 
-  function handleStartEditing() {
+  useEffect(() => {
+    if (!editing) return;
+    requestAnimationFrame(() => {
+      composerRef.current?.focus();
+    });
+  }, [editing]);
+
+  function startEditing() {
     if (!readme) return;
-    setDraftContent(readme.content);
+    setSegments(createInlineMediaSegments(readme.content, referenceTasks));
     setEditing(true);
-    setEditTab("write");
     setSaveError(null);
-    setTimeout(() => {
-      textareaRef.current?.focus();
-    }, 50);
   }
 
-  function handleCancelEditing() {
+  function cancelEditing() {
+    setSegments(createInlineMediaSegments(readme?.content ?? "", referenceTasks));
     setEditing(false);
-    setDraftContent(readme?.content ?? "");
     setSaveError(null);
   }
 
-  async function handleSave() {
+  async function save() {
     if (saving || !readme) return;
+    const draftContent = serializeInlineMedia(segments).trim();
+    const inlineImages = inlineMediaImages(segments);
+    if (draftContent === readme.content && inlineImages.length === 0) {
+      setEditing(false);
+      return;
+    }
+
     setSaving(true);
     setSaveError(null);
+    onError?.(null);
 
     try {
-      const updated = await saveProjectReadme(
-        project.id,
-        draftContent,
-        readme.version,
+      const uploaded = await Promise.all(
+        inlineImages.map((image) => uploadProjectReadmeAttachment(project.id, image.file)),
       );
+      const resolvedContent = resolveInlineMediaMarkdown(
+        draftContent,
+        inlineImages,
+        uploaded,
+      ).trim();
+      const updated = await saveProjectReadme(project.id, resolvedContent, readme.version);
       setReadme(updated);
-      setDraftContent(updated.content);
+      setSegments(createInlineMediaSegments(updated.content, referenceTasks));
       setEditing(false);
     } catch (err) {
       if (err instanceof ApiError && err.code === "VERSION_CONFLICT") {
-        setSaveError(
-          text(
-            "项目文档已被其他协作者或 Agent 更新，请刷新后重试。",
-            "Project Docs were modified elsewhere. Please refresh and try again.",
-          ),
-        );
+        setSaveError(text(
+          "项目文档已被其他协作者或 Agent 更新，请刷新后重试。",
+          "Project Docs were modified elsewhere. Please refresh and try again.",
+        ));
       } else {
-        const msg = err instanceof Error ? err.message : String(err);
-        setSaveError(msg);
-        onError?.(msg);
+        const message = err instanceof Error ? err.message : String(err);
+        setSaveError(message);
+        onError?.(message);
       }
     } finally {
       setSaving(false);
     }
   }
-
-  const hasContent = Boolean(readme?.content && readme.content.trim().length > 0);
 
   if (loading) {
     return (
@@ -136,183 +167,93 @@ export function ProjectReadmeView({
     );
   }
 
+  const content = readme?.content ?? "";
+
   return (
     <div className="project-readme-container">
-      <div className="project-readme-header">
-        <div className="project-readme-title-group">
-          <span className="project-readme-icon" aria-hidden="true">
-            <LinearIcon name="file" />
-          </span>
-          <div className="project-readme-title-info">
-            <h1 className="project-readme-heading">
-              {text("项目文档", "Project Docs")}
-            </h1>
-            <div className="project-readme-meta">
-              <span className="project-readme-project-badge">{project.name}</span>
-              {readme?.updatedAt && (
-                <span className="project-readme-timestamp">
-                  {text("更新于", "Updated at")}{" "}
-                  {new Date(readme.updatedAt).toLocaleDateString(
-                    language === "zh" ? "zh-CN" : "en-US",
-                    {
-                      month: "short",
-                      day: "numeric",
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    },
-                  )}
-                </span>
-              )}
-            </div>
+      <div className="project-readme-content">
+        {saveError && (
+          <div className="project-readme-alert error" role="alert">
+            <LinearIcon name="alert" />
+            <span>{saveError}</span>
           </div>
-        </div>
+        )}
 
-        <div className="project-readme-actions">
-          {!editing ? (
+        {loadError && !editing && (
+          <div className="project-readme-alert error" role="alert">
+            <LinearIcon name="alert" />
+            <span>{loadError}</span>
             <button
               type="button"
-              className="button secondary project-readme-edit-btn"
-              onClick={handleStartEditing}
+              className="button secondary"
+              onClick={() => {
+                setLoading(true);
+                setLoadRequest((current) => current + 1);
+              }}
             >
-              <EditIcon color="currentColor" />
-              <span>{hasContent ? text("编辑项目文档", "Edit Project Docs") : text("编写项目文档", "Write Project Docs")}</span>
+              {text("重试", "Try again")}
             </button>
-          ) : (
-            <div className="project-readme-edit-actions">
-              <div className="project-readme-tab-toggle" role="tablist">
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={editTab === "write"}
-                  className={`project-readme-tab${editTab === "write" ? " is-active" : ""}`}
-                  onClick={() => setEditTab("write")}
-                >
-                  <EditIcon color="currentColor" />
-                  <span>{text("编辑", "Write")}</span>
-                </button>
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={editTab === "preview"}
-                  className={`project-readme-tab${editTab === "preview" ? " is-active" : ""}`}
-                  onClick={() => setEditTab("preview")}
-                >
-                  <LinearIcon name="file" />
-                  <span>{text("预览", "Preview")}</span>
-                </button>
-              </div>
+          </div>
+        )}
 
-              <button
-                type="button"
-                className="button ghost"
-                disabled={saving}
-                onClick={handleCancelEditing}
-              >
-                {text("取消", "Cancel")}
-              </button>
-
-              <button
-                type="button"
-                className="button primary"
-                disabled={saving}
-                onClick={() => void handleSave()}
-              >
-                {saving ? text("保存中…", "Saving…") : text("保存", "Save")}
-              </button>
-            </div>
-          )}
-        </div>
-      </div>
-
-      {saveError && (
-        <div className="project-readme-alert error" role="alert">
-          <LinearIcon name="alert" />
-          <span>{saveError}</span>
-        </div>
-      )}
-
-      {loadError && !editing && (
-        <div className="project-readme-alert error" role="alert">
-          <LinearIcon name="alert" />
-          <span>{loadError}</span>
-          <button
-            type="button"
-            className="button secondary"
-            onClick={() => {
-              setLoading(true);
-              setLoadRequest((current) => current + 1);
+        {editing ? (
+          <div
+            className="issue-description-composer"
+            onBlur={(event) => {
+              if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
+              void save();
             }}
           >
-            {text("重试", "Try again")}
-          </button>
-        </div>
-      )}
-
-      {editing ? (
-        <div className="project-readme-editor-wrapper">
-          {editTab === "write" ? (
-            <div className="project-readme-textarea-wrapper">
-              <textarea
-                ref={textareaRef}
-                className="project-readme-textarea"
-                value={draftContent}
-                onChange={(e) => setDraftContent(e.target.value)}
-                placeholder={text(
-                  "输入项目文档内容，支持 Markdown 语法…",
-                  "Enter Project Docs content in Markdown…",
-                )}
-                aria-label={text("项目文档内容", "Project Docs content")}
-                rows={24}
-              />
-              <div className="project-readme-editor-footer">
-                <span className="project-readme-char-count">
-                  {text(`${draftContent.length} 字符`, `${draftContent.length} characters`)}
-                </span>
-                <span className="project-readme-tip">
-                  {text("💡 提示：更详细的多页文档建议放置于项目本地 docs/ 目录", "💡 Tip: Detailed multi-page docs belong in the local docs/ directory")}
-                </span>
-              </div>
-            </div>
-          ) : (
-            <div className="project-readme-preview-wrapper markdown-preview-surface">
-              {draftContent.trim() ? (
-                <MarkdownDocument value={draftContent} />
-              ) : (
-                <p className="project-readme-preview-empty">
-                  {text("暂无预览内容", "No content to preview")}
-                </p>
-              )}
-            </div>
-          )}
-        </div>
-      ) : hasContent ? (
-        <div className="project-readme-content-wrapper markdown-preview-surface">
-          <MarkdownDocument value={readme?.content ?? ""} />
-        </div>
-      ) : (
-        <div className="project-readme-empty-state">
-          <div className="project-readme-empty-icon">
-            <LinearIcon name="file" />
+            <InlineMediaComposer
+              ref={composerRef}
+              segments={segments}
+              mentionTasks={tasks}
+              referenceTasks={referenceTasks}
+              completionContext={{
+                projectId: project.id,
+                surface: "issue-description",
+              }}
+              placeholder={text("添加说明...", "Add notes...")}
+              ariaLabel={text("项目文档", "Project Docs")}
+              disabled={saving}
+              onChange={setSegments}
+              onError={(message) => onError?.(message)}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  cancelEditing();
+                }
+              }}
+            />
           </div>
-          <h2 className="project-readme-empty-title">
-            {text("暂无项目文档", "No Project Docs for this project yet")}
-          </h2>
-          <p className="project-readme-empty-desc">
-            {text(
-              "创建项目文档，记录项目目标、技术栈、架构与规范，方便团队协作者与 Agent 快速上手。",
-              "Create Project Docs to document goals, architecture, tech stack, and conventions for collaborators and AI agents.",
-            )}
-          </p>
-          <button
-            type="button"
-            className="button primary project-readme-create-btn"
-            onClick={handleStartEditing}
+        ) : (
+          <div
+            className={`issue-description-read${content ? "" : " empty"}`}
+            role="button"
+            tabIndex={0}
+            aria-label={text("编辑项目文档", "Edit Project Docs")}
+            onClick={() => {
+              if (window.getSelection()?.isCollapsed === false) return;
+              startEditing();
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                startEditing();
+              }
+            }}
           >
-            <PlusIcon color="currentColor" size={16} />
-            <span>{text("开始编写项目文档", "Create Project Docs")}</span>
-          </button>
-        </div>
-      )}
+            {content
+              ? <DescriptionDocument
+                  value={content}
+                  referenceTasks={referenceTasks}
+                  onOpenTask={onOpenTask}
+                />
+              : text("添加说明...", "Add notes...")}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -2,7 +2,6 @@ import {
   useEffect,
   useRef,
   useState,
-  type ClipboardEvent,
   type KeyboardEvent,
   type MouseEvent,
 } from "react";
@@ -76,13 +75,11 @@ import {
 } from "./PendingAttachments";
 import {
   createInlineMediaSegments,
-  createInlineMediaSegmentsFromHtml,
   InlineMediaComposer,
   inlineMediaImages,
   inlineMediaText,
   resolveInlineMediaMarkdown,
   serializeInlineMedia,
-  writeInlineMediaClipboard,
   type InlineMediaComposerHandle,
   type InlineMediaSegment,
 } from "./InlineMediaComposer";
@@ -93,11 +90,11 @@ import {
   type RelationMutationResult,
 } from "./IssueRelations";
 import { TaskPropertyPicker } from "./TaskPropertyPicker";
-import { buildIssueUrl, readIssueIdentifier } from "../issueRoute";
+import { buildIssueUrl } from "../issueRoute";
 import { postEmbeddedHostMessage } from "../embeddedHost.mjs";
 import copyIdIcon from "../assets/figma-taskboard/copy-id.svg";
 import copyLinkIcon from "../assets/figma-taskboard/copy-link.svg";
-import { MarkdownDocument } from "./MarkdownDocument";
+import { DescriptionDocument } from "./DescriptionDocument";
 
 type TaskDetailError = string | readonly [string, string];
 
@@ -335,102 +332,6 @@ function ActivityChangeIcon({ field, before, after }: {
   if (field === "recurrence") return <RecurrenceIcon color="currentColor" size={14} />;
   if (field === "archivedAt") return <DeleteIcon color="currentColor" size={14} />;
   return <EditIcon color="currentColor" size={14} />;
-}
-
-function referencedTask(
-  href: string,
-  referenceTasks: Task[],
-): { identifier: string; task: Task | null } | null {
-  try {
-    const base = new URL(document.baseURI);
-    base.search = "";
-    base.hash = "";
-    const url = new URL(href, base);
-    if (url.origin !== base.origin || url.pathname !== base.pathname) return null;
-    const identifier = readIssueIdentifier(url.search);
-    const projectId = url.searchParams.get("project");
-    if (!identifier || !projectId) return null;
-    const task = referenceTasks.find((candidate) => (
-      candidate.projectId === projectId && candidate.identifier === identifier
-    )) ?? null;
-    return { identifier: task?.externalKey ?? identifier, task };
-  } catch {
-    return null;
-  }
-}
-
-function DescriptionDocument({
-  value,
-  referenceTasks,
-  onOpenTask,
-}: {
-  value: string;
-  referenceTasks: Task[];
-  onOpenTask: (task: TaskRelationSummary) => void;
-}) {
-  return (
-    <MarkdownDocument
-      value={value}
-      onCopy={(event: ClipboardEvent<HTMLDivElement>) => {
-        const selection = event.currentTarget.ownerDocument.getSelection();
-        if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return;
-        const range = selection.getRangeAt(0);
-        if (
-          !event.currentTarget.contains(range.startContainer)
-          || !event.currentTarget.contains(range.endContainer)
-        ) return;
-        const selectedRange = range.cloneRange();
-        const wrapper = event.currentTarget.ownerDocument.createElement("div");
-        wrapper.append(selectedRange.cloneContents());
-        const segments = createInlineMediaSegmentsFromHtml(wrapper.innerHTML, referenceTasks);
-        if (!segments) return;
-        event.preventDefault();
-        writeInlineMediaClipboard(
-          event.clipboardData,
-          segments,
-          event.currentTarget.ownerDocument,
-        );
-      }}
-      renderLink={(href) => {
-        const reference = href ? referencedTask(href, referenceTasks) : null;
-        if (!reference) return null;
-        const { task } = reference;
-        if (!task) {
-          return (
-            <span className="issue-reference-inline">
-              <span className="issue-reference-identity">
-                <span className="issue-reference-id">{reference.identifier}</span>
-              </span>
-            </span>
-          );
-        }
-        return (
-          <span className={`issue-reference-inline issue-reference-status-${task.status}`}>
-            <span className="issue-reference-identity">
-              <span className={`status-icon issue-reference-status status-icon-${STATUS_DETAILS[task.status].tone}`}>
-                <StatusIcon status={task.status} color="var(--column-status-color)" size={15} />
-              </span>
-              <span className="issue-reference-id">{task.externalKey ?? task.identifier}</span>
-            </span>
-            <span className="issue-reference-title">{task.title}</span>
-          </span>
-        );
-      }}
-      onLinkClick={(event, href) => {
-        const reference = href ? referencedTask(href, referenceTasks) : null;
-        if (
-          !reference
-          || event.button !== 0
-          || event.metaKey
-          || event.ctrlKey
-          || event.shiftKey
-          || event.altKey
-        ) return;
-        event.preventDefault();
-        if (reference.task) onOpenTask(reference.task);
-      }}
-    />
-  );
 }
 
 function ConversationLink({

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -356,6 +356,16 @@ export interface ProjectReadme {
   updatedAt: string | null;
 }
 
+export interface ProjectReadmeAttachment {
+  id: string;
+  projectId: string;
+  kind: "inline";
+  filename: string;
+  contentType: string;
+  size: number;
+  createdAt: string;
+}
+
 export interface TaskRelationSummary {
   id: string;
   identifier: string;


### PR DESCRIPTION
## Summary

- replace the standalone project document UI with the issue-description display and edit interaction
- reuse InlineMediaComposer, task references, copy and paste, image paste and drop, save-on-blur, and Escape cancel
- persist inline project-document images in local SQLite and Cloudflare D1/R2
- use 添加说明... for empty content

## Direct verification

- opened 项目文档 from the real top tab in an isolated Taskboard runtime
- verified click-to-edit and Escape cancel without a write
- verified task reference selection, clipboard image paste, upload 201, save 200, preview, and persistence after reload
- npm run typecheck
- npm run build:web
- git diff --check

Taskboard: LOCAL-270

This PR must not merge before the final integrated UI demo and user confirmation.