### PR TITLE
LOCAL-313 默认隐藏空的「遇到阻碍」栏

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -867,10 +867,8 @@ export function App() {
   const selectedProject = projects.find((project) => project.id === selectedProjectId) ?? null;
   const isAllProjects = selectedProjectId === ALL_PROJECTS_ID;
   const isJiraProject = selectedProject?.source === "jira";
-  const boardDisplaySettings = {
-    ...DEFAULT_BOARD_DISPLAY_SETTINGS,
-    ...projectBoardDisplaySettings[selectedProjectId],
-  };
+  const boardDisplaySettings = projectBoardDisplaySettings[selectedProjectId]
+    ?? DEFAULT_BOARD_DISPLAY_SETTINGS;
   const automationModels = automationCatalog && automationCatalog.projectId === selectedProject?.id
     ? automationCatalog.models
     : [];
@@ -2211,11 +2209,10 @@ export function App() {
     ) as Record<TaskStatus, Task[]>;
   }, [filteredTasks]);
 
-  const showBlockedColumn = !boardDisplaySettings.hideBlockedWhenEmpty
-    || !hasLoadedTasks
-    || tasks.some((task) => task.status === "blocked");
   const mainBoardItems = boardDisplaySettings.mainStatuses.filter(
-    (status) => status !== "blocked" || showBlockedColumn,
+    (status) => status !== "blocked"
+      || !hasLoadedTasks
+      || tasks.some((task) => task.status === "blocked"),
   );
   const mainColumnCount = Math.max(mainBoardItems.length, 1);
   const mainBoardMinWidth = (mainColumnCount * 300) + ((mainColumnCount - 1) * 24);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -867,8 +867,10 @@ export function App() {
   const selectedProject = projects.find((project) => project.id === selectedProjectId) ?? null;
   const isAllProjects = selectedProjectId === ALL_PROJECTS_ID;
   const isJiraProject = selectedProject?.source === "jira";
-  const boardDisplaySettings = projectBoardDisplaySettings[selectedProjectId]
-    ?? DEFAULT_BOARD_DISPLAY_SETTINGS;
+  const boardDisplaySettings = {
+    ...DEFAULT_BOARD_DISPLAY_SETTINGS,
+    ...projectBoardDisplaySettings[selectedProjectId],
+  };
   const automationModels = automationCatalog && automationCatalog.projectId === selectedProject?.id
     ? automationCatalog.models
     : [];
@@ -2209,7 +2211,12 @@ export function App() {
     ) as Record<TaskStatus, Task[]>;
   }, [filteredTasks]);
 
-  const mainBoardItems = boardDisplaySettings.mainStatuses;
+  const showBlockedColumn = !boardDisplaySettings.hideBlockedWhenEmpty
+    || !hasLoadedTasks
+    || tasks.some((task) => task.status === "blocked");
+  const mainBoardItems = boardDisplaySettings.mainStatuses.filter(
+    (status) => status !== "blocked" || showBlockedColumn,
+  );
   const mainColumnCount = Math.max(mainBoardItems.length, 1);
   const mainBoardMinWidth = (mainColumnCount * 300) + ((mainColumnCount - 1) * 24);
   const mainBoardMaxWidth = (mainColumnCount * 400) + ((mainColumnCount - 1) * 24);

--- a/web/src/components/BoardCardDisplayMenu.tsx
+++ b/web/src/components/BoardCardDisplayMenu.tsx
@@ -16,7 +16,6 @@ export type BoardStatusPlacement = "main" | "sidebar" | "hidden";
 export interface BoardDisplaySettings {
   cover: boolean;
   body: boolean;
-  hideBlockedWhenEmpty: boolean;
   mainStatuses: OtherTaskTab[];
   sidebarStatuses: OtherTaskTab[];
   hiddenStatuses: OtherTaskTab[];
@@ -25,7 +24,6 @@ export interface BoardDisplaySettings {
 export const DEFAULT_BOARD_DISPLAY_SETTINGS: BoardDisplaySettings = {
   cover: true,
   body: false,
-  hideBlockedWhenEmpty: true,
   mainStatuses: [...MAIN_STATUSES],
   sidebarStatuses: [...SECONDARY_STATUSES, "archived"],
   hiddenStatuses: [],
@@ -312,6 +310,8 @@ export function BoardCardDisplayMenu({
                         : <StatusIcon status={status as TaskStatus} color="var(--display-status-color)" size={15} />}
                       <span>{status === "archived"
                         ? text("已归档", "Archived")
+                        : status === "blocked"
+                          ? text("遇到阻碍（默认隐藏）", "Blocked (hidden by default)")
                         : taskStatusLabel(language, status)}</span>
                     </div>
                   );
@@ -319,29 +319,6 @@ export function BoardCardDisplayMenu({
               </div>
             </section>
           ))}
-        </div>
-
-        <div className="project-automation-switch display-settings-option">
-          <span>{text(
-            "无阻塞时隐藏「遇到阻碍」栏",
-            "Hide the “Blocked” column when empty",
-          )}</span>
-          <button
-            type="button"
-            className={"board-setting-switch" + (settings.hideBlockedWhenEmpty ? " is-on" : "")}
-            role="switch"
-            aria-label={text(
-              "无阻塞时隐藏「遇到阻碍」栏",
-              "Hide the “Blocked” column when empty",
-            )}
-            aria-checked={settings.hideBlockedWhenEmpty}
-            onClick={() => onChange({
-              ...settings,
-              hideBlockedWhenEmpty: !settings.hideBlockedWhenEmpty,
-            })}
-          >
-            <span aria-hidden="true" />
-          </button>
         </div>
 
         <footer className="display-settings-footer">

--- a/web/src/components/BoardCardDisplayMenu.tsx
+++ b/web/src/components/BoardCardDisplayMenu.tsx
@@ -16,6 +16,7 @@ export type BoardStatusPlacement = "main" | "sidebar" | "hidden";
 export interface BoardDisplaySettings {
   cover: boolean;
   body: boolean;
+  hideBlockedWhenEmpty: boolean;
   mainStatuses: OtherTaskTab[];
   sidebarStatuses: OtherTaskTab[];
   hiddenStatuses: OtherTaskTab[];
@@ -24,6 +25,7 @@ export interface BoardDisplaySettings {
 export const DEFAULT_BOARD_DISPLAY_SETTINGS: BoardDisplaySettings = {
   cover: true,
   body: false,
+  hideBlockedWhenEmpty: true,
   mainStatuses: [...MAIN_STATUSES],
   sidebarStatuses: [...SECONDARY_STATUSES, "archived"],
   hiddenStatuses: [],
@@ -317,6 +319,29 @@ export function BoardCardDisplayMenu({
               </div>
             </section>
           ))}
+        </div>
+
+        <div className="project-automation-switch display-settings-option">
+          <span>{text(
+            "无阻塞时隐藏「遇到阻碍」栏",
+            "Hide the “Blocked” column when empty",
+          )}</span>
+          <button
+            type="button"
+            className={"board-setting-switch" + (settings.hideBlockedWhenEmpty ? " is-on" : "")}
+            role="switch"
+            aria-label={text(
+              "无阻塞时隐藏「遇到阻碍」栏",
+              "Hide the “Blocked” column when empty",
+            )}
+            aria-checked={settings.hideBlockedWhenEmpty}
+            onClick={() => onChange({
+              ...settings,
+              hideBlockedWhenEmpty: !settings.hideBlockedWhenEmpty,
+            })}
+          >
+            <span aria-hidden="true" />
+          </button>
         </div>
 
         <footer className="display-settings-footer">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1404,11 +1404,6 @@ kbd {
   content: "";
 }
 
-.display-settings-option {
-  flex: 0 0 auto;
-  padding: 0 18px 12px;
-}
-
 .display-settings-footer {
   flex: 0 0 auto;
   gap: 8px;
@@ -1430,8 +1425,7 @@ kbd {
   }
 
   .display-settings-header,
-  .display-settings-footer,
-  .display-settings-option {
+  .display-settings-footer {
     padding-right: 12px;
     padding-left: 12px;
   }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1404,6 +1404,11 @@ kbd {
   content: "";
 }
 
+.display-settings-option {
+  flex: 0 0 auto;
+  padding: 0 18px 12px;
+}
+
 .display-settings-footer {
   flex: 0 0 auto;
   gap: 8px;
@@ -1425,7 +1430,8 @@ kbd {
   }
 
   .display-settings-header,
-  .display-settings-footer {
+  .display-settings-footer,
+  .display-settings-option {
     padding-right: 12px;
     padding-left: 12px;
   }


### PR DESCRIPTION
## Summary

- 在真实项目没有 blocked 议题时，加载完成后自动隐藏「遇到阻碍」栏
- 项目存在 blocked 议题时保留该栏
- 在「更多显示设置」中显示「遇到阻碍（默认隐藏）」；不增加开关或持久化设置

## Verification

- 用户已确认真实 Taskboard 数据 Demo 的功能与视觉
- `npm run typecheck`
- `npm run build:web`
- `git diff --check origin/main...HEAD`

## Review

低风险 Agent review：通过，无阻塞问题。