### PR TITLE
Fix Markdown image boundaries and blank-line previews

### DIFF
--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -460,7 +460,20 @@ export function createInlineMediaSegments(
   }
 
   if (offset < text.length) segments.push(textSegment(text.slice(offset)));
-  return normalizeSegments(segments);
+  const normalized = normalizeSegments(segments);
+  return normalized.map((segment, index) => {
+    if (segment.type !== "text") return segment;
+    const previousIsImage = isTaskboardAttachmentImage(normalized[index - 1]);
+    const nextIsImage = isTaskboardAttachmentImage(normalized[index + 1]);
+    let value = segment.text;
+    if (previousIsImage && nextIsImage && /^\n+$/.test(value)) {
+      value = value.slice(1);
+    } else {
+      if (previousIsImage && value.startsWith("\n")) value = value.slice(1);
+      if (nextIsImage && value.endsWith("\n")) value = value.slice(0, -1);
+    }
+    return value === segment.text ? segment : { ...segment, text: value };
+  });
 }
 
 export function inlineMediaImages(segments: InlineMediaSegment[]): PendingInlineImage[] {
@@ -487,30 +500,58 @@ export function inlineMediaText(segments: InlineMediaSegment[]): string {
   }).join("");
 }
 
-export function serializeInlineMedia(segments: InlineMediaSegment[]): string {
+function isTaskboardAttachmentImage(segment: InlineMediaSegment | undefined): boolean {
+  return segment?.type === "pending-image" || (
+    segment?.type === "persisted-image"
+    && /^\/?api\/attachments\/[^/?#]+\/content$/.test(segment.url)
+  );
+}
+
+function serializeInlineMediaSegments(
+  segments: InlineMediaSegment[],
+  segmentValue: (segment: InlineMediaSegment) => string,
+): string {
   let markdown = "";
+  let previousWasImage = false;
+  let sharedImageBoundary = false;
   segments.forEach((segment, index) => {
-    const value = segment.type === "text"
+    const value = segmentValue(segment);
+    if (
+      segment.type === "text"
+      && isTaskboardAttachmentImage(segments[index - 1])
+      && isTaskboardAttachmentImage(segments[index + 1])
+      && /^\n*$/.test(value)
+    ) {
+      markdown += `\n${value}`;
+      previousWasImage = false;
+      sharedImageBoundary = true;
+      return;
+    }
+    if (!value) return;
+    const isImage = isTaskboardAttachmentImage(segment);
+    if (isImage) {
+      if (markdown && !sharedImageBoundary) markdown += "\n";
+      markdown += value;
+      previousWasImage = true;
+      sharedImageBoundary = false;
+      return;
+    }
+    if (previousWasImage) markdown += "\n";
+    markdown += value;
+    previousWasImage = false;
+    sharedImageBoundary = false;
+  });
+  return markdown;
+}
+
+export function serializeInlineMedia(segments: InlineMediaSegment[]): string {
+  return serializeInlineMediaSegments(segments, (segment) => (
+    segment.type === "text"
       ? segment.text
       : segment.type === "pending-image"
         ? segment.token
-        : segment.markdown;
-    const isTaskboardImage = segment.type === "pending-image" || (
-      segment.type === "persisted-image"
-      && /^\/?api\/attachments\/[^/?#]+\/content$/.test(segment.url)
-    );
-    if (isTaskboardImage && markdown && !markdown.endsWith("\n")) markdown += "\n";
-    markdown += value;
-    if (!isTaskboardImage) return;
-    const next = segments[index + 1];
-    const nextValue = next?.type === "text"
-      ? next.text
-      : next?.type === "pending-image"
-        ? next.token
-        : next?.markdown ?? "";
-    if (nextValue && !nextValue.startsWith("\n")) markdown += "\n";
-  });
-  return markdown;
+        : segment.markdown
+  ));
 }
 
 export function resolveInlineMediaMarkdown(
@@ -596,13 +637,13 @@ function inlineMediaRangeSegments(
 }
 
 function inlineMediaClipboardText(segments: InlineMediaSegment[]): string {
-  return segments.map((segment) => {
+  return serializeInlineMediaSegments(segments, (segment) => {
     if (segment.type === "text") return segment.text;
     if (segment.type === "pending-image") {
       return pendingImageClipboardMarkdown(segment) ?? segment.file.name;
     }
     return segment.markdown;
-  }).join("");
+  });
 }
 
 function pendingImageClipboardMarkdown(segment: InlineImageSegment): string | null {

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -488,11 +488,29 @@ export function inlineMediaText(segments: InlineMediaSegment[]): string {
 }
 
 export function serializeInlineMedia(segments: InlineMediaSegment[]): string {
-  return segments.map((segment) => {
-    if (segment.type === "text") return segment.text;
-    if (segment.type === "pending-image") return segment.token;
-    return segment.markdown;
-  }).join("");
+  let markdown = "";
+  segments.forEach((segment, index) => {
+    const value = segment.type === "text"
+      ? segment.text
+      : segment.type === "pending-image"
+        ? segment.token
+        : segment.markdown;
+    const isTaskboardImage = segment.type === "pending-image" || (
+      segment.type === "persisted-image"
+      && /^\/?api\/attachments\/[^/?#]+\/content$/.test(segment.url)
+    );
+    if (isTaskboardImage && markdown && !markdown.endsWith("\n")) markdown += "\n";
+    markdown += value;
+    if (!isTaskboardImage) return;
+    const next = segments[index + 1];
+    const nextValue = next?.type === "text"
+      ? next.text
+      : next?.type === "pending-image"
+        ? next.token
+        : next?.markdown ?? "";
+    if (nextValue && !nextValue.startsWith("\n")) markdown += "\n";
+  });
+  return markdown;
 }
 
 export function resolveInlineMediaMarkdown(

--- a/web/src/components/MarkdownDocument.tsx
+++ b/web/src/components/MarkdownDocument.tsx
@@ -23,6 +23,10 @@ interface MarkdownAstNode {
   type: string;
   value?: string;
   children?: MarkdownAstNode[];
+  data?: {
+    hName?: string;
+    hProperties?: Record<string, unknown>;
+  };
   position?: {
     start: { offset?: number };
     end: { offset?: number };
@@ -332,6 +336,43 @@ export function remarkStripMarkdownComments() {
   };
 }
 
+function remarkPreserveExtraBlankLines() {
+  return (tree: MarkdownAstNode, file: { value?: unknown }) => {
+    const source = String(file.value ?? "");
+    const children = tree.children;
+    if (!children || children.length < 2) return;
+    const nextChildren: MarkdownAstNode[] = [];
+
+    children.forEach((child, index) => {
+      const previous = children[index - 1];
+      const previousEnd = previous?.position?.end.offset;
+      const childStart = child.position?.start.offset;
+      if (previousEnd !== undefined && childStart !== undefined) {
+        const gap = source.slice(previousEnd, childStart);
+        if (/^[\t \r\n]*$/.test(gap)) {
+          const extraBlankLines = Math.max(0, (gap.match(/\r\n|\r|\n/g)?.length ?? 0) - 2);
+          for (let blankLine = 0; blankLine < extraBlankLines; blankLine += 1) {
+            nextChildren.push({
+              type: "paragraph",
+              children: [],
+              data: {
+                hName: "div",
+                hProperties: {
+                  className: ["markdown-blank-line"],
+                  "aria-hidden": "true",
+                },
+              },
+            });
+          }
+        }
+      }
+      nextChildren.push(child);
+    });
+
+    tree.children = nextChildren;
+  };
+}
+
 function codeBlockLanguage(children: ReactNode): { language: string | null; source: string } {
   const code = Children.toArray(children).find(
     (child): child is ReactElement<{ className?: string; children?: ReactNode }> => (
@@ -482,7 +523,12 @@ export function MarkdownDocument({
   return (
     <div className="issue-description-document" onCopy={onCopy}>
       <ReactMarkdown
-        remarkPlugins={[remarkGfm, remarkStripMarkdownComments, remarkBreaks]}
+        remarkPlugins={[
+          remarkGfm,
+          remarkStripMarkdownComments,
+          remarkPreserveExtraBlankLines,
+          remarkBreaks,
+        ]}
         urlTransform={(url) => defaultUrlTransform(resolvePersistedAttachmentUrl(url))}
         components={{
           a: ({ node, href, children, className, ...props }) => {

--- a/web/src/components/MarkdownDocument.tsx
+++ b/web/src/components/MarkdownDocument.tsx
@@ -333,12 +333,6 @@ export function remarkStripMarkdownComments() {
       return true;
     };
     visit(tree, true);
-  };
-}
-
-function remarkPreserveExtraBlankLines() {
-  return (tree: MarkdownAstNode, file: { value?: unknown }) => {
-    const source = String(file.value ?? "");
     const children = tree.children;
     if (!children || children.length < 2) return;
     const nextChildren: MarkdownAstNode[] = [];
@@ -368,7 +362,6 @@ function remarkPreserveExtraBlankLines() {
       }
       nextChildren.push(child);
     });
-
     tree.children = nextChildren;
   };
 }
@@ -523,12 +516,7 @@ export function MarkdownDocument({
   return (
     <div className="issue-description-document" onCopy={onCopy}>
       <ReactMarkdown
-        remarkPlugins={[
-          remarkGfm,
-          remarkStripMarkdownComments,
-          remarkPreserveExtraBlankLines,
-          remarkBreaks,
-        ]}
+        remarkPlugins={[remarkGfm, remarkStripMarkdownComments, remarkBreaks]}
         urlTransform={(url) => defaultUrlTransform(resolvePersistedAttachmentUrl(url))}
         components={{
           a: ({ node, href, children, className, ...props }) => {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3172,6 +3172,10 @@ kbd {
   object-fit: contain;
 }
 
+.issue-description-document img[src*="/api/attachments/"] + br {
+  display: none;
+}
+
 .issue-conversation-list {
   display: grid;
   justify-items: start;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2901,6 +2901,10 @@ kbd {
   margin: 0 0 10px;
 }
 
+.issue-description-document .markdown-blank-line {
+  height: 1lh;
+}
+
 .issue-description-document h1,
 .issue-description-document h2,
 .issue-description-document h3,


### PR DESCRIPTION
## Summary

- Normalize the shared composer serialization boundary for new and persisted Taskboard images, so a saved `# heading + image + body` reopens and saves as separate Markdown blocks without growing blank lines.
- Preserve user-entered extra top-level blank lines in the shared Markdown preview for task descriptions and comments.
- Keep external images, issue references, ordinary line breaks, persistence formats, and parser dependencies unchanged.

Tracks LOCAL-291 and child issues LOCAL-300 / LOCAL-301.

## E3 evidence

- Existing saved failure source `# 标题![image](...)普通正文` entered the real edit/save path and persisted as `# 标题\n![image](...)\n普通正文`; preview changed from one contaminated heading node to a heading plus a normal paragraph.
- `普通正文\n\n\n\n空行后的正文` remained unchanged in the API body and previewed with two additional visible blank-line spacers.
- A second no-change edit/save kept the same body and version. A normal Markdown comment also created, previewed, and reopened for edit without changes.

## Checks

- `npm run typecheck`
- `npm run build:web`
- `git diff --check`
- Low-risk Agent review: no blocking findings

No new tests were added; validation stayed on the reported browser paths.