### PR TITLE
Default new users to all issues

### DIFF
--- a/test/project-home.test.mjs
+++ b/test/project-home.test.mjs
@@ -41,7 +41,7 @@ test("imported Codex projects persist their exact device identity", () => {
 
 test("project selection starts from the route or recent projects and updates the route", () => {
   assert.match(appSource, /const RECENT_PROJECT_IDS_KEY = "taskboard\.recentProjectIds\.v1"/);
-  assert.match(appSource, /const initialProjectId = query\.get\("project"\) \?\? recentProjectIds\[0\] \?\? GLOBAL_PROJECT_ID/);
+  assert.match(appSource, /const initialProjectId = query\.get\("project"\) \?\? recentProjectIds\[0\] \?\? ALL_PROJECTS_ID/);
   assert.match(appSource, /const rememberProjectOpen = useCallback/);
   assert.match(appSource, /taskboardStorage\.setItem\(RECENT_PROJECT_IDS_KEY, JSON\.stringify\(next\)\)/);
   assert.match(appSource, /function changeProject\(projectId: string\)/);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -722,7 +722,7 @@ export function App() {
   >({});
   const [processingNow, setProcessingNow] = useState(() => Date.now());
   const [recentProjectIds, setRecentProjectIds] = useState(readRecentProjectIds);
-  const initialProjectId = query.get("project") ?? recentProjectIds[0] ?? GLOBAL_PROJECT_ID;
+  const initialProjectId = query.get("project") ?? recentProjectIds[0] ?? ALL_PROJECTS_ID;
   const [projects, setProjects] = useState<Project[]>([]);
   const [selectedProjectId, setSelectedProjectId] = useState(initialProjectId);
   const [tasks, setTasks] = useState<Task[]>([]);


### PR DESCRIPTION
## Summary
- default a new user with no route or recent project to All projects
- preserve explicit URL and recent-project selections
- update the existing source contract assertion for the new default

## Verification
- npm run typecheck
- npm run build:web
- node --test test/project-home.test.mjs (13/13)
- headed Chromium: empty storage opened All projects with aggregate task requests
- headed Chromium: saved recent project local still opened Temporary tasks with projectId=local