### PR TITLE
fix: prefer a stable Taskboard launcher port

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -85,6 +85,7 @@ const KNOWN_TASKBOARD_SKILL_DIGESTS: [&str; 6] = [
     "27131c82ac63c2884c1fcb7dd22a4e1c75975c7d79eb3fa3483a7949dd5f284d",
     "ae74aec793decf6d9013c36f4b53e01723796a45567b77e9e9f22b4a168d3fbe",
 ];
+const TASKBOARD_PREFERRED_PORT: u16 = 47823;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 const TASKBOARD_LISTEN_FD: i32 = 5;
 
@@ -590,11 +591,17 @@ fn loopback_listener() -> Result<TcpListener, String> {
     TcpListener::bind(("127.0.0.1", 0)).map_err(|error| error.to_string())
 }
 
+fn taskboard_loopback_listener() -> Result<TcpListener, String> {
+    TcpListener::bind(("127.0.0.1", TASKBOARD_PREFERRED_PORT))
+        .or_else(|_| TcpListener::bind(("127.0.0.1", 0)))
+        .map_err(|error| error.to_string())
+}
+
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 fn taskboard_listener(state: &LauncherState) -> Result<(Option<i32>, u16), String> {
     let mut listener = state.taskboard_listener.lock().unwrap();
     if listener.is_none() {
-        *listener = Some(loopback_listener()?);
+        *listener = Some(taskboard_loopback_listener()?);
     }
     let listener = listener.as_ref().unwrap();
     let port = listener
@@ -606,7 +613,7 @@ fn taskboard_listener(state: &LauncherState) -> Result<(Option<i32>, u16), Strin
 
 #[cfg(target_os = "windows")]
 fn taskboard_listener(_state: &LauncherState) -> Result<(Option<i32>, u16), String> {
-    let listener = loopback_listener()?;
+    let listener = taskboard_loopback_listener()?;
     let port = listener
         .local_addr()
         .map_err(|error| error.to_string())?

--- a/test/launcher-release.test.mjs
+++ b/test/launcher-release.test.mjs
@@ -7,13 +7,30 @@ const tauriConfig = JSON.parse(await readFile(new URL("../src-tauri/tauri.conf.j
 const releaseWorkflow = await readFile(new URL("../.github/workflows/release-macos.yml", import.meta.url), "utf8");
 const checkWorkflow = await readFile(new URL("../.github/workflows/check.yml", import.meta.url), "utf8");
 
-test("the macOS launcher uses one instance, serialized lifecycle changes, and a loopback CDP port", () => {
+test("the launcher keeps CDP random and prefers the Taskboard port with a fallback", () => {
   assert.match(launcherSource, /libc::flock/);
   assert.match(launcherSource, /lifecycle: Mutex/);
   assert.match(launcherSource, /generation: AtomicU64/);
-  assert.match(launcherSource, /TcpListener::bind\(\("127\.0\.0\.1", 0\)\)/);
-  assert.equal(launcherSource.match(/TcpListener::bind/g)?.length, 1);
+  assert.match(
+    launcherSource,
+    /fn loopback_listener\(\)[\s\S]*?TcpListener::bind\(\("127\.0\.0\.1", 0\)\)/,
+  );
+  assert.match(launcherSource, /const TASKBOARD_PREFERRED_PORT: u16 = 47823;/);
+  assert.match(
+    launcherSource,
+    /fn taskboard_loopback_listener\(\)[\s\S]*?TcpListener::bind\(\("127\.0\.0\.1", TASKBOARD_PREFERRED_PORT\)\)[\s\S]*?\.or_else\(\|_\| TcpListener::bind\(\("127\.0\.0\.1", 0\)\)\)/,
+  );
+  assert.equal(
+    launcherSource.match(
+      /fn taskboard_listener\([^)]*\)[\s\S]*?taskboard_loopback_listener\(\)\?/g,
+    )?.length,
+    2,
+  );
   assert.match(launcherSource, /codex_port: Mutex<Option<u16>>/);
+  assert.match(
+    launcherSource,
+    /fn codex_port\([\s\S]*?let listener = loopback_listener\(\)\?;/,
+  );
   assert.match(
     launcherSource,
     /#\[cfg\(target_os = "macos"\)\]\s+command\.args\(\["--launch", "--watch", "--open", "--port", &codex_port\]\);/,


### PR DESCRIPTION
## Summary
- prefer the canonical Taskboard port `47823` for Launcher-owned Taskboard listeners
- fall back to an OS-selected loopback port only when `47823` cannot be bound
- keep the macOS Codex CDP/debug listener on its existing random port
- continue publishing the actual selected port through `CODEX_TASKBOARD_PORT`, the tokenized runtime descriptor, injection, browser access, and taskctl

## Scope
- product change: `src-tauri/src/main.rs`
- existing contract update: `test/launcher-release.test.mjs`
- no settings UI, port range, generic port manager, compatibility layer, guardrail, or unrelated refactor

The existing launcher contract test was updated after exact-head CI exposed its stale requirement that the source contain only one `TcpListener::bind` and no fixed port. The same test now checks the requested product contract: CDP remains random, Taskboard prefers `47823` with a random fallback, and both platform implementations use the Taskboard-specific helper.

## Verification
- `node --test test/launcher-release.test.mjs`: 5 passed
- `git diff --check`
- final product patch SHA-256: `8e5fc52116fecb647d93affb0ea152fba424312fcab527218bef4dec78ac90fd`
- the product patch exactly matches the patch reviewed in the existing ChatGPT Pro engineering conversation: https://chatgpt.com/c/6a8d1bd9-e714-83e8-95b0-228bf17ea30b
- isolated listener/Launcher evidence:
  - preferred free -> selected `47823`; tokenized descriptor and installed taskctl used `47823`
  - preferred occupied -> selected the actual OS fallback; tokenized descriptor and installed taskctl used that fallback
  - collision released -> a fresh isolated listener selection returned to `47823`
- the actual candidate App evidence covers preferred-port and collision-fallback behavior. Recovery to the preferred port is supported by the direct listener/isolation harness evidence.
- the abandoned temporary ChatGPT-copy crash path is not treated as a product failure or acceptance result.
- superseded CI failure: https://github.com/chuspeeism/dashi-taskboard/actions/runs/32841160318 (only the stale launcher contract assertion failed)

## Review boundary
Review only implementation correctness and confirmed defects. Avoid over-design and speculative defensive changes.

## Local limitation
The available local `cargo` binary is x86_64-only and cannot execute on this arm64 host without Rosetta (`bad CPU type in executable`). Exact-head CI is therefore the Rust compile/platform gate.