### PR TITLE
Fix Windows Codex takeover

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-updater",
  "uuid",
+ "windows",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,3 +28,6 @@ dispatch2 = "0.3.1"
 objc2 = "0.6.4"
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "libc", "NSAlert", "NSApplication", "NSButton", "NSControl", "NSProgressIndicator", "NSResponder", "NSRunningApplication", "NSView", "NSWindow"] }
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSString"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.61", features = ["Win32_Foundation", "Win32_System_RestartManager", "Win32_System_Threading"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -56,7 +56,7 @@ use tauri_plugin_updater::{Update, UpdaterExt};
 use uuid::Uuid;
 
 const STOP_TIMEOUT: Duration = Duration::from_secs(5);
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 const LAUNCHER_STOP_TIMEOUT: Duration = Duration::from_secs(36);
 const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(30 * 60);
 // Unique whole-directory snapshots shipped from app-v0.2.0 through v1.1.2.
@@ -714,6 +714,55 @@ fn find_codex_app(_home_directory: &Path) -> Option<PathBuf> {
     candidate.is_file().then_some(candidate)
 }
 
+#[cfg(target_os = "windows")]
+fn ordinary_codex_process(app_path: &Path) -> Result<Option<u32>, String> {
+    let output = StdCommand::new("powershell.exe")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "$ErrorActionPreference = 'Stop'; $name = [IO.Path]::GetFileNameWithoutExtension($env:CODEX_TASKBOARD_CODEX_APP_PATH); $process = Get-Process -Name $name -ErrorAction SilentlyContinue | Where-Object { $_.Path -eq $env:CODEX_TASKBOARD_CODEX_APP_PATH -and $_.MainWindowHandle -ne 0 } | Select-Object -First 1; if ($null -ne $process) { [Console]::Out.Write($process.Id) }",
+        ])
+        .env("CODEX_TASKBOARD_CODEX_APP_PATH", app_path)
+        .output()
+        .map_err(|error| error.to_string())?;
+    if !output.status.success() {
+        return Err("无法检查正在运行的 Codex".to_string());
+    }
+    let pid = String::from_utf8_lossy(&output.stdout);
+    let pid = pid.trim();
+    if pid.is_empty() {
+        return Ok(None);
+    }
+    pid.parse()
+        .map(Some)
+        .map_err(|_| "无法检查正在运行的 Codex".to_string())
+}
+
+#[cfg(target_os = "windows")]
+fn quit_codex_normally(pid: u32) -> Result<(), String> {
+    let status = StdCommand::new("powershell.exe")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "$ErrorActionPreference = 'Stop'; $process = Get-Process -Id $env:CODEX_TASKBOARD_CODEX_PID -ErrorAction SilentlyContinue; if ($null -eq $process) { exit 0 }; if (-not $process.CloseMainWindow()) { exit 2 }; if (-not $process.WaitForExit([int]$env:CODEX_TASKBOARD_CODEX_EXIT_TIMEOUT_MS)) { exit 3 }",
+        ])
+        .env("CODEX_TASKBOARD_CODEX_PID", pid.to_string())
+        .env(
+            "CODEX_TASKBOARD_CODEX_EXIT_TIMEOUT_MS",
+            LAUNCHER_STOP_TIMEOUT.as_millis().to_string(),
+        )
+        .status()
+        .map_err(|error| error.to_string())?;
+    match status.code() {
+        Some(0) => Ok(()),
+        Some(2) => Err("Codex 没有接受退出请求".to_string()),
+        Some(3) => Err("Codex 尚未退出，任务面板没有启动".to_string()),
+        _ => Err("无法正常关闭 Codex".to_string()),
+    }
+}
+
 #[cfg(target_os = "macos")]
 fn missing_codex_app_message() -> String {
     "未找到官方 ChatGPT.app 或 Codex.app。请先安装到 Applications 文件夹。".to_string()
@@ -1039,7 +1088,7 @@ fn start_launcher_locked(
             "node"
         });
     stop_recorded_child(state);
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     if let Some(codex_pid) = ordinary_codex_process(&codex_app)? {
         let restart = app
             .dialog()

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -727,7 +727,9 @@ fn find_codex_app(_home_directory: &Path) -> Option<PathBuf> {
         return None;
     }
     let install_location = String::from_utf8_lossy(&output.stdout);
-    let candidate = PathBuf::from(install_location.trim()).join("app/ChatGPT.exe");
+    let candidate = PathBuf::from(install_location.trim())
+        .join("app")
+        .join("ChatGPT.exe");
     candidate.is_file().then_some(candidate)
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -54,6 +54,23 @@ use tauri_plugin_autostart::{MacosLauncher, ManagerExt};
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 use tauri_plugin_updater::{Update, UpdaterExt};
 use uuid::Uuid;
+#[cfg(target_os = "windows")]
+use windows::{
+    core::PWSTR,
+    Win32::{
+        Foundation::{CloseHandle, ERROR_SUCCESS, FILETIME, WAIT_OBJECT_0},
+        System::{
+            RestartManager::{
+                RmEndSession, RmRegisterResources, RmShutdown, RmStartSession, CCH_RM_SESSION_KEY,
+                RM_UNIQUE_PROCESS,
+            },
+            Threading::{
+                GetProcessTimes, OpenProcess, WaitForSingleObject,
+                PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE,
+            },
+        },
+    },
+};
 
 const STOP_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(any(target_os = "macos", target_os = "windows"))]
@@ -715,15 +732,16 @@ fn find_codex_app(_home_directory: &Path) -> Option<PathBuf> {
 }
 
 #[cfg(target_os = "windows")]
-fn ordinary_codex_process(app_path: &Path) -> Result<Option<u32>, String> {
+fn ordinary_codex_process(app_path: &Path, codex_profile: &Path) -> Result<Option<u32>, String> {
     let output = StdCommand::new("powershell.exe")
         .args([
             "-NoProfile",
             "-NonInteractive",
             "-Command",
-            "$ErrorActionPreference = 'Stop'; $name = [IO.Path]::GetFileNameWithoutExtension($env:CODEX_TASKBOARD_CODEX_APP_PATH); $process = Get-Process -Name $name -ErrorAction SilentlyContinue | Where-Object { $_.Path -eq $env:CODEX_TASKBOARD_CODEX_APP_PATH -and $_.MainWindowHandle -ne 0 } | Select-Object -First 1; if ($null -ne $process) { [Console]::Out.Write($process.Id) }",
+            "$ErrorActionPreference = 'Stop'; $app = $env:CODEX_TASKBOARD_CODEX_APP_PATH; $profile = $env:CODEX_TASKBOARD_CODEX_PROFILE; $name = [IO.Path]::GetFileName($app); $all = @(Get-CimInstance Win32_Process -Filter \"Name = '$name'\" | Where-Object { $_.ExecutablePath -eq $app }); $pids = @{}; foreach ($item in $all) { $pids[[uint32]$item.ProcessId] = $true }; $process = $all | Where-Object { $command = [string]$_.CommandLine; $isRoot = -not $pids.ContainsKey([uint32]$_.ParentProcessId); $isManaged = $command.IndexOf('--remote-debugging-pipe', [StringComparison]::OrdinalIgnoreCase) -ge 0 -and $command.IndexOf(('--user-data-dir=' + $profile), [StringComparison]::OrdinalIgnoreCase) -ge 0; $isRoot -and -not $isManaged } | Select-Object -First 1; if ($null -ne $process) { [Console]::Out.Write($process.ProcessId) }",
         ])
         .env("CODEX_TASKBOARD_CODEX_APP_PATH", app_path)
+        .env("CODEX_TASKBOARD_CODEX_PROFILE", codex_profile)
         .output()
         .map_err(|error| error.to_string())?;
     if !output.status.success() {
@@ -741,25 +759,67 @@ fn ordinary_codex_process(app_path: &Path) -> Result<Option<u32>, String> {
 
 #[cfg(target_os = "windows")]
 fn quit_codex_normally(pid: u32) -> Result<(), String> {
-    let status = StdCommand::new("powershell.exe")
-        .args([
-            "-NoProfile",
-            "-NonInteractive",
-            "-Command",
-            "$ErrorActionPreference = 'Stop'; $process = Get-Process -Id $env:CODEX_TASKBOARD_CODEX_PID -ErrorAction SilentlyContinue; if ($null -eq $process) { exit 0 }; if (-not $process.CloseMainWindow()) { exit 2 }; if (-not $process.WaitForExit([int]$env:CODEX_TASKBOARD_CODEX_EXIT_TIMEOUT_MS)) { exit 3 }",
-        ])
-        .env("CODEX_TASKBOARD_CODEX_PID", pid.to_string())
-        .env(
-            "CODEX_TASKBOARD_CODEX_EXIT_TIMEOUT_MS",
-            LAUNCHER_STOP_TIMEOUT.as_millis().to_string(),
+    let process = unsafe {
+        OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SYNCHRONIZE,
+            false,
+            pid,
         )
-        .status()
-        .map_err(|error| error.to_string())?;
-    match status.code() {
-        Some(0) => Ok(()),
-        Some(2) => Err("Codex 没有接受退出请求".to_string()),
-        Some(3) => Err("Codex 尚未退出，任务面板没有启动".to_string()),
-        _ => Err("无法正常关闭 Codex".to_string()),
+    }
+    .map_err(|error| error.to_string())?;
+    let mut creation_time = FILETIME::default();
+    let mut exit_time = FILETIME::default();
+    let mut kernel_time = FILETIME::default();
+    let mut user_time = FILETIME::default();
+    if unsafe {
+        GetProcessTimes(
+            process,
+            &mut creation_time,
+            &mut exit_time,
+            &mut kernel_time,
+            &mut user_time,
+        )
+    }
+    .is_err()
+    {
+        let _ = unsafe { CloseHandle(process) };
+        return Err("无法检查正在运行的 Codex".to_string());
+    }
+
+    let mut session = 0;
+    let mut session_key = [0u16; CCH_RM_SESSION_KEY as usize + 1];
+    let started = unsafe { RmStartSession(&mut session, None, PWSTR(session_key.as_mut_ptr())) };
+    if started != ERROR_SUCCESS {
+        let _ = unsafe { CloseHandle(process) };
+        return Err("无法请求 Codex 退出".to_string());
+    }
+    let application = RM_UNIQUE_PROCESS {
+        dwProcessId: pid,
+        ProcessStartTime: creation_time,
+    };
+    let registered = unsafe { RmRegisterResources(session, None, Some(&[application]), None) };
+    let shutdown = if registered == ERROR_SUCCESS {
+        unsafe { RmShutdown(session, 0, None) }
+    } else {
+        registered
+    };
+    let _ = unsafe { RmEndSession(session) };
+    if shutdown != ERROR_SUCCESS {
+        let _ = unsafe { CloseHandle(process) };
+        return Err("Codex 没有接受退出请求".to_string());
+    }
+
+    let exited = unsafe {
+        WaitForSingleObject(
+            process,
+            LAUNCHER_STOP_TIMEOUT.as_millis().try_into().unwrap(),
+        )
+    } == WAIT_OBJECT_0;
+    let _ = unsafe { CloseHandle(process) };
+    if exited {
+        Ok(())
+    } else {
+        Err("Codex 尚未退出，任务面板没有启动".to_string())
     }
 }
 
@@ -1087,9 +1147,13 @@ fn start_launcher_locked(
         } else {
             "node"
         });
+    let codex_profile = state.data_directory.join("codex-profile");
     stop_recorded_child(state);
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
-    if let Some(codex_pid) = ordinary_codex_process(&codex_app)? {
+    #[cfg(target_os = "macos")]
+    let ordinary_codex_pid = ordinary_codex_process(&codex_app)?;
+    #[cfg(target_os = "windows")]
+    let ordinary_codex_pid = ordinary_codex_process(&codex_app, &codex_profile)?;
+    if let Some(codex_pid) = ordinary_codex_pid {
         let restart = app
             .dialog()
             .message("需要重新启动 Codex 才能显示任务面板")
@@ -1145,7 +1209,6 @@ fn start_launcher_locked(
     let instance_token = Uuid::new_v4().to_string();
     let instance_secret = Uuid::new_v4().to_string();
     let version = state.snapshot.lock().unwrap().version.clone();
-    let codex_profile = state.data_directory.join("codex-profile");
     #[cfg(target_os = "macos")]
     let codex_source_profile = home_directory.join("Library/Application Support/Codex");
     #[cfg(target_os = "windows")]
@@ -1367,9 +1430,7 @@ fn restart_launcher(
         }
         stop_managed_child_locked(app, state);
         let result = start_launcher_locked(app, state);
-        if result.is_err() {
-            state.intentional_stop.store(false, Ordering::SeqCst);
-        }
+        state.intentional_stop.store(false, Ordering::SeqCst);
         let generation = state.generation.load(Ordering::SeqCst);
         (result, generation)
     };


### PR DESCRIPTION
## Summary
- detect an open official Codex main window before the Windows private CDP pipe launch
- keep cancel side-effect free; on confirmation request a normal window close and wait for the process to exit
- preserve the existing managed-child and tray open reuse paths

## Validation
- npm run typecheck
- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- macOS Tauri cargo check with Rust 1.88
- Windows x64 CI and the four real Codex lifecycle paths remain to complete

Closes #198