### PR TITLE
Fix AI chat panel position and activity alignment

### DIFF
--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -189,6 +189,7 @@ type PanelResizeSession = {
 };
 
 const LAST_THREAD_KEY = "taskboard.aiChat.lastThreadId";
+const PANEL_VIEW_KEY = "taskboard.aiChat.panelView";
 const PANEL_GEOMETRY_KEY = "taskboard.aiChat.panelGeometry";
 const PANEL_EDGE_GAP = 8;
 const PANEL_MIN_WIDTH = 420;
@@ -1303,7 +1304,9 @@ export function AiChat({
 }: AiChatProps) {
   const { locale, text } = useTaskboardI18n();
   const [panelOpen, setPanelOpen] = useState(false);
-  const [historyOpen, setHistoryOpen] = useState(false);
+  const [historyOpen, setHistoryOpen] = useState(
+    () => taskboardStorage.getItem(PANEL_VIEW_KEY) === "history",
+  );
   const [menu, setMenu] = useState<MenuName>(null);
   const [threads, setThreads] = useState<AiChatThread[]>([]);
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(
@@ -1373,6 +1376,10 @@ export function AiChat({
     if (selectedThreadId) taskboardStorage.setItem(LAST_THREAD_KEY, selectedThreadId);
     else taskboardStorage.removeItem(LAST_THREAD_KEY);
   }, [selectedThreadId]);
+
+  useEffect(() => {
+    taskboardStorage.setItem(PANEL_VIEW_KEY, historyOpen ? "history" : "thread");
+  }, [historyOpen]);
 
   useEffect(() => {
     panelOpenRef.current = panelOpen;
@@ -1548,6 +1555,7 @@ export function AiChat({
     try {
       const next = await listAiChatThreads();
       setThreads(next);
+      if (next.length === 0) setHistoryOpen(false);
       setSelectedThreadId((current) => {
         const selected = current && next.some((thread) => thread.id === current)
           ? current
@@ -2097,6 +2105,7 @@ export function AiChat({
       await deleteAiChatThread(thread.id);
       const remainingThreads = threads.filter((candidate) => candidate.id !== thread.id);
       setThreads(remainingThreads);
+      if (remainingThreads.length === 0) setHistoryOpen(false);
       if (selectedThreadRef.current === thread.id) {
         setSnapshot(null);
         setDraftOrigin(null);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6807,12 +6807,12 @@ kbd {
 
 .ai-chat-thinking-detail-trigger {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   width: 100%;
   min-width: 0;
   min-height: 26px;
   gap: 6px;
-  padding: 4px 12px;
+  padding: 0 12px;
   border: 0;
   border-radius: 6px;
   background: transparent;


### PR DESCRIPTION
## Summary

- Persist the AI chat panel's list/detail position across close and remount.
- Open a new chat when the real thread list is empty.
- Align command activity labels with their terminal icons.

## Validation

- npm run typecheck
- npm run build:web
- Real browser: detail close/reopen, list close/reopen, and empty-list first open
- Same-row visual check: terminal icon and command label center delta 0.375 CSS px