### PR TITLE
Fix AI chat Escape behavior

### DIFF
--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -1751,21 +1751,12 @@ export function AiChat({
       event.preventDefault();
       event.stopPropagation();
       if (typeof event.stopImmediatePropagation === "function") event.stopImmediatePropagation();
-      if (dangerConfirmOpen) setPendingDangerInput(null);
-      else if (composerQueryState) {
-        dismissedComposerQueryRef.current = `${composerQueryState.trigger}${composerQueryState.query}`;
-        setComposerQueryState(null);
-      }
-      else if (menu) setMenu(null);
-      else if (historyOpen) setHistoryOpen(false);
-      else {
-        restorePersistedConversationFromDraft();
-        setPanelOpen(false);
-      }
+      restorePersistedConversationFromDraft();
+      setPanelOpen(false);
     }
     document.addEventListener("keydown", closeWithEscape, true);
     return () => document.removeEventListener("keydown", closeWithEscape, true);
-  }, [composerQueryState, dangerConfirmOpen, draftOrigin, historyOpen, menu, panelOpen, threads]);
+  }, [draftOrigin, panelOpen, threads]);
 
   const visibleComposerCandidates = useMemo(() => {
     const candidates = composerCandidates?.candidates.filter((candidate) => (


### PR DESCRIPTION
## Summary

- Make Esc close the entire AI chat panel from any internal view.
- Preserve the existing list/detail position, thread selection, and close behavior.

## Validation

- npm run typecheck
- npm run build:web
- Real browser: detail -> Esc closes the panel
- Real browser: history list -> Esc closes the panel without returning to thread detail; reopening restores the list
- git diff --check