### PR TITLE
Fix submitted editor clipboard image export

### DIFF
--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -709,7 +709,18 @@ function inlineMediaClipboardHtml(
       wrapper.append(issue);
       continue;
     }
-    if (isInlineReference(segment) || segment.type === "persisted-image") {
+    if (segment.type === "persisted-image") {
+      const persistedImage = ownerDocument.createElement("img");
+      persistedImage.dataset.taskboardInlineMediaMarkdown = segment.markdown;
+      persistedImage.src = new URL(
+        resolvePersistedAttachmentUrl(segment.url),
+        ownerDocument.baseURI,
+      ).toString();
+      persistedImage.alt = segment.alt;
+      wrapper.append(persistedImage);
+      continue;
+    }
+    if (isInlineReference(segment)) {
       const markdown = ownerDocument.createElement("span");
       markdown.dataset.taskboardInlineMediaMarkdown = segment.markdown;
       markdown.textContent = segment.markdown;


### PR DESCRIPTION
## Summary
- export persisted inline images as real clipboard HTML images
- keep stable Taskboard Markdown metadata for in-app paste recovery
- preserve existing reference and pending-image clipboard behavior

## Direct verification
- Real Chrome pending mixed description -> Cmd+A/Cmd+C -> TextEdit: text, clickable issue link, and image present
- Submit the same description -> mouse selection/Cmd+C -> TextEdit: text, clickable issue link, and image present; no taskboard:// Markdown is exposed
- LOCAL-272 Backspace path on exact main: plain text end, mouse caret, selected text, and text after a persisted image all delete normally. No speculative deletion change was added because the reported failure did not reproduce in the isolated runtime.

## Checks
- npm run typecheck
- npm run build:web

Issues remain in_progress for coordinator handoff. This PR does not merge or release.