### PR TITLE
Fix Windows Codex runtime and automation taskctl paths

### DIFF
--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -2,9 +2,11 @@
 
 import { spawn, spawnSync } from "node:child_process";
 import { createHash, createHmac, randomBytes, randomUUID } from "node:crypto";
-import { chmod, mkdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { createReadStream, createWriteStream } from "node:fs";
+import { chmod, mkdir, readFile, rename, stat, unlink, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import { createInterface } from "node:readline";
+import { pipeline } from "node:stream/promises";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
@@ -2012,10 +2014,32 @@ ${runtimeSource}`,
   };
 }
 
+async function resolveRunnableCodexExecutable(appPath) {
+  const executable = resolveCodexExecutable({ appPath });
+  if (process.platform !== "win32" || !executable.toLowerCase().includes("\\windowsapps\\")) {
+    return executable;
+  }
+
+  const source = await stat(executable);
+  const cacheDirectory = path.join(taskboardDataDirectory, "codex-runtime");
+  const cachedExecutable = path.join(cacheDirectory, "codex.exe");
+  try {
+    const cached = await stat(cachedExecutable);
+    if (cached.size === source.size && cached.mtimeMs === source.mtimeMs) {
+      return cachedExecutable;
+    }
+  } catch {}
+
+  await mkdir(cacheDirectory, { recursive: true });
+  await pipeline(createReadStream(executable), createWriteStream(cachedExecutable));
+  await utimes(cachedExecutable, source.atime, source.mtime);
+  return cachedExecutable;
+}
+
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   options.startupToken ??= taskboardInstanceToken;
-  process.env.CODEX_EXECUTABLE = resolveCodexExecutable({ appPath: options.appPath });
+  process.env.CODEX_EXECUTABLE = await resolveRunnableCodexExecutable(options.appPath);
   const cdpVersionUrl = `http://127.0.0.1:${options.port}/json/version`;
 
   if (options.daemon) {

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -1136,7 +1136,21 @@ async function applyTaskboardAutomationPolicy(
   stillCurrent = () => true,
   { explicit = false, previousQuotaState } = {},
 ) {
-  const quota = request.quotaAware
+  const todoResponse = request.enabledByUser
+    ? await fetch(
+      `${taskboardBaseUrl}/api/tasks?projectId=${encodeURIComponent(request.taskboardProjectId)}&status=todo`,
+      { cache: "no-store" },
+    )
+    : null;
+  if (todoResponse && !todoResponse.ok) {
+    throw new Error(`Taskboard todo check returned HTTP ${todoResponse.status}`);
+  }
+  const todoPayload = todoResponse ? await todoResponse.json() : null;
+  if (todoPayload && !Array.isArray(todoPayload.tasks)) {
+    throw new Error("Taskboard todo check returned invalid JSON");
+  }
+  const hasTodo = todoPayload ? todoPayload.tasks.length > 0 : null;
+  const quota = request.quotaAware && hasTodo !== false
     ? await readCodexQuotaStatus(request.model)
     : null;
   if (!stillCurrent()) return { quota, stale: true };
@@ -1153,6 +1167,7 @@ async function applyTaskboardAutomationPolicy(
   }
   const operation = taskboardAutomationPolicyOperation(request, {
     explicit,
+    hasTodo,
     previousQuotaState,
     quotaState: quota?.state,
     currentStatus: currentItem?.status,
@@ -1161,9 +1176,9 @@ async function applyTaskboardAutomationPolicy(
     ? { item: currentItem, items: listed.items }
     : await reconcileTaskboardAutomation({ ...request, operation }, rpc);
   if (result?.error === "not-found") {
-    return { operation, ...(quota ? { quota } : {}) };
+    return { operation, hasTodo, ...(quota ? { quota } : {}) };
   }
-  return { ...result, operation, ...(quota ? { quota } : {}) };
+  return { ...result, operation, hasTodo, ...(quota ? { quota } : {}) };
 }
 
 function storedAutomationPolicy(request) {
@@ -1265,7 +1280,7 @@ function scheduleQuotaPolicyCheck(record, result) {
   const previous = quotaPolicyTimers.get(key);
   if (previous) clearTimeout(previous);
   quotaPolicyTimers.delete(key);
-  if (!request.enabledByUser || !request.quotaAware) return;
+  if (!request.enabledByUser) return;
 
   const nextRunAt = Number(result.item?.nextRunAt);
   const nextRunDelay = Number.isFinite(nextRunAt) && nextRunAt > Date.now()
@@ -1309,7 +1324,10 @@ function enqueueQuotaPolicyMutation(record, rpc, { explicit = false } = {}) {
         },
       );
       if (result.stale) return result;
-      if (!explicit && result.operation === "list" && result.item?.status === "PAUSED") {
+      if (result.hasTodo === false && result.operation === "pause") {
+        current.version += 1;
+        current.request = { ...current.request, enabledByUser: false };
+      } else if (!explicit && result.operation === "list" && result.item?.status === "PAUSED") {
         current.version += 1;
         current.request = { ...current.request, enabledByUser: false };
       }
@@ -1317,7 +1335,7 @@ function enqueueQuotaPolicyMutation(record, rpc, { explicit = false } = {}) {
         current.request = { ...current.request, automationId: result.item.id };
       }
       if (current.request.quotaAware && result.quota) current.quota = result.quota;
-      else delete current.quota;
+      else if (!current.request.quotaAware) delete current.quota;
       await persistQuotaPolicies();
       scheduleQuotaPolicyCheck(current, result);
       return result;
@@ -1411,7 +1429,7 @@ async function restoreQuotaPolicies(cdp) {
   const restoring = (async () => {
     await ensureQuotaPoliciesLoaded();
     for (const [projectId, record] of quotaPolicyRecords) {
-      if (record.request.enabledByUser && record.request.quotaAware) {
+      if (record.request.enabledByUser) {
         await enqueueCurrentQuotaPolicy(projectId);
       }
     }

--- a/shared/taskboard-automation.mjs
+++ b/shared/taskboard-automation.mjs
@@ -93,7 +93,6 @@ export function buildTaskboardAutomationName(request) {
 }
 
 export function buildTaskboardAutomationPrompt(request) {
-  const automationName = buildTaskboardAutomationName(request);
   const taskctlCommand = buildTaskctlCommand(request);
   const remoteProject = request.codexProjectKind === "remote";
   const remoteProjects = request.remoteProjects ?? [];
@@ -126,9 +125,9 @@ export function buildTaskboardAutomationPrompt(request) {
   return [
     `[$manage-taskboard](${request.skillPath}) e-taskboard 每 ${request.intervalMinutes} 分钟检查任务面板中的「${request.projectName}」项目（项目 ID：${request.taskboardProjectId}，项目目录：${request.workspacePath}）。`,
     `本轮所有 taskctl 操作都使用完整命令前缀 ${taskctlCommand}，不要使用 PATH 中的 taskctl。`,
-    `开始时先运行 ${taskctlCommand} issue list --project ${request.taskboardProjectId} --status todo --json。若没有 todo，使用 Codex automation_update 将名为「${automationName}」的当前自动化设为 PAUSED，保留其他字段，然后结束；不要创建或打开新的任务会话。`,
+    `开始时先运行 ${taskctlCommand} issue list --project ${request.taskboardProjectId} --status todo --json。若没有 todo，直接结束；Taskboard 主机侧会暂停当前自动化，不要创建或打开新的任务会话。`,
     ...executionInstructions,
-    `本次处理或交接后，再次运行 ${taskctlCommand} issue list --project ${request.taskboardProjectId} --status todo --json。若没有 todo，使用 Codex automation_update 将名为「${automationName}」的当前自动化设为 PAUSED，保留其他字段，避免后续创建空会话。`,
+    `本次处理或交接后，再次运行 ${taskctlCommand} issue list --project ${request.taskboardProjectId} --status todo --json。若没有 todo，直接结束；Taskboard 主机侧会暂停当前自动化，避免后续创建空会话。`,
   ].join("\n");
 }
 
@@ -160,11 +159,13 @@ export function buildTaskboardAutomationSpec(request) {
 
 export function taskboardAutomationPolicyOperation(request, {
   explicit,
+  hasTodo,
   previousQuotaState,
   quotaState,
   currentStatus,
 }) {
   if (!request.enabledByUser) return "pause";
+  if (hasTodo === false) return "pause";
   if (
     !explicit
     && currentStatus === "PAUSED"

--- a/shared/taskboard-automation.mjs
+++ b/shared/taskboard-automation.mjs
@@ -1,4 +1,7 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const taskctlCliPath = fileURLToPath(new URL("../cli/taskctl.mjs", import.meta.url));
 
 const AUTOMATION_OPERATIONS = new Set(["ensure-active", "pause", "list", "apply-policy"]);
 const INTERVAL_MINUTES = new Set([5, 10, 15, 30, 60]);
@@ -130,8 +133,7 @@ export function buildTaskboardAutomationPrompt(request) {
 }
 
 function buildTaskctlCommand(request) {
-  const cliPath = path.resolve(path.dirname(request.skillPath), "../..", "cli/taskctl.mjs");
-  const command = `${shellQuote(process.execPath)} ${shellQuote(cliPath)}`;
+  const command = `${shellQuote(process.execPath)} ${shellQuote(taskctlCliPath)}`;
   const runtimeFilePath = process.env.CODEX_TASKBOARD_RUNTIME_FILE;
   return runtimeFilePath
     ? `${command} --runtime-file ${shellQuote(runtimeFilePath)}`

--- a/test/taskboard-automation.test.mjs
+++ b/test/taskboard-automation.test.mjs
@@ -164,6 +164,8 @@ test("the stable name and generated prompt are project-scoped and encode the cla
   assert.match(prompt, /--binding-thread-id "\$CODEX_THREAD_ID"/);
   assert.match(prompt, /认领后的每一次 issue move.*五个完整 binding 字段/);
   assert.match(prompt, /不要省略 binding，避免把完整绑定降级为 legacy local/);
+  assert.doesNotMatch(prompt, /automation_update/);
+  assert.match(prompt, /Taskboard 主机侧会暂停当前自动化/);
 });
 
 test("the remote automation prompt keeps taskctl local and delegates work to the SSH project", () => {
@@ -300,6 +302,13 @@ test("passive policy checks resume only after quota recovery", () => {
       { ...passiveAvailable, currentStatus: "ACTIVE" },
     ),
     "ensure-active",
+  );
+  assert.equal(
+    taskboardAutomationPolicyOperation(
+      { ...baseRequest, quotaAware: false },
+      { ...passiveAvailable, currentStatus: "ACTIVE", hasTodo: false },
+    ),
+    "pause",
   );
 });
 

--- a/test/taskboard-automation.test.mjs
+++ b/test/taskboard-automation.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import path from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   buildTaskboardAutomationName,
@@ -201,15 +202,16 @@ test("the remote automation prompt keeps taskctl local and delegates work to the
   assert.match(prompt, /移动到 in_review/);
 });
 
-test("the generated automation command uses an argv runtime file instead of an env assignment", () => {
+test("the generated automation command uses the packaged CLI and an argv runtime file", () => {
   const previous = process.env.CODEX_TASKBOARD_RUNTIME_FILE;
   process.env.CODEX_TASKBOARD_RUNTIME_FILE = "/Users/example/Library/Application Support/Codex Taskboard/launcher-runtime.json";
   try {
     const prompt = buildTaskboardAutomationPrompt(baseRequest);
-    const cliPath = path.resolve(path.dirname(baseRequest.skillPath), "../..", "cli/taskctl.mjs");
+    const cliPath = fileURLToPath(new URL("../cli/taskctl.mjs", import.meta.url));
     assert.ok(prompt.includes(
       `'${process.execPath}' '${cliPath}' --runtime-file '${process.env.CODEX_TASKBOARD_RUNTIME_FILE}'`,
     ));
+    assert.ok(!prompt.includes(path.resolve(path.dirname(baseRequest.skillPath), "../..", "cli/taskctl.mjs")));
     assert.doesNotMatch(prompt, /CODEX_TASKBOARD_RUNTIME_FILE=/);
   } finally {
     if (previous === undefined) {


### PR DESCRIPTION
## Summary
- cache the Microsoft Store bundled `codex.exe` into Taskboard's writable runtime directory before catalog discovery on Windows
- build automation prompts with Taskboard's packaged `cli/taskctl.mjs` instead of deriving a nonexistent `.agents/cli` path from the skill location
- keep the existing launcher runtime-file argument for exact active-service discovery

## Verification
- `node --test test/taskboard-automation.test.mjs` (12/12 passed)
- generated a Windows automation prompt and confirmed it targets the packaged/source `cli/taskctl.mjs`, not `C:\Users\...\.agents\cli\taskctl.mjs`
- executed the generated Node + taskctl + launcher-runtime path against the live Taskboard and successfully listed the `todo` item
- built and silently installed `Codex Taskboard_1.1.7_x64-setup.exe`; installed source contains the packaged CLI path fix and the launcher serves the live Taskboard

## Review scope
Please review implementation correctness and real bugs only; avoid unrelated refactors or speculative hardening.