### PR TITLE
Fix non-ASCII issue identifiers

### DIFF
--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -378,11 +378,9 @@ function validateProjectId(value) {
 function projectPrefix(project) {
   const idPrefix = project.id.toUpperCase().replace(/[^A-Z0-9]+/g, "").slice(0, 12) || "TASK";
   const existingPrefix = project.first_identifier?.replace(/-\d+$/, "");
-  if (existingPrefix && existingPrefix !== idPrefix) return existingPrefix;
+  if (existingPrefix && /^[A-Z0-9]+$/i.test(existingPrefix) && existingPrefix !== idPrefix) return existingPrefix;
   if (idPrefix.length <= 5) return idPrefix;
-  const namePrefix = [...project.name.toUpperCase().replace(/[^\p{L}\p{N}]+/gu, "")]
-    .slice(0, 3)
-    .join("");
+  const namePrefix = project.name.toUpperCase().replace(/[^A-Z0-9]+/g, "").slice(0, 3);
   return namePrefix || idPrefix.slice(0, 3);
 }
 

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -421,11 +421,9 @@ function aiChatEventFromRow(row) {
 function projectPrefix(project) {
   const idPrefix = project.id.toUpperCase().replace(/[^A-Z0-9]+/g, "").slice(0, 12) || "TASK";
   const existingPrefix = project.first_identifier?.replace(/-\d+$/, "");
-  if (existingPrefix && existingPrefix !== idPrefix) return existingPrefix;
+  if (existingPrefix && /^[A-Z0-9]+$/i.test(existingPrefix) && existingPrefix !== idPrefix) return existingPrefix;
   if (idPrefix.length <= 5) return idPrefix;
-  const namePrefix = [...project.name.toUpperCase().replace(/[^\p{L}\p{N}]+/gu, "")]
-    .slice(0, 3)
-    .join("");
+  const namePrefix = project.name.toUpperCase().replace(/[^A-Z0-9]+/g, "").slice(0, 3);
   return namePrefix || idPrefix.slice(0, 3);
 }
 


### PR DESCRIPTION
## Summary

- Preserve an existing project prefix only when it contains ASCII letters or digits.
- Build new project-name prefixes from ASCII letters or digits only; Chinese-only names use the existing stable project-ID fallback.
- Keep the local SQLite and Cloud D1 creation paths identical. Existing identifiers are not migrated or rewritten.

## Direct verification

- Real browser flow on project `日常任务`: new issue displayed as `TEM-2` on the card, detail route, and Copy ID action; existing `日常任-1` stayed unchanged.
- Installed `taskctl`: returned `TEM-2`, `LOCAL-2`, and the unchanged existing `日常任-1`.
- Isolated Cloud D1 worker: returned `TEM-2`, kept `日常任-1`, and preserved the custom prefix as `LOCAL-2`.

## Checks

- `node --test test/server.test.mjs test/cloud-shared-worker.test.mjs` — 47 passed
- `npm run typecheck`
- `npm run cloud:deploy:dry-run`
- `git diff --check`

No schema, migration, UI, CLI, compatibility layer, or new test was added.