### PR TITLE
Release Ubuntu 24.04 x64 desktop app

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -120,6 +120,11 @@ jobs:
       - run: npm ci
       - name: Build the Ubuntu 24.04 x64 packages
         run: npm run app:build:linux:x64
+      - name: Verify the Ubuntu 24.04 x64 package contents
+        run: >-
+          node scripts/verify-linux-packages.mjs
+          src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb
+          src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage
       - name: Preserve the Ubuntu 24.04 x64 packages
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -87,3 +87,44 @@ jobs:
           name: windows-x64-nsis-${{ github.sha }}
           path: src-tauri/target/x86_64-pc-windows-msvc/release/bundle/nsis/*-setup.exe
           if-no-files-found: error
+
+  linux-launcher:
+    name: Ubuntu 24.04 x64 launcher
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22
+          cache: npm
+      - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b # 1.88.0
+        with:
+          targets: x86_64-unknown-linux-gnu
+      - name: Install Ubuntu build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            curl \
+            file \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            patchelf \
+            wget
+      - run: npm ci
+      - name: Build the Ubuntu 24.04 x64 packages
+        run: npm run app:build:linux:x64
+      - name: Preserve the Ubuntu 24.04 x64 packages
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: linux-x64-deb-appimage-${{ github.sha }}
+          path: |
+            src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb
+            src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage
+          if-no-files-found: error

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -14,6 +14,68 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  release-linux:
+    name: Build Ubuntu 24.04 x64 packages
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js 22
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Set up Rust 1.88
+        uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b # 1.88.0
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Install Ubuntu build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            curl \
+            file \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            patchelf \
+            wget
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Ubuntu 24.04 x64 packages
+        run: npm run app:build:linux:x64
+
+      - name: Stage Ubuntu 24.04 x64 release assets
+        run: |
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          LINUX_RELEASE="$RUNNER_TEMP/linux-release"
+          mkdir -p "$LINUX_RELEASE"
+          cp \
+            src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb \
+            "$LINUX_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb"
+          cp \
+            src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage \
+            "$LINUX_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage"
+
+      - name: Preserve Ubuntu 24.04 x64 release assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: linux-release-${{ github.sha }}
+          path: ${{ runner.temp }}/linux-release
+          if-no-files-found: error
+
   release-windows-preview:
     name: Build unsigned Windows x64 Preview
     runs-on: windows-2025
@@ -51,7 +113,9 @@ jobs:
 
   release-macos:
     name: Build signed universal macOS app
-    needs: release-windows-preview
+    needs:
+      - release-linux
+      - release-windows-preview
     runs-on: macos-latest
     timeout-minutes: 90
 
@@ -296,6 +360,12 @@ jobs:
           name: windows-preview-${{ github.sha }}
           path: ${{ runner.temp }}/windows-preview
 
+      - name: Restore Ubuntu 24.04 x64 release assets
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: linux-release-${{ github.sha }}
+          path: ${{ runner.temp }}/linux-release
+
       - name: Create trusted release asset manifest
         run: |
           set -euo pipefail
@@ -312,10 +382,18 @@ jobs:
           cp \
             "$RUNNER_TEMP/windows-preview/Codex Taskboard_${PACKAGE_VERSION}_x64-setup.exe" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_NSIS-x64-unsigned.exe"
+          cp \
+            "$RUNNER_TEMP/linux-release/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb" \
+            "$RELEASE_ASSETS/"
+          cp \
+            "$RUNNER_TEMP/linux-release/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage" \
+            "$RELEASE_ASSETS/"
           (
             cd "$RELEASE_ASSETS"
             shasum -a 256 \
               "Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg" \
+              "Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb" \
+              "Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage" \
               "Codex.Taskboard_${PACKAGE_VERSION}_NSIS-x64-unsigned.exe" \
               "Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" \
               "Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" \
@@ -343,6 +421,12 @@ jobs:
             --title "Codex Taskboard $RELEASE_TAG" \
             --generate-notes \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg"
+          gh release upload "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb"
+          gh release upload "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage"
           gh release upload "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_NSIS-x64-unsigned.exe"

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -54,8 +54,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build Ubuntu 24.04 x64 packages
-        run: npm run app:build:linux:x64
+      - name: Build Ubuntu 24.04 x64 packages and updater
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: >-
+          npm run app:build:linux:x64 --
+          --config '{"bundle":{"createUpdaterArtifacts":true}}'
+
+      - name: Verify Ubuntu 24.04 x64 package contents
+        run: >-
+          node scripts/verify-linux-packages.mjs
+          src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb
+          src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage
 
       - name: Stage Ubuntu 24.04 x64 release assets
         run: |
@@ -66,8 +77,14 @@ jobs:
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb \
             "$LINUX_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb"
           cp \
+            src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb.sig \
+            "$LINUX_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb.sig"
+          cp \
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage \
             "$LINUX_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage"
+          cp \
+            src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage.sig \
+            "$LINUX_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage.sig"
 
       - name: Preserve Ubuntu 24.04 x64 release assets
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -366,6 +383,29 @@ jobs:
           name: linux-release-${{ github.sha }}
           path: ${{ runner.temp }}/linux-release
 
+      - name: Add and verify the Linux x64 updater
+        run: |
+          BUNDLE_ROOT="src-tauri/target/universal-apple-darwin/release/bundle"
+          LATEST_PATH="$BUNDLE_ROOT/release/latest.json"
+          LINUX_DEB_NAME="Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb"
+          LINUX_APPIMAGE_NAME="Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage"
+          LINUX_DEB="$RUNNER_TEMP/linux-release/$LINUX_DEB_NAME"
+          LINUX_APPIMAGE="$RUNNER_TEMP/linux-release/$LINUX_APPIMAGE_NAME"
+          jq \
+            --rawfile deb_signature "$LINUX_DEB.sig" \
+            --rawfile appimage_signature "$LINUX_APPIMAGE.sig" \
+            --arg deb_url "https://github.com/chuspeeism/dashi-taskboard/releases/download/$RELEASE_TAG/$LINUX_DEB_NAME" \
+            --arg appimage_url "https://github.com/chuspeeism/dashi-taskboard/releases/download/$RELEASE_TAG/$LINUX_APPIMAGE_NAME" \
+            '.platforms["linux-x86_64-deb"] = {signature: $deb_signature, url: $deb_url}
+             | .platforms["linux-x86_64-appimage"] = {signature: $appimage_signature, url: $appimage_url}' \
+            "$LATEST_PATH" > "$LATEST_PATH.linux"
+          mv "$LATEST_PATH.linux" "$LATEST_PATH"
+          node scripts/verify-linux-updater.mjs \
+            "$LINUX_DEB" \
+            "$LINUX_APPIMAGE" \
+            "$LATEST_PATH" \
+            "$RELEASE_TAG"
+
       - name: Create trusted release asset manifest
         run: |
           set -euo pipefail
@@ -386,14 +426,22 @@ jobs:
             "$RUNNER_TEMP/linux-release/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb" \
             "$RELEASE_ASSETS/"
           cp \
+            "$RUNNER_TEMP/linux-release/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb.sig" \
+            "$RELEASE_ASSETS/"
+          cp \
             "$RUNNER_TEMP/linux-release/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage" \
+            "$RELEASE_ASSETS/"
+          cp \
+            "$RUNNER_TEMP/linux-release/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage.sig" \
             "$RELEASE_ASSETS/"
           (
             cd "$RELEASE_ASSETS"
             shasum -a 256 \
               "Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg" \
               "Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb" \
+              "Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb.sig" \
               "Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage" \
+              "Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage.sig" \
               "Codex.Taskboard_${PACKAGE_VERSION}_NSIS-x64-unsigned.exe" \
               "Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" \
               "Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" \
@@ -426,7 +474,13 @@ jobs:
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb"
           gh release upload "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
+            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb.sig"
+          gh release upload "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage"
+          gh release upload "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage.sig"
           gh release upload "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_NSIS-x64-unsigned.exe"
@@ -604,10 +658,23 @@ jobs:
           tar -xzf \
             "$DRAFT_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" \
             -C "$UPDATER_ROOT"
+          MACOS_RELEASE_ROOT="$RUNNER_TEMP/remote-macos-release"
+          mkdir -p "$MACOS_RELEASE_ROOT"
+          cp \
+            "$DRAFT_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" \
+            "$DRAFT_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" \
+            "$MACOS_RELEASE_ROOT/"
+          jq 'del(.platforms["linux-x86_64-deb"], .platforms["linux-x86_64-appimage"])' \
+            "$DRAFT_ASSETS/latest.json" > "$MACOS_RELEASE_ROOT/latest.json"
           npm run app:verify-release -- \
             "$UPDATER_ROOT/Codex Taskboard.app" \
             "$DRAFT_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg" \
-            "$DRAFT_ASSETS" \
+            "$MACOS_RELEASE_ROOT" \
+            "$RELEASE_TAG"
+          node scripts/verify-linux-updater.mjs \
+            "$DRAFT_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb" \
+            "$DRAFT_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage" \
+            "$DRAFT_ASSETS/latest.json" \
             "$RELEASE_TAG"
 
       - name: Publish verified Release

--- a/README.md
+++ b/README.md
@@ -113,6 +113,32 @@ Open `src-tauri/target/universal-apple-darwin/release/bundle/macos/Codex Taskboa
 
 The App contains its own Node runtime, Taskboard service, built web UI, Skill, CLI wrapper, and injection script. It starts the service, reuses an open Codex with a reachable CDP renderer, opens Taskboard in the native browser panel of an ordinary Codex without CDP, or launches the official Codex app when no Codex is open. It waits for the renderer, injects the sidebar entry when CDP is available, and opens the panel without showing a terminal window. The App can be copied away from this checkout; the target Mac only needs the official Codex app and does not need this repository, a system Node installation, or a separate Codex CLI installation. Taskboard data is stored in `~/Library/Application Support/Codex Taskboard`, and launcher output is written to `~/Library/Logs/Codex Taskboard/codex-taskboard-launcher.log`.
 
+### Linux App: Ubuntu 24.04 x64 packages
+
+The first Linux desktop release supports Ubuntu 24.04 LTS on x64 only. Install the official ChatGPT desktop `.deb` first and confirm that `chatgpt` opens it. Then download either the Codex Taskboard `.deb` or `.AppImage` from [GitHub Releases](https://github.com/chuspeeism/dashi-taskboard/releases/latest). Replace `<file>` below with the downloaded filename.
+
+Install the `.deb` package:
+
+```bash
+sudo apt install ./<file>.deb
+```
+
+Or run the AppImage:
+
+```bash
+chmod +x ./<file>.AppImage
+./<file>.AppImage
+```
+
+To build both packages on Ubuntu 24.04 x64, run:
+
+```bash
+npm ci
+npm run app:build:linux:x64
+```
+
+This first release does not support ARM64, Fedora, RPM packages, or other Linux distributions.
+
 ### Windows code signing
 
 For official Windows releases after the application is approved: **Free code signing provided by [SignPath.io](https://signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).** Current Windows CI artifacts remain unsigned until that approval. See the [Code signing policy](docs/code-signing-policy.md), [Privacy policy](PRIVACY.md), and [Windows uninstall instructions](docs/windows-uninstall.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -115,6 +115,32 @@ npm run app:build
 
 本地构建使用 ad-hoc 代码签名进行直接验证。公开的 macOS 下载仍需要 Developer ID 签名和 Apple 公证。
 
+### Linux App：Ubuntu 24.04 x64 软件包
+
+Linux 桌面版第一版仅支持 Ubuntu 24.04 LTS x64。请先安装官方 ChatGPT 桌面版 `.deb`，并确认运行 `chatgpt` 可以打开它。然后从 [GitHub Releases](https://github.com/chuspeeism/dashi-taskboard/releases/latest) 下载 Codex Taskboard `.deb` 或 `.AppImage`。请将以下命令中的 `<file>` 替换为下载的文件名。
+
+安装 `.deb` 软件包：
+
+```bash
+sudo apt install ./<file>.deb
+```
+
+或者运行 AppImage：
+
+```bash
+chmod +x ./<file>.AppImage
+./<file>.AppImage
+```
+
+如需在 Ubuntu 24.04 x64 上构建这两种软件包，请运行：
+
+```bash
+npm ci
+npm run app:build:linux:x64
+```
+
+第一版不支持 ARM64、Fedora、RPM 软件包或其他 Linux 发行版。
+
 ### Windows App：托盘启动器与内置 Taskboard
 
 先从 Microsoft Store 安装官方 Codex App。在 Windows x64 上运行以下命令构建当前用户级 NSIS 安装包：

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "app:prepare": "npm run build:web && node scripts/prepare-tauri-app.mjs",
     "app:dev": "npm run app:prepare && tauri dev",
     "app:build": "npm run app:prepare -- --target universal-apple-darwin && CI=true tauri build --target universal-apple-darwin --bundles app,dmg --config '{\"bundle\":{\"createUpdaterArtifacts\":false}}'",
+    "app:build:linux:x64": "npm run app:prepare -- --target x86_64-unknown-linux-gnu && tauri build --target x86_64-unknown-linux-gnu --bundles deb,appimage --ci --config src-tauri/tauri.linux.conf.json",
     "app:build:windows": "npm run app:prepare -- --target x86_64-pc-windows-msvc && tauri build --target x86_64-pc-windows-msvc --bundles nsis --no-sign --ci --config src-tauri/tauri.windows.conf.json",
     "app:preflight": "node scripts/preflight-macos-app.mjs",
     "app:verify-packaged-taskctl": "node scripts/verify-packaged-taskctl.mjs",

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -3,6 +3,7 @@
 import { spawn, spawnSync } from "node:child_process";
 import { createHash, createHmac, randomBytes, randomUUID } from "node:crypto";
 import { chmod, mkdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
+import os from "node:os";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -33,7 +34,9 @@ const projectRoot = path.resolve(path.dirname(injectorPath), "..");
 const defaultCodexDebuggingPort = 9229;
 const independentCodexProfilePath = process.env.CODEX_TASKBOARD_CODEX_PROFILE
   ? path.resolve(process.env.CODEX_TASKBOARD_CODEX_PROFILE)
-  : "/private/tmp/codex-taskboard-independent-profile-v2";
+  : process.platform === "linux"
+    ? path.join(os.tmpdir(), "codex-taskboard-independent-profile-v2")
+    : "/private/tmp/codex-taskboard-independent-profile-v2";
 const sourceCodexProfilePath = process.env.CODEX_TASKBOARD_CODEX_SOURCE_PROFILE
   ? path.resolve(process.env.CODEX_TASKBOARD_CODEX_SOURCE_PROFILE)
   : null;
@@ -113,7 +116,7 @@ function parseArgs(argv) {
     startupToken: null,
     daemon: false,
     screenshot: null,
-    appPath: "/Applications/ChatGPT.app",
+    appPath: process.platform === "linux" ? "/usr/bin/chatgpt" : "/Applications/ChatGPT.app",
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -293,7 +296,10 @@ async function importCodexBrowserProfile() {
 }
 
 function codexExecutablePath(appPath) {
-  if (process.platform === "win32") return appPath;
+  if (process.platform === "linux") {
+    return appPath === "/usr/bin/chatgpt" ? "/usr/lib/chatgpt/ChatGPT" : appPath;
+  }
+  if (process.platform !== "darwin") return appPath;
   return path.join(
     appPath,
     "Contents",
@@ -883,7 +889,9 @@ async function loadTaskboardFrameViaCdp(cdp, frameName, frameCapability) {
 async function openWithDefaultApplication(target) {
   await new Promise((resolve, reject) => {
     const child = spawn(
-      process.platform === "win32" ? "explorer.exe" : "/usr/bin/open",
+      process.platform === "win32"
+        ? "explorer.exe"
+        : process.platform === "linux" ? "xdg-open" : "/usr/bin/open",
       [target],
       {
         detached: true,
@@ -900,6 +908,10 @@ async function openWithDefaultApplication(target) {
 }
 
 async function revealAttachmentInFinder(attachmentPath, directory) {
+  if (process.platform === "linux") {
+    await openWithDefaultApplication(directory);
+    return;
+  }
   try {
     await new Promise((resolve, reject) => {
       const child = spawn("/usr/bin/open", ["-R", attachmentPath], {

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -144,6 +144,8 @@ function parseArgs(argv) {
     else throw new Error(`Unknown option: ${arg}`);
   }
 
+  if (process.platform === "linux" && options.launch) options.cdpPipe = true;
+
   if (!Number.isInteger(options.port) || options.port < 1 || options.port > 65535) {
     throw new Error("--port must be an integer between 1 and 65535");
   }

--- a/scripts/prepare-tauri-app.mjs
+++ b/scripts/prepare-tauri-app.mjs
@@ -27,11 +27,16 @@ const windowsTarget = "x86_64-pc-windows-msvc";
 const windowsNodeArchiveName = `node-v${nodeVersion}-win-x64.zip`;
 const windowsNodeArchiveSha256 =
   "1177b4137ba5adaa56354ae40f1080c7450e8ae09cecb47da459d1c52ac99f97";
+const linuxTarget = "x86_64-unknown-linux-gnu";
+const linuxNodeArchiveName = `node-v${nodeVersion}-linux-x64.tar.gz`;
+const linuxNodeArchiveSha256 =
+  "b294a556e639d64338823920e5866c21c02741742d2e1529ee1a225c1ec9252a";
 const supportedTargets = new Set([
   "aarch64-apple-darwin",
   "x86_64-apple-darwin",
   "universal-apple-darwin",
   windowsTarget,
+  linuxTarget,
 ]);
 const scriptPath = fileURLToPath(import.meta.url);
 const projectRoot = path.resolve(path.dirname(scriptPath), "..");
@@ -45,12 +50,19 @@ const target = parseTarget(process.argv.slice(2));
 if (target === windowsTarget && process.platform !== "win32") {
   throw new Error("Codex Taskboard for Windows must be prepared on Windows");
 }
-if (target !== windowsTarget && process.platform !== "darwin") {
+if (target === linuxTarget && process.platform !== "linux") {
+  throw new Error("Codex Taskboard for Linux must be prepared on Linux");
+}
+if (target !== windowsTarget && target !== linuxTarget && process.platform !== "darwin") {
   throw new Error("Codex Taskboard for macOS must be prepared on macOS");
 }
 
 function parseTarget(argv) {
-  let selected = process.platform === "win32" ? windowsTarget : "universal-apple-darwin";
+  let selected = process.platform === "win32"
+    ? windowsTarget
+    : process.platform === "linux"
+      ? linuxTarget
+      : "universal-apple-darwin";
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
     if (argument === "--target") selected = argv[++index];
@@ -180,6 +192,32 @@ async function prepareWindowsNodeRuntime() {
   );
 }
 
+async function prepareLinuxNodeRuntime() {
+  const { archivePath } = await verifiedNodeArchive(
+    linuxNodeArchiveName,
+    linuxNodeArchiveSha256,
+  );
+  const destination = path.join(extractionDirectory, "linux-x64");
+  await rm(destination, { recursive: true, force: true });
+  await mkdir(destination, { recursive: true });
+  run("/usr/bin/tar", ["-xzf", archivePath, "-C", destination]);
+
+  const runtime = path.join(destination, `node-v${nodeVersion}-linux-x64`);
+  const targetPath = path.join(
+    binariesDirectory,
+    `codex-taskboard-node-${linuxTarget}`,
+  );
+  await mkdir(binariesDirectory, { recursive: true });
+  await rm(targetPath, { force: true });
+  await copyFile(path.join(runtime, "bin", "node"), targetPath);
+  await chmod(targetPath, 0o755);
+  await mkdir(path.join(resourcesDirectory, "licenses"), { recursive: true });
+  await copyFile(
+    path.join(runtime, "LICENSE"),
+    path.join(resourcesDirectory, "licenses", "Node-LICENSE"),
+  );
+}
+
 async function copyApplicationResources() {
   const appResources = path.join(resourcesDirectory, "app");
   await rm(resourcesDirectory, { recursive: true, force: true });
@@ -242,6 +280,23 @@ async function copyApplicationResources() {
     return;
   }
 
+  if (target === linuxTarget) {
+    const taskctlWrapper = `#!/bin/sh
+set -u
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+RESOURCE_DIR="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
+export CODEX_TASKBOARD_DATA_DIR="\${XDG_DATA_HOME:-$HOME/.local/share}/Codex Taskboard"
+export CODEX_TASKBOARD_RUNTIME_FILE="$CODEX_TASKBOARD_DATA_DIR/launcher-runtime.json"
+exec "$RESOURCE_DIR/../../bin/codex-taskboard-node" "$RESOURCE_DIR/app/cli/taskctl.mjs" "$@"
+`;
+    const taskctlPath = path.join(resourcesDirectory, "bin", "taskctl");
+    await mkdir(path.dirname(taskctlPath), { recursive: true });
+    await writeFile(taskctlPath, taskctlWrapper);
+    await chmod(taskctlPath, 0o755);
+    return;
+  }
+
   const taskctlWrapper = `#!/bin/zsh
 set -u
 
@@ -260,6 +315,7 @@ exec "$CONTENTS_DIR/MacOS/node" "$CONTENTS_DIR/Resources/app/cli/taskctl.mjs" "$
 await mkdir(runtimeCacheDirectory, { recursive: true });
 await copyApplicationResources();
 if (target === windowsTarget) await prepareWindowsNodeRuntime();
+else if (target === linuxTarget) await prepareLinuxNodeRuntime();
 else await prepareMacNodeRuntime();
 await rm(extractionDirectory, { recursive: true, force: true });
 console.log(`Prepared Tauri resources for ${target} with Node.js ${nodeVersion}`);

--- a/scripts/verify-linux-packages.mjs
+++ b/scripts/verify-linux-packages.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, open, readFile, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const debPath = process.argv[2] ? path.resolve(process.argv[2]) : null;
+const appImagePath = process.argv[3] ? path.resolve(process.argv[3]) : null;
+if (!debPath || !appImagePath || process.argv.length !== 4) {
+  throw new Error("Usage: verify-linux-packages.mjs <package.deb> <package.AppImage>");
+}
+if (process.platform !== "linux") {
+  throw new Error("Linux packages must be verified on Linux");
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    ...options,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      result.error?.message
+      || result.stderr?.trim()
+      || result.stdout?.trim()
+      || `${command} failed`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+async function assertExecutable(filePath) {
+  const details = await stat(filePath);
+  if (!details.isFile() || (details.mode & 0o111) === 0) {
+    throw new Error(`Expected executable file: ${filePath}`);
+  }
+}
+
+async function assertElfX64(filePath) {
+  const header = Buffer.alloc(20);
+  const file = await open(filePath, "r");
+  const { bytesRead } = await file.read(header, 0, header.length, 0);
+  await file.close();
+  if (
+    bytesRead !== header.length
+    || !header.subarray(0, 4).equals(Buffer.from([0x7f, 0x45, 0x4c, 0x46]))
+    || header[4] !== 2
+    || header[5] !== 1
+    || header.readUInt16LE(18) !== 0x3e
+  ) {
+    throw new Error(`Expected Linux x86_64 ELF: ${filePath}`);
+  }
+}
+
+async function verifyPackageRoot(root, label) {
+  const launcherPath = path.join(root, "usr", "bin", "codex-taskboard-launcher");
+  const nodePath = path.join(root, "usr", "bin", "codex-taskboard-node");
+  const resourceRoot = path.join(root, "usr", "lib", "Codex Taskboard");
+  const taskctlPath = path.join(resourceRoot, "bin", "taskctl");
+  const requiredResources = [
+    "app/cli/taskctl.mjs",
+    "app/dist/web/index.html",
+    "app/inject/codex-taskboard.user.js",
+    "app/node_modules/smol-toml/package.json",
+    "app/scripts/codex-injector.mjs",
+    "app/server/app.mjs",
+    "app/server/index.mjs",
+    "app/shared/codex-executable.mjs",
+    "app/skills/manage-taskboard/SKILL.md",
+  ];
+
+  await assertExecutable(launcherPath);
+  await assertElfX64(launcherPath);
+  await assertExecutable(nodePath);
+  await assertElfX64(nodePath);
+  await assertExecutable(taskctlPath);
+  for (const resource of requiredResources) {
+    const details = await stat(path.join(resourceRoot, resource));
+    if (!details.isFile()) throw new Error(`${label} is missing ${resource}`);
+  }
+
+  const wrapper = await readFile(taskctlPath, "utf8");
+  if (
+    !wrapper.includes("codex-taskboard-node")
+    || !wrapper.includes("app/cli/taskctl.mjs")
+  ) {
+    throw new Error(`${label} taskctl does not use the packaged Node and CLI`);
+  }
+  const nodeVersion = run(nodePath, ["--version"]);
+  if (nodeVersion !== "v22.23.2") {
+    throw new Error(`${label} contains unexpected Node.js ${nodeVersion}`);
+  }
+}
+
+const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "codex-taskboard-linux-packages."));
+try {
+  if (run("dpkg-deb", ["--field", debPath, "Architecture"]) !== "amd64") {
+    throw new Error("Debian package architecture is not amd64");
+  }
+  const debRoot = path.join(temporaryRoot, "deb");
+  run("dpkg-deb", ["--extract", debPath, debRoot]);
+  await verifyPackageRoot(debRoot, "Debian package");
+
+  await assertExecutable(appImagePath);
+  await assertElfX64(appImagePath);
+  const appImageRoot = path.join(temporaryRoot, "appimage");
+  await mkdir(appImageRoot);
+  run(appImagePath, ["--appimage-extract"], {
+    cwd: appImageRoot,
+  });
+  await verifyPackageRoot(path.join(appImageRoot, "squashfs-root"), "AppImage");
+} finally {
+  await rm(temporaryRoot, { recursive: true, force: true });
+}
+
+console.log("Verified Linux x64 deb and AppImage package contents");

--- a/scripts/verify-linux-updater.mjs
+++ b/scripts/verify-linux-updater.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import { verifyUpdaterSignature } from "./verify-updater-signature.mjs";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const projectRoot = path.resolve(path.dirname(scriptPath), "..");
+const debPath = process.argv[2] ? path.resolve(process.argv[2]) : null;
+const appImagePath = process.argv[3] ? path.resolve(process.argv[3]) : null;
+const latestPath = process.argv[4] ? path.resolve(process.argv[4]) : null;
+const releaseTag = process.argv[5]?.trim();
+if (!debPath || !appImagePath || !latestPath || !releaseTag) {
+  throw new Error(
+    "Usage: verify-linux-updater.mjs <package.deb> <package.AppImage> <latest.json> <release-tag>",
+  );
+}
+
+const packageJson = JSON.parse(await readFile(path.join(projectRoot, "package.json"), "utf8"));
+const tauriConfig = JSON.parse(await readFile(
+  path.join(projectRoot, "src-tauri", "tauri.conf.json"),
+  "utf8",
+));
+if (releaseTag !== `v${packageJson.version}`) {
+  throw new Error("Release tag does not match package.json version");
+}
+
+const latest = JSON.parse(await readFile(latestPath, "utf8"));
+if (latest.version !== packageJson.version) throw new Error("latest.json version is incorrect");
+if (latest.platforms?.["linux-x86_64"]) {
+  throw new Error("latest.json must use installer-specific Linux updater entries");
+}
+
+for (const [platformKey, artifactPath] of [
+  ["linux-x86_64-deb", debPath],
+  ["linux-x86_64-appimage", appImagePath],
+]) {
+  const signature = await readFile(`${artifactPath}.sig`, "utf8");
+  await verifyUpdaterSignature({
+    publicKey: tauriConfig.plugins.updater.pubkey,
+    artifactPath,
+    signature,
+  });
+
+  const expectedUrl = `https://github.com/chuspeeism/dashi-taskboard/releases/download/${releaseTag}/${path.basename(artifactPath)}`;
+  const platform = latest.platforms?.[platformKey];
+  if (platform?.url !== expectedUrl || platform.signature !== signature) {
+    throw new Error(`latest.json ${platformKey} updater entry is incorrect`);
+  }
+}
+
+console.log(`Verified Linux x86_64 deb and AppImage updaters for ${releaseTag}`);

--- a/shared/codex-executable.mjs
+++ b/shared/codex-executable.mjs
@@ -40,6 +40,7 @@ export function codexExecutableInApp(appPath, platform = process.platform) {
   if (platform === "win32") {
     return path.win32.join(path.win32.dirname(appPath), "resources", "codex.exe");
   }
+  if (platform === "linux") return "/usr/lib/chatgpt/resources/codex";
   return path.join(appPath, "Contents", "Resources", "codex");
 }
 

--- a/skills/manage-taskboard/SKILL.md
+++ b/skills/manage-taskboard/SKILL.md
@@ -13,6 +13,7 @@ Open only the relevant section of [references/cli.md](references/cli.md) when co
 
 - Use the exact `taskctl` binary and Taskboard URL supplied by the task or injected runtime. Do not replace them with a global CLI, the default port, or another board.
 - On macOS, when no binary is injected and the desktop app is installed, use `'/Applications/Codex Taskboard.app/Contents/Resources/bin/taskctl' issue get ID --json`. Keep the single quotes because the path contains a space. The packaged wrapper reads the active launcher runtime; do not search the filesystem for another CLI or reconstruct the tokenized URL.
+- On Linux, when no binary is injected and Codex was started by the desktop app, use `taskctl issue get ID --json`. The desktop app adds its packaged wrapper to the managed Codex `PATH`; do not search the filesystem for another CLI or reconstruct the tokenized URL.
 - If that exact command reaches a sandbox restriction on the loopback service, retry the same command with the required permission. Do not switch binaries or endpoints.
 
 ## Terminology: local companion

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "codex-taskboard-launcher"
 version = "1.1.4"
-description = "Codex Taskboard macOS launcher"
+description = "Codex Taskboard launcher"
 edition = "2021"
 rust-version = "1.88"
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 #[cfg(target_os = "macos")]
 use std::cell::RefCell;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 use std::os::{fd::AsRawFd, unix::process::CommandExt};
 use std::{
     fs::{self, File, OpenOptions},
@@ -73,7 +73,7 @@ use windows::{
 };
 
 const STOP_TIMEOUT: Duration = Duration::from_secs(5);
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 const LAUNCHER_STOP_TIMEOUT: Duration = Duration::from_secs(36);
 const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(30 * 60);
 // Unique whole-directory snapshots shipped from app-v0.2.0 through v1.1.2.
@@ -85,7 +85,7 @@ const KNOWN_TASKBOARD_SKILL_DIGESTS: [&str; 6] = [
     "27131c82ac63c2884c1fcb7dd22a4e1c75975c7d79eb3fa3483a7949dd5f284d",
     "ae74aec793decf6d9013c36f4b53e01723796a45567b77e9e9f22b4a168d3fbe",
 ];
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 const TASKBOARD_LISTEN_FD: i32 = 5;
 
 #[derive(Clone, Serialize)]
@@ -124,7 +124,7 @@ struct LauncherState {
     update_in_progress: AtomicBool,
     generation: AtomicU64,
     lifecycle: Mutex<()>,
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     taskboard_listener: Mutex<Option<TcpListener>>,
     #[cfg(target_os = "macos")]
     codex_port: Mutex<Option<u16>>,
@@ -219,7 +219,7 @@ struct UpdateDialog {
 
 #[cfg(target_os = "macos")]
 impl UpdateDialog {
-    fn prompt(version: &str) -> Option<Self> {
+    fn prompt(_app: &AppHandle, version: &str) -> Option<Self> {
         let message = format!("发现 Codex Taskboard {version}。是否现在下载、安装并重启？");
         let (response, result) = std::sync::mpsc::channel();
         let dialog = run_on_main(move |mtm| {
@@ -333,13 +333,47 @@ impl UpdateDialog {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
 #[derive(Clone)]
 struct UpdateDialog;
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
 impl UpdateDialog {
-    fn prompt(_version: &str) -> Option<Self> {
+    fn prompt(app: &AppHandle, version: &str) -> Option<Self> {
+        app.dialog()
+            .message(format!(
+                "发现 Codex Taskboard {version}。是否现在下载、安装并重启？"
+            ))
+            .title("Codex Taskboard 更新")
+            .kind(MessageDialogKind::Info)
+            .buttons(MessageDialogButtons::OkCancelCustom(
+                "立即更新".into(),
+                "稍后".into(),
+            ))
+            .blocking_show()
+            .then_some(Self)
+    }
+
+    fn show_progress(
+        &self,
+        _message: &str,
+        _cancel: tauri::async_runtime::Sender<()>,
+        _cancel_requested: Arc<AtomicBool>,
+    ) {
+    }
+
+    fn set_progress(&self, _message: &str, _progress: Option<u64>, _cancellable: bool) {}
+
+    fn close(&self) {}
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+#[derive(Clone)]
+struct UpdateDialog;
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+impl UpdateDialog {
+    fn prompt(_app: &AppHandle, _version: &str) -> Option<Self> {
         None
     }
 
@@ -382,7 +416,7 @@ impl LauncherState {
             update_in_progress: AtomicBool::new(false),
             generation: AtomicU64::new(0),
             lifecycle: Mutex::new(()),
-            #[cfg(target_os = "macos")]
+            #[cfg(any(target_os = "macos", target_os = "linux"))]
             taskboard_listener: Mutex::new(None),
             #[cfg(target_os = "macos")]
             codex_port: Mutex::new(None),
@@ -396,7 +430,7 @@ impl LauncherState {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn acquire_instance_lock(path: &Path) -> Result<Option<File>, std::io::Error> {
     let file = OpenOptions::new()
         .create(true)
@@ -556,7 +590,7 @@ fn loopback_listener() -> Result<TcpListener, String> {
     TcpListener::bind(("127.0.0.1", 0)).map_err(|error| error.to_string())
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn taskboard_listener(state: &LauncherState) -> Result<(Option<i32>, u16), String> {
     let mut listener = state.taskboard_listener.lock().unwrap();
     if listener.is_none() {
@@ -689,7 +723,7 @@ fn ordinary_codex_process(app_path: &Path) -> Result<Option<u32>, String> {
     Ok(ordinary_pid)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn process_is_running(pid: u32) -> bool {
     unsafe { libc::kill(pid as i32, 0) == 0 }
 }
@@ -825,6 +859,74 @@ fn quit_codex_normally(pid: u32) -> Result<(), String> {
     }
 }
 
+#[cfg(target_os = "linux")]
+fn find_codex_app(_home_directory: &Path) -> Option<PathBuf> {
+    let candidate = PathBuf::from("/usr/lib/chatgpt/ChatGPT");
+    candidate.is_file().then_some(candidate)
+}
+
+#[cfg(target_os = "linux")]
+fn ordinary_codex_process(app_path: &Path, codex_profile: &Path) -> Result<Option<u32>, String> {
+    let output = StdCommand::new("/bin/ps")
+        .args(["-ww", "-axo", "pid=,ppid=,command="])
+        .output()
+        .map_err(|error| error.to_string())?;
+    if !output.status.success() {
+        return Err("无法检查正在运行的 Codex".to_string());
+    }
+
+    let executable = app_path.to_string_lossy();
+    let mut processes = Vec::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let line = line.trim_start();
+        let Some(pid_separator) = line.find(char::is_whitespace) else {
+            continue;
+        };
+        let Some(pid) = line[..pid_separator].parse::<u32>().ok() else {
+            continue;
+        };
+        let parent_and_command = line[pid_separator..].trim_start();
+        let Some(parent_separator) = parent_and_command.find(char::is_whitespace) else {
+            continue;
+        };
+        let Some(parent_pid) = parent_and_command[..parent_separator].parse::<u32>().ok() else {
+            continue;
+        };
+        let command = parent_and_command[parent_separator..].trim_start();
+        if command != executable && !command.starts_with(&format!("{executable} ")) {
+            continue;
+        }
+        processes.push((pid, parent_pid, command.to_string()));
+    }
+
+    let managed_profile = format!("--user-data-dir={}", codex_profile.display());
+    Ok(processes
+        .iter()
+        .find(|(pid, parent_pid, command)| {
+            !processes
+                .iter()
+                .any(|(candidate_pid, _, _)| candidate_pid == parent_pid && candidate_pid != pid)
+                && !(command.contains(" --remote-debugging-pipe")
+                    && command.contains(&format!(" {managed_profile}")))
+        })
+        .map(|(pid, _, _)| *pid))
+}
+
+#[cfg(target_os = "linux")]
+fn quit_codex_normally(pid: u32) -> Result<(), String> {
+    if unsafe { libc::kill(pid as i32, libc::SIGTERM) } != 0 {
+        return Err("Codex 没有接受退出请求".to_string());
+    }
+    let deadline = Instant::now() + LAUNCHER_STOP_TIMEOUT;
+    while process_is_running(pid) && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(100));
+    }
+    if process_is_running(pid) {
+        return Err("Codex 尚未退出，任务面板没有启动".to_string());
+    }
+    Ok(())
+}
+
 #[cfg(target_os = "macos")]
 fn missing_codex_app_message() -> String {
     "未找到官方 ChatGPT.app 或 Codex.app。请先安装到 Applications 文件夹。".to_string()
@@ -835,7 +937,12 @@ fn missing_codex_app_message() -> String {
     "未找到官方 Codex App。请先从 Microsoft Store 安装。".to_string()
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(target_os = "linux")]
+fn missing_codex_app_message() -> String {
+    "未找到官方 ChatGPT App。请先安装 Ubuntu x64 .deb。".to_string()
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn send_process_group_signal(pid: u32, signal: i32) {
     unsafe {
         if libc::kill(-(pid as i32), signal) != 0 {
@@ -844,7 +951,7 @@ fn send_process_group_signal(pid: u32, signal: i32) {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn process_group_is_running(pid: u32) -> bool {
     unsafe { libc::kill(-(pid as i32), 0) == 0 }
 }
@@ -864,7 +971,7 @@ fn process_group_is_running(pid: u32) -> bool {
         .is_ok_and(|status| status.success())
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn signal_pending_taskboard_open(state: &LauncherState) -> Result<(), String> {
     let mut snapshot = state.snapshot.lock().unwrap();
     if !snapshot.open_request_pending {
@@ -915,7 +1022,7 @@ fn wait_for_process_group_exit(pid: u32, timeout: Duration) -> bool {
     !process_group_is_running(pid)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn terminate_process_group(pid: u32) {
     send_process_group_signal(pid, libc::SIGTERM);
     if !wait_for_process_group_exit(pid, STOP_TIMEOUT) {
@@ -933,7 +1040,7 @@ fn terminate_process_group(pid: u32) {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn stop_launcher_process_group(pid: u32) {
     unsafe {
         libc::kill(pid as i32, libc::SIGTERM);
@@ -949,7 +1056,7 @@ fn stop_launcher_process_group(pid: u32) {
     terminate_process_group(pid);
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn process_matches_record(record: &LauncherPidRecord) -> bool {
     let output = StdCommand::new("/bin/ps")
         .args(["-p", &record.pid.to_string(), "-o", "command="])
@@ -1034,7 +1141,7 @@ fn stop_managed_child_locked(app: &AppHandle, state: &Arc<LauncherState>) {
         if !wait_for_process_group_exit(pid, STOP_TIMEOUT) {
             terminate_process_group(pid);
         }
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
         stop_launcher_process_group(pid);
         clear_pid_record(state, pid);
     }
@@ -1146,6 +1253,8 @@ fn start_launcher_locked(
         .ok_or_else(|| "无法定位 App 可执行文件目录".to_string())?
         .join(if cfg!(target_os = "windows") {
             "node.exe"
+        } else if cfg!(target_os = "linux") {
+            "codex-taskboard-node"
         } else {
             "node"
         });
@@ -1154,6 +1263,8 @@ fn start_launcher_locked(
     #[cfg(target_os = "macos")]
     let ordinary_codex_pid = ordinary_codex_process(&codex_app)?;
     #[cfg(target_os = "windows")]
+    let ordinary_codex_pid = ordinary_codex_process(&codex_app, &codex_profile)?;
+    #[cfg(target_os = "linux")]
     let ordinary_codex_pid = ordinary_codex_process(&codex_app, &codex_profile)?;
     if let Some(codex_pid) = ordinary_codex_pid {
         let restart = app
@@ -1196,7 +1307,7 @@ fn start_launcher_locked(
         "{}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
         resource_directory.join("bin").display()
     );
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     let path_value = {
         let current_path = std::env::var_os("PATH").unwrap_or_default();
         std::env::join_paths(
@@ -1220,14 +1331,20 @@ fn start_launcher_locked(
         .map(PathBuf::from)
         .ok_or_else(|| "APPDATA is unavailable".to_string())?
         .join("Codex/web/Codex");
+    #[cfg(target_os = "linux")]
+    let codex_source_profile = std::env::var_os("XDG_CONFIG_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home_directory.join(".config"))
+        .join("Codex");
     let mut command = StdCommand::new(&node_path);
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     command.arg(&injector_path);
     #[cfg(target_os = "windows")]
     command.arg(r"scripts\codex-injector.mjs");
     #[cfg(target_os = "macos")]
     command.args(["--launch", "--watch", "--open", "--port", &codex_port]);
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     command.args(["--launch", "--watch", "--open", "--cdp-pipe"]);
     command
         .args(["--startup-token", &instance_token, "--app-path"])
@@ -1259,7 +1376,7 @@ fn start_launcher_locked(
         .stderr(Stdio::piped());
     #[cfg(target_os = "windows")]
     command.stdin(Stdio::piped());
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     unsafe {
         let taskboard_listener_fd = _taskboard_listener_fd.unwrap();
         command
@@ -1301,7 +1418,7 @@ fn start_launcher_locked(
             "Started launcher child {pid} on Taskboard {taskboard_port} with Codex CDP {codex_port}"
         ),
     );
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     append_log(
         state,
         &format!(
@@ -1473,6 +1590,11 @@ fn open_taskboard_in_browser(state: &LauncherState) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     let status = StdCommand::new("rundll32.exe")
         .args(["url.dll,FileProtocolHandler", &url])
+        .status()
+        .map_err(|error| error.to_string())?;
+    #[cfg(target_os = "linux")]
+    let status = StdCommand::new("xdg-open")
+        .arg(&url)
         .status()
         .map_err(|error| error.to_string())?;
     status
@@ -1833,7 +1955,7 @@ async fn offer_update(
 
     let version = update.version.clone();
     append_log(state, &format!("Showing update prompt for {version}"));
-    let Some(update_dialog) = UpdateDialog::prompt(&version) else {
+    let Some(update_dialog) = UpdateDialog::prompt(app, &version) else {
         append_log(state, &format!("Update {version} deferred by user"));
         finish_update_flow(state, check_update, quit);
         return;
@@ -1903,6 +2025,18 @@ fn main() {
                 .map(PathBuf::from)
                 .ok_or_else(|| std::io::Error::other("LOCALAPPDATA is unavailable"))?
                 .join("Codex Taskboard/Logs");
+            #[cfg(target_os = "linux")]
+            let data_directory = std::env::var_os("XDG_DATA_HOME")
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+                .unwrap_or_else(|| home_directory.join(".local/share"))
+                .join("Codex Taskboard");
+            #[cfg(target_os = "linux")]
+            let log_directory = std::env::var_os("XDG_STATE_HOME")
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+                .unwrap_or_else(|| home_directory.join(".local/state"))
+                .join("Codex Taskboard");
             fs::create_dir_all(&data_directory)?;
             fs::create_dir_all(&log_directory)?;
             let Some(instance_lock) = acquire_instance_lock(&data_directory.join("launcher.lock"))?
@@ -2190,7 +2324,7 @@ fn main() {
         tauri::RunEvent::Exit => {
             if let Some(state) = app_handle.try_state::<Arc<LauncherState>>() {
                 stop_managed_child(app_handle, &state);
-                #[cfg(target_os = "macos")]
+                #[cfg(any(target_os = "macos", target_os = "linux"))]
                 unsafe {
                     libc::flock(state._instance_lock.as_raw_fd(), libc::LOCK_UN);
                 }

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "bundle": {
+    "targets": ["deb", "appimage"],
+    "createUpdaterArtifacts": false,
+    "externalBin": ["binaries/codex-taskboard-node"],
+    "icon": ["../web/public/codex-app-icon.png"]
+  }
+}


### PR DESCRIPTION
## Summary

- add Ubuntu 24.04 x64 `.deb` and AppImage packaging with bundled Node.js, `taskctl`, Skill, injector, and Taskboard service
- add the Linux XDG launcher path for the official ChatGPT desktop `.deb`, including single-instance handling, private CDP pipe launch, tray/autostart, URL opening, and updates
- build and inspect both Linux packages in Ubuntu 24.04 CI; publish installer-specific signed Linux updater entries in the existing single Release while keeping the DMG first

Closes #143. Taskboard: LOCAL-237.

## Local verification

- Rust 1.88 `cargo fmt --check`
- Rust 1.88 macOS x64 `cargo check`
- Linux x64 locked Cargo metadata
- JS syntax, JSON, and workflow YAML parsing
- focused launcher, injector, executable, and release tests
- web typecheck and build

## Environment limitation

The real Ubuntu 24.04 package build and package-content inspection run in this PR's `Ubuntu 24.04 x64 launcher` job. The Linux GUI lifecycle and updater install path still require an Ubuntu 24.04 GUI host with the signed-in official ChatGPT desktop app.
