### PR TITLE
fix: keep LAN board usable without local Jira

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -150,7 +150,11 @@ export async function getJiraConnection(signal?: AbortSignal): Promise<JiraConne
   } catch (error) {
     if (
       error instanceof ApiError
-      && (error.code === "LOCAL_COMPANION_REQUIRED" || error.status === 404)
+      && (
+        error.code === "LOCAL_COMPANION_REQUIRED"
+        || (error.status === 403 && error.code === "LOCAL_ONLY")
+        || error.status === 404
+      )
     ) {
       return {
         configured: false,


### PR DESCRIPTION
## Summary

- Treat the optional Jira status response `403 LOCAL_ONLY` as a device capability that is unavailable on the current connection.
- Keep the main board usable over a real LAN address without changing the server's loopback-only boundary.
- Preserve the existing `127.0.0.1` Jira status path and keep PR #266's trusted HTTPS origin work out of scope.

## Direct verification

- Isolated service at `http://192.168.2.11:48962`:
  - `/api/projects` and ordinary task APIs returned `200`.
  - `/api/local/jira-connection` still returned `403 LOCAL_ONLY`.
  - The global load error banner was absent.
  - The `LAN Demo` project could be selected.
  - `LAN-1` opened with its title and description visible.
  - Project documentation opened and displayed its seeded content.
- Loopback control at `http://127.0.0.1:48962`:
  - `/api/local/jira-connection` returned `200` with the existing unconfigured Jira state.
  - The board loaded without an error banner.

## Focused checks

- `npm run typecheck`
- `npm run build:web`
- `git diff --check`

Refs #268

Issue #268 should remain open until a release containing this fix is published.
