### PR TITLE
Fix delayed project summary refresh

### DIFF
--- a/server/project-summary.mjs
+++ b/server/project-summary.mjs
@@ -24,7 +24,11 @@ function buildPrompt(project, tasks) {
     STATUS_LABELS[status],
     tasks.filter((task) => task.status === status).length,
   ]));
-  const issues = tasks.map((task) => ({
+  const recentCutoff = Date.now() - 7 * DAY_MS;
+  const issues = tasks.filter((task) => (
+    (task.status !== "done" && task.status !== "canceled")
+    || new Date(task.activityUpdatedAt).getTime() >= recentCutoff
+  )).map((task) => ({
     id: task.identifier,
     title: task.title,
     status: STATUS_LABELS[task.status],

--- a/web/src/components/DashboardView.tsx
+++ b/web/src/components/DashboardView.tsx
@@ -434,12 +434,17 @@ export function DashboardView({
         `Across all projects, ${tasks.length} issues are tracked: ${completedTasks.length} completed and ${activeTasks.length} still open; ${tasks.filter((task) => task.status === "blocked").length} are blocked and ${overdueTasks.length} overdue.`,
       )
     : projectSummary?.summary
-      ?? (summaryLoadFailed || projectSummary?.error
-        ? text("Codex 暂时无法生成项目总结。", "Codex cannot generate the project summary now.")
-        : text(
+      ?? (projectSummary?.refreshing
+        ? text(
             "Codex 正在整理当前项目的进展、风险和下一步重点…",
             "Codex is reviewing the project's progress, risks, and next steps…",
-          ));
+          )
+        : summaryLoadFailed || projectSummary?.error
+          ? text("Codex 暂时无法生成项目总结。", "Codex cannot generate the project summary now.")
+          : text(
+              "Codex 正在整理当前项目的进展、风险和下一步重点…",
+              "Codex is reviewing the project's progress, risks, and next steps…",
+            ));
   const hour = new Date().getHours();
   const greeting = hour < 12
     ? text("上午好", "Good morning")


### PR DESCRIPTION
## 产品结果

- 项目总结刷新期间不再继续显示上一次失败，而是显示正在整理。
- 保留全部状态数量，只向总结模型发送未结束事项和最近 7 天更新的完成/取消事项，避免大型项目被全部历史明细拖慢。

## 验证

- 真实 codex-taskboard 数据：362 条议题、约 74.5 KB 明细收窄到 86 条、约 17.8 KB；19 条未结束事项全部保留。
- 隔离真实数据路径：`summary=null + refreshing=true + 旧 error` 显示正在整理；受控生成完成后显示新总结。
- 正常项目的既有总结保持正常。
- `npm run typecheck`、`npm run build:web`、`git diff --check` 通过。

Taskboard: LOCAL-309