### PR TITLE
Add project switcher search and scrolling

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1121,15 +1121,15 @@ export function App() {
       ...sortedChoices.filter((project) => project.issueCount === 0),
     ];
   }, [hostContext?.projects, projectCodexIdentities, projects, recentProjectIds, text]);
-  const projectMenuChoices = projectChoices.filter(
+  const projectMenuCandidates = projectChoices.filter(
     (project) => project.id !== GLOBAL_PROJECT_ID || project.issueCount > 0,
   );
   const projectMenuNeedle = projectMenuSearch.trim().toLocaleLowerCase();
-  const visibleProjectMenuChoices = projectMenuNeedle
-    ? projectMenuChoices.filter((project) => project.name.toLocaleLowerCase().includes(projectMenuNeedle))
-    : projectMenuChoices;
-  const firstEmptyProjectId = visibleProjectMenuChoices.find((project) => project.issueCount === 0)?.id ?? null;
-  const hasProjectsWithIssues = visibleProjectMenuChoices.some((project) => project.issueCount > 0);
+  const projectMenuChoices = projectMenuNeedle
+    ? projectMenuCandidates.filter((project) => project.name.toLocaleLowerCase().includes(projectMenuNeedle))
+    : projectMenuCandidates;
+  const firstEmptyProjectId = projectMenuChoices.find((project) => project.issueCount === 0)?.id ?? null;
+  const hasProjectsWithIssues = projectMenuChoices.some((project) => project.issueCount > 0);
   const editorProjectId = editor?.task?.projectId
     ?? editor?.projectId
     ?? (newTaskDraft?.projectId === selectedProjectId ? newTaskDraft.targetProjectId : undefined)
@@ -3327,7 +3327,7 @@ export function App() {
                           <div className="project-menu-divider" role="separator" />
                         </>
                       )}
-                      {visibleProjectMenuChoices.map((project) => (
+                      {projectMenuChoices.map((project) => (
                         <Fragment key={project.id}>
                           {hasProjectsWithIssues && project.id === firstEmptyProjectId && (
                             <div className="project-menu-divider" role="separator" />
@@ -3356,7 +3356,7 @@ export function App() {
                           </button>
                         </Fragment>
                       ))}
-                      {projectMenuNeedle && visibleProjectMenuChoices.length === 0 && (
+                      {projectMenuNeedle && projectMenuChoices.length === 0 && (
                         <div className="project-menu-empty">{text("没有匹配项目", "No matching projects")}</div>
                       )}
                     </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3296,17 +3296,30 @@ export function App() {
                 {projectMenuOpen && (
                   <div className="header-project-menu" role="menu" aria-label={text("项目", "Projects")}>
                     <span>{text("切换项目", "Switch project")}</span>
-                    <label className="project-menu-search">
-                      <span className="sr-only">{text("按名称筛选项目", "Filter projects by name")}</span>
+                    <div className="project-menu-search">
+                      <label className="sr-only" htmlFor="project-menu-search-input">
+                        {text("按名称筛选项目", "Filter projects by name")}
+                      </label>
                       <TaskboardIcon name="search" />
                       <input
+                        id="project-menu-search-input"
                         autoFocus
                         type="search"
                         value={projectMenuSearch}
                         onChange={(event) => setProjectMenuSearch(event.target.value)}
                         placeholder={text("筛选项目…", "Filter projects…")}
                       />
-                    </label>
+                      {projectMenuSearch && (
+                        <button
+                          className="search-clear"
+                          type="button"
+                          aria-label={text("清除项目筛选", "Clear project filter")}
+                          onClick={() => setProjectMenuSearch("")}
+                        >
+                          <LinearIcon name="close" />
+                        </button>
+                      )}
+                    </div>
                     <div className="project-menu-list">
                       {!projectMenuNeedle && (
                         <>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -767,6 +767,7 @@ export function App() {
   const [projectMenuOpen, setProjectMenuOpen] = useState(
     () => taskboardStorage.getItem(FIRST_USE_COMPLETE_KEY) === null,
   );
+  const [projectMenuSearch, setProjectMenuSearch] = useState("");
   const [projectContextMenu, setProjectContextMenu] = useState<ProjectContextMenuState | null>(null);
   const [projectCreateOpen, setProjectCreateOpen] = useState(false);
   const [projectName, setProjectName] = useState("");
@@ -1123,8 +1124,12 @@ export function App() {
   const projectMenuChoices = projectChoices.filter(
     (project) => project.id !== GLOBAL_PROJECT_ID || project.issueCount > 0,
   );
-  const firstEmptyProjectId = projectMenuChoices.find((project) => project.issueCount === 0)?.id ?? null;
-  const hasProjectsWithIssues = projectMenuChoices.some((project) => project.issueCount > 0);
+  const projectMenuNeedle = projectMenuSearch.trim().toLocaleLowerCase();
+  const visibleProjectMenuChoices = projectMenuNeedle
+    ? projectMenuChoices.filter((project) => project.name.toLocaleLowerCase().includes(projectMenuNeedle))
+    : projectMenuChoices;
+  const firstEmptyProjectId = visibleProjectMenuChoices.find((project) => project.issueCount === 0)?.id ?? null;
+  const hasProjectsWithIssues = visibleProjectMenuChoices.some((project) => project.issueCount > 0);
   const editorProjectId = editor?.task?.projectId
     ?? editor?.projectId
     ?? (newTaskDraft?.projectId === selectedProjectId ? newTaskDraft.targetProjectId : undefined)
@@ -3281,6 +3286,7 @@ export function App() {
                   aria-expanded={projectMenuOpen}
                   onClick={() => {
                     setProjectContextMenu(null);
+                    setProjectMenuSearch("");
                     setProjectMenuOpen((current) => !current);
                   }}
                 >
@@ -3290,73 +3296,95 @@ export function App() {
                 {projectMenuOpen && (
                   <div className="header-project-menu" role="menu" aria-label={text("项目", "Projects")}>
                     <span>{text("切换项目", "Switch project")}</span>
-                    <button
-                      type="button"
-                      role="menuitemradio"
-                      aria-checked={isAllProjects}
-                      disabled={openingProjectId !== null}
-                      onClick={() => {
-                        if (isAllProjects) setProjectMenuOpen(false);
-                        else changeProject(ALL_PROJECTS_ID);
-                      }}
-                    >
-                      <TaskboardIcon className="project-avatar" name="projectFolder" />
-                      <span>{text("所有项目", "All projects")}</span>
-                      {isAllProjects && <span className="project-menu-check" aria-hidden="true"><LinearIcon name="check" /></span>}
-                    </button>
-                    <div className="project-menu-divider" role="separator" />
-                    {projectMenuChoices.map((project) => (
-                      <Fragment key={project.id}>
-                        {hasProjectsWithIssues && project.id === firstEmptyProjectId && (
+                    <label className="project-menu-search">
+                      <span className="sr-only">{text("按名称筛选项目", "Filter projects by name")}</span>
+                      <TaskboardIcon name="search" />
+                      <input
+                        autoFocus
+                        type="search"
+                        value={projectMenuSearch}
+                        onChange={(event) => setProjectMenuSearch(event.target.value)}
+                        placeholder={text("筛选项目…", "Filter projects…")}
+                      />
+                    </label>
+                    <div className="project-menu-list">
+                      {!projectMenuNeedle && (
+                        <>
+                          <button
+                            type="button"
+                            role="menuitemradio"
+                            aria-checked={isAllProjects}
+                            disabled={openingProjectId !== null}
+                            onClick={() => {
+                              if (isAllProjects) setProjectMenuOpen(false);
+                              else changeProject(ALL_PROJECTS_ID);
+                            }}
+                          >
+                            <TaskboardIcon className="project-avatar" name="projectFolder" />
+                            <span>{text("所有项目", "All projects")}</span>
+                            {isAllProjects && <span className="project-menu-check" aria-hidden="true"><LinearIcon name="check" /></span>}
+                          </button>
                           <div className="project-menu-divider" role="separator" />
-                        )}
-                        <button
-                          type="button"
-                          role="menuitemradio"
-                          aria-checked={project.id === selectedProjectId}
-                          disabled={openingProjectId !== null}
-                          onContextMenu={project.id.startsWith("temp-") ? (event) => {
-                            event.preventDefault();
-                            setProjectContextMenu({
-                              project,
-                              x: event.clientX,
-                              y: event.clientY,
-                            });
-                          } : undefined}
-                          onClick={() => {
-                            if (project.id === selectedProjectId) setProjectMenuOpen(false);
-                            else void selectProject(project);
-                          }}
-                        >
-                          <TaskboardIcon className="project-avatar" name="projectFolder" />
-                          <span>{project.name}</span>
-                          {project.id === selectedProjectId && <span className="project-menu-check" aria-hidden="true"><LinearIcon name="check" /></span>}
-                        </button>
-                      </Fragment>
-                    ))}
-                    <div className="project-menu-divider" role="separator" />
-                    <button
-                      type="button"
-                      role="menuitem"
-                      disabled={openingProjectId !== null}
-                      onClick={openJiraDialog}
-                    >
-                      <RelationIcon className="project-avatar" color="currentColor" size={16} />
-                      <span>
-                        {jiraConnection?.configured
-                          ? text("Jira 设置", "Jira settings")
-                          : text("连接 Jira", "Connect Jira")}
-                      </span>
-                    </button>
-                    <button
-                      type="button"
-                      role="menuitem"
-                      disabled={openingProjectId !== null}
-                      onClick={openCreateProjectDialog}
-                    >
-                      <PlusIcon className="project-avatar" color="currentColor" size={16} />
-                      <span>{text("创建项目", "Create project")}</span>
-                    </button>
+                        </>
+                      )}
+                      {visibleProjectMenuChoices.map((project) => (
+                        <Fragment key={project.id}>
+                          {hasProjectsWithIssues && project.id === firstEmptyProjectId && (
+                            <div className="project-menu-divider" role="separator" />
+                          )}
+                          <button
+                            type="button"
+                            role="menuitemradio"
+                            aria-checked={project.id === selectedProjectId}
+                            disabled={openingProjectId !== null}
+                            onContextMenu={project.id.startsWith("temp-") ? (event) => {
+                              event.preventDefault();
+                              setProjectContextMenu({
+                                project,
+                                x: event.clientX,
+                                y: event.clientY,
+                              });
+                            } : undefined}
+                            onClick={() => {
+                              if (project.id === selectedProjectId) setProjectMenuOpen(false);
+                              else void selectProject(project);
+                            }}
+                          >
+                            <TaskboardIcon className="project-avatar" name="projectFolder" />
+                            <span>{project.name}</span>
+                            {project.id === selectedProjectId && <span className="project-menu-check" aria-hidden="true"><LinearIcon name="check" /></span>}
+                          </button>
+                        </Fragment>
+                      ))}
+                      {projectMenuNeedle && visibleProjectMenuChoices.length === 0 && (
+                        <div className="project-menu-empty">{text("没有匹配项目", "No matching projects")}</div>
+                      )}
+                    </div>
+                    <div className="project-menu-actions">
+                      <div className="project-menu-divider" role="separator" />
+                      <button
+                        type="button"
+                        role="menuitem"
+                        disabled={openingProjectId !== null}
+                        onClick={openJiraDialog}
+                      >
+                        <RelationIcon className="project-avatar" color="currentColor" size={16} />
+                        <span>
+                          {jiraConnection?.configured
+                            ? text("Jira 设置", "Jira settings")
+                            : text("连接 Jira", "Connect Jira")}
+                        </span>
+                      </button>
+                      <button
+                        type="button"
+                        role="menuitem"
+                        disabled={openingProjectId !== null}
+                        onClick={openCreateProjectDialog}
+                      >
+                        <PlusIcon className="project-avatar" color="currentColor" size={16} />
+                        <span>{text("创建项目", "Create project")}</span>
+                      </button>
+                    </div>
                   </div>
                 )}
               </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -823,7 +823,7 @@ kbd {
 .project-menu-search input {
   width: 100%;
   height: 100%;
-  padding: 0 8px 0 27px;
+  padding: 0 27px;
   border: var(--border-hairline) solid var(--border);
   border-radius: 6px;
   outline: 0;
@@ -858,7 +858,7 @@ kbd {
   font-size: 11px;
 }
 
-.header-project-menu button {
+.header-project-menu button:not(.search-clear) {
   display: grid;
   grid-template-columns: 22px minmax(0, 1fr) auto auto;
   align-items: center;
@@ -874,13 +874,13 @@ kbd {
   text-align: left;
 }
 
-.header-project-menu button:hover:not(:disabled),
-.header-project-menu button:focus-visible {
+.header-project-menu button:not(.search-clear):hover:not(:disabled),
+.header-project-menu button:not(.search-clear):focus-visible {
   background: var(--surface-hover);
   outline: none;
 }
 
-.header-project-menu button > span:nth-child(2) {
+.header-project-menu button:not(.search-clear) > span:nth-child(2) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1132,7 +1132,8 @@ kbd {
   color: var(--text-tertiary);
 }
 
-.search-field input::-webkit-search-cancel-button {
+.search-field input::-webkit-search-cancel-button,
+.project-menu-search input::-webkit-search-cancel-button {
   appearance: none;
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -782,8 +782,12 @@ kbd {
   z-index: 50;
   top: 33px;
   left: -4px;
+  display: flex;
+  flex-direction: column;
   width: min(240px, calc(100vw - 24px));
+  max-height: min(480px, calc(100vh - 56px));
   padding: 5px;
+  overflow: hidden;
   border: var(--border-hairline) solid var(--border-strong);
   border-radius: 9px;
   background: var(--surface-raised);
@@ -797,6 +801,61 @@ kbd {
   color: var(--text-tertiary);
   font-size: 9px;
   font-weight: 550;
+}
+
+.project-menu-search {
+  position: relative;
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  height: 32px;
+  margin: 0 2px 5px;
+}
+
+.project-menu-search .taskboard-icon {
+  position: absolute;
+  left: 8px;
+  width: 13px;
+  height: 13px;
+  pointer-events: none;
+}
+
+.project-menu-search input {
+  width: 100%;
+  height: 100%;
+  padding: 0 8px 0 27px;
+  border: var(--border-hairline) solid var(--border);
+  border-radius: 6px;
+  outline: 0;
+  background: var(--surface);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 11px;
+}
+
+.project-menu-search input:focus {
+  border-color: var(--border-strong);
+}
+
+.project-menu-search input::placeholder {
+  color: var(--text-tertiary);
+}
+
+.project-menu-list {
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.project-menu-actions {
+  flex: 0 0 auto;
+}
+
+.project-menu-empty {
+  padding: 10px 7px;
+  color: var(--text-tertiary);
+  font-size: 11px;
 }
 
 .header-project-menu button {


### PR DESCRIPTION
## Summary

- keep long project menus within the available height and scroll inside the project list
- add project-name filtering while preserving the existing project selection path
- keep the menu compact when only a few projects are available
- use the existing Taskboard search SVG and shared `LinearIcon close` for the clear control instead of the browser-native icon

## Verification

- verified in a real browser with an isolated snapshot of current Taskboard data
- long list scrolls internally (`scrollTop` 0 → 66, `overflow-y: auto`)
- `DeepSeek` leaves only `DeepSeek Harness`; clicking it changes the real project and loads its issues
- clearing the search restores all 12 project candidates
- clear control measures 16×16 with a 10×10 SVG, `currentColor`, and a 6px right gap
- `npm run typecheck`
- `npm run build:web`
- `node --test test/project-home.test.mjs`

Relates to #276.