### PR TITLE
fix: remove display settings done button

### DIFF
--- a/web/src/components/BoardCardDisplayMenu.tsx
+++ b/web/src/components/BoardCardDisplayMenu.tsx
@@ -323,9 +323,6 @@ export function BoardCardDisplayMenu({
           <button className="button secondary" type="button" onClick={onReset}>
             {text("重置为默认", "Reset to default")}
           </button>
-          <button className="button primary" type="button" onClick={closeDialog}>
-            {text("完成", "Done")}
-          </button>
         </footer>
       </div>
     </div>,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1346,7 +1346,6 @@ kbd {
 
 .display-settings-footer {
   flex: 0 0 auto;
-  justify-content: space-between;
   gap: 8px;
   padding: 12px 18px;
   border-top: var(--border-hairline) solid var(--border);


### PR DESCRIPTION
## Summary

- remove the redundant bottom Done button from More display settings
- keep the existing Reset to default action and close paths unchanged

## Direct verification

- used an isolated Demo backed by a snapshot of real Taskboard data
- confirmed the dialog footer no longer shows Done
- dragged a status, reloaded, and confirmed the existing immediate persistence still works
- toggled body display and confirmed immediate persistence
- reset settings and closed through the top-right button and Escape

## Checks

- `npm run typecheck`
- `npm run build:web`
- `git diff --check origin/main...HEAD`
- Agent review: PASS; no Pro review used for this small UI deletion

Exact head at PR creation: `f6327bfafc03c7968dce3c1d67cf7598923e06d7`

Taskboard: LOCAL-283