### PR TITLE
Focus AI composer when opening a conversation

### DIFF
--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -1365,6 +1365,9 @@ export function AiChat({
   const snapshotLoadingRequestRef = useRef(0);
   const observedRunStatusesRef = useRef(new Map<string, AiChatRun["status"]>());
   const dangerConfirmOpen = pendingDangerInput !== null;
+  const openThreadRequestId = openThreadRequest && "threadId" in openThreadRequest
+    ? openThreadRequest.requestId
+    : null;
 
   const selectThread = useCallback((threadId: string | null) => {
     selectedThreadRef.current = threadId;
@@ -1391,7 +1394,7 @@ export function AiChat({
 
   useEffect(() => {
     if (panelOpen && selectedThreadId) editorRef.current?.focus();
-  }, [panelOpen, selectedThreadId]);
+  }, [panelOpen, selectedThreadId, openThreadRequestId]);
 
   useEffect(() => {
     function finishPanelResize(pointerId?: number) {

--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -1390,6 +1390,10 @@ export function AiChat({
   }, [panelOpen]);
 
   useEffect(() => {
+    if (panelOpen && selectedThreadId) editorRef.current?.focus();
+  }, [panelOpen, selectedThreadId]);
+
+  useEffect(() => {
     function finishPanelResize(pointerId?: number) {
       const session = panelResizeSessionRef.current;
       if (!session || (pointerId !== undefined && session.pointerId !== pointerId)) return;


### PR DESCRIPTION
## Summary

- focus the AI composer after a specific conversation panel opens
- preserve the existing layout and conversation behavior

## Direct verification

- real Taskboard data snapshot on isolated port 62382
- opened a concrete LOCAL-182 AI conversation from the task card
- confirmed the composer was document.activeElement on first open and reopen
- typed through the real keyboard path without sending
- event count stayed 40 and run count stayed 1
- npm run build:web
- git diff --check

No tests were added before user confirmation, per the current feature workflow.