### PR TITLE
feat: add deterministic task tree queries

### DIFF
--- a/cli/taskctl.mjs
+++ b/cli/taskctl.mjs
@@ -92,6 +92,7 @@ const COMMAND_OPTIONS = new Map([
   ])],
   ["issue archive", new Set(["thread-id", "if-version", "json"])],
   ["issue restore", new Set(["thread-id", "if-version", "json"])],
+  ["issue tree", new Set(["direction", "depth", "json"])],
   ["issue relation", new Set(["type", "issue", "thread-id", "if-version", "json"])],
   ["comment list", new Set(["after", "json"])],
   ["comment add", new Set([
@@ -126,7 +127,7 @@ Commands:
   project readme set [PROJECT_ID] (--content TEXT | --file FILE) [--if-version N]
   cloud login --url URL --actor-name NAME
   cloud status|logout
-  issue list|get|create|update|move|archive|restore|relation
+  issue list|get|create|update|move|archive|restore|tree|relation
   comment list ISSUE_ID [--after CURSOR]
   comment add ISSUE_ID (--body TEXT | --body-file FILE) [--thread-id ID]
   comment update COMMENT_ID --body TEXT --if-version N [--thread-id ID]
@@ -174,6 +175,7 @@ Actions:
     [--if-version N] [--json]
   archive ISSUE_ID [--thread-id ID] [--if-version N] [--json]
   restore ISSUE_ID [--thread-id ID] [--if-version N] [--json]
+  tree ISSUE_ID --direction descendants|ancestors --depth N [--json]
   relation add|remove ISSUE_ID --type parent|blocks|blocked_by|related
     --issue RELATED_ISSUE_ID [--thread-id ID] [--if-version N] [--json]
 
@@ -304,7 +306,7 @@ async function execute(parsed, overrides) {
   const allowedOptions = COMMAND_OPTIONS.get(command);
   if (!allowedOptions) {
     throw usageError(
-      "Expected one of: project list/create/map/readme, cloud login/status/logout, issue list/get/create/update/move/archive/restore/relation, comment list/add/update/delete, attachment list/download/upload, context current",
+      "Expected one of: project list/create/map/readme, cloud login/status/logout, issue list/get/create/update/move/archive/restore/tree/relation, comment list/add/update/delete, attachment list/download/upload, context current",
     );
   }
   validateOptions(parsed.options, allowedOptions);
@@ -384,6 +386,9 @@ async function execute(parsed, overrides) {
     case "issue restore":
       expectOperandCount(parsed, 1);
       return archiveIssue(api, parsed.operands[0], parsed.options, overrides, "restore");
+    case "issue tree":
+      expectOperandCount(parsed, 1);
+      return getIssueTree(api, parsed.operands[0], parsed.options);
     case "issue relation":
       expectOperandCount(parsed, 2);
       return mutateIssueRelation(
@@ -969,6 +974,20 @@ async function archiveIssue(api, taskId, options, overrides, action) {
     threadId,
     version: await resolveVersion(api, taskId, options["if-version"]),
   });
+}
+
+async function getIssueTree(api, taskId, options) {
+  const direction = requiredOption(options, "direction");
+  if (direction !== "descendants" && direction !== "ancestors") {
+    throw usageError("--direction must be descendants or ancestors");
+  }
+  const rawDepth = requiredOption(options, "depth");
+  const depth = Number(rawDepth);
+  if (!/^\d+$/.test(rawDepth) || !Number.isSafeInteger(depth) || depth < 1 || depth > 25) {
+    throw usageError("--depth must be an integer from 1 to 25");
+  }
+  const query = new URLSearchParams({ direction, depth: String(depth) });
+  return api.request("GET", `${taskPath(taskId)}/tree?${query}`);
 }
 
 async function mutateIssueRelation(api, action, taskId, options, overrides) {

--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -29,6 +29,7 @@ const INLINE_ATTACHMENT_TYPES = new Set([
 const REALTIME_HUB_NAME = "global";
 const SESSION_COOKIE_NAME = "__Host-taskboard_session";
 const SESSION_MAX_AGE_SECONDS = 24 * 60 * 60;
+const TASK_TREE_MAX_NODES = 1_000;
 
 export class RealtimeHub extends DurableObject {
   async fetch(request) {
@@ -909,6 +910,22 @@ function taskRelationSummaryFromRow(row) {
   };
 }
 
+function taskTreeNode(row, parentId, depth, path) {
+  return {
+    id: row.id,
+    parentId,
+    depth,
+    path,
+    summary: {
+      identifier: row.identifier,
+      title: row.title,
+      status: row.status,
+      priority: row.priority,
+      archivedAt: row.archived_at,
+    },
+  };
+}
+
 function commentFromRow(row, attachments = []) {
   return {
     id: row.id,
@@ -1130,6 +1147,66 @@ async function hydrateTask(env, row, activityComments = null, activityChanges = 
 async function getTask(env, id) {
   const row = await taskRow(env, id);
   return row ? hydrateTask(env, row) : null;
+}
+
+async function getTaskTree(env, id, direction, depth) {
+  const root = await requireTaskRow(env, id);
+  const nodes = [taskTreeNode(root, null, 0, [root.id])];
+  const seen = new Set([root.id]);
+  let frontier = [nodes[0]];
+  const relationJoin = direction === "descendants"
+    ? `
+      FROM task_relations
+      JOIN tasks ON tasks.id = task_relations.target_task_id
+      WHERE task_relations.relation_type = 'parent'
+        AND task_relations.source_task_id IN (%PLACEHOLDERS%)
+    `
+    : `
+      FROM task_relations
+      JOIN tasks ON tasks.id = task_relations.source_task_id
+      WHERE task_relations.relation_type = 'parent'
+        AND task_relations.target_task_id IN (%PLACEHOLDERS%)
+    `;
+  const parentColumn = direction === "descendants"
+    ? "task_relations.source_task_id"
+    : "task_relations.target_task_id";
+
+  for (let level = 1; level <= depth && frontier.length > 0; level += 1) {
+    const placeholders = frontier.map(() => "?").join(", ");
+    const rows = await all(env.DB.prepare(`
+      SELECT tasks.*, ${parentColumn} AS tree_parent_id
+      ${relationJoin.replace("%PLACEHOLDERS%", placeholders)}
+      ORDER BY tasks.sort_order, tasks.created_at, tasks.id
+    `).bind(...frontier.map((node) => node.id)));
+    const rowsByParent = new Map();
+    for (const row of rows) {
+      const siblings = rowsByParent.get(row.tree_parent_id) ?? [];
+      siblings.push(row);
+      rowsByParent.set(row.tree_parent_id, siblings);
+    }
+    const next = [];
+    for (const parent of frontier) {
+      for (const row of rowsByParent.get(parent.id) ?? []) {
+        if (seen.has(row.id)) continue;
+        if (nodes.length >= TASK_TREE_MAX_NODES) {
+          throw new ApiError(413, "TREE_TOO_LARGE", `Task tree cannot exceed ${TASK_TREE_MAX_NODES} nodes`);
+        }
+        const node = taskTreeNode(row, parent.id, level, [...parent.path, row.id]);
+        nodes.push(node);
+        next.push(node);
+        seen.add(row.id);
+      }
+    }
+    frontier = next;
+  }
+
+  return {
+    rootId: root.id,
+    direction,
+    depth,
+    nodeCount: nodes.length,
+    nodes,
+  };
 }
 
 async function taskActivityComments(env, taskIds) {
@@ -1378,6 +1455,28 @@ function parseTaskFilters(searchParams) {
     );
   }
   return { projectId, status, archived };
+}
+
+function parseTaskTreeQuery(searchParams) {
+  const allowed = new Set(["direction", "depth"]);
+  for (const key of searchParams.keys()) {
+    if (!allowed.has(key)) {
+      throw new ApiError(400, "UNKNOWN_QUERY_PARAMETER", `Unknown query parameter: ${key}`);
+    }
+    if (searchParams.getAll(key).length !== 1) {
+      throw new ApiError(400, "INVALID_TREE_QUERY", `'${key}' cannot be repeated`);
+    }
+  }
+  const direction = searchParams.get("direction");
+  if (direction !== "descendants" && direction !== "ancestors") {
+    throw new ApiError(400, "INVALID_TREE_QUERY", "'direction' must be descendants or ancestors");
+  }
+  const rawDepth = searchParams.get("depth");
+  const depth = Number(rawDepth);
+  if (!/^\d+$/.test(rawDepth ?? "") || !Number.isSafeInteger(depth) || depth < 1 || depth > 25) {
+    throw new ApiError(400, "INVALID_TREE_QUERY", "'depth' must be an integer from 1 to 25");
+  }
+  return { direction, depth };
 }
 
 function parseAfterCursor(searchParams) {
@@ -3089,6 +3188,14 @@ async function routeApi(request, env, actor, url) {
       });
     }
     methodNotAllowed(["GET", "POST"]);
+  }
+
+  const taskTreeMatch = pathname.match(/^\/api\/tasks\/([^/]+)\/tree$/);
+  if (taskTreeMatch) {
+    if (request.method !== "GET") methodNotAllowed(["GET"]);
+    const taskId = decodePathPart(taskTreeMatch[1], "Task id");
+    const { direction, depth } = parseTaskTreeQuery(url.searchParams);
+    return json(200, { tree: await getTaskTree(env, taskId, direction, depth) });
   }
 
   const relationMatch = pathname.match(

--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -1170,17 +1170,23 @@ async function getTaskTree(env, id, direction, depth) {
     : "task_relations.target_task_id";
 
   for (let level = 1; level <= depth && frontier.length > 0; level += 1) {
-    const placeholders = frontier.map(() => "?").join(", ");
-    const rows = await all(env.DB.prepare(`
-      SELECT tasks.*, ${parentColumn} AS tree_parent_id
-      ${relationJoin.replace("%PLACEHOLDERS%", placeholders)}
-      ORDER BY tasks.sort_order, tasks.created_at, tasks.id
-    `).bind(...frontier.map((node) => node.id)));
+    const batches = [];
+    for (let offset = 0; offset < frontier.length; offset += 80) {
+      const chunk = frontier.slice(offset, offset + 80);
+      const placeholders = chunk.map(() => "?").join(", ");
+      batches.push(all(env.DB.prepare(`
+        SELECT tasks.*, ${parentColumn} AS tree_parent_id
+        ${relationJoin.replace("%PLACEHOLDERS%", placeholders)}
+        ORDER BY tasks.sort_order, tasks.created_at, tasks.id
+      `).bind(...chunk.map((node) => node.id))));
+    }
     const rowsByParent = new Map();
-    for (const row of rows) {
-      const siblings = rowsByParent.get(row.tree_parent_id) ?? [];
-      siblings.push(row);
-      rowsByParent.set(row.tree_parent_id, siblings);
+    for (const rows of await Promise.all(batches)) {
+      for (const row of rows) {
+        const siblings = rowsByParent.get(row.tree_parent_id) ?? [];
+        siblings.push(row);
+        rowsByParent.set(row.tree_parent_id, siblings);
+      }
     }
     const next = [];
     for (const parent of frontier) {

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -822,6 +822,28 @@ function parseTaskFilters(searchParams) {
   return { projectId, status: statusValue ?? undefined, archived };
 }
 
+function parseTaskTreeQuery(searchParams) {
+  const allowed = new Set(["direction", "depth"]);
+  for (const key of searchParams.keys()) {
+    if (!allowed.has(key)) {
+      throw new ApiError(400, "UNKNOWN_QUERY_PARAMETER", `Unknown query parameter '${key}'`);
+    }
+    if (searchParams.getAll(key).length !== 1) {
+      throw new ApiError(400, "INVALID_TREE_QUERY", `Query parameter '${key}' cannot be repeated`);
+    }
+  }
+  const direction = searchParams.get("direction");
+  if (direction !== "descendants" && direction !== "ancestors") {
+    throw new ApiError(400, "INVALID_TREE_QUERY", "'direction' must be descendants or ancestors");
+  }
+  const rawDepth = searchParams.get("depth");
+  const depth = Number(rawDepth);
+  if (!/^\d+$/.test(rawDepth ?? "") || !Number.isSafeInteger(depth) || depth < 1 || depth > 25) {
+    throw new ApiError(400, "INVALID_TREE_QUERY", "'depth' must be an integer from 1 to 25");
+  }
+  return { direction, depth };
+}
+
 function parseAiSandbox(value) {
   if (value === undefined) return undefined;
   if (!["read-only", "workspace-write", "danger-full-access"].includes(value)) {
@@ -2932,6 +2954,22 @@ export function createTaskboardServer(options = {}) {
         const task = database.getTask(attachment.taskId);
         events.emit("attachment.deleted", { attachment, task });
         return sendEmpty(response, 204);
+      }
+
+      const taskTreeRoute = pathname.match(/^\/api\/tasks\/([^/]+)\/tree$/);
+      if (taskTreeRoute) {
+        let id;
+        try {
+          id = decodeURIComponent(taskTreeRoute[1]);
+        } catch {
+          throw new ApiError(400, "INVALID_PATH", "Task id contains invalid encoding");
+        }
+        if (id.length === 0 || id.length > 128) {
+          throw new ApiError(400, "INVALID_PATH", "Task id is invalid");
+        }
+        if (request.method !== "GET") return methodNotAllowed(response, ["GET"]);
+        const { direction, depth } = parseTaskTreeQuery(url.searchParams);
+        return sendJson(response, 200, { tree: database.getTaskTree(id, direction, depth) });
       }
 
       const taskRoute = pathname.match(/^\/api\/tasks\/([^/]+)(?:\/(archive|restore|move))?$/);

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -6,6 +6,7 @@ import { DatabaseSync } from "node:sqlite";
 import { DEFAULT_LABEL_NAMES, JIRA_PROJECT_ID } from "../shared/domain.mjs";
 
 const DEFAULT_PROJECT_LABELS_JSON = JSON.stringify(DEFAULT_LABEL_NAMES);
+const TASK_TREE_MAX_NODES = 1_000;
 
 export class ApiError extends Error {
   constructor(status, code, message, details) {
@@ -286,6 +287,22 @@ function taskRelationSummaryFromRow(row) {
       avatarUrl: row.assignee_avatar_url,
     },
     archivedAt: row.archived_at,
+  };
+}
+
+function taskTreeNode(row, parentId, depth, path) {
+  return {
+    id: row.id,
+    parentId,
+    depth,
+    path,
+    summary: {
+      identifier: row.identifier,
+      title: row.title,
+      status: row.status,
+      priority: row.priority,
+      archivedAt: row.archived_at,
+    },
   };
 }
 
@@ -805,6 +822,39 @@ export class TaskboardDatabase {
       CREATE UNIQUE INDEX IF NOT EXISTS task_relations_one_parent
         ON task_relations(target_task_id)
         WHERE relation_type = 'parent';
+
+      CREATE TRIGGER IF NOT EXISTS task_relations_require_same_project
+      BEFORE INSERT ON task_relations
+      BEGIN
+        SELECT RAISE(ABORT, 'CROSS_PROJECT_RELATION')
+        WHERE EXISTS (
+          SELECT 1
+          FROM tasks AS source
+          JOIN tasks AS target ON target.id = NEW.target_task_id
+          WHERE source.id = NEW.source_task_id
+            AND source.project_id != target.project_id
+        );
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS task_relations_prevent_parent_cycle
+      BEFORE INSERT ON task_relations
+      WHEN NEW.relation_type = 'parent'
+      BEGIN
+        SELECT RAISE(ABORT, 'RELATION_CYCLE')
+        WHERE EXISTS (
+          WITH RECURSIVE ancestors(id) AS (
+            SELECT source_task_id
+            FROM task_relations
+            WHERE relation_type = 'parent' AND target_task_id = NEW.source_task_id
+            UNION
+            SELECT task_relations.source_task_id
+            FROM task_relations
+            JOIN ancestors ON task_relations.target_task_id = ancestors.id
+            WHERE task_relations.relation_type = 'parent'
+          )
+          SELECT 1 FROM ancestors WHERE id = NEW.target_task_id
+        );
+      END;
     `);
 
     const taskRelationColumns = this.database.prepare("PRAGMA table_info(task_relations)").all();
@@ -1840,6 +1890,70 @@ export class TaskboardDatabase {
     const activities = this.#activitiesForTasks([task.id]).get(task.id) ?? [];
     const previewImage = this.#taskPreviewImages([task.id]).get(task.id) ?? null;
     return attachTaskActivity(task, comments, activities, previewImage);
+  }
+
+  getTaskTree(id, direction, depth) {
+    const root = this.database.prepare(
+      "SELECT * FROM tasks WHERE id = ? OR identifier = ?",
+    ).get(id, id);
+    if (!root) throw new ApiError(404, "TASK_NOT_FOUND", `Task '${id}' does not exist`);
+
+    const nodes = [taskTreeNode(root, null, 0, [root.id])];
+    const seen = new Set([root.id]);
+    let frontier = [nodes[0]];
+    const relationJoin = direction === "descendants"
+      ? `
+        FROM task_relations
+        JOIN tasks ON tasks.id = task_relations.target_task_id
+        WHERE task_relations.relation_type = 'parent'
+          AND task_relations.source_task_id IN (%PLACEHOLDERS%)
+      `
+      : `
+        FROM task_relations
+        JOIN tasks ON tasks.id = task_relations.source_task_id
+        WHERE task_relations.relation_type = 'parent'
+          AND task_relations.target_task_id IN (%PLACEHOLDERS%)
+      `;
+    const parentColumn = direction === "descendants"
+      ? "task_relations.source_task_id"
+      : "task_relations.target_task_id";
+
+    for (let level = 1; level <= depth && frontier.length > 0; level += 1) {
+      const placeholders = frontier.map(() => "?").join(", ");
+      const rows = this.database.prepare(`
+        SELECT tasks.*, ${parentColumn} AS tree_parent_id
+        ${relationJoin.replace("%PLACEHOLDERS%", placeholders)}
+        ORDER BY tasks.sort_order, tasks.created_at, tasks.id
+      `).all(...frontier.map((node) => node.id));
+      const rowsByParent = new Map();
+      for (const row of rows) {
+        const siblings = rowsByParent.get(row.tree_parent_id) ?? [];
+        siblings.push(row);
+        rowsByParent.set(row.tree_parent_id, siblings);
+      }
+      const next = [];
+      for (const parent of frontier) {
+        for (const row of rowsByParent.get(parent.id) ?? []) {
+          if (seen.has(row.id)) continue;
+          if (nodes.length >= TASK_TREE_MAX_NODES) {
+            throw new ApiError(413, "TREE_TOO_LARGE", `Task tree cannot exceed ${TASK_TREE_MAX_NODES} nodes`);
+          }
+          const node = taskTreeNode(row, parent.id, level, [...parent.path, row.id]);
+          nodes.push(node);
+          next.push(node);
+          seen.add(row.id);
+        }
+      }
+      frontier = next;
+    }
+
+    return {
+      rootId: root.id,
+      direction,
+      depth,
+      nodeCount: nodes.length,
+      nodes,
+    };
   }
 
   createTask(input) {

--- a/skills/manage-taskboard/references/cli.md
+++ b/skills/manage-taskboard/references/cli.md
@@ -59,7 +59,10 @@ Except for built-in help, every successful command writes one JSON object with `
 ```bash
 taskctl issue list [--project PROJECT_ID] [--status STATUS] [--archived true|false|all] [--json]
 taskctl issue get ID [--json]
+taskctl issue tree ID --direction descendants|ancestors --depth N [--json]
 ```
+
+`issue tree` is a bounded structural read. `--depth 1` returns only direct children or the direct parent; larger values include that many levels, up to 25. The response is flat and deterministic: every node carries `id`, traversal `parentId`, `depth`, and `path` (usable as a breadcrumb), plus a small task summary. It never calculates status rollups or changes issues.
 
 ## Create issues
 
@@ -157,7 +160,7 @@ taskctl issue relation remove ISSUE_ID \
 
 For `--type parent`, `ISSUE_ID` is the child and `PARENT_ISSUE_ID` is its parent. Adding another parent replaces the child's current parent atomically. To add an existing issue as a sub-issue, anchor the command on the child and pass the exact parent identifier with `--issue PARENT_ISSUE_ID`.
 
-For `blocks`, the anchor issue blocks the related issue. For `blocked_by`, the related issue blocks the anchor. `related` is symmetric. Self-relations, duplicates, parent cycles, and relations between different projects are rejected.
+For `blocks`, the anchor issue blocks the related issue. For `blocked_by`, the related issue blocks the anchor. `related` is symmetric. Self-relations, duplicates, and parent cycles are rejected. For compatibility, relation writes between different projects remain rejected for now; this is a temporary boundary, not the final hierarchy contract.
 
 ## Issue comments
 

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -427,6 +427,32 @@ test("issue relation add and remove use typed relation endpoints", async () => {
   });
 });
 
+test("issue tree uses the bounded directional tree endpoint", async () => {
+  let requestedUrl;
+  const result = await run(
+    ["issue", "tree", "TASK/1", "--direction", "ancestors", "--depth", "3", "--json"],
+    async (url, init) => {
+      requestedUrl = url;
+      assert.equal(init.method, "GET");
+      return response({ tree: { rootId: "TASK/1", direction: "ancestors", depth: 3, nodes: [] } });
+    },
+  );
+  assert.equal(result.exitCode, 0);
+  assert.equal(requestedUrl.pathname, "/api/tasks/TASK%2F1/tree");
+  assert.equal(requestedUrl.searchParams.get("direction"), "ancestors");
+  assert.equal(requestedUrl.searchParams.get("depth"), "3");
+
+  for (const argv of [
+    ["issue", "tree", "TASK-1", "--direction", "down", "--depth", "1"],
+    ["issue", "tree", "TASK-1", "--direction", "descendants", "--depth", "0"],
+    ["issue", "tree", "TASK-1", "--direction", "descendants"],
+  ]) {
+    const invalid = await run(argv, async () => assert.fail("fetch should not be called"));
+    assert.equal(invalid.exitCode, 2);
+    assert.equal(invalid.stderr.error.code, "USAGE_ERROR");
+  }
+});
+
 test("issue relation validates its action and relation type before fetching", async () => {
   for (const argv of [
     ["issue", "relation", "replace", "TASK-1", "--type", "related", "--issue", "TASK-2"],

--- a/test/cloud-shared-worker.test.mjs
+++ b/test/cloud-shared-worker.test.mjs
@@ -759,6 +759,125 @@ test("relation direction, deletion, and parent-cycle checks match the local cont
   assert.equal(cycle.body.error.code, "RELATION_CYCLE");
 });
 
+test("tree queries keep direct and nested ancestor/descendant traversal in cloud parity", async () => {
+  const projectId = "tree-cloud-parity";
+  await createProject(projectId);
+  const root = await createTask(projectId, "Tree root");
+  const child = await createTask(projectId, "Tree child");
+  const sibling = await createTask(projectId, "Tree sibling");
+  const grandchild = await createTask(projectId, "Tree grandchild");
+  const addParent = async (childTask, parentTask) => cloud.request(
+    `/api/tasks/${childTask.id}/relations/parent/${parentTask.id}`,
+    { method: "POST", actorName: alice, json: { version: childTask.version } },
+  );
+  for (const [childTask, parentTask] of [
+    [child.body.task, root.body.task],
+    [sibling.body.task, root.body.task],
+    [grandchild.body.task, child.body.task],
+  ]) {
+    assert.equal((await addParent(childTask, parentTask)).response.status, 200);
+  }
+
+  const direct = await cloud.request(
+    `/api/tasks/${root.body.task.id}/tree?direction=descendants&depth=1`,
+    { actorName: alice },
+  );
+  assert.equal(direct.response.status, 200);
+  assert.deepEqual(direct.body.tree.nodes.map((node) => [node.id, node.parentId, node.depth]), [
+    [root.body.task.id, null, 0],
+    [child.body.task.id, root.body.task.id, 1],
+    [sibling.body.task.id, root.body.task.id, 1],
+  ]);
+
+  const descendants = await cloud.request(
+    `/api/tasks/${root.body.task.id}/tree?direction=descendants&depth=2`,
+    { actorName: alice },
+  );
+  assert.equal(descendants.body.tree.nodeCount, 4);
+  assert.deepEqual(descendants.body.tree.nodes.at(-1).path, [
+    root.body.task.id,
+    child.body.task.id,
+    grandchild.body.task.id,
+  ]);
+
+  const ancestors = await cloud.request(
+    `/api/tasks/${grandchild.body.task.id}/tree?direction=ancestors&depth=2`,
+    { actorName: alice },
+  );
+  assert.equal(ancestors.response.status, 200);
+  assert.deepEqual(ancestors.body.tree.nodes.map((node) => [node.id, node.parentId, node.depth]), [
+    [grandchild.body.task.id, null, 0],
+    [child.body.task.id, grandchild.body.task.id, 1],
+    [root.body.task.id, child.body.task.id, 2],
+  ]);
+
+  const invalid = await cloud.request(
+    `/api/tasks/${root.body.task.id}/tree?direction=descendants&depth=0`,
+    { actorName: alice },
+  );
+  assert.equal(invalid.response.status, 400);
+  assert.equal(invalid.body.error.code, "INVALID_TREE_QUERY");
+});
+
+test("cloud tree rejects a breadth that exceeds the 1,000-node cap", async () => {
+  const projectId = "tree-cloud-cap";
+  await createProject(projectId);
+  const root = await createTask(projectId, "Tree cap root");
+  const timestamp = new Date().toISOString();
+
+  // A recursive CTE keeps this cap fixture to two D1 writes instead of 1,000 API mutations.
+  await cloud.db.prepare(`
+    WITH RECURSIVE sequence(value) AS (
+      SELECT 1
+      UNION ALL
+      SELECT value + 1 FROM sequence WHERE value < 1000
+    )
+    INSERT INTO tasks (
+      id, identifier, project_id, title, description, status, priority, labels, sort_order,
+      creator_type, creator_id, creator_name,
+      assignee_type, assignee_id, assignee_name,
+      version, created_at, updated_at
+    )
+    SELECT
+      'tree-cap-child-' || value,
+      'TREECAP-' || value,
+      ?,
+      'Tree cap child',
+      '',
+      'backlog',
+      'none',
+      '[]',
+      value,
+      'user',
+      'tree-cap-fixture',
+      'Tree cap fixture',
+      'user',
+      'tree-cap-fixture',
+      'Tree cap fixture',
+      1,
+      ?,
+      ?
+    FROM sequence
+  `).bind(projectId, timestamp, timestamp).run();
+  await cloud.db.prepare(`
+    WITH RECURSIVE sequence(value) AS (
+      SELECT 1
+      UNION ALL
+      SELECT value + 1 FROM sequence WHERE value < 1000
+    )
+    INSERT INTO task_relations (relation_type, source_task_id, target_task_id, created_at)
+    SELECT 'parent', ?, 'tree-cap-child-' || value, ?
+    FROM sequence
+  `).bind(root.body.task.id, timestamp).run();
+
+  const result = await cloud.request(
+    `/api/tasks/${root.body.task.id}/tree?direction=descendants&depth=1`,
+    { actorName: alice },
+  );
+  assert.equal(result.response.status, 413);
+  assert.equal(result.body.error.code, "TREE_TOO_LARGE");
+});
+
 test("concurrent inverse parent writes cannot create a cycle", async () => {
   await createProject("concurrent-parent-cycle");
   const first = await createTask("concurrent-parent-cycle", "First");

--- a/test/cloud-shared-worker.test.mjs
+++ b/test/cloud-shared-worker.test.mjs
@@ -819,6 +819,64 @@ test("tree queries keep direct and nested ancestor/descendant traversal in cloud
   assert.equal(invalid.body.error.code, "INVALID_TREE_QUERY");
 });
 
+test("cloud tree handles a 101-node frontier at depth 2", async () => {
+  const projectId = "tree-cloud-frontier";
+  await createProject(projectId);
+  const root = await createTask(projectId, "Tree frontier root");
+  const timestamp = new Date().toISOString();
+
+  await cloud.db.prepare(`
+    WITH RECURSIVE sequence(value) AS (
+      SELECT 1
+      UNION ALL
+      SELECT value + 1 FROM sequence WHERE value < 101
+    )
+    INSERT INTO tasks (
+      id, identifier, project_id, title, description, status, priority, labels, sort_order,
+      creator_type, creator_id, creator_name,
+      assignee_type, assignee_id, assignee_name,
+      version, created_at, updated_at
+    )
+    SELECT
+      'tree-frontier-child-' || value,
+      'TREEFRONTIER-' || value,
+      ?,
+      'Tree frontier child',
+      '',
+      'backlog',
+      'none',
+      '[]',
+      value,
+      'user',
+      'tree-frontier-fixture',
+      'Tree frontier fixture',
+      'user',
+      'tree-frontier-fixture',
+      'Tree frontier fixture',
+      1,
+      ?,
+      ?
+    FROM sequence
+  `).bind(projectId, timestamp, timestamp).run();
+  await cloud.db.prepare(`
+    WITH RECURSIVE sequence(value) AS (
+      SELECT 1
+      UNION ALL
+      SELECT value + 1 FROM sequence WHERE value < 101
+    )
+    INSERT INTO task_relations (relation_type, source_task_id, target_task_id, created_at)
+    SELECT 'parent', ?, 'tree-frontier-child-' || value, ?
+    FROM sequence
+  `).bind(root.body.task.id, timestamp).run();
+
+  const result = await cloud.request(
+    `/api/tasks/${root.body.task.id}/tree?direction=descendants&depth=2`,
+    { actorName: alice },
+  );
+  assert.equal(result.response.status, 200);
+  assert.equal(result.body.tree.nodeCount, 102);
+});
+
 test("cloud tree rejects a breadth that exceeds the 1,000-node cap", async () => {
   const projectId = "tree-cloud-cap";
   await createProject(projectId);

--- a/test/server.test.mjs
+++ b/test/server.test.mjs
@@ -774,6 +774,138 @@ test("issues support parent, sub-issue, blocking, and related issue relationship
   assert.equal(crossProjectRelation.body.error.code, "CROSS_PROJECT_RELATION");
 });
 
+test("issue tree returns deterministic direct and nested parent paths without changing relation APIs", async () => {
+  const baseUrl = await startServer();
+  const createIssue = async (title, projectId = "local") => {
+    const result = await request(baseUrl, "/api/tasks", {
+      method: "POST",
+      body: { projectId, title },
+    });
+    assert.equal(result.response.status, 201);
+    return result.body.task;
+  };
+  const latest = async (id) => (await request(baseUrl, `/api/tasks/${id}`)).body.task;
+  const addParent = async (child, parent) => request(
+    baseUrl,
+    `/api/tasks/${child.id}/relations/parent/${parent.id}`,
+    { method: "POST", body: { version: child.version } },
+  );
+
+  const root = await createIssue("Tree root");
+  const first = await createIssue("Tree first");
+  const second = await createIssue("Tree second");
+  const grandchild = await createIssue("Tree grandchild");
+  const greatGrandchild = await createIssue("Tree great-grandchild");
+  for (const [child, parent] of [
+    [first, root],
+    [second, root],
+    [grandchild, first],
+    [greatGrandchild, grandchild],
+  ]) {
+    assert.equal((await addParent(child, parent)).response.status, 200);
+  }
+
+  const direct = await request(
+    baseUrl,
+    `/api/tasks/${root.id}/tree?direction=descendants&depth=1`,
+  );
+  assert.equal(direct.response.status, 200);
+  assert.equal(direct.body.tree.nodeCount, 3);
+  const directChildIds = direct.body.tree.nodes.slice(1).map((node) => node.id);
+  assert.deepEqual([...directChildIds].sort(), [first.id, second.id].sort());
+  assert.ok(direct.body.tree.nodes.every((node) => (
+    node.depth === 0 ? node.parentId === null : node.parentId === root.id
+  )));
+  const directRepeat = await request(
+    baseUrl,
+    `/api/tasks/${root.id}/tree?direction=descendants&depth=1`,
+  );
+  assert.deepEqual(directRepeat.body.tree.nodes, direct.body.tree.nodes);
+
+  const descendants = await request(
+    baseUrl,
+    `/api/tasks/${root.id}/tree?direction=descendants&depth=3`,
+  );
+  assert.equal(descendants.response.status, 200);
+  assert.deepEqual(descendants.body.tree.nodes.map((node) => node.id), [
+    root.id,
+    ...directChildIds,
+    grandchild.id,
+    greatGrandchild.id,
+  ]);
+  assert.deepEqual(descendants.body.tree.nodes.slice(-2).map((node) => [node.parentId, node.depth]), [
+    [first.id, 2],
+    [grandchild.id, 3],
+  ]);
+  assert.deepEqual(descendants.body.tree.nodes.at(-1).path, [
+    root.id,
+    first.id,
+    grandchild.id,
+    greatGrandchild.id,
+  ]);
+  assert.deepEqual(descendants.body.tree.nodes.at(-1).summary, {
+    identifier: greatGrandchild.identifier,
+    title: "Tree great-grandchild",
+    status: "backlog",
+    priority: "none",
+    archivedAt: null,
+  });
+
+  const ancestors = await request(
+    baseUrl,
+    `/api/tasks/${greatGrandchild.id}/tree?direction=ancestors&depth=3`,
+  );
+  assert.equal(ancestors.response.status, 200);
+  assert.deepEqual(ancestors.body.tree.nodes.map((node) => [node.id, node.parentId, node.depth]), [
+    [greatGrandchild.id, null, 0],
+    [grandchild.id, greatGrandchild.id, 1],
+    [first.id, grandchild.id, 2],
+    [root.id, first.id, 3],
+  ]);
+
+  const reparented = await addParent(await latest(grandchild.id), await latest(second.id));
+  assert.equal(reparented.response.status, 200);
+  const afterReparent = await request(
+    baseUrl,
+    `/api/tasks/${root.id}/tree?direction=descendants&depth=3`,
+  );
+  assert.deepEqual(afterReparent.body.tree.nodes.map((node) => node.id), [
+    root.id,
+    ...directChildIds,
+    grandchild.id,
+    greatGrandchild.id,
+  ]);
+  assert.deepEqual(afterReparent.body.tree.nodes.find((node) => node.id === grandchild.id).path, [
+    root.id,
+    second.id,
+    grandchild.id,
+  ]);
+
+  const invalidDepth = await request(
+    baseUrl,
+    `/api/tasks/${root.id}/tree?direction=descendants&depth=26`,
+  );
+  assert.equal(invalidDepth.response.status, 400);
+  assert.equal(invalidDepth.body.error.code, "INVALID_TREE_QUERY");
+
+  const database = runningApps.at(-1).app.database.database;
+  assert.throws(() => database.prepare(`
+    INSERT INTO task_relations (relation_type, source_task_id, target_task_id, origin, created_at)
+    VALUES ('parent', ?, ?, 'manual', ?)
+  `).run(greatGrandchild.id, root.id, new Date().toISOString()), /RELATION_CYCLE/);
+
+  const otherProject = await request(baseUrl, "/api/projects", {
+    method: "POST",
+    body: { id: "tree-other", name: "Tree other" },
+  });
+  assert.equal(otherProject.response.status, 201);
+  const external = await createIssue("Tree external", "tree-other");
+  assert.throws(() => database.prepare(`
+    INSERT INTO task_relations (relation_type, source_task_id, target_task_id, origin, created_at)
+    VALUES ('blocks', ?, ?, 'manual', ?)
+  `).run(root.id, external.id, new Date().toISOString()), /CROSS_PROJECT_RELATION/);
+});
+
 test("issue relationship changes are broadcast in realtime", async () => {
   const baseUrl = await startServer();
   const first = (await request(baseUrl, "/api/tasks", {


### PR DESCRIPTION
## Summary

Dashi already models parent/sub-issues. This adds a read-only, deterministic task-tree query for local and Cloud deployments:

- `GET /api/tasks/:id/tree` returns ancestors and descendants.
- Supports depth `1..25`, deterministic flat paths/breadcrumbs, and a 1,000-node cap (`413`).
- Adds `taskctl issue tree`.
- Local SQLite now rejects same-project cycles consistently with the existing Cloud invariants.
- Existing CRUD endpoints and task payloads are preserved.

Verification:
- Server: 26/26 passing.
- Cloud: 24/24 passing.
- CLI: 30/30 passing.
- Real 1,001-node cap verified.
- Diff hygiene passed.

No workflow, rollup, UI, or product-specific policy is included.