### PR TITLE
Fix inline image spacing and issue hover feedback

### DIFF
--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -490,7 +490,7 @@ export function inlineMediaText(segments: InlineMediaSegment[]): string {
 export function serializeInlineMedia(segments: InlineMediaSegment[]): string {
   return segments.map((segment) => {
     if (segment.type === "text") return segment.text;
-    if (segment.type === "pending-image") return `\n\n${segment.token}\n\n`;
+    if (segment.type === "pending-image") return segment.token;
     return segment.markdown;
   }).join("");
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4607,6 +4607,10 @@ kbd {
   line-height: 20px;
 }
 
+.detail-label-trigger:hover:not(:disabled) .label-trigger-chip {
+  background: var(--surface-active);
+}
+
 .detail-label-trigger .label-trigger-chip i {
   display: block;
   width: 5px;
@@ -8555,7 +8559,7 @@ kbd {
 .task-card:hover,
 .task-card.is-context-open {
   border-color: var(--border-strong);
-  background: var(--surface-raised);
+  background: var(--surface-hover);
   box-shadow: var(--card-shadow);
 }
 
@@ -8819,6 +8823,17 @@ kbd {
 .due-date-chip .taskboard-icon {
   width: 11px;
   height: 12px;
+}
+
+.priority-chip:hover:not(:disabled),
+.card-label-trigger:hover:not(:disabled) .label-chip,
+.due-date-chip:has(input:not(:disabled)):hover {
+  background: var(--surface-active);
+}
+
+.task-assignee-trigger:hover:not(:disabled) {
+  border-radius: 999px;
+  box-shadow: 0 0 0 2px var(--surface-active);
 }
 
 .label-more {


### PR DESCRIPTION
## Summary

- preserve the user's authored line breaks when pending inline images are serialized for task descriptions and comments
- reuse existing surface tokens for clear hover feedback on issue cards and editable property pills
- keep click behavior, layout, and information hierarchy unchanged

## Direct-path verification

- `npm run typecheck`
- `npm run build:web`
- isolated headed browser: description image upload produced a task PATCH with exactly one authored newline on each side of the image, then reopened without extra blank lines
- isolated headed browser: image comment produced POST/PATCH bodies with exactly one authored newline on each side, then reopened in comment edit mode without extra blank lines
- isolated headed browser: card hover changed from `rgb(255, 255, 255)` to `rgb(246, 246, 247)`; editable priority and label pills changed to `rgb(236, 236, 237)`; assignee gained the matching 2 px hover ring
- the card's existing open action still navigated to the same issue detail

Taskboard: LOCAL-291, LOCAL-290
