### PR TITLE
Release v1.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-taskboard",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-taskboard",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dependencies": {
         "dhtmlx-gantt": "^10.0.0",
         "dompurify": "^3.4.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-taskboard",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "codex-taskboard-launcher"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "base64 0.22.1",
  "dispatch2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-taskboard-launcher"
-version = "1.1.2"
+version = "1.1.3"
 description = "Codex Taskboard macOS launcher"
 edition = "2021"
 rust-version = "1.88"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex Taskboard",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "identifier": "com.chuspeeism.codex-taskboard",
   "app": {
     "windows": []


### PR DESCRIPTION
## Summary
- bump the app version to 1.1.3

## Verification
- package, lockfile, Cargo, and Tauri versions agree
- git diff --check passes