### PR TITLE
Prefill manage-taskboard skill in new task conversations

### DIFF
--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -1086,11 +1086,12 @@
             "The target project or worktree is not mapped in Codex",
           ));
         }
+        const { targetRoot } = target;
         bridge.sendMessageFromView({
           type: "electron-add-new-workspace-root-option",
-          root: target.targetRoot,
+          root: targetRoot,
         });
-        lastNativeProjectId = await waitForNativeProject(target.targetRoot);
+        lastNativeProjectId = await waitForNativeProject(targetRoot);
       }
 
       closeTaskboard(false);

--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -25,7 +25,6 @@
   const REATTACH_DELAY_MS = 160;
   const FRAME_READY_TIMEOUT_MS = 12_000;
   const HOST_REQUEST_TIMEOUT_MS = 12_000;
-  const TASK_CONVERSATION_REQUEST_TIMEOUT_MS = 75_000;
   const HOST_HEARTBEAT_MAX_AGE_MS = 8_000;
   const MACOS_TITLEBAR_SAFE_LEFT = 80;
   const FRAME_REFRESH_PARAM = "__codex_taskboard_refresh";
@@ -1071,28 +1070,15 @@
         ));
       }
 
-      const previousComposerRoot = Array.from(document.querySelectorAll(
-        '[data-codex-composer-root][data-composer-placement="thread"]',
-      )).find((candidate) => candidate.getClientRects().length > 0);
-      const previousThreadId = normalizeThreadId(
-        previousComposerRoot
-          ?.querySelector("[data-above-composer-conversation-id]")
-          ?.getAttribute("data-above-composer-conversation-id"),
-      );
-      let codexHostId = "local";
-      let targetRoot;
-      if (projectless) {
-        targetRoot = "";
-      } else if (codexProjectKind === "remote") {
-        codexHostId = typeof payload?.codexHostId === "string"
+      if (!projectless && codexProjectKind === "remote") {
+        const codexHostId = typeof payload?.codexHostId === "string"
           ? payload.codexHostId.trim()
           : "";
         const codexProjectWorkspacePath = typeof payload?.codexProjectWorkspacePath === "string"
           ? payload.codexProjectWorkspacePath.trim()
           : "";
         await waitForRemoteProject(requestedProjectId, codexHostId, codexProjectWorkspacePath);
-        targetRoot = codexProjectWorkspacePath;
-      } else {
+      } else if (!projectless) {
         const target = await resolveNativeProject(requestedProjectId, workspacePath);
         if (!target) {
           throw new Error(hostText(
@@ -1100,12 +1086,11 @@
             "The target project or worktree is not mapped in Codex",
           ));
         }
-        targetRoot = target.targetRoot;
         bridge.sendMessageFromView({
           type: "electron-add-new-workspace-root-option",
-          root: targetRoot,
+          root: target.targetRoot,
         });
-        lastNativeProjectId = await waitForNativeProject(targetRoot);
+        lastNativeProjectId = await waitForNativeProject(target.targetRoot);
       }
 
       closeTaskboard(false);
@@ -1119,41 +1104,8 @@
           ...(projectless ? { project: null } : {}),
         },
       });
-      const started = await requestHostTaskConversationStart({
-        taskId,
-        previousThreadId,
-        codexHostId,
-        projectless,
-        targetRoot,
-        instruction,
-        title,
-      });
-      const startedThreadId = normalizeThreadId(started.threadId);
-      const visibleThreadComposer = Array.from(document.querySelectorAll(
-        '[data-codex-composer-root][data-composer-placement="thread"]',
-      )).find((candidate) => candidate.getClientRects().length > 0);
-      const visibleThreadId = normalizeThreadId(
-        visibleThreadComposer
-          ?.querySelector("[data-above-composer-conversation-id]")
-          ?.getAttribute("data-above-composer-conversation-id"),
-      );
-      if (visibleThreadId !== startedThreadId) {
-        await dispatchHostMessage({
-          type: "navigate-to-route",
-          path: routeForThread(startedThreadId),
-        });
-      }
-      lastNativeThreadId = startedThreadId;
-      postToFrame({ type: "taskboard:thread-prepared", payload: { taskId, threadId: started.threadId } });
+      postToFrame({ type: "taskboard:thread-prepared", payload: { taskId } });
     } catch (error) {
-      const createdThreadId = normalizeThreadId(error?.threadId);
-      if (createdThreadId && codexProjectKind !== "remote") {
-        await dispatchHostMessage({
-          type: "navigate-to-route",
-          path: routeForThread(createdThreadId),
-        });
-        lastNativeThreadId = createdThreadId;
-      }
       postToFrame({
         type: "taskboard:thread-create-error",
         payload: {
@@ -1161,8 +1113,6 @@
           error: error instanceof Error
             ? error.message
             : hostText("无法创建 Codex 对话", "Could not create the Codex conversation"),
-          ...(typeof error?.threadId === "string" ? { threadId: error.threadId } : {}),
-          ...(error?.uncertain === true ? { uncertain: true } : {}),
         },
       });
     } finally {
@@ -1583,26 +1533,6 @@
 
   function requestHostLoadFrame({ frameName, frameCapability: capability }) {
     return requestHost("load-frame", { frameName, frameCapability: capability });
-  }
-
-  function requestHostTaskConversationStart({
-    taskId,
-    previousThreadId,
-    codexHostId,
-    projectless,
-    targetRoot,
-    instruction,
-    title,
-  }) {
-    return requestHost("start-task-conversation", {
-      taskId,
-      previousThreadId,
-      codexHostId,
-      projectless,
-      targetRoot,
-      instruction,
-      title,
-    }, TASK_CONVERSATION_REQUEST_TIMEOUT_MS);
   }
 
   function frameMatchesTaskboardUrl(taskboardUrl) {

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -1549,7 +1549,9 @@ export function resolveServerOptions(options = {}) {
     jiraConfigPath: options.jiraConfigPath ?? path.join(dataDirectory, "jira-connection.json"),
     clientStoragePath: options.clientStoragePath ?? path.join(dataDirectory, "client-storage.json"),
     staticDirectory: options.staticDirectory ?? path.join(PROJECT_ROOT, "dist", "web"),
-    skillPath: options.skillPath ?? path.join(PROJECT_ROOT, "skills", "manage-taskboard", "SKILL.md"),
+    skillPath: options.skillPath
+      ?? process.env.CODEX_TASKBOARD_SKILL_PATH
+      ?? path.join(PROJECT_ROOT, "skills", "manage-taskboard", "SKILL.md"),
     codexExecutable: resolveCodexExecutable({ explicit: options.codexExecutable }),
     codexStatePath: options.codexStatePath
       ?? path.join(codexHome, ".codex-global-state.json"),

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1211,6 +1211,8 @@ fn start_launcher_locked(
     let instance_token = Uuid::new_v4().to_string();
     let instance_secret = Uuid::new_v4().to_string();
     let version = state.snapshot.lock().unwrap().version.clone();
+    let manage_taskboard_skill_path =
+        home_directory.join(".agents/skills/manage-taskboard/SKILL.md");
     #[cfg(target_os = "macos")]
     let codex_source_profile = home_directory.join("Library/Application Support/Codex");
     #[cfg(target_os = "windows")]
@@ -1240,6 +1242,7 @@ fn start_launcher_locked(
         .env("CODEX_TASKBOARD_INSTANCE_TOKEN", &instance_token)
         .env("CODEX_TASKBOARD_INSTANCE_SECRET", &instance_secret)
         .env("CODEX_TASKBOARD_VERSION", &version)
+        .env("CODEX_TASKBOARD_SKILL_PATH", &manage_taskboard_skill_path)
         .env_remove("CODEX_API_KEY")
         .env(
             "CODEX_TASKBOARD_CODEX_PROFILE",

--- a/test/inject.test.mjs
+++ b/test/inject.test.mjs
@@ -255,10 +255,10 @@ test("only a loopback Taskboard iframe can request native automation", () => {
   );
 });
 
-test("issues start a native Codex conversation in the confirmed project with the task title", () => {
+test("issues open an unsent native Codex composer in the confirmed project", () => {
   const createThreadSource = source.slice(
     source.indexOf("async function createThreadForTask"),
-    source.indexOf("async function handleAutomationRequest"),
+    source.indexOf("function buildAutomationHostPayload"),
   );
   assert.match(source, /async function createThreadForTask\(payload\)/);
   assert.match(source, /async function nativeProjectContext\(\)/);
@@ -281,34 +281,17 @@ test("issues start a native Codex conversation in the confirmed project with the
   assert.match(source, /await waitForNativeProject\(targetRoot\)/);
   assert.match(
     createThreadSource,
-    /if \(codexProjectKind === "remote"\) \{[\s\S]*?codexHostId = typeof payload\?\.codexHostId[\s\S]*?codexProjectWorkspacePath[\s\S]*?await waitForRemoteProject\(requestedProjectId, codexHostId, codexProjectWorkspacePath\);\s*targetRoot = codexProjectWorkspacePath;/,
+    /if \(!projectless && codexProjectKind === "remote"\) \{[\s\S]*?codexHostId = typeof payload\?\.codexHostId[\s\S]*?codexProjectWorkspacePath[\s\S]*?await waitForRemoteProject\(requestedProjectId, codexHostId, codexProjectWorkspacePath\);/,
   );
-  assert.match(source, /const previousThreadId = normalizeThreadId/);
   assert.match(source, /const focusComposerNonce = crypto\.randomUUID\(\)/);
-  assert.match(source, /state: \{\s*focusComposerNonce,\s*prefillPrompt: instruction,/);
-  assert.match(source, /const HOST_REQUEST_TIMEOUT_MS = 12_000/);
-  assert.match(source, /const TASK_CONVERSATION_REQUEST_TIMEOUT_MS = 75_000/);
-  assert.match(source, /function requestHost\(action, payload = \{\}, timeoutMs = HOST_REQUEST_TIMEOUT_MS\)/);
-  assert.match(source, /requestHostTaskConversationStart\(\{\s*taskId,\s*previousThreadId,\s*codexHostId,\s*projectless,\s*targetRoot,\s*instruction,\s*title,/);
-  assert.match(
-    source,
-    /requestHost\("start-task-conversation", \{\s*taskId,\s*previousThreadId,\s*codexHostId,\s*projectless,\s*targetRoot,\s*instruction,\s*title,\s*\}, TASK_CONVERSATION_REQUEST_TIMEOUT_MS\)/,
-  );
-  assert.match(source, /lastNativeThreadId = startedThreadId/);
-  assert.match(source, /type: "taskboard:thread-prepared", payload: \{ taskId, threadId: started\.threadId \}/);
-  assert.match(webApp, /Promise\.all\(\[getTask\(task\.id\), listComments\(task\.id\)\]\)/);
-  assert.match(webApp, /moveTaskRequest\(latestTask, "in_progress", undefined, null\)/);
-  assert.match(webApp, /pendingRemoteThreadClaimsRef\.current\.set/);
-  assert.match(webApp, /完整描述[\s\S]*全部评论[\s\S]*开发上下文/);
-  assert.match(webApp, /远程 worker 不得运行 taskctl/);
+  assert.match(createThreadSource, /type: "navigate-to-route",\s*path: "\/",\s*state: \{\s*focusComposerNonce,\s*prefillPrompt: instruction,/);
+  assert.match(createThreadSource, /type: "taskboard:thread-prepared", payload: \{ taskId \}/);
+  assert.doesNotMatch(createThreadSource, /start-task-conversation|previousThreadId|threadId:/);
   assert.match(webApp, /title: task\.title,/);
+  assert.match(webApp, /instruction: embeddedInstruction,/);
   assert.match(webApp, /type: "taskboard:create-thread"/);
-  assert.match(webApp, /codexProjectWorkspacePath: identity\.workspacePath/);
-  assert.match(webApp, /workspacePath: identity\.workspacePath/);
-  assert.match(webApp, /const binding: CodexThreadBinding = \{ threadId, \.\.\.pending\.identity \}/);
-  assert.match(webApp, /moveTaskRequest\([\s\S]*pending\.claimedTask,[\s\S]*"in_progress",[\s\S]*binding/);
-  assert.match(webApp, /pending\.previousTask\.status[\s\S]*binding/);
-  assert.match(webApp, /type: "taskboard:open-thread",[\s\S]*?payload: binding/);
+  assert.match(webApp, /codexProjectWorkspacePath: codexProjectContext\?\.workspacePath/);
+  assert.match(webApp, /workspacePath,/);
 });
 
 test("the standalone web page opens linked Codex tasks through the app deep link", () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,7 +18,6 @@ import {
   archiveTask as archiveTaskRequest,
   createProjectLabel as createProjectLabelRequest,
   createProject as createProjectRequest,
-  createComment,
   createTask as createTaskRequest,
   configureJiraConnection,
   deleteArchivedTask as deleteArchivedTaskRequest,
@@ -28,14 +27,12 @@ import {
   getCodexThreadProgress,
   getHostRuntime,
   getJiraConnection,
-  getTask,
   getTaskboardRevision,
   getTaskboardMetadata,
   listArchivedTasks,
   listDevelopmentContexts,
   listDeviceWorkspaces,
   listProjects,
-  listComments,
   listTasks,
   moveTask as moveTaskRequest,
   publishHostRuntime,
@@ -201,12 +198,6 @@ interface UndoOperation {
 interface UndoNotice {
   id: number;
   message: string;
-}
-
-interface PendingRemoteThreadClaim {
-  claimedTask: Task;
-  previousTask: Task;
-  identity: CodexProjectIdentity;
 }
 
 type ProjectAutomationStatus = "ACTIVE" | "PAUSED";
@@ -825,7 +816,6 @@ export function App() {
     );
   }
   const pendingAutomationRequestsRef = useRef(new Map<string, PendingAutomationRequest>());
-  const pendingRemoteThreadClaimsRef = useRef(new Map<string, PendingRemoteThreadClaim>());
   const automationRequestInFlightRef = useRef<"list" | "save" | null>(null);
   const loadedAutomationProjectIdsRef = useRef(new Set<string>());
   const queuedAutomationSavesRef = useRef(new Map<string, QueuedProjectAutomationSave>());
@@ -1696,35 +1686,16 @@ export function App() {
       }
 
       if (message.type === "taskboard:thread-prepared" && message.payload) {
-        const payload = message.payload as { taskId?: unknown; threadId?: unknown };
-        if (typeof payload.taskId === "string" && pendingRemoteThreadClaimsRef.current.has(payload.taskId)) {
-          void bindPreparedRemoteThread(payload.taskId, payload.threadId);
-        } else {
-          setOpeningThreadTaskId(null);
-        }
+        setOpeningThreadTaskId(null);
         return;
       }
 
       if (message.type === "taskboard:thread-create-error" && message.payload) {
-        const payload = message.payload as {
-          taskId?: unknown;
-          error?: unknown;
-          threadId?: unknown;
-          uncertain?: unknown;
-        };
-        if (typeof payload.taskId === "string" && pendingRemoteThreadClaimsRef.current.has(payload.taskId)) {
-          void compensateFailedRemoteThread(
-            payload.taskId,
-            payload.error,
-            payload.threadId,
-            payload.uncertain === true,
-          );
-        } else {
-          setOpeningThreadTaskId(null);
-          setActionError(typeof payload.error === "string"
-            ? payload.error
-            : textRef.current("无法在 Codex 中创建对话。", "Could not create the conversation in Codex."));
-        }
+        const payload = message.payload as { error?: unknown };
+        setOpeningThreadTaskId(null);
+        setActionError(typeof payload.error === "string"
+          ? payload.error
+          : textRef.current("无法在 Codex 中打开新对话。", "Could not open a new conversation in Codex."));
         return;
       }
 
@@ -2875,218 +2846,6 @@ export function App() {
     return liveProject ? baseIdentity : null;
   }
 
-  function remoteTaskInstruction(task: Task, comments: Awaited<ReturnType<typeof listComments>>) {
-    const commentText = comments.length === 0
-      ? "（无评论）"
-      : comments.map((comment) => (
-          `- ${comment.authorName}（${comment.createdAt}）\n${comment.body}`
-        )).join("\n\n");
-    return [
-      `处理 Taskboard 议题 ${task.identifier}：${task.title}`,
-      `\n完整描述：\n${task.description || "（无描述）"}`,
-      `\n全部评论：\n${commentText}`,
-      `\n开发上下文：\n${JSON.stringify(task.developmentContext)}`,
-      "\n本地 Taskboard 控制器已负责认领、对话绑定、评论和状态写回。远程 worker 不得运行 taskctl。请只完成实现和必要验证，并返回改动、验证结果、执行结果和剩余风险。",
-    ].join("\n");
-  }
-
-  function updateTaskFromRemoteThread(task: Task) {
-    setTasks((current) => sortTasks(current.map((candidate) => (
-      candidate.id === task.id ? task : candidate
-    ))));
-  }
-
-  async function addRemoteThreadFailureComment(taskId: string, body: string) {
-    try {
-      await createComment(taskId, body, undefined, null);
-      setCommentsRevision((current) => current + 1);
-    } catch {}
-  }
-
-  async function bindPreparedRemoteThread(taskId: string, rawThreadId: unknown) {
-    const pending = pendingRemoteThreadClaimsRef.current.get(taskId);
-    if (!pending) return;
-    const threadId = typeof rawThreadId === "string" ? rawThreadId.trim() : "";
-    if (!threadId) {
-      await compensateFailedRemoteThread(taskId, textRef.current(
-        "Codex 没有返回新对话 ID。",
-        "Codex did not return the new conversation ID.",
-      ));
-      return;
-    }
-    const binding: CodexThreadBinding = { threadId, ...pending.identity };
-    try {
-      const boundTask = await moveTaskRequest(
-        pending.claimedTask,
-        "in_progress",
-        pending.claimedTask.sortOrder,
-        binding,
-      );
-      pendingRemoteThreadClaimsRef.current.delete(taskId);
-      updateTaskFromRemoteThread(boundTask);
-      setOpeningThreadTaskId(null);
-      setAnnouncement(textRef.current(
-        `${boundTask.identifier} 已绑定到新的 SSH 对话。`,
-        `${boundTask.identifier} is bound to the new SSH conversation.`,
-      ));
-    } catch (error) {
-      let recoveredTask: Task | null = null;
-      if (!(error instanceof ApiError && error.code === "VERSION_CONFLICT")) {
-        try {
-          const latest = await getTask(taskId);
-          const bindingWasSaved = latest.status === "in_progress"
-            && latest.projectId === pending.claimedTask.projectId
-            && latest.archivedAt === null
-            && latest.threadBinding?.threadId === binding.threadId
-            && latest.threadBinding.codexProjectId === binding.codexProjectId
-            && latest.threadBinding.codexProjectKind === binding.codexProjectKind
-            && latest.threadBinding.codexHostId === binding.codexHostId
-            && latest.threadBinding.workspacePath === binding.workspacePath;
-          if (bindingWasSaved) {
-            recoveredTask = latest;
-          } else if (
-            latest.version === pending.claimedTask.version
-            && latest.projectId === pending.claimedTask.projectId
-            && latest.status === "in_progress"
-            && latest.archivedAt === null
-            && latest.threadId === null
-            && latest.threadBinding === null
-          ) {
-            recoveredTask = await moveTaskRequest(
-              latest,
-              "blocked",
-              undefined,
-              binding,
-            );
-          }
-        } catch {}
-      }
-      pendingRemoteThreadClaimsRef.current.delete(taskId);
-      setOpeningThreadTaskId(null);
-      if (recoveredTask) {
-        updateTaskFromRemoteThread(recoveredTask);
-        if (recoveredTask.status === "in_progress") return;
-      }
-      await addRemoteThreadFailureComment(taskId, textRef.current(
-        `已创建 SSH 对话 ${threadId}，但任务 binding 写入发生冲突或失败；未覆盖其他控制端的更新。`,
-        `SSH conversation ${threadId} was created, but saving the task binding conflicted or failed. No other controller update was overwritten.`,
-      ));
-      setActionError(error instanceof ApiError && error.code === "VERSION_CONFLICT"
-        ? textRef.current(
-          `SSH 对话 ${threadId} 已创建，但议题已在其他位置更新，未覆盖该更新。`,
-          `SSH conversation ${threadId} was created, but the issue changed elsewhere. That update was not overwritten.`,
-        )
-        : errorMessage(error));
-    }
-  }
-
-  async function compensateFailedRemoteThread(
-    taskId: string,
-    rawError: unknown,
-    rawThreadId?: unknown,
-    uncertain = false,
-  ) {
-    const pending = pendingRemoteThreadClaimsRef.current.get(taskId);
-    if (!pending) return;
-    pendingRemoteThreadClaimsRef.current.delete(taskId);
-    const error = typeof rawError === "string"
-      ? rawError
-      : textRef.current("无法创建 Codex 对话。", "Could not create the Codex conversation.");
-    const threadId = typeof rawThreadId === "string" ? rawThreadId.trim() : "";
-    const binding = threadId ? { threadId, ...pending.identity } : null;
-    const status: TaskStatus = threadId || uncertain ? "blocked" : pending.previousTask.status;
-    await addRemoteThreadFailureComment(taskId, threadId
-      ? textRef.current(
-        `SSH 对话 ${threadId} 已创建，但后续确认失败：${error}`,
-        `SSH conversation ${threadId} was created, but follow-up confirmation failed: ${error}`,
-      )
-      : uncertain
-        ? textRef.current(
-          `创建 SSH 对话的结果不确定，任务已停止自动重试：${error}`,
-          `The SSH conversation result is uncertain, so automatic retry was stopped: ${error}`,
-        )
-        : textRef.current(
-          `创建 SSH 对话失败，任务已退回 ${pending.previousTask.status}：${error}`,
-          `Creating the SSH conversation failed. The task was returned to ${pending.previousTask.status}: ${error}`,
-        ));
-    try {
-      const compensated = await moveTaskRequest(
-        pending.claimedTask,
-        status,
-        pending.previousTask.sortOrder,
-        binding,
-      );
-      updateTaskFromRemoteThread(compensated);
-    } catch (moveError) {
-      if (!(moveError instanceof ApiError && moveError.code === "VERSION_CONFLICT")) {
-        setActionError(errorMessage(moveError));
-      }
-    } finally {
-      setOpeningThreadTaskId(null);
-    }
-    setActionError(error);
-  }
-
-  async function openRemoteTaskInThread(task: Task, baseIdentity: CodexProjectIdentity) {
-    try {
-      const [latestTask, comments] = await Promise.all([getTask(task.id), listComments(task.id)]);
-      if (latestTask.threadBinding) {
-        setOpeningThreadTaskId(null);
-        openThread(latestTask.threadBinding);
-        return;
-      }
-      if (latestTask.status !== "todo" || latestTask.archivedAt !== null || latestTask.threadId) {
-        throw new Error(textRef.current(
-          "该议题已被其他控制器认领或绑定，请刷新后重试。",
-          "This issue was claimed or bound by another controller. Refresh and try again.",
-        ));
-      }
-      const identity = remoteIdentityForTask(latestTask, baseIdentity);
-      if (!identity) {
-        throw new Error(latestTask.developmentContext?.type === "worktree"
-          ? textRef.current(
-            "目标 SSH worktree 未在保存的主机中添加或映射。",
-            "The target SSH worktree is not added or mapped on the saved host.",
-          )
-          : textRef.current(
-            "已保存的 SSH 远程项目或主机当前不可用。",
-            "The saved SSH remote project or host is not available.",
-          ));
-      }
-      const claimedTask = await moveTaskRequest(latestTask, "in_progress", undefined, null);
-      pendingRemoteThreadClaimsRef.current.set(task.id, {
-        claimedTask,
-        previousTask: latestTask,
-        identity,
-      });
-      updateTaskFromRemoteThread(claimedTask);
-      postEmbeddedHostMessage({
-        type: "taskboard:create-thread",
-        payload: {
-          taskId: latestTask.id,
-          identifier: latestTask.identifier,
-          title: latestTask.title,
-          instruction: remoteTaskInstruction(latestTask, comments),
-          codexProjectId: identity.codexProjectId,
-          codexProjectKind: identity.codexProjectKind,
-          codexHostId: identity.codexHostId,
-          codexProjectWorkspacePath: identity.workspacePath,
-          workspacePath: identity.workspacePath,
-          projectless: false,
-        },
-      });
-    } catch (error) {
-      setOpeningThreadTaskId(null);
-      setActionError(error instanceof ApiError && error.code === "VERSION_CONFLICT"
-        ? textRef.current(
-          "该议题已在其他位置更新，未创建重复对话。",
-          "This issue changed elsewhere. No duplicate conversation was created.",
-        )
-        : errorMessage(error));
-      if (taskScopeProjectId) void refreshTasks(taskScopeProjectId, { quiet: true });
-    }
-  }
-
   async function openTaskInThread(task: Task) {
     const standalone = !embedded || window.parent === window;
     const projectless = task.projectId === GLOBAL_PROJECT_ID;
@@ -3094,7 +2853,7 @@ export function App() {
     const savedRemoteIdentity = projectCodexIdentities[task.projectId]?.codexProjectKind === "remote"
       ? projectCodexIdentities[task.projectId]
       : null;
-    const codexProjectContext = savedRemoteIdentity
+    let codexProjectContext = savedRemoteIdentity
       ?? codexProjectContextForTaskProject(task.projectId);
     if (
       projectCodexIdentities[task.projectId]?.codexProjectKind === "remote"
@@ -3106,6 +2865,22 @@ export function App() {
       ));
       return;
     }
+    if (!standalone && codexProjectContext?.codexProjectKind === "remote") {
+      const identity = remoteIdentityForTask(task, codexProjectContext);
+      if (!identity) {
+        setActionError(task.developmentContext?.type === "worktree"
+          ? text(
+            "目标 SSH worktree 未在保存的主机中添加或映射。",
+            "The target SSH worktree is not added or mapped on the saved host.",
+          )
+          : text(
+            "已保存的 SSH 远程项目或主机当前不可用。",
+            "The saved SSH remote project or host is not available.",
+          ));
+        return;
+      }
+      codexProjectContext = identity;
+    }
     let workspacePath = projectless
       ? undefined
       : task.developmentContext?.type === "worktree"
@@ -3113,7 +2888,10 @@ export function App() {
         : codexProjectContext?.workspacePath
           ?? deviceWorkspacePaths[task.projectId]
           ?? taskboardProject?.workspacePath;
-    const instruction = `e-taskboard 处理任务面板任务 ${task.identifier}，并同步进度状态。`;
+    const instruction = text(
+      `[$manage-taskboard](${manageTaskboardSkillPath}) 议题 ID：${task.identifier}`,
+      `[$manage-taskboard](${manageTaskboardSkillPath}) Issue ID: ${task.identifier}`,
+    );
 
     if (
       !projectless
@@ -3157,42 +2935,6 @@ export function App() {
       return;
     }
     if (openingThreadTaskId) return;
-    const canonicalReferences = [
-      ...(task.relations.parent
-        ? [{
-            relation: "parent",
-            identifier: task.relations.parent.identifier,
-            title: task.relations.parent.title,
-          }]
-        : []),
-      ...task.relations.subIssues.map((relation) => ({
-        relation: "subIssues",
-        identifier: relation.identifier,
-        title: relation.title,
-      })),
-      ...task.relations.blockedBy.map((relation) => ({
-        relation: "blockedBy",
-        identifier: relation.identifier,
-        title: relation.title,
-      })),
-      ...task.relations.blocks.map((relation) => ({
-        relation: "blocks",
-        identifier: relation.identifier,
-        title: relation.title,
-      })),
-      ...task.relations.related.map((relation) => ({
-        relation: "related",
-        identifier: relation.identifier,
-        title: relation.title,
-      })),
-    ];
-    const beforeDescription = `${instruction}\n\n议题：${task.identifier} ${task.title}\n\n正文：\n`;
-    const afterDescription = `\n\nCanonical references：\n${canonicalReferences.length > 0
-      ? canonicalReferences.map((reference) => (
-          `- ${reference.relation}: ${reference.identifier} ${reference.title}`
-        )).join("\n")
-      : "（无）"}`;
-    const embeddedInstruction = `${beforeDescription}${task.description}${afterDescription}`;
     if (standalone) {
       if (codexProjectContext?.codexProjectKind === "remote") {
         setActionError(text(
@@ -3203,29 +2945,19 @@ export function App() {
       }
       const deepLink = new URL("codex://threads/new");
       if (workspacePath) deepLink.searchParams.set("path", workspacePath);
-      deepLink.searchParams.set("prompt", embeddedInstruction);
+      deepLink.searchParams.set("prompt", instruction);
       window.location.assign(deepLink.toString());
       return;
     }
     setOpeningThreadTaskId(task.id);
     setActionError(null);
-    if (codexProjectContext?.codexProjectKind === "remote" && codexProjectContext.workspacePath) {
-      void openRemoteTaskInThread(task, {
-        ...codexProjectContext,
-        workspacePath: codexProjectContext.workspacePath,
-      });
-      return;
-    }
     postEmbeddedHostMessage({
       type: "taskboard:create-thread",
       payload: {
         taskId: task.id,
         identifier: task.identifier,
         title: task.title,
-        description: task.description,
-        canonicalReferences,
-        instruction: embeddedInstruction,
-        projectName: taskboardProject?.name,
+        instruction,
         projectless,
         codexProjectId: codexProjectContext?.codexProjectId,
         codexProjectKind: codexProjectContext?.codexProjectKind ?? "local",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2888,7 +2888,7 @@ export function App() {
         : codexProjectContext?.workspacePath
           ?? deviceWorkspacePaths[task.projectId]
           ?? taskboardProject?.workspacePath;
-    const instruction = text(
+    const embeddedInstruction = text(
       `[$manage-taskboard](${manageTaskboardSkillPath}) 议题 ID：${task.identifier}`,
       `[$manage-taskboard](${manageTaskboardSkillPath}) Issue ID: ${task.identifier}`,
     );
@@ -2945,7 +2945,7 @@ export function App() {
       }
       const deepLink = new URL("codex://threads/new");
       if (workspacePath) deepLink.searchParams.set("path", workspacePath);
-      deepLink.searchParams.set("prompt", instruction);
+      deepLink.searchParams.set("prompt", embeddedInstruction);
       window.location.assign(deepLink.toString());
       return;
     }
@@ -2957,7 +2957,7 @@ export function App() {
         taskId: task.id,
         identifier: task.identifier,
         title: task.title,
-        instruction,
+        instruction: embeddedInstruction,
         projectless,
         codexProjectId: codexProjectContext?.codexProjectId,
         codexProjectKind: codexProjectContext?.codexProjectKind ?? "local",


### PR DESCRIPTION
## Summary

- open a new Codex composer with a localized `manage-taskboard` Skill reference and the exact issue ID
- keep the composer unsent while preserving project, worktree, remote, and projectless routing
- expose the user's installed global Skill path through `/api/meta`

## Verification

- `npm run typecheck`
- `npm run build:web`
- `node --check inject/codex-taskboard.user.js`
- `node --check server/app.mjs`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- Rust 1.88 `cargo check --manifest-path src-tauri/Cargo.toml`
- ordinary web Taskboard: real right-click → Open in new conversation → existing managed Codex, correct worktree and Skill mention, no submission

## Validation limitation

The injected-App right-click was exercised once in the shared managed Codex. Its resident installed injector replaced the current-branch iframe during the attempt, so that path is not claimed as a current-branch runtime pass. The shared `createThreadForTask` implementation and focused static checks were used for this path, per the E3 stop boundary.

Related to #225. Keep the issue open until the fixed version is released.
