### PR TITLE
Fix ChatGPT first-click navigation

### DIFF
--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -31,6 +31,7 @@
   const PLUGIN_LABELS = ["插件", "plugins"];
   const NATIVE_PAGE_LABELS = [
     "新建任务",
+    "新聊天",
     "新对话",
     "new task",
     "new chat",

--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -1724,6 +1724,10 @@
     if (!clickable.closest("aside nav[role='navigation']")) return false;
     if (clickable.hasAttribute("data-app-action-sidebar-section-toggle")) return false;
     if (buttonMatches(clickable, NATIVE_PAGE_LABELS)) return true;
+    if (
+      clickable.matches("[role='button']")
+      && clickable.closest("[data-sidebar-chatgpt-conversation-key]")
+    ) return true;
     return Boolean(clickable.closest(
       "[data-app-action-sidebar-thread-id],"
       + "[data-app-action-sidebar-project-row],"


### PR DESCRIPTION
## Summary

- Treat native ChatGPT Recent conversation rows as page navigation while Taskboard is active.
- Recognize the ChatGPT-mode top New Chat label `新聊天` in the existing native navigation label path.
- Close the Taskboard surface before the native navigation continues.

## Root cause

The New Chat click was not blocked by Taskboard or the right Browser panel. A real pointer click reached the native `新聊天` button and the hidden native main area changed to the blank ChatGPT composer, but Taskboard stayed visible. The injection label table contained `新对话` and `new chat`, not the actual ChatGPT-mode label `新聊天`, so the existing `closeTaskboard(false)` path did not run.

## Direct verification

- Fully quit and cold-started an isolated ChatGPT app copy with an independent profile, Taskboard port `62712`, CDP port `62713`, and runtime descriptor.
- On the first top New Chat click, `data-codex-taskboard-open` was removed, the Taskboard page became hidden, Taskboard host/native-hidden counts became `0/0`, and the visible `给 ChatGPT 发消息` composer appeared.
- Reopened Taskboard, expanded Recent, and clicked existing conversation `启动uu远程`; Taskboard closed and the row became active.
- During both checks, the right Browser webview was hidden with `pointer-events:none`.
- `node --check inject/codex-taskboard.user.js`
- `git diff --check`

Exact head: `f5d85438a50362d1851da7f9fda383b659ebd5a7`.

No tests were added, per the repository workflow for this implementation phase. Pro review remains gated on user confirmation of the working Demo.