### PR TITLE
Fix packaged project summary generation

### DIFF
--- a/server/project-summary.mjs
+++ b/server/project-summary.mjs
@@ -104,6 +104,7 @@ export class ProjectSummaryService {
           "--json",
           "--color",
           "never",
+          "--skip-git-repo-check",
           "-C",
           this.workspacePath,
           "-s",


### PR DESCRIPTION
## 产品问题
安装版 Taskboard 在仪表盘生成项目总结时，从打包目录启动 Codex。该目录不是 Git 仓库，Codex 会在读取提示词前以退出码 1 终止，所以界面长期显示“暂时无法生成项目总结”。

## 修复
仅在项目总结这条只读、禁止审批的 Codex 调用中加入 `--skip-git-repo-check`。不改变总结提示词、数据持久化、刷新周期或界面。

## 直接验证
- 修复前：使用安装版相同工作目录和参数可稳定复现 trusted directory 错误与退出码 1。
- 修复后：同一工作目录下 Codex 成功返回 agent message。
- 隔离真实数据快照中，项目总结成功写入并在仪表盘显示，API 返回 `error: null`。
- `node --check server/project-summary.mjs`
- `npm run typecheck`
- `npm run build:web`
- `git diff --check`

按项目流程未新增测试。