### PR TITLE
fix: allow deleting empty projects

### DIFF
--- a/server/database.mjs
+++ b/server/database.mjs
@@ -3,7 +3,7 @@ import { mkdirSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
-import { DEFAULT_LABEL_NAMES, JIRA_PROJECT_ID } from "../shared/domain.mjs";
+import { DEFAULT_LABEL_NAMES, DEFAULT_PROJECT_ID, JIRA_PROJECT_ID } from "../shared/domain.mjs";
 
 const DEFAULT_PROJECT_LABELS_JSON = JSON.stringify(DEFAULT_LABEL_NAMES);
 
@@ -1281,8 +1281,8 @@ export class TaskboardDatabase {
     if (!project) {
       throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${id}' does not exist`);
     }
-    if (!id.startsWith("temp-")) {
-      throw new ApiError(403, "PROJECT_DELETE_FORBIDDEN", "Only manually created projects can be deleted");
+    if (id === DEFAULT_PROJECT_ID) {
+      throw new ApiError(403, "PROJECT_DELETE_FORBIDDEN", "The default project cannot be deleted");
     }
     const result = this.database.prepare(`
       DELETE FROM projects

--- a/test/server.test.mjs
+++ b/test/server.test.mjs
@@ -90,6 +90,23 @@ test("health and the default local project are available", async () => {
   assert.equal(result.body.projects[0].issueCount, 0);
 });
 
+test("an empty named project can be deleted", async () => {
+  const baseUrl = await startServer();
+  const created = await request(baseUrl, "/api/projects", {
+    method: "POST",
+    body: { id: "named-project", name: "Named project" },
+  });
+  assert.equal(created.response.status, 201);
+
+  const deleted = await request(baseUrl, "/api/projects/named-project", {
+    method: "DELETE",
+  });
+  assert.equal(deleted.response.status, 204);
+
+  const projects = await request(baseUrl, "/api/projects");
+  assert.equal(projects.body.projects.some((project) => project.id === "named-project"), false);
+});
+
 test("launcher mode proves service identity and hides every route behind its instance token", async () => {
   const instanceToken = "7a6f8d37-78ce-46c9-87a8-08e10db88da2";
   const instanceSecret = "2e587946-96d6-47b5-930a-1ba70214fa88";


### PR DESCRIPTION
## Summary
- allow deletion of any empty non-default local project
- keep the default project and projects with tasks protected
- add API coverage for deleting an empty named project

## Test plan
- `node --test --test-name-pattern="an empty named project can be deleted" test/server.test.mjs`
- `node --test test/server.test.mjs`