### PR TITLE
Show Dashboard across all projects

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3618,16 +3618,14 @@ export function App() {
 
         {selectedProjectId && !detailTask && <div className="board-toolbar">
           <div className="view-tabs" aria-label={text("看板视图", "Board views")}>
-            {!isAllProjects && (
-              <button
-                className={`view-tab${boardView === "dashboard" ? " active" : ""}`}
-                type="button"
-                aria-pressed={boardView === "dashboard"}
-                onClick={() => selectBoardView("dashboard")}
-              >
-                {text("仪表盘", "Dashboard")}
-              </button>
-            )}
+            <button
+              className={`view-tab${boardView === "dashboard" ? " active" : ""}`}
+              type="button"
+              aria-pressed={boardView === "dashboard"}
+              onClick={() => selectBoardView("dashboard")}
+            >
+              {text("仪表盘", "Dashboard")}
+            </button>
             <button
               className={`view-tab${boardView === "issues" ? " active" : ""}`}
               type="button"
@@ -3843,11 +3841,12 @@ export function App() {
             onOpenTask={openTaskDetail}
             onError={setActionError}
           />
-        ) : boardView === "dashboard" && selectedProject ? (
+        ) : boardView === "dashboard" && (selectedProject || isAllProjects) ? (
           <DashboardView
             key={selectedProjectId}
             projectId={selectedProjectId}
             projectCreatedAt={selectedProject?.createdAt ?? null}
+            isAllProjects={isAllProjects}
             tasks={tasks}
             presentations={taskPresentations}
             currentUser={currentUser}

--- a/web/src/components/DashboardView.tsx
+++ b/web/src/components/DashboardView.tsx
@@ -19,6 +19,7 @@ import { TaskConversationMenu } from "./TaskConversationMenu";
 interface DashboardViewProps {
   projectId: string;
   projectCreatedAt: string | null;
+  isAllProjects: boolean;
   tasks: Task[];
   presentations: Record<string, TaskCardPresentation>;
   currentUser: ActorIdentity;
@@ -165,6 +166,7 @@ function shortDate(value: string, locale: string) {
 export function DashboardView({
   projectId,
   projectCreatedAt,
+  isAllProjects,
   tasks,
   presentations,
   currentUser,
@@ -190,6 +192,11 @@ export function DashboardView({
   }, [animateSummaryOnMount, onSummaryAnimationStart, projectId]);
 
   useEffect(() => {
+    if (isAllProjects) {
+      setProjectSummary(null);
+      setSummaryLoadFailed(false);
+      return undefined;
+    }
     let disposed = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
     const controller = new AbortController();
@@ -217,7 +224,7 @@ export function DashboardView({
       controller.abort();
       if (timer) clearTimeout(timer);
     };
-  }, [projectId]);
+  }, [isAllProjects, projectId]);
 
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -237,7 +244,16 @@ export function DashboardView({
   const completionRate = tasks.length
     ? Math.round((completedTasks.length / tasks.length) * 100)
     : 0;
-  const progressData = buildProgressData(tasks, todayValue, projectCreatedAt);
+  const aggregateCreatedAt = isAllProjects
+    ? tasks.reduce<string | null>((earliest, task) => (
+        !earliest || task.createdAt < earliest ? task.createdAt : earliest
+      ), null)
+    : null;
+  const progressData = buildProgressData(
+    tasks,
+    todayValue,
+    projectCreatedAt ?? aggregateCreatedAt,
+  );
   const progressChart = (() => {
     const left = 0;
     const right = 426;
@@ -412,13 +428,18 @@ export function DashboardView({
     },
   ];
 
-  const summaryBody = projectSummary?.summary
-    ?? (summaryLoadFailed || projectSummary?.error
-      ? text("Codex 暂时无法生成项目总结。", "Codex cannot generate the project summary now.")
-      : text(
-          "Codex 正在整理当前项目的进展、风险和下一步重点…",
-          "Codex is reviewing the project's progress, risks, and next steps…",
-        ));
+  const summaryBody = isAllProjects
+    ? text(
+        `所有项目共有 ${tasks.length} 个议题，${completedTasks.length} 个已完成，${activeTasks.length} 个尚未结束；当前 ${tasks.filter((task) => task.status === "blocked").length} 个遇到阻碍，${overdueTasks.length} 个已逾期。`,
+        `Across all projects, ${tasks.length} issues are tracked: ${completedTasks.length} completed and ${activeTasks.length} still open; ${tasks.filter((task) => task.status === "blocked").length} are blocked and ${overdueTasks.length} overdue.`,
+      )
+    : projectSummary?.summary
+      ?? (summaryLoadFailed || projectSummary?.error
+        ? text("Codex 暂时无法生成项目总结。", "Codex cannot generate the project summary now.")
+        : text(
+            "Codex 正在整理当前项目的进展、风险和下一步重点…",
+            "Codex is reviewing the project's progress, risks, and next steps…",
+          ));
   const hour = new Date().getHours();
   const greeting = hour < 12
     ? text("上午好", "Good morning")
@@ -430,7 +451,7 @@ export function DashboardView({
     `${greeting}，${currentUser.name}，今天是${summaryDate}，${summaryBody}`,
     `${greeting}, ${currentUser.name}. Today is ${summaryDate}. ${summaryBody}`,
   );
-  const summaryReady = projectSummary !== null || summaryLoadFailed;
+  const summaryReady = isAllProjects || projectSummary !== null || summaryLoadFailed;
 
   useEffect(() => {
     if (!summaryReady) {


### PR DESCRIPTION
## Summary

- expose the existing Dashboard tab on the virtual All projects view
- reuse the existing aggregate task reads and Dashboard components
- build the aggregate summary and progress range from the returned tasks
- keep each task's real project ID for Dashboard-to-detail navigation

## Direct verification

- `npm run typecheck`
- `npm run build:web`
- headed Chrome with the current worktree build routed to the installed active Taskboard runtime
  - All projects returned 570 active tasks across 6 real project IDs
  - aggregate reads were `GET /api/tasks?archived=false` and `GET /api/tasks?archived=true`, with no `projectId`
  - Dashboard counts matched the aggregate response
  - clicking DEE-5 opened its real DeepSeek Harness project and issue
  - concrete-project control opened LOCAL-194 from the existing Dashboard
  - no POST, PATCH, PUT, or DELETE request occurred

## Scope

- no new Dashboard layout or parallel UI
- no server, data-model, or task-write API changes
- no added tests or compatibility layer
