### PR TITLE
Polish issue detail UI controls

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1129,7 +1129,7 @@ export function App() {
     ?? editor?.projectId
     ?? (newTaskDraft?.projectId === selectedProjectId ? newTaskDraft.targetProjectId : undefined)
     ?? (isAllProjects ? GLOBAL_PROJECT_ID : selectedProjectId);
-  const developmentEditorProjectId = editor ? editorProjectId : null;
+  const developmentEditorProjectId = isAllProjects && editor ? editorProjectId : null;
   const createTargetProjects = projectChoices.flatMap((choice) => {
     const project = projects.find((candidate) => candidate.id === choice.id);
     return project && project.source !== "jira"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1129,6 +1129,7 @@ export function App() {
     ?? editor?.projectId
     ?? (newTaskDraft?.projectId === selectedProjectId ? newTaskDraft.targetProjectId : undefined)
     ?? (isAllProjects ? GLOBAL_PROJECT_ID : selectedProjectId);
+  const developmentEditorProjectId = editor ? editorProjectId : null;
   const createTargetProjects = projectChoices.flatMap((choice) => {
     const project = projects.find((candidate) => candidate.id === choice.id);
     return project && project.source !== "jira"
@@ -1950,7 +1951,7 @@ export function App() {
   useEffect(() => {
     const standalone = !embedded || window.parent === window;
     const developmentProjectId = isAllProjects
-      ? standalone ? contextMenuTask?.projectId : null
+      ? developmentEditorProjectId ?? (standalone ? contextMenuTask?.projectId : null)
       : selectedProjectId;
     if (!developmentProjectId) {
       setDevelopmentScan({ workspacePath: null, contexts: [] });
@@ -1964,7 +1965,11 @@ export function App() {
     const codexThreadId = hostContext?.threadId
       ?? (isAllProjects ? contextMenuTask?.threadId : detailTask?.threadId)
       ?? undefined;
-    const workspacePath = isAllProjects ? contextMenuWorkspacePath : selectedDeviceWorkspacePath;
+    const workspacePath = isAllProjects
+      ? developmentEditorProjectId
+        ? deviceWorkspacePaths[developmentEditorProjectId]
+        : contextMenuWorkspacePath
+      : selectedDeviceWorkspacePath;
     setDevelopmentScan({ workspacePath: workspacePath ?? null, contexts: [] });
     setDevelopmentScanLoading(true);
     void listDevelopmentContexts(
@@ -1992,6 +1997,8 @@ export function App() {
     contextMenuTask?.threadId,
     contextMenuWorkspacePath,
     detailTask?.threadId,
+    deviceWorkspacePaths,
+    developmentEditorProjectId,
     embedded,
     hostContext?.projectId,
     hostContext?.threadId,

--- a/web/src/components/SemanticIcons.tsx
+++ b/web/src/components/SemanticIcons.tsx
@@ -183,7 +183,13 @@ export function PlusIcon(props: BasicIconProps) {
 }
 
 export function DeleteIcon(props: BasicIconProps) {
-  return <SvgIcon {...props}><path fillRule="evenodd" d="M12.369 6.5a.5.5 0 0 1 .486.615l-1.492 6.343A2 2 0 0 1 9.416 15H6.584a2 2 0 0 1-1.947-1.542L3.145 7.115A.5.5 0 0 1 3.63 6.5zM8.5 1A2.5 2.5 0 0 1 11 3.5h2a1 1 0 0 1 1 1V5a.5.5 0 0 1-.5.5h-11A.5.5 0 0 1 2 5v-.5a1 1 0 0 1 1-1h2A2.5 2.5 0 0 1 7.5 1zm0 1.5h-1a1 1 0 0 0-1 1h3a1 1 0 0 0-1-1" clipRule="evenodd" /></SvgIcon>;
+  return (
+    <SvgIcon {...props}>
+      <path d="M12.7834 6.56006C12.7834 11.9061 13.5529 14.3226 8.37704 14.3226C3.20053 14.3226 3.98593 11.9061 3.98593 6.56006" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M13.767 4.51058H3" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M10.6667 4.51048C10.6667 4.51048 11.019 2 8.38285 2C5.74729 2 6.09967 4.51048 6.09967 4.51048" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </SvgIcon>
+  );
 }
 
 export function ProjectIcon(props: BasicIconProps) {
@@ -192,6 +198,14 @@ export function ProjectIcon(props: BasicIconProps) {
 
 export function ConversationIcon(props: Omit<MaskIconProps, "source">) {
   return <MaskIcon {...props} source={conversationSource} />;
+}
+
+export function NewConversationIcon(props: BasicIconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M5.7002 6.30005L6.7002 8.00005L5.7002 9.70005M8.59961 9.6001H10.7996M7.20215 1.93018C7.96231 1.93039 8.65815 2.20565 9.19629 2.66162L9.3877 2.82373L9.63379 2.77881C9.8134 2.74642 9.99778 2.72904 10.1836 2.729C11.8882 2.72952 13.2711 4.11205 13.2715 5.81689L13.2578 6.09326C13.2492 6.18462 13.237 6.27556 13.2207 6.36572L13.1758 6.61182L13.3379 6.80322C13.7943 7.34178 14.0702 8.03877 14.0703 8.79932C14.0699 10.1375 13.2176 11.2764 12.0254 11.7046L11.79 11.7896L11.7051 12.0249C11.2769 13.2172 10.138 14.0695 8.7998 14.0698C8.03929 14.0698 7.34241 13.7941 6.80371 13.3374L6.61328 13.1753L6.36719 13.2202C6.27684 13.2365 6.18551 13.2487 6.09375 13.2573L5.81738 13.271C4.11286 13.2707 2.73101 11.8881 2.73047 10.1831C2.73049 9.997 2.74782 9.81293 2.78027 9.6333L2.8252 9.38721L2.66309 9.1958C2.29195 8.7578 2.03996 8.21562 1.95898 7.61963L1.93555 7.36084L1.93066 7.20068C1.93084 5.86226 2.78273 4.7218 3.97461 4.29346L4.20996 4.2085L4.29492 3.97412C4.72324 2.78211 5.86353 1.93019 7.20215 1.93018Z" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </SvgIcon>
+  );
 }
 
 export function CodexResumeIcon({ color = "#5D5D5F", ...props }: BasicIconProps) {

--- a/web/src/components/TaskContextMenu.tsx
+++ b/web/src/components/TaskContextMenu.tsx
@@ -22,8 +22,8 @@ import {
   DeleteIcon,
   EditIcon,
   LabelIcon,
+  NewConversationIcon,
   PriorityIcon,
-  RelationIcon,
   StatusIcon,
 } from "./SemanticIcons";
 
@@ -426,7 +426,7 @@ export function TaskContextMenu({
         </MenuItem>
         <MenuItem
           label={text("在新对话打开", "Open in new conversation")}
-          icon={<RelationIcon color="currentColor" size={16} />}
+          icon={<NewConversationIcon color="currentColor" size={16} />}
           disabled={openInThreadDisabled}
           onPointerEnter={closeSubmenu}
           onClick={() => closeThen(() => onOpenInThread(task))}

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -65,6 +65,7 @@ import {
   EditIcon,
   LabelIcon,
   MoreIcon,
+  NewConversationIcon,
   PriorityIcon,
   ProjectIcon,
   RecurrenceIcon,
@@ -1627,7 +1628,7 @@ export function TaskDetail({
                 disabled={openingThread}
                 onClick={() => onOpenInThread(currentTask)}
               >
-                <ActorAvatar actor={CODEX_AGENT_ACTOR} className="detail-thread-avatar" />
+                <NewConversationIcon color="currentColor" />
                 <span>{openingThread
                   ? text("正在打开…", "Opening…")
                   : text("在新对话打开", "Open in new conversation")}</span>
@@ -1794,6 +1795,7 @@ export function TaskDetail({
                 open={propertyMenu === "development"}
                 disabled={developmentScanLoading || savingProperty === "developmentContext"}
                 className="detail-property-picker"
+                popoverClassName="development-context-popover"
                 triggerClassName="detail-property-trigger"
                 ariaLabel={text("开发上下文", "Development context")}
                 title={currentTask.developmentContext?.type === "worktree" ? currentTask.developmentContext.path : undefined}

--- a/web/src/components/TaskEditor.tsx
+++ b/web/src/components/TaskEditor.tsx
@@ -681,6 +681,7 @@ export function TaskEditor({
               ]}
               open={menu === "development"}
               disabled={developmentScanLoading}
+              popoverClassName="development-context-popover"
               triggerClassName="property-control property-development"
               ariaLabel={text("代码分支或 Worktree", "Code branch or worktree")}
               title={developmentScan.workspacePath ?? undefined}

--- a/web/src/components/TaskEditor.tsx
+++ b/web/src/components/TaskEditor.tsx
@@ -602,7 +602,11 @@ export function TaskEditor({
                 triggerClassName="property-control property-project"
                 ariaLabel={text("项目", "Project")}
                 onOpenChange={(open) => setMenu(open ? "project" : null)}
-                onChange={(value) => onProjectChange?.(value || null)}
+                onChange={(value) => {
+                  const nextProjectId = value || null;
+                  if (nextProjectId !== projectId) setDevelopmentContext(null);
+                  onProjectChange?.(nextProjectId);
+                }}
               />
             )}
             <TaskPropertyPicker

--- a/web/src/components/TaskPropertyPicker.tsx
+++ b/web/src/components/TaskPropertyPicker.tsx
@@ -23,6 +23,7 @@ interface TaskPropertyPickerProps<Value extends string> {
   open: boolean;
   disabled?: boolean;
   className?: string;
+  popoverClassName?: string;
   triggerClassName: string;
   triggerContent?: ReactNode;
   ariaLabel: string;
@@ -37,6 +38,7 @@ export function TaskPropertyPicker<Value extends string>({
   open,
   disabled = false,
   className = "",
+  popoverClassName = "",
   triggerClassName,
   triggerContent,
   ariaLabel,
@@ -156,7 +158,7 @@ export function TaskPropertyPicker<Value extends string>({
   const menu = open ? createPortal(
     <div
       ref={menuRef}
-      className="composer-popover task-property-popover"
+      className={`composer-popover task-property-popover${popoverClassName ? ` ${popoverClassName}` : ""}`}
       role="listbox"
       aria-label={ariaLabel}
       style={{ position: "fixed", left: position.left, top: position.top }}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3605,6 +3605,10 @@ kbd {
   margin-left: auto;
 }
 
+.issue-attachment-controls {
+  margin-top: 18px;
+}
+
 .attachments-heading > div {
   display: flex;
   align-items: center;
@@ -4531,13 +4535,6 @@ kbd {
 .detail-open-thread-action svg {
   width: 16px;
   height: 16px;
-}
-
-.detail-thread-avatar {
-  width: 16px;
-  height: 16px;
-  border: 0;
-  font-size: 7px;
 }
 
 .detail-copy-action {
@@ -6059,6 +6056,14 @@ kbd {
   width: 207px;
   max-height: min(402px, calc(100vh - 16px));
   padding: 6px;
+}
+
+.development-context-popover {
+  width: min(360px, calc(100vw - 16px));
+}
+
+.development-context-popover .task-property-option {
+  min-height: 32px;
 }
 
 .task-property-options {


### PR DESCRIPTION
## Summary

- LOCAL-293: align create/detail development-context popovers with existing property pickers while keeping selection behavior unchanged.
- LOCAL-294: replace the shared delete/archive icon with the supplied 16×16 SVG and keep size/color inheritance through `currentColor`.
- LOCAL-295: add 18px vertical spacing before the attachment heading/list in issue detail.
- LOCAL-302: add the supplied reusable 16×16 new-conversation icon to the detail action and its real context-menu entry; text, layout, handler, and payload are unchanged.
- LOCAL-303: after switching the target project in All Projects → New Issue, scan that project's workspace and clear the previously selected development context. Concrete-project creation keeps its existing scan path.

## E3 direct verification

- Create and detail development-context popovers render at 360px with 32px option rows.
- The detail new-conversation action shows the new 16×16 icon, keeps the existing text, and remains clickable.
- The context menu shows the new-conversation and archive icons.
- A permanent-delete entry renders the supplied icon at 16×16 and inherits its danger color.
- Formal task data renders an 18px gap before a five-item attachment list.
- In All Projects → New Issue, selecting PPT Skill exposes its branches; after selecting `dev` and switching to 大师的 AI 小灶选题调研, the old options clear and only that project's `master` Worktree is shown.
- The isolated Demo created `大师的-1` with the selected project ID and `developmentContext: { type: "worktree", branch: "master" }`.
- Isolated formal-data Demo: http://jadon.local:49302/ and http://localhost:49302/

## Checks

- `npm run typecheck`
- `npm run build:web`
- `git diff --check origin/main...HEAD`
- Agent review: passed on the exact head after one scoped follow-up fix
- Exact-head CI: [run #1027](https://github.com/chuspeeism/dashi-taskboard/actions/runs/32814980524), 4/4 successful
- No tests added or run, per the requested low-risk UI and narrow logic scope.

Exact head: `d0140626c7087e9cb1490e85bd17c824c3eaa61a`