### PR TITLE
feat: support Codex and Kimi task conversations

### DIFF
--- a/server/ai-chat-process.mjs
+++ b/server/ai-chat-process.mjs
@@ -260,6 +260,66 @@ export function buildCodexPrompt(thread, { message, skills, attachmentPaths }, s
   ].join("\n");
 }
 
+export function buildKimiArgs(thread, prompt) {
+  const args = ["--output-format", "stream-json"];
+  if (thread.agentSessionId) args.push("--session", thread.agentSessionId);
+  args.push("--prompt", prompt);
+  return args;
+}
+
+export function buildKimiPrompt(thread, message, issue) {
+  const context = [
+    `project_id: ${thread.origin.projectId}`,
+    `project_name: ${thread.origin.projectName}`,
+    `workspace_path: ${thread.origin.workspacePath}`,
+  ];
+  if (issue) {
+    context.push(
+      `issue_identifier: ${issue.identifier}`,
+      `issue_title: ${issue.title}`,
+      "issue_description:",
+      issue.description || "(empty)",
+    );
+  }
+  return [
+    "<taskboard_context>",
+    ...context,
+    "</taskboard_context>",
+    "",
+    "<user_message>",
+    message,
+    "</user_message>",
+  ].join("\n");
+}
+
+export function normalizeKimiEvent(raw) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  if (raw.role === "meta" && raw.type === "session.resume_hint") {
+    const sessionId = typeof raw.session_id === "string" ? raw.session_id.trim() : "";
+    if (!sessionId || sessionId.length > 256 || sessionId.includes("\0")) return null;
+    return { kind: "session.started", sessionId };
+  }
+  if (raw.role === "assistant" && typeof raw.content === "string") {
+    return {
+      kind: "event",
+      type: "agent_message",
+      role: "assistant",
+      content: cappedText(raw.content),
+      data: { status: "completed", agentType: "kimi" },
+    };
+  }
+  if (raw.role === "error") {
+    return {
+      kind: "event",
+      type: typeof raw.type === "string" ? cappedText(raw.type) : "error",
+      role: "error",
+      content: errorMessage(raw.content ?? raw.message ?? raw.error),
+      data: { status: "failed", agentType: "kimi" },
+    };
+  }
+  return null;
+}
+
 export function normalizeCodexEvent(raw) {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
 
@@ -340,10 +400,12 @@ export function spawnCodexTurn({
   args,
   prompt,
   env,
+  cwd,
   onRawEvent,
   maxLineBytes = MAX_CODEX_JSONL_LINE_BYTES,
 }) {
   const child = spawn(process.execPath, [TURN_OWNER_PATH, executable, JSON.stringify(args)], {
+    cwd,
     detached: true,
     env: withoutTaskboardLauncherEnvironment(env),
     stdio: ["pipe", "pipe", "pipe", "pipe"],

--- a/server/ai-chat.mjs
+++ b/server/ai-chat.mjs
@@ -14,7 +14,10 @@ import { CodexAppServer } from "./codex-app-server.mjs";
 import {
   buildCodexArgs,
   buildCodexPrompt,
+  buildKimiArgs,
+  buildKimiPrompt,
   normalizeCodexEvent,
+  normalizeKimiEvent,
   spawnCodexTurn,
 } from "./ai-chat-process.mjs";
 
@@ -64,6 +67,13 @@ function appServerThreadSettings(thread, resolved) {
       : { approvalsReviewer: thread.sandbox === "read-only" ? "user" : "auto_review" }),
     sandbox: thread.sandbox,
   };
+}
+
+function resolvedIssueWorkspace(resolved) {
+  const worktreePath = resolved.issue?.developmentContext?.type === "worktree"
+    ? resolved.issue.developmentContext.path
+    : null;
+  return worktreePath ? { ...resolved, workspacePath: worktreePath } : resolved;
 }
 
 function normalizedAppServerItem(item) {
@@ -125,6 +135,7 @@ export class AiChatService {
   constructor(options) {
     this.database = options.database;
     this.codexExecutable = options.codexExecutable;
+    this.kimiExecutable = options.kimiExecutable;
     this.codexStatePath = options.codexStatePath;
     this.manageTaskboardSkillPath = options.manageTaskboardSkillPath;
     this.processEnv = options.processEnv ?? process.env;
@@ -283,6 +294,9 @@ export class AiChatService {
 
   async compactThread(threadId) {
     const thread = this.getThread(threadId);
+    if (thread.agentType === "kimi") {
+      throw new ApiError(400, "KIMI_COMPACTION_UNAVAILABLE", "Kimi conversations cannot be compacted here");
+    }
     if (thread.status === "running") {
       throw new ApiError(409, "AI_CHAT_THREAD_RUNNING", "Cannot compact a running conversation");
     }
@@ -294,25 +308,39 @@ export class AiChatService {
   }
 
   async createThread(input) {
-    const resolved = await this.resolveContext(input.projectId, input.issueId);
-    const catalog = await this.getCatalog(input.projectId, resolved);
-    const model = this.#resolveModel(catalog, input.model);
-    const reasoningEffort = input.reasoningEffort ?? model.defaultReasoningEffort;
-    this.#validateReasoningEffort(model, reasoningEffort);
-    const sandbox = input.sandbox ?? "workspace-write";
-    this.#validateSandbox(sandbox);
+    const resolved = resolvedIssueWorkspace(
+      await this.resolveContext(input.projectId, input.issueId),
+    );
+    const agentType = input.agentType ?? "codex";
+    let model;
+    let reasoningEffort;
+    let sandbox;
+    if (agentType === "kimi") {
+      model = "kimi-default";
+      reasoningEffort = "default";
+      sandbox = "workspace-write";
+    } else {
+      const catalog = await this.getCatalog(input.projectId, resolved);
+      const resolvedModel = this.#resolveModel(catalog, input.model);
+      model = resolvedModel.slug;
+      reasoningEffort = input.reasoningEffort ?? resolvedModel.defaultReasoningEffort;
+      this.#validateReasoningEffort(resolvedModel, reasoningEffort);
+      sandbox = input.sandbox ?? "workspace-write";
+      this.#validateSandbox(sandbox);
+    }
 
     const issue = resolved.issue;
 
     return this.database.createAiChatThread({
       title: input.title ?? issue?.identifier ?? "New conversation",
+      agentType,
       origin: {
         projectId: resolved.project.id,
         projectName: resolved.project.name,
         workspacePath: resolved.workspacePath,
         ...(issue ? { issueId: issue.id, issueIdentifier: issue.identifier } : {}),
       },
-      model: model.slug,
+      model,
       reasoningEffort,
       sandbox,
     });
@@ -323,6 +351,9 @@ export class AiChatService {
     const changesSettings = ["model", "reasoningEffort", "sandbox"].some(
       (key) => Object.hasOwn(changes, key),
     );
+    if (thread.agentType === "kimi" && changesSettings) {
+      throw new ApiError(400, "KIMI_SETTINGS_UNAVAILABLE", "Kimi settings are managed by Kimi Code");
+    }
     const wasActive = changesSettings && this.#threadIsActive(thread);
 
     if (Object.hasOwn(changes, "sandbox")) this.#validateSandbox(changes.sandbox);
@@ -366,6 +397,9 @@ export class AiChatService {
       );
     }
     if (input?.contractVersion === "composer.v1") {
+      if (thread.agentType === "kimi") {
+        throw new ApiError(400, "KIMI_COMPOSER_UNSUPPORTED", "Kimi conversations accept plain text turns");
+      }
       return this.#startComposerTurn(thread, input);
     }
     this.#validateTurnInput(input);
@@ -377,10 +411,13 @@ export class AiChatService {
       );
     }
 
-    const resolved = await this.resolveContext(
+    const resolved = resolvedIssueWorkspace(await this.resolveContext(
       thread.origin.projectId,
       thread.origin.issueId,
-    );
+    ));
+    if (thread.agentType === "kimi") {
+      return this.#startKimiTurn(thread, input, resolved);
+    }
     const catalog = await this.getCatalog(thread.origin.projectId, resolved);
 
     thread = this.getThread(threadId);
@@ -534,6 +571,115 @@ export class AiChatService {
       if (temporaryDirectory) {
         await rm(temporaryDirectory, { recursive: true, force: true });
       }
+      throw error;
+    }
+  }
+
+  async #startKimiTurn(thread, input, resolved) {
+    if (resolved.workspacePath !== thread.origin.workspacePath) {
+      throw new ApiError(
+        409,
+        "PROJECT_WORKSPACE_CHANGED",
+        "The project's device workspace no longer matches this conversation",
+      );
+    }
+    const attachments = input.attachments ?? [];
+    const { temporaryDirectory, attachmentPaths } = await this.#writeTurnAttachments(attachments);
+    const attachmentMessage = attachmentPaths.length > 0
+      ? `${input.message}\n\nAttached files:\n${attachmentPaths.map((item) => `- ${item}`).join("\n")}`
+      : input.message;
+    try {
+      const prompt = buildKimiPrompt(thread, attachmentMessage, resolved.issue);
+      const args = buildKimiArgs(thread, prompt);
+      const run = this.database.createAiChatRun({ threadId: thread.id });
+      this.#emit(thread.id, { type: "ai.run", run });
+      const userEvent = this.database.insertAiChatEvent({
+        threadId: thread.id,
+        runId: run.id,
+        type: "user_message",
+        role: "user",
+        content: input.message,
+        data: attachments.length > 0 ? {
+          attachments: attachments.map(({ filename, contentType, size }) => ({
+            filename,
+            contentType,
+            size,
+          })),
+        } : undefined,
+      });
+      this.#emit(thread.id, { type: "ai.event", event: userEvent });
+
+      const resumingSessionId = thread.agentSessionId;
+      let startedSessionId = null;
+      let terminalOutcome = null;
+      let terminalError = "";
+      const { child, completion } = spawnCodexTurn({
+        executable: this.kimiExecutable,
+        args,
+        prompt: "",
+        env: this.processEnv,
+        cwd: resolved.workspacePath,
+        onRawEvent: (raw) => {
+          const normalized = normalizeKimiEvent(raw);
+          if (!normalized) return;
+          if (normalized.kind === "session.started") {
+            if (
+              (resumingSessionId && normalized.sessionId !== resumingSessionId)
+              || (startedSessionId && normalized.sessionId !== startedSessionId)
+            ) {
+              throw new Error("Kimi returned an unexpected session id");
+            }
+            startedSessionId = normalized.sessionId;
+            this.database.updateAiChatThread(thread.id, { agentSessionId: normalized.sessionId });
+            return;
+          }
+          const event = this.database.insertAiChatEvent({
+            threadId: thread.id,
+            runId: run.id,
+            type: normalized.type,
+            role: normalized.role,
+            content: normalized.content,
+            data: normalized.data,
+          });
+          if (normalized.role === "assistant") terminalOutcome = "completed";
+          if (normalized.role === "error") {
+            terminalOutcome = "failed";
+            terminalError ||= normalized.content;
+          }
+          this.#emit(thread.id, { type: "ai.event", event });
+        },
+      });
+      const active = { child, threadId: thread.id, interrupted: false, temporaryDirectory };
+      this.active.set(run.id, active);
+      const finalization = completion.then(
+        (result) => this.#finishRun({
+          run,
+          active,
+          result,
+          resumingThreadId: resumingSessionId,
+          startedThreadId: () => startedSessionId,
+          terminalOutcome: () => terminalOutcome,
+          terminalError: () => terminalError,
+          pendingError: () => "",
+          agentLabel: "Kimi",
+        }),
+        (error) => this.#finishRun({
+          run,
+          active,
+          error,
+          resumingThreadId: resumingSessionId,
+          startedThreadId: () => startedSessionId,
+          terminalOutcome: () => terminalOutcome,
+          terminalError: () => terminalError,
+          pendingError: () => "",
+          agentLabel: "Kimi",
+        }),
+      );
+      this.completions.set(run.id, finalization);
+      void finalization.finally(() => this.completions.delete(run.id)).catch(() => {});
+      return run;
+    } catch (error) {
+      if (temporaryDirectory) await rm(temporaryDirectory, { recursive: true, force: true });
       throw error;
     }
   }
@@ -986,6 +1132,7 @@ export class AiChatService {
     terminalOutcome,
     terminalError,
     pendingError,
+    agentLabel = "Codex",
   }) {
     let status;
     let publicError = null;
@@ -994,21 +1141,21 @@ export class AiChatService {
       publicError = "Interrupted";
     } else if (error) {
       status = "failed";
-      publicError = cappedError(error) || "Codex turn failed";
+      publicError = cappedError(error) || `${agentLabel} turn failed`;
     } else if (terminalOutcome() === "failed") {
       status = "failed";
-      publicError = terminalError() || "Codex reported a failed turn";
+      publicError = terminalError() || `${agentLabel} reported a failed turn`;
     } else if (result.exitCode !== 0) {
       status = "failed";
       publicError = result.exitCode === null
-        ? `Codex exited due to signal ${result.signal ?? "unknown"}`
-        : `Codex exited with code ${result.exitCode}`;
+        ? `${agentLabel} exited due to signal ${result.signal ?? "unknown"}`
+        : `${agentLabel} exited with code ${result.exitCode}`;
     } else if (terminalOutcome() !== "completed") {
       status = "failed";
-      publicError = pendingError() || "Codex exited without reporting turn completion";
+      publicError = pendingError() || `${agentLabel} exited without reporting turn completion`;
     } else if (!resumingThreadId && !startedThreadId()) {
       status = "failed";
-      publicError = "Codex did not provide a thread id";
+      publicError = `${agentLabel} did not provide a ${agentLabel === "Codex" ? "thread" : "session"} id`;
     } else {
       status = "completed";
     }

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -895,6 +895,14 @@ function parseAiSandbox(value) {
   return value;
 }
 
+function parseAiAgentType(value) {
+  if (value === undefined) return undefined;
+  if (value !== "codex" && value !== "kimi") {
+    throw new ApiError(400, "INVALID_AGENT_TYPE", "'agentType' must be codex or kimi");
+  }
+  return value;
+}
+
 function parseAiSetting(value, name, maxLength) {
   const setting = stringField(value, name, { maxLength });
   if (setting === "") {
@@ -909,6 +917,7 @@ function parseAiThreadCreate(body) {
     "projectId",
     "issueId",
     "title",
+    "agentType",
     "model",
     "reasoningEffort",
     "sandbox",
@@ -917,6 +926,7 @@ function parseAiThreadCreate(body) {
     projectId: validateProjectId(body.projectId),
     issueId: parseAiSetting(body.issueId, "issueId", 128),
     title: parseAiSetting(body.title, "title", 160),
+    agentType: parseAiAgentType(body.agentType),
     model: parseAiSetting(body.model, "model", 128),
     reasoningEffort: parseAiSetting(body.reasoningEffort, "reasoningEffort", 64),
     sandbox: parseAiSandbox(body.sandbox),
@@ -1616,6 +1626,9 @@ export function resolveServerOptions(options = {}) {
       ?? environment.CODEX_TASKBOARD_SKILL_PATH
       ?? path.join(PROJECT_ROOT, "skills", "manage-taskboard", "SKILL.md"),
     codexExecutable: resolveCodexExecutable({ explicit: options.codexExecutable }),
+    kimiExecutable: options.kimiExecutable
+      ?? environment.KIMI_CODE_EXECUTABLE
+      ?? path.join(os.homedir(), ".kimi-code", "bin", "kimi"),
     codexStatePath: options.codexStatePath
       ?? path.join(codexHome, ".codex-global-state.json"),
     codexProcessesPath: options.codexProcessesPath
@@ -1835,6 +1848,7 @@ export function createTaskboardServer(options = {}) {
   const aiChat = new AiChatService({
     database,
     codexExecutable: resolved.codexExecutable,
+    kimiExecutable: resolved.kimiExecutable,
     codexStatePath: resolved.codexStatePath,
     manageTaskboardSkillPath: resolved.skillPath,
     processEnv: codexProcessEnvironment,

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -404,6 +404,8 @@ function aiChatThreadFromRow(row) {
     id: row.id,
     title: row.title,
     status: row.status,
+    agentType: row.agent_type ?? "codex",
+    agentSessionId: row.agent_session_id ?? null,
     origin: {
       projectId: row.origin_project_id,
       projectName: row.origin_project_name,
@@ -596,6 +598,8 @@ export class TaskboardDatabase {
         id TEXT PRIMARY KEY,
         title TEXT NOT NULL,
         status TEXT NOT NULL CHECK (status IN ('idle', 'running', 'failed')),
+        agent_type TEXT NOT NULL DEFAULT 'codex' CHECK (agent_type IN ('codex', 'kimi')),
+        agent_session_id TEXT,
         origin_project_id TEXT NOT NULL,
         origin_project_name TEXT NOT NULL,
         origin_workspace_path TEXT NOT NULL,
@@ -648,6 +652,14 @@ export class TaskboardDatabase {
         ON ai_chat_events(thread_id, created_at, id);
 
     `);
+
+    const aiChatThreadColumns = this.database.prepare("PRAGMA table_info(ai_chat_threads)").all();
+    if (!aiChatThreadColumns.some((column) => column.name === "agent_type")) {
+      this.database.exec("ALTER TABLE ai_chat_threads ADD COLUMN agent_type TEXT NOT NULL DEFAULT 'codex'");
+    }
+    if (!aiChatThreadColumns.some((column) => column.name === "agent_session_id")) {
+      this.database.exec("ALTER TABLE ai_chat_threads ADD COLUMN agent_session_id TEXT");
+    }
 
     const projectColumns = this.database.prepare("PRAGMA table_info(projects)").all();
     if (!projectColumns.some((column) => column.name === "workspace_path")) {
@@ -1617,16 +1629,18 @@ export class TaskboardDatabase {
     const timestamp = input.createdAt ?? now();
     this.database.prepare(`
       INSERT INTO ai_chat_threads (
-        id, title, status,
+        id, title, status, agent_type, agent_session_id,
         origin_project_id, origin_project_name, origin_workspace_path,
         origin_issue_id, origin_issue_identifier,
         codex_thread_id, model, reasoning_effort, sandbox,
         created_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       id,
       input.title,
       input.status ?? "idle",
+      input.agentType ?? "codex",
+      input.agentSessionId ?? null,
       input.origin.projectId,
       input.origin.projectName,
       input.origin.workspacePath,
@@ -1650,6 +1664,7 @@ export class TaskboardDatabase {
     const columns = {
       title: "title",
       status: "status",
+      agentSessionId: "agent_session_id",
       codexThreadId: "codex_thread_id",
       model: "model",
       reasoningEffort: "reasoning_effort",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3023,6 +3023,27 @@ export function App() {
     });
   }
 
+  function openTaskInKimi(task: Task) {
+    if (!localAiChatAvailable) {
+      setActionError(text(
+        "Kimi 仅可通过本机 Taskboard 运行。",
+        "Kimi is available only through the local Taskboard runtime.",
+      ));
+      return;
+    }
+    setActionError(null);
+    setAiOpenThreadRequest((current) => ({
+      projectId: task.projectId,
+      issueId: task.id,
+      agentType: "kimi",
+      composerText: text(
+        `处理 Taskboard 议题 ${task.identifier}。请在议题绑定的工作目录中执行，持续报告进度，完成后总结改动、验证结果和剩余限制。`,
+        `Work on Taskboard issue ${task.identifier} in its bound workspace. Report progress as you work, then summarize changes, verification, and remaining limitations.`,
+      ),
+      requestId: (current?.requestId ?? 0) + 1,
+    }));
+  }
+
   function changeProject(projectId: string) {
     closeContextMenu();
     setProjectContextMenu(null);
@@ -3578,6 +3599,7 @@ export function App() {
             onOpenThread={openThread}
             onOpenLegacyLocalThread={openLegacyLocalThread}
             onOpenInThread={openTaskInThread}
+            onOpenInKimi={openTaskInKimi}
             onCopy={(text, message) => void copyText(text, message)}
             openingThread={openingThreadTaskId === detailTask.id}
             onError={setActionError}
@@ -4049,6 +4071,7 @@ export function App() {
           onCopy={(text, message) => void copyText(text, message)}
           openInThreadDisabled={developmentScanLoading}
           onOpenInThread={openTaskInThread}
+          onOpenInKimi={openTaskInKimi}
           onArchive={(task) => void archiveTask(task)}
         />
       )}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -2,6 +2,7 @@ import type {
   ActorIdentity,
   AiChatCatalog,
   AiChatAttachmentInput,
+  AiAgentType,
   AiChatRun,
   AiChatSandbox,
   AiChatThread,
@@ -320,6 +321,7 @@ export async function createAiChatThread(input: {
   projectId: string;
   issueId?: string;
   title?: string;
+  agentType?: AiAgentType;
   model?: string;
   reasoningEffort?: string;
   sandbox?: AiChatSandbox;

--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -51,6 +51,7 @@ import {
   serializeComposerDocument,
 } from "../aiChatState";
 import type {
+  AiAgentType,
   AiChatCatalog,
   AiChatEvent,
   AiChatAttachmentInput,
@@ -94,11 +95,13 @@ export type AiChatOpenThreadRequest = {
 } | {
   projectId: string;
   issueId: string | null;
+  agentType?: AiAgentType;
   composerText: string;
   requestId: number;
 } | {
   projectId: string;
   issueId: string | null;
+  agentType?: AiAgentType;
   composerDraft: {
     ready: boolean;
     revision: string;
@@ -171,6 +174,7 @@ type ComposerBeforeInput = {
 type DraftThreadOrigin = {
   projectId: string;
   issueId: string | null;
+  agentType: AiAgentType;
 };
 type PanelResizeEdge = "top" | "left" | "top-left";
 type PanelGeometry = {
@@ -1644,6 +1648,10 @@ export function AiChat({
   ]);
 
   const selectedThreadSummary = threads.find((thread) => thread.id === selectedThreadId) ?? null;
+  const activeAgentType = snapshot?.thread.agentType
+    ?? selectedThreadSummary?.agentType
+    ?? draftOrigin?.agentType
+    ?? "codex";
   const catalogProjectId = snapshot?.thread.origin.projectId
     ?? selectedThreadSummary?.origin.projectId
     ?? draftOrigin?.projectId
@@ -1780,7 +1788,7 @@ export function AiChat({
   const currentRun = snapshot?.thread.currentRun
     ?? snapshot?.runs.find((run) => run.status === "running")
     ?? null;
-  const visibleError = error ?? catalogError;
+  const visibleError = error ?? (activeAgentType === "codex" ? catalogError : null);
   const composerBlocked = Boolean(
     selectedThreadId && deletingThreadId === selectedThreadId,
   ) || composerRebindBlocked;
@@ -1864,10 +1872,12 @@ export function AiChat({
       setDraftOrigin({
         projectId: openThreadRequest.projectId,
         issueId: openThreadRequest.issueId,
+        agentType: openThreadRequest.agentType ?? "codex",
       });
       taskComposerDraftOriginRef.current = {
         projectId: openThreadRequest.projectId,
         issueId: openThreadRequest.issueId,
+        agentType: openThreadRequest.agentType ?? "codex",
       };
       setSnapshot(null);
       selectThread(null);
@@ -2028,6 +2038,7 @@ export function AiChat({
     setDraftOrigin({
       projectId: input.projectId,
       issueId: input.issueId ?? null,
+      agentType: "codex",
     });
     setSnapshot(null);
     selectThread(null);
@@ -2038,7 +2049,7 @@ export function AiChat({
 
   async function createThreadForDraftOrigin(): Promise<AiChatThread | null> {
     const origin = draftOrigin ?? (
-      projectId ? { projectId, issueId } : null
+      projectId ? { projectId, issueId, agentType: "codex" as const } : null
     );
     const input = buildThreadCreateInput(origin?.projectId ?? "", origin?.issueId ?? null);
     if (!input) {
@@ -2055,26 +2066,30 @@ export function AiChat({
     };
     setLoading(true);
     try {
-      const targetCatalog = catalogLoadedProjectId === input.projectId && activeCatalog
-        ? activeCatalog
-        : await getAiChatCatalog(input.projectId);
-      const normalized = normalizeChatSelection(
-        targetCatalog.models,
-        inheritedSettings.model,
-        inheritedSettings.reasoningEffort,
-      );
-      const sandbox = targetCatalog.sandboxes.includes(inheritedSettings.sandbox)
-        ? inheritedSettings.sandbox
-        : targetCatalog.sandboxes.find(
-          (candidate): candidate is AiChatSandbox => candidate === "workspace-write",
-        ) ?? targetCatalog.sandboxes.find(isAiChatSandbox) ?? inheritedSettings.sandbox;
-      const settings = {
-        model: normalized?.model ?? inheritedSettings.model,
-        reasoningEffort: normalized?.reasoningEffort ?? inheritedSettings.reasoningEffort,
-        sandbox,
-      };
+      let settings = {};
+      if (origin?.agentType !== "kimi") {
+        const targetCatalog = catalogLoadedProjectId === input.projectId && activeCatalog
+          ? activeCatalog
+          : await getAiChatCatalog(input.projectId);
+        const normalized = normalizeChatSelection(
+          targetCatalog.models,
+          inheritedSettings.model,
+          inheritedSettings.reasoningEffort,
+        );
+        const sandbox = targetCatalog.sandboxes.includes(inheritedSettings.sandbox)
+          ? inheritedSettings.sandbox
+          : targetCatalog.sandboxes.find(
+            (candidate): candidate is AiChatSandbox => candidate === "workspace-write",
+          ) ?? targetCatalog.sandboxes.find(isAiChatSandbox) ?? inheritedSettings.sandbox;
+        settings = {
+          model: normalized?.model ?? inheritedSettings.model,
+          reasoningEffort: normalized?.reasoningEffort ?? inheritedSettings.reasoningEffort,
+          sandbox,
+        };
+      }
       const thread = await createAiChatThread({
         ...input,
+        agentType: origin?.agentType ?? "codex",
         ...settings,
       });
       replaceThread(thread);
@@ -2479,7 +2494,7 @@ export function AiChat({
       || node.type === "unsupportedReference"
     )) ?? false;
     const isTaskOriginPlainTextDraft = Boolean(
-      taskComposerDraftOriginRef.current
+      taskComposerDraftOriginRef.current?.agentType === "codex"
       && currentComposerDocument?.nodes.every((node) => node.type === "text"),
     );
     if (isTaskOriginPlainTextDraft) {
@@ -2505,7 +2520,8 @@ export function AiChat({
         }
       }
     }
-    const useComposerTurn = hasStructuredReference || isTaskOriginPlainTextDraft;
+    const useComposerTurn = activeAgentType === "codex"
+      && (hasStructuredReference || isTaskOriginPlainTextDraft);
     if (useComposerTurn && !hasPersistedReference && !currentComposerRevision) {
       setError(text(
         "补全来源已失效，请重新选择 Skill",
@@ -2880,8 +2896,8 @@ export function AiChat({
           ref={panelRef}
           className={`ai-chat-panel${panelResizeEdge ? ` is-resizing-${panelResizeEdge}` : ""}`}
           style={panelGeometry ?? undefined}
-          aria-label={text("Codex AI 对话", "Codex AI chat")}
-          data-screen-label={text("Codex AI 对话", "Codex AI chat")}
+          aria-label={activeAgentType === "kimi" ? "Kimi Code" : text("Codex AI 对话", "Codex AI chat")}
+          data-screen-label={activeAgentType === "kimi" ? "Kimi Code" : text("Codex AI 对话", "Codex AI chat")}
         >
           <div
             className="ai-chat-resize-handle is-top"
@@ -2901,7 +2917,7 @@ export function AiChat({
           <header className="ai-chat-panel-header">
             <div className="ai-chat-panel-title">
               <strong>{snapshot?.thread.title ?? text("新对话", "New chat")}</strong>
-              <span>{snapshot?.thread.origin.projectName ?? text(
+              <span>{activeAgentType === "kimi" ? "Kimi Code · " : "Codex · "}{snapshot?.thread.origin.projectName ?? text(
                 "选择对话或从当前项目新建",
                 "Select a chat or start one in the current project",
               )}</span>
@@ -2963,7 +2979,7 @@ export function AiChat({
                     <span className={`ai-chat-thread-status is-${thread.status}`} aria-hidden="true" />
                     <span>
                       <strong>{thread.title}</strong>
-                      <small>{thread.origin.projectName} · {dateLabel(thread.updatedAt, locale)}</small>
+                      <small>{thread.agentType === "kimi" ? "Kimi" : "Codex"} · {thread.origin.projectName} · {dateLabel(thread.updatedAt, locale)}</small>
                     </span>
                   </button>
                   <button
@@ -3004,7 +3020,9 @@ export function AiChat({
                 {snapshot.thread.status === "running" && (
                   <div className="ai-chat-running" role="status">
                     <span className="ai-chat-spinner" />
-                    {text("Codex 正在处理", "Codex is working")}
+                    {snapshot.thread.agentType === "kimi"
+                      ? text("Kimi 正在处理", "Kimi is working")
+                      : text("Codex 正在处理", "Codex is working")}
                   </div>
                 )}
                 {retryableUserEvent && (
@@ -3033,10 +3051,15 @@ export function AiChat({
                   ? text("在当前项目中开始对话", "Start a chat in the current project")
                   : text("打开一个历史对话", "Open a chat from history")}</strong>
                 <p>{projectId
-                  ? text(
-                    "Codex 会在新对话创建时记住当前项目。",
-                    "Codex will remember the current project when it creates the new chat.",
-                  )
+                  ? activeAgentType === "kimi"
+                    ? text(
+                        "Kimi 会在议题绑定的项目或 worktree 中执行。",
+                        "Kimi will run in the project or worktree bound to this issue.",
+                      )
+                    : text(
+                        "Codex 会在新对话创建时记住当前项目。",
+                        "Codex will remember the current project when it creates the new chat.",
+                      )
                   : text("进入项目后可以新建对话。", "Open a project to start a new chat.")}</p>
               </div>
             )}
@@ -3100,9 +3123,9 @@ export function AiChat({
                 ref={editorRef}
                 className="ai-chat-composer-editor"
                 contentEditable={!composerBlocked}
-                data-placeholder={text("询问 Codex", "Ask Codex")}
+                data-placeholder={activeAgentType === "kimi" ? text("交给 Kimi", "Ask Kimi") : text("询问 Codex", "Ask Codex")}
                 role="textbox"
-                aria-label={text("发送给 Codex 的消息", "Message to Codex")}
+                aria-label={activeAgentType === "kimi" ? text("发送给 Kimi 的消息", "Message to Kimi") : text("发送给 Codex 的消息", "Message to Codex")}
                 aria-multiline="true"
                 aria-autocomplete="list"
                 aria-controls={composerQueryState ? "ai-chat-composer-candidates" : undefined}
@@ -3258,7 +3281,7 @@ export function AiChat({
               >
                 <PlusIcon color="currentColor" size={15} />
               </button>
-              <div className="ai-chat-menu-wrap ai-chat-permission-menu-wrap">
+              {activeAgentType === "codex" && <div className="ai-chat-menu-wrap ai-chat-permission-menu-wrap">
                 <button
                   className="ai-chat-permission-trigger"
                   type="button"
@@ -3311,10 +3334,10 @@ export function AiChat({
                     ))}
                   </div>
                 )}
-              </div>
+              </div>}
 
               <span className="ai-chat-toolbar-spacer" />
-              <div className="ai-chat-menu-wrap ai-chat-model-menu-wrap">
+              {activeAgentType === "codex" && <div className="ai-chat-menu-wrap ai-chat-model-menu-wrap">
                 <button
                   className="ai-chat-model-trigger"
                   type="button"
@@ -3424,7 +3447,7 @@ export function AiChat({
                     ))}
                   </div>
                 )}
-              </div>
+              </div>}
 
               {primaryAction === "stop" ? (
                 <button
@@ -3446,7 +3469,7 @@ export function AiChat({
                     primaryAction === "disabled"
                     || loading
                     || settingsSaving
-                    || Boolean(catalogError)
+                    || (activeAgentType === "codex" && Boolean(catalogError))
                   }
                   onClick={() => void startMessage(draft, false)}
                 >

--- a/web/src/components/TaskContextMenu.tsx
+++ b/web/src/components/TaskContextMenu.tsx
@@ -19,6 +19,7 @@ import { labelPresentation } from "../labels";
 import { taskPriorityLabel, taskStatusLabel, useTaskboardI18n } from "../i18n";
 import { LinearIcon } from "./LinearIcon";
 import {
+  ConversationIcon,
   DeleteIcon,
   EditIcon,
   LabelIcon,
@@ -42,6 +43,7 @@ interface TaskContextMenuProps {
   onCopy: (text: string, announcement: string) => void;
   openInThreadDisabled?: boolean;
   onOpenInThread: (task: Task) => void;
+  onOpenInKimi: (task: Task) => void;
   onArchive: (task: Task) => void;
 }
 
@@ -114,6 +116,7 @@ export function TaskContextMenu({
   onCopy,
   openInThreadDisabled = false,
   onOpenInThread,
+  onOpenInKimi,
   onArchive,
 }: TaskContextMenuProps) {
   const { language, text } = useTaskboardI18n();
@@ -425,11 +428,18 @@ export function TaskContextMenu({
           )}
         </MenuItem>
         <MenuItem
-          label={text("在新对话打开", "Open in new conversation")}
+          label={text("使用 Codex", "Use Codex")}
           icon={<NewConversationIcon color="currentColor" size={16} />}
           disabled={openInThreadDisabled}
           onPointerEnter={closeSubmenu}
           onClick={() => closeThen(() => onOpenInThread(task))}
+        />
+        <MenuItem
+          label={text("使用 Kimi", "Use Kimi")}
+          icon={<ConversationIcon color="currentColor" size={16} />}
+          disabled={openInThreadDisabled}
+          onPointerEnter={closeSubmenu}
+          onClick={() => closeThen(() => onOpenInKimi(task))}
         />
       </div>
 

--- a/web/src/components/TaskConversationMenu.tsx
+++ b/web/src/components/TaskConversationMenu.tsx
@@ -13,7 +13,8 @@ function conversationSource(
   conversation: TaskConversationItem,
   text: (chinese: string, english: string) => string,
 ) {
-  if (conversation.kind === "local-ai") return text("内置 AI", "Built-in AI");
+  if (conversation.agentType === "kimi") return "Kimi Code";
+  if (conversation.kind === "local-ai") return text("内置 Codex", "Built-in Codex");
   return conversation.source === "comment"
     ? text("评论对话", "Comment conversation")
     : text("任务对话", "Task conversation");
@@ -29,6 +30,7 @@ function conversationStatus(
     }
     return text("正在处理", "Processing");
   }
+  if (conversation.agentType === "kimi") return "Kimi";
   return conversation.kind === "local-ai" ? text("已暂停", "Paused") : "Codex";
 }
 

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -131,6 +131,7 @@ interface TaskDetailProps {
   onOpenThread: (binding: CodexThreadBinding) => void;
   onOpenLegacyLocalThread: (threadId: string) => void;
   onOpenInThread: (task: Task) => void;
+  onOpenInKimi: (task: Task) => void;
   onCopy: (text: string, announcement: string) => void;
   openingThread: boolean;
   onError: (message: TaskDetailError | null) => void;
@@ -398,6 +399,7 @@ export function TaskDetail({
   onOpenThread,
   onOpenLegacyLocalThread,
   onOpenInThread,
+  onOpenInKimi,
   onCopy,
   openingThread,
   onError,
@@ -1631,7 +1633,15 @@ export function TaskDetail({
                 <NewConversationIcon color="currentColor" />
                 <span>{openingThread
                   ? text("正在打开…", "Opening…")
-                  : text("在新对话打开", "Open in new conversation")}</span>
+                  : text("使用 Codex", "Use Codex")}</span>
+              </button>
+              <button
+                className="detail-open-thread-action is-kimi"
+                type="button"
+                onClick={() => onOpenInKimi(currentTask)}
+              >
+                <ConversationIcon color="currentColor" />
+                <span>{text("使用 Kimi", "Use Kimi")}</span>
               </button>
               {currentTask.externalUrl && (
                 <a

--- a/web/src/taskConversations.ts
+++ b/web/src/taskConversations.ts
@@ -12,6 +12,7 @@ export interface TaskConversationItem {
   key: string;
   projectId: string;
   kind: "native" | "local-ai";
+  agentType: "codex" | "kimi";
   title: string;
   source: "task" | "comment" | "local-ai";
   nativeThreadId: string | null;
@@ -97,6 +98,7 @@ export function taskConversations(task: Task, aiThreads: AiChatThread[]) {
       key,
       projectId: task.projectId,
       kind: "native",
+      agentType: "codex",
       title: ref.title || task.title,
       source: ref.source,
       nativeThreadId: ref.threadId,
@@ -130,6 +132,7 @@ export function taskConversations(task: Task, aiThreads: AiChatThread[]) {
       key,
       projectId: task.projectId,
       kind: "local-ai",
+      agentType: thread.agentType,
       title: thread.title || thread.origin.issueIdentifier || task.title,
       source: "local-ai",
       nativeThreadId: current?.nativeThreadId ?? thread.codexThreadId,

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -54,6 +54,7 @@ export interface TaskboardCapabilities {
 }
 
 export type AiChatSandbox = "read-only" | "workspace-write" | "danger-full-access";
+export type AiAgentType = "codex" | "kimi";
 export type AiChatThreadStatus = "idle" | "running" | "failed";
 export type AiChatRunStatus = "running" | "completed" | "failed" | "interrupted";
 
@@ -290,6 +291,8 @@ export interface AiChatThread {
   id: string;
   title: string;
   status: AiChatThreadStatus;
+  agentType: AiAgentType;
+  agentSessionId: string | null;
   origin: AiChatOrigin;
   codexThreadId: string | null;
   model: string;


### PR DESCRIPTION
## Summary

- add explicit Codex and Kimi actions to task detail and context menus
- run Kimi Code locally in the task project/worktree and persist its agent/session identity
- surface Kimi progress and results in the existing unified conversation history

## Direct verification

- real Kimi CLI first turn returned KIMI_DIRECT_PATH_OK in the bound worktree
- refreshing and continuing the same session returned KIMI_SESSION_RESUMED
- TypeScript typecheck and Vite production build passed
- 39 existing focused AI chat database/API/server/runner checks passed

## Kimi 0.38 protocol note

--prompt is already non-interactive and cannot be combined with --auto/--yolo; session continuation uses --session <id> --prompt.