### PR TITLE
fix: route Taskboard work to Codex SSH projects

### DIFF
--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -514,6 +514,9 @@
           projectKind: "remote",
           workspacePath,
           hostId,
+          name: typeof project?.label === "string" && project.label.trim()
+            ? project.label.trim()
+            : id,
         });
       });
     }
@@ -538,7 +541,7 @@
 
   function readCodexProjects(metadata = codexProjectMetadata) {
     const seen = new Set();
-    return Array.from(document.querySelectorAll("[data-app-action-sidebar-project-row]"))
+    const projects = Array.from(document.querySelectorAll("[data-app-action-sidebar-project-row]"))
       .flatMap((row) => {
         const id = row.getAttribute("data-app-action-sidebar-project-id")?.trim();
         const name = (
@@ -550,6 +553,11 @@
         seen.add(id);
         return [{ id, name, ...metadata.get(id) }];
       });
+    for (const [id, project] of metadata) {
+      if (project.projectKind !== "remote" || seen.has(id)) continue;
+      projects.push({ id, ...project });
+    }
+    return projects;
   }
 
   function findProjectsSection() {

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -1208,10 +1208,11 @@ function remoteAutomationTarget(request, task) {
 }
 
 function eligibleRemoteAutomationTask(task) {
+  const remoteBinding = task?.threadBinding?.codexProjectKind === "remote"
+    && task.threadId === task.threadBinding.threadId;
   return task?.status === "todo"
     && task.archivedAt === null
-    && !task.threadId
-    && !task.threadBinding
+    && ((!task.threadId && !task.threadBinding) || remoteBinding)
     && (task.relations?.blockedBy ?? []).every((dependency) => dependency.status === "done");
 }
 
@@ -1308,7 +1309,10 @@ async function runRemoteTaskboardAutomation(record) {
     taskboardRequest(attachmentsPath),
   ]);
   if (!eligibleRemoteAutomationTask(task) || task.projectId !== request.taskboardProjectId) return;
-  const target = remoteAutomationTarget(request, task);
+  const existingBinding = task.threadBinding?.codexProjectKind === "remote"
+    ? task.threadBinding
+    : null;
+  const target = existingBinding ?? remoteAutomationTarget(request, task);
   if (!target) {
     await taskboardRequest(commentsPath, {
       method: "POST",
@@ -1322,8 +1326,9 @@ async function runRemoteTaskboardAutomation(record) {
     cdp,
     undefined,
     target.codexHostId,
-    "thread/start",
+    existingBinding ? "thread/resume" : "thread/start",
     {
+      ...(existingBinding ? { threadId: existingBinding.threadId } : {}),
       model: request.model,
       cwd: target.workspacePath,
       runtimeWorkspaceRoots: [target.workspacePath],
@@ -1337,7 +1342,7 @@ async function runRemoteTaskboardAutomation(record) {
     || !threadId
     || normalizeRemoteWorkspace(started.thread.cwd) !== normalizeRemoteWorkspace(target.workspacePath)
   ) {
-    throw new Error("Codex did not create the automation thread in the selected SSH workspace");
+    throw new Error(`Codex did not ${existingBinding ? "resume" : "create"} the automation thread in the selected SSH workspace`);
   }
 
   const refreshed = await Promise.all([
@@ -1348,7 +1353,9 @@ async function runRemoteTaskboardAutomation(record) {
   const refreshedTask = refreshed[0].task;
   const refreshedComments = refreshed[1].comments;
   const refreshedAttachments = refreshed[2].attachments;
-  const refreshedTarget = remoteAutomationTarget(request, refreshedTask);
+  const refreshedTarget = refreshedTask.threadBinding?.codexProjectKind === "remote"
+    ? refreshedTask.threadBinding
+    : remoteAutomationTarget(request, refreshedTask);
   if (
     !eligibleRemoteAutomationTask(refreshedTask)
     || remoteAutomationSnapshot(refreshedTask, refreshedComments, refreshedAttachments) !== snapshot
@@ -1356,9 +1363,10 @@ async function runRemoteTaskboardAutomation(record) {
     || refreshedTarget?.codexProjectKind !== target.codexProjectKind
     || refreshedTarget?.codexHostId !== target.codexHostId
     || refreshedTarget?.workspacePath !== target.workspacePath
+    || refreshedTarget?.threadId !== target.threadId
   ) return;
 
-  const threadBinding = {
+  const threadBinding = existingBinding ?? {
     threadId,
     codexProjectId: target.codexProjectId,
     codexProjectKind: "remote",

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -82,6 +82,7 @@ const hostRequestMessage = "__codexTaskboardHostRequestV1";
 const hostResponseMessage = "__codexTaskboardHostResponseV1";
 const hostHeartbeatMessage = "__codexTaskboardHostHeartbeatV1";
 const hostStartupTokenName = "__codexTaskboardHostStartupTokenV1";
+const codexNotificationBindingName = "__codexTaskboardCodexNotificationV1";
 const hostCapability = randomUUID();
 const injectionSourceHashName = "__CODEX_TASKBOARD_SOURCE_HASH__";
 const injectionScriptIdentifierName = "__CODEX_TASKBOARD_SCRIPT_IDENTIFIER__";
@@ -103,6 +104,7 @@ const quotaPolicyRestorePromises = new WeakMap();
 let quotaPoliciesLoadPromise = null;
 let quotaPoliciesWritePromise = Promise.resolve();
 const taskConversationAppServerTimeoutMs = 30_000;
+const remoteAutomationTurnTimeoutMs = 30 * 60_000;
 
 function parseArgs(argv) {
   const options = {
@@ -213,18 +215,42 @@ async function waitUntilTaskboardReachable(timeoutMs) {
   throw new Error(`Timed out waiting for authenticated ${taskboardHealthUrl}`);
 }
 
-function startTaskboard({ detached }) {
-  const stdio = taskboardListenFd === null
-    ? (detached ? "ignore" : "inherit")
+function startTaskboard({ detached, onCodexAppServerRequest }) {
+  const baseStdio = taskboardListenFd === null
+    ? Array(3).fill(detached ? "ignore" : "inherit")
     : Array.from(
       { length: taskboardListenFd + 1 },
       (_, fd) => (fd === taskboardListenFd ? "inherit" : (fd < 3 && !detached ? "inherit" : "ignore")),
     );
-  return spawn(process.execPath, [path.join(projectRoot, "server", "index.mjs")], {
+  const child = spawn(process.execPath, [path.join(projectRoot, "server", "index.mjs")], {
     cwd: projectRoot,
     detached,
-    stdio,
+    stdio: [...baseStdio, "ipc"],
   });
+  child.on("message", (message) => {
+    if (message?.type !== "taskboard:codex-app-server-request") return;
+    void Promise.resolve(onCodexAppServerRequest(message)).then(
+      (result) => {
+        if (!child.connected) return;
+        child.send({
+          type: "taskboard:codex-app-server-response",
+          requestId: message.requestId,
+          hostId: message.hostId,
+          result,
+        });
+      },
+      (error) => {
+        if (!child.connected) return;
+        child.send({
+          type: "taskboard:codex-app-server-response",
+          requestId: message.requestId,
+          hostId: message.hostId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      },
+    );
+  });
+  return child;
 }
 
 async function publishTaskboardRuntime() {
@@ -1130,11 +1156,347 @@ async function requestCodexAppServerViaCdp(
   return response.result;
 }
 
+async function taskboardRequest(pathname, { method = "GET", body } = {}) {
+  const response = await fetch(`${taskboardBaseUrl}${pathname}`, {
+    method,
+    cache: "no-store",
+    headers: {
+      accept: "application/json",
+      "x-taskboard-client": "taskctl",
+      ...(body === undefined ? {} : { "content-type": "application/json" }),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+  const text = await response.text();
+  let payload = {};
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      throw new Error(`Taskboard returned invalid JSON for ${method} ${pathname}`);
+    }
+  }
+  if (!response.ok) {
+    throw new Error(
+      payload?.error?.message || `Taskboard returned HTTP ${response.status} for ${method} ${pathname}`,
+    );
+  }
+  return payload;
+}
+
+function normalizeRemoteWorkspace(value) {
+  const workspacePath = String(value || "").trim().replaceAll("\\", "/").replace(/\/+$/, "");
+  return /^[A-Za-z]:/.test(workspacePath)
+    ? `${workspacePath[0].toLowerCase()}${workspacePath.slice(1)}`
+    : workspacePath;
+}
+
+function remoteAutomationTarget(request, task) {
+  const workspacePath = task.developmentContext?.type === "worktree"
+    ? task.developmentContext.path
+    : request.workspacePath;
+  const matches = (request.remoteProjects ?? []).filter((project) => (
+    project.codexProjectKind === "remote"
+    && project.codexHostId === request.codexHostId
+    && normalizeRemoteWorkspace(project.workspacePath) === normalizeRemoteWorkspace(workspacePath)
+    && (
+      task.developmentContext?.type === "worktree"
+      || project.codexProjectId === request.codexProjectId
+    )
+  ));
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function eligibleRemoteAutomationTask(task) {
+  return task?.status === "todo"
+    && task.archivedAt === null
+    && !task.threadId
+    && !task.threadBinding
+    && (task.relations?.blockedBy ?? []).every((dependency) => dependency.status === "done");
+}
+
+function remoteAutomationSnapshot(task, comments, attachments) {
+  return JSON.stringify({
+    task: {
+      version: task.version,
+      projectId: task.projectId,
+      title: task.title,
+      description: task.description,
+      developmentContext: task.developmentContext,
+      blockedBy: (task.relations?.blockedBy ?? []).map((dependency) => [
+        dependency.id,
+        dependency.status,
+      ]),
+    },
+    comments: comments.map((comment) => [
+      comment.id,
+      comment.version,
+      comment.body,
+      (comment.attachments ?? []).map((attachment) => [
+        attachment.id,
+        attachment.filename,
+        attachment.contentType,
+        attachment.size,
+      ]),
+    ]),
+    attachments: attachments.map((attachment) => [
+      attachment.id,
+      attachment.filename,
+      attachment.contentType,
+      attachment.size,
+    ]),
+  });
+}
+
+function remoteAutomationPrompt(task, comments, attachments, target) {
+  const commentText = comments.length > 0
+    ? comments.map((comment) => (
+      `- ${comment.authorName} (${comment.createdAt}):\n${comment.body}`
+    )).join("\n\n")
+    : "（无）";
+  const attachmentItems = [
+    ...attachments,
+    ...comments.flatMap((comment) => comment.attachments ?? []),
+  ];
+  const attachmentText = attachmentItems.length > 0
+    ? attachmentItems.map((attachment) => (
+      `- ${attachment.filename} (${attachment.contentType}, ${attachment.size} bytes)`
+    )).join("\n")
+    : "（无）";
+  const developmentContext = task.developmentContext
+    ? JSON.stringify(task.developmentContext)
+    : "（项目根目录）";
+  return [
+    `处理 Taskboard 议题 ${task.identifier}：${task.title}`,
+    "",
+    `远程工作目录：${target.workspacePath}`,
+    `开发上下文：${developmentContext}`,
+    "",
+    "完整描述：",
+    task.description || "（无）",
+    "",
+    "全部评论：",
+    commentText,
+    "",
+    "附件：",
+    attachmentText,
+    "",
+    "你只负责在当前远程项目和工作目录内完成实现与直接验证。不要运行 taskctl，也不要访问或修改 Taskboard。完成后返回改动、验证结果、执行结果和剩余限制。",
+  ].join("\n");
+}
+
+async function runRemoteTaskboardAutomation(record) {
+  const { request, version } = record;
+  if (
+    !request.enabledByUser
+    || request.codexProjectKind !== "remote"
+    || quotaPolicyRecords.get(request.taskboardProjectId)?.version !== version
+  ) return;
+
+  const listed = await taskboardRequest(
+    `/api/tasks?projectId=${encodeURIComponent(request.taskboardProjectId)}&status=todo`,
+  );
+  const listedTask = listed.tasks?.find(eligibleRemoteAutomationTask);
+  if (!listedTask) return;
+
+  const taskPath = `/api/tasks/${encodeURIComponent(listedTask.id)}`;
+  const commentsPath = `${taskPath}/comments`;
+  const attachmentsPath = `${taskPath}/attachments`;
+  const [{ task }, { comments }, { attachments }] = await Promise.all([
+    taskboardRequest(taskPath),
+    taskboardRequest(commentsPath),
+    taskboardRequest(attachmentsPath),
+  ]);
+  if (!eligibleRemoteAutomationTask(task) || task.projectId !== request.taskboardProjectId) return;
+  const target = remoteAutomationTarget(request, task);
+  if (!target) {
+    await taskboardRequest(commentsPath, {
+      method: "POST",
+      body: { body: "自动认领未开始：目标 SSH 工作目录没有唯一的已登记 Codex 项目映射。" },
+    });
+    return;
+  }
+  const snapshot = remoteAutomationSnapshot(task, comments, attachments);
+  const cdp = currentQuotaPolicyCdp();
+  const started = await requestCodexAppServerViaCdp(
+    cdp,
+    undefined,
+    target.codexHostId,
+    "thread/start",
+    {
+      model: request.model,
+      cwd: target.workspacePath,
+      runtimeWorkspaceRoots: [target.workspacePath],
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+    },
+  );
+  const threadId = started?.thread?.id;
+  if (
+    typeof threadId !== "string"
+    || !threadId
+    || normalizeRemoteWorkspace(started.thread.cwd) !== normalizeRemoteWorkspace(target.workspacePath)
+  ) {
+    throw new Error("Codex did not create the automation thread in the selected SSH workspace");
+  }
+
+  const refreshed = await Promise.all([
+    taskboardRequest(taskPath),
+    taskboardRequest(commentsPath),
+    taskboardRequest(attachmentsPath),
+  ]);
+  const refreshedTask = refreshed[0].task;
+  const refreshedComments = refreshed[1].comments;
+  const refreshedAttachments = refreshed[2].attachments;
+  const refreshedTarget = remoteAutomationTarget(request, refreshedTask);
+  if (
+    !eligibleRemoteAutomationTask(refreshedTask)
+    || remoteAutomationSnapshot(refreshedTask, refreshedComments, refreshedAttachments) !== snapshot
+    || refreshedTarget?.codexProjectId !== target.codexProjectId
+    || refreshedTarget?.codexProjectKind !== target.codexProjectKind
+    || refreshedTarget?.codexHostId !== target.codexHostId
+    || refreshedTarget?.workspacePath !== target.workspacePath
+  ) return;
+
+  const threadBinding = {
+    threadId,
+    codexProjectId: target.codexProjectId,
+    codexProjectKind: "remote",
+    codexHostId: target.codexHostId,
+    workspacePath: target.workspacePath,
+  };
+  let ownedTask = (
+    await taskboardRequest(`${taskPath}/move`, {
+      method: "POST",
+      body: {
+        version: refreshedTask.version,
+        status: "in_progress",
+        threadId,
+        threadBinding,
+      },
+    })
+  ).task;
+
+  try {
+    const turnStarted = await requestCodexAppServerViaCdp(
+      cdp,
+      undefined,
+      target.codexHostId,
+      "turn/start",
+      {
+        threadId,
+        input: [{
+          type: "text",
+          text: remoteAutomationPrompt(
+            refreshedTask,
+            refreshedComments,
+            refreshedAttachments,
+            target,
+          ),
+        }],
+        effort: request.reasoningEffort,
+      },
+    );
+    const turnId = turnStarted?.turn?.id;
+    if (typeof turnId !== "string" || !turnId) {
+      throw new Error("Codex did not return the remote automation turn id");
+    }
+
+    const deadline = Date.now() + remoteAutomationTurnTimeoutMs;
+    let finalText = "";
+    while (Date.now() < deadline) {
+      let read;
+      try {
+        read = await requestCodexAppServerViaCdp(
+          cdp,
+          undefined,
+          target.codexHostId,
+          "thread/read",
+          { threadId, includeTurns: true },
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!message.includes("rollout") || !message.includes("is empty")) throw error;
+        await new Promise((resolve) => setTimeout(resolve, 1_000));
+        continue;
+      }
+      const turn = read?.thread?.turns?.find((candidate) => candidate.id === turnId);
+      if (turn?.status === "completed") {
+        finalText = [...turn.items].reverse().find((item) => item.type === "agentMessage")?.text?.trim() || "";
+        if (!finalText) throw new Error("Codex completed without a final result");
+        break;
+      }
+      if (turn?.status === "failed" || turn?.status === "interrupted") {
+        throw new Error(turn.error?.message || `Codex remote turn ${turn.status}`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1_000));
+    }
+    if (!finalText) throw new Error("Codex remote automation turn timed out");
+
+    await taskboardRequest(commentsPath, {
+      method: "POST",
+      body: {
+        body: [
+          "自动认领远程执行完成。",
+          `- Codex host：${target.codexHostId}`,
+          `- 远程目录：${target.workspacePath}`,
+          `- 远程 thread：${threadId}`,
+          "",
+          finalText,
+        ].join("\n").slice(0, 100_000),
+        threadId,
+        threadBinding,
+      },
+    });
+    ownedTask = (
+      await taskboardRequest(`${taskPath}/move`, {
+        method: "POST",
+        body: {
+          version: ownedTask.version,
+          status: "in_review",
+          threadId,
+          threadBinding,
+        },
+      })
+    ).task;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await taskboardRequest(commentsPath, {
+      method: "POST",
+      body: {
+        body: `自动认领远程执行失败：${message}`.slice(0, 100_000),
+        threadId,
+        threadBinding,
+      },
+    });
+    await taskboardRequest(`${taskPath}/move`, {
+      method: "POST",
+      body: {
+        version: ownedTask.version,
+        status: "blocked",
+        threadId,
+        threadBinding,
+      },
+    });
+  }
+}
+
+function remoteAutomationItem(request, status, nextRunAt) {
+  return {
+    id: request.automationId || `taskboard-${request.taskboardProjectId}`,
+    status,
+    model: request.model,
+    reasoningEffort: request.reasoningEffort,
+    rrule: `RRULE:FREQ=MINUTELY;INTERVAL=${request.intervalMinutes}`,
+    nextRunAt: status === "ACTIVE" ? nextRunAt : null,
+  };
+}
+
 async function applyTaskboardAutomationPolicy(
   request,
   rpc,
   stillCurrent = () => true,
-  { explicit = false, previousQuotaState } = {},
+  { explicit = false, previousQuotaState, remoteNextRunAt } = {},
 ) {
   const todoResponse = request.enabledByUser
     ? await fetch(
@@ -1154,6 +1516,39 @@ async function applyTaskboardAutomationPolicy(
     ? await readCodexQuotaStatus(request.model)
     : null;
   if (!stillCurrent()) return { quota, stale: true };
+  if (request.codexProjectKind === "remote") {
+    const currentStatus = request.enabledByUser
+      && (!request.quotaAware || previousQuotaState === "available")
+      ? "ACTIVE"
+      : "PAUSED";
+    const currentItem = remoteAutomationItem(request, currentStatus, remoteNextRunAt);
+    const operation = taskboardAutomationPolicyOperation(request, {
+      explicit,
+      hasTodo,
+      previousQuotaState,
+      quotaState: quota?.state,
+      currentStatus,
+    });
+    const status = operation === "pause" ? "PAUSED" : "ACTIVE";
+    const existingNextRunAt = Number(remoteNextRunAt);
+    const nextRunAt = status === "ACTIVE"
+      ? (
+        Number.isFinite(existingNextRunAt) && existingNextRunAt > Date.now()
+          ? existingNextRunAt
+          : Date.now() + request.intervalMinutes * 60_000
+      )
+      : null;
+    const item = operation === "list"
+      ? currentItem
+      : remoteAutomationItem(request, status, nextRunAt);
+    return {
+      item,
+      items: [item],
+      operation,
+      hasTodo,
+      ...(quota ? { quota } : {}),
+    };
+  }
   let listed = null;
   let currentItem;
   if (!explicit && request.enabledByUser) {
@@ -1202,7 +1597,7 @@ function storedAutomationPolicy(request) {
 
 function restoredAutomationPolicy(value) {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  const { quota, ...stored } = value;
+  const { nextRunAt, quota, ...stored } = value;
   const request = parseTaskboardAutomationHostRequest({
     ...stored,
     id: "restored-policy",
@@ -1210,7 +1605,13 @@ function restoredAutomationPolicy(value) {
     requestId: "restored-policy",
     operation: "apply-policy",
   });
-  return request ? { request, ...(quota ? { quota } : {}) } : null;
+  return request
+    ? {
+      request,
+      ...(quota ? { quota } : {}),
+      ...(Number.isFinite(nextRunAt) ? { nextRunAt } : {}),
+    }
+    : null;
 }
 
 async function ensureQuotaPoliciesLoaded() {
@@ -1242,6 +1643,7 @@ function persistQuotaPolicies() {
       {
         ...storedAutomationPolicy(record.request),
         ...(record.quota ? { quota: record.quota } : {}),
+        ...(Number.isFinite(record.nextRunAt) ? { nextRunAt: record.nextRunAt } : {}),
       },
     ]),
   );
@@ -1284,7 +1686,10 @@ function scheduleQuotaPolicyCheck(record, result) {
 
   const nextRunAt = Number(result.item?.nextRunAt);
   const nextRunDelay = Number.isFinite(nextRunAt) && nextRunAt > Date.now()
-    ? Math.max(1_000, nextRunAt - Date.now() - 15_000)
+    ? Math.max(
+      1_000,
+      nextRunAt - Date.now() - (request.codexProjectKind === "remote" ? 0 : 15_000),
+    )
     : 60_000;
   const resetDelay = result.quota?.state === "blocked"
     && Number.isFinite(result.quota.resetsAt)
@@ -1293,6 +1698,9 @@ function scheduleQuotaPolicyCheck(record, result) {
   const timer = setTimeout(async () => {
     if (quotaPolicyRecords.get(key)?.version !== version) return;
     try {
+      if (request.codexProjectKind === "remote" && result.item?.status === "ACTIVE") {
+        await runRemoteTaskboardAutomation(record);
+      }
       await enqueueCurrentQuotaPolicy(key);
     } catch (error) {
       console.error(`Taskboard quota policy check failed: ${error.message}`);
@@ -1321,6 +1729,7 @@ function enqueueQuotaPolicyMutation(record, rpc, { explicit = false } = {}) {
         {
           explicit,
           previousQuotaState: current.quota?.state,
+          remoteNextRunAt: current.nextRunAt,
         },
       );
       if (result.stale) return result;
@@ -1333,6 +1742,14 @@ function enqueueQuotaPolicyMutation(record, rpc, { explicit = false } = {}) {
       }
       if (result.item?.id) {
         current.request = { ...current.request, automationId: result.item.id };
+      }
+      if (current.request.codexProjectKind === "remote") {
+        const nextRunAt = Number(result.item?.nextRunAt);
+        if (result.item?.status === "ACTIVE" && Number.isFinite(nextRunAt)) {
+          current.nextRunAt = nextRunAt;
+        } else {
+          delete current.nextRunAt;
+        }
       }
       if (current.request.quotaAware && result.quota) current.quota = result.quota;
       else if (!current.request.quotaAware) delete current.quota;
@@ -1666,13 +2083,30 @@ async function sendHostResponse(cdp, executionContextId, response) {
   });
 }
 
-function installTaskboardHostBinding(cdp, supervisor, startupToken) {
+function installTaskboardHostBinding(
+  cdp,
+  supervisor,
+  startupToken,
+  onCodexAppServerNotification,
+  onCodexAppServerReady,
+) {
   let activeContextId = null;
   let installInFlight = null;
 
   cdp.on("Runtime.bindingCalled", async (params) => {
-    if (params.name !== hostBindingName) return;
     if (params.executionContextId !== activeContextId) return;
+    if (params.name === codexNotificationBindingName) {
+      try {
+        const notification = JSON.parse(params.payload);
+        if (
+          notification
+          && typeof notification.hostId === "string"
+          && typeof notification.method === "string"
+        ) onCodexAppServerNotification(cdp, notification);
+      } catch {}
+      return;
+    }
+    if (params.name !== hostBindingName) return;
     await handleHostBindingPayload(params, {
       isAuthorizedContext: (executionContextId) => executionContextId === activeContextId,
       parseAutomationRequest: parseTaskboardAutomationHostRequest,
@@ -1697,7 +2131,11 @@ function installTaskboardHostBinding(cdp, supervisor, startupToken) {
               request,
               rpc,
             );
-            return stored ?? reconcileTaskboardAutomation(request, rpc);
+            return stored ?? (
+              request.codexProjectKind === "remote"
+                ? { items: [] }
+                : reconcileTaskboardAutomation(request, rpc)
+            );
           }
           return request.operation === "apply-policy"
             ? updateAndApplyQuotaPolicy(request, rpc)
@@ -1726,6 +2164,10 @@ function installTaskboardHostBinding(cdp, supervisor, startupToken) {
         name: hostBindingName,
         executionContextId: activeContextId,
       });
+      await cdp.send("Runtime.addBinding", {
+        name: codexNotificationBindingName,
+        executionContextId: activeContextId,
+      });
       await cdp.send("Runtime.evaluate", {
         contextId: activeContextId,
         expression: `(() => {
@@ -1735,10 +2177,24 @@ function installTaskboardHostBinding(cdp, supervisor, startupToken) {
           window.addEventListener("message", (event) => {
             const message = event.data;
             if (
+              !message
+              || typeof message !== "object"
+            ) return;
+            if (
+              message.type === "mcp-notification"
+              && typeof message.hostId === "string"
+              && typeof message.method === "string"
+            ) {
+              globalThis[${JSON.stringify(codexNotificationBindingName)}](JSON.stringify({
+                hostId: message.hostId,
+                method: message.method,
+                params: message.params
+              }));
+              return;
+            }
+            if (
               event.source !== window
               || event.origin !== window.location.origin
-              || !message
-              || typeof message !== "object"
               || message.type !== ${JSON.stringify(hostRequestMessage)}
               || message.capability !== capability
             ) return;
@@ -1747,6 +2203,7 @@ function installTaskboardHostBinding(cdp, supervisor, startupToken) {
         })()`,
         returnByValue: true,
       });
+      onCodexAppServerReady(cdp);
       await restoreQuotaPolicies(cdp);
       return activeContextId;
     })();
@@ -1861,11 +2318,20 @@ async function injectTarget(
   supervisor,
   attachExisting,
   startupToken,
+  onCodexAppServerNotification,
+  onCodexAppServerReady,
+  onCodexAppServerUnavailable,
 ) {
   const cdp = await runtime.connect(target);
   let retained = false;
   const hostBridge = keepAlive
-    ? installTaskboardHostBinding(cdp, supervisor, startupToken)
+    ? installTaskboardHostBinding(
+        cdp,
+        supervisor,
+        startupToken,
+        onCodexAppServerNotification,
+        onCodexAppServerReady,
+      )
     : null;
   cdp.hostBridge = hostBridge;
   try {
@@ -1963,6 +2429,7 @@ async function injectTarget(
     return { result, connection: retained ? cdp : null };
   } finally {
     if (!retained) {
+      onCodexAppServerUnavailable(cdp);
       unregisterQuotaPolicyCdp(cdp);
       cdp.close();
     }
@@ -1980,6 +2447,9 @@ async function injectAll(
   supervisor,
   attachExisting,
   startupToken,
+  onCodexAppServerNotification,
+  onCodexAppServerReady,
+  onCodexAppServerUnavailable,
 ) {
   const targets = await runtime.targets();
   if (targets.length === 0) {
@@ -1990,6 +2460,7 @@ async function injectAll(
   const activeIds = new Set(targets.map((target) => target.id));
   for (const [id, connection] of injectedTargets) {
     if (!activeIds.has(id) || connection.closed) {
+      onCodexAppServerUnavailable(connection);
       unregisterQuotaPolicyCdp(connection);
       connection.close();
       injectedTargets.delete(id);
@@ -2011,6 +2482,9 @@ async function injectAll(
       supervisor,
       attachExisting,
       startupToken,
+      onCodexAppServerNotification,
+      onCodexAppServerReady,
+      onCodexAppServerUnavailable,
     );
     if (connection) injectedTargets.set(target.id, connection);
     results.push({ targetId: target.id, title: target.title, url: target.url, ...result });
@@ -2108,6 +2582,27 @@ async function main() {
   let nativeCodexBrowser = false;
   let runtimePublishPromise = null;
   const injectedTargets = new Map();
+  const remoteCodexConnections = new Map();
+  const routableCodexConnections = new Set();
+  const codexRendererWaiters = new Set();
+  const waitForCodexRenderer = () => new Promise((resolve) => {
+    codexRendererWaiters.add(resolve);
+  });
+  const wakeCodexRendererRequests = () => {
+    for (const resolve of codexRendererWaiters) resolve();
+    codexRendererWaiters.clear();
+  };
+  const registerRoutableCodexConnection = (connection) => {
+    routableCodexConnections.add(connection);
+    wakeCodexRendererRequests();
+  };
+  const unregisterRoutableCodexConnection = (connection) => {
+    routableCodexConnections.delete(connection);
+    for (const [hostId, current] of remoteCodexConnections) {
+      if (current === connection) remoteCodexConnections.delete(hostId);
+    }
+  };
+  let taskboardChild = null;
   let idleAfterNormalExit = false;
   let openRequestGeneration = options.open ? 1 : 0;
   let openedRequestGeneration = 0;
@@ -2170,6 +2665,7 @@ async function main() {
   const requestStop = () => {
     if (stopping) return;
     stopping = true;
+    wakeCodexRendererRequests();
     wakeStop();
     cleanup().catch((error) => {
       console.error(`Cleanup failed: ${error.message}`);
@@ -2188,11 +2684,64 @@ async function main() {
     console.log(JSON.stringify({ openTaskboardSignalReady: true }));
   }
   const detached = !options.watch;
+  const codexConnectionForHost = async (hostId) => {
+    while (!stopping) {
+      for (const connection of routableCodexConnections) {
+        if (connection.closed) routableCodexConnections.delete(connection);
+      }
+      const current = remoteCodexConnections.get(hostId);
+      if (current && routableCodexConnections.has(current)) {
+        return current;
+      }
+      const connection = routableCodexConnections.values().next().value;
+      if (connection) {
+        remoteCodexConnections.set(hostId, connection);
+        return connection;
+      }
+      await waitForCodexRenderer();
+    }
+    throw new Error("Codex renderer stopped before the remote request was sent");
+  };
+  const handleCodexAppServerRequest = async (message) => {
+    if (
+      typeof message.requestId !== "string"
+      || typeof message.hostId !== "string"
+      || typeof message.method !== "string"
+    ) throw new Error("Invalid Codex host request");
+    const connection = await codexConnectionForHost(message.hostId);
+    return requestCodexAppServerViaCdp(
+      connection,
+      undefined,
+      message.hostId,
+      message.method,
+      message.params,
+    );
+  };
+  const forwardCodexAppServerNotification = (cdp, notification) => {
+    if (remoteCodexConnections.get(notification.hostId) !== cdp) return;
+    if (!taskboardChild?.connected) return;
+    taskboardChild.send({
+      type: "taskboard:codex-app-server-notification",
+      hostId: notification.hostId,
+      method: notification.method,
+      params: notification.params,
+    });
+  };
   const supervisor = createTaskboardSupervisor({
     detached,
     isReachable: isTaskboardReachable,
     waitUntilReachable: waitUntilTaskboardReachable,
-    start: () => startTaskboard({ detached }),
+    start: () => {
+      const child = startTaskboard({
+        detached,
+        onCodexAppServerRequest: handleCodexAppServerRequest,
+      });
+      taskboardChild = child;
+      child.once("exit", () => {
+        if (taskboardChild === child) taskboardChild = null;
+      });
+      return child;
+    },
     onProcessError: (error) => {
       console.error(`Taskboard process error: ${error.message}`);
     },
@@ -2288,6 +2837,7 @@ async function main() {
     if (cleanupPromise) return cleanupPromise;
     cleanupPromise = (async () => {
       injectedTargets.forEach((connection) => {
+        unregisterRoutableCodexConnection(connection);
         unregisterQuotaPolicyCdp(connection);
         connection.close();
       });
@@ -2416,6 +2966,9 @@ async function main() {
           supervisor,
           options.attachExisting,
           options.startupToken,
+          forwardCodexAppServerNotification,
+          registerRoutableCodexConnection,
+          unregisterRoutableCodexConnection,
         );
       } catch (error) {
         if (!options.watch) throw error;
@@ -2493,6 +3046,9 @@ async function main() {
           supervisor,
           options.attachExisting,
           options.startupToken,
+          forwardCodexAppServerNotification,
+          registerRoutableCodexConnection,
+          unregisterRoutableCodexConnection,
         );
         if (results.length > 0) {
           console.log(JSON.stringify({ injected: results }, null, 2));
@@ -2516,6 +3072,7 @@ async function main() {
           }
           if (launchedCodex?.exitCode === 0) {
             injectedTargets.forEach((connection) => {
+              unregisterRoutableCodexConnection(connection);
               unregisterQuotaPolicyCdp(connection);
               connection.close();
             });
@@ -2543,6 +3100,7 @@ async function main() {
             .some((record) => record.pid === codexAppPid);
         if (launchedCodexExited) {
           injectedTargets.forEach((connection) => {
+            unregisterRoutableCodexConnection(connection);
             unregisterQuotaPolicyCdp(connection);
             connection.close();
           });

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -101,6 +101,7 @@ const quotaPolicyQueues = new Map();
 const quotaPolicyCdps = new Set();
 const restoredQuotaPolicyCdps = new WeakSet();
 const quotaPolicyRestorePromises = new WeakMap();
+const remoteAutomationDecisionWaiters = new Map();
 let quotaPoliciesLoadPromise = null;
 let quotaPoliciesWritePromise = Promise.resolve();
 const taskConversationAppServerTimeoutMs = 30_000;
@@ -1286,6 +1287,127 @@ function remoteAutomationPrompt(task, comments, attachments, target) {
   ].join("\n");
 }
 
+function waitForRemoteAutomationDecision(hostId, threadId) {
+  const key = `${hostId}\0${threadId}`;
+  let cancel;
+  const promise = new Promise((resolve, reject) => {
+    const finish = (error, answer) => {
+      clearTimeout(timer);
+      remoteAutomationDecisionWaiters.delete(key);
+      if (error) reject(error);
+      else resolve(answer);
+    };
+    const timer = setTimeout(
+      () => finish(new Error("Codex 自动认领判断超时")),
+      remoteAutomationTurnTimeoutMs,
+    );
+    timer.unref();
+    remoteAutomationDecisionWaiters.set(key, { finish });
+    cancel = () => {
+      clearTimeout(timer);
+      remoteAutomationDecisionWaiters.delete(key);
+    };
+  });
+  return { promise, cancel };
+}
+
+function handleRemoteAutomationDecisionNotification(notification) {
+  const params = notification.params;
+  const waiter = remoteAutomationDecisionWaiters.get(
+    `${notification.hostId}\0${params?.threadId}`,
+  );
+  if (!waiter) return;
+  if (notification.method !== "turn/completed") return;
+  if (params.turn?.status !== "completed") {
+    waiter.finish(new Error(params.turn?.error?.message || "Codex 自动认领判断失败"));
+    return;
+  }
+  const answer = [...params.turn.items].reverse()
+    .find((item) => item.type === "agentMessage")?.text?.trim() || "";
+  waiter.finish(null, answer);
+}
+
+async function remoteAutomationCanStart(cdp, request, task, comments) {
+  const latestComment = comments.at(-1);
+  const started = await requestCodexAppServerViaCdp(
+    cdp,
+    undefined,
+    request.codexHostId,
+    "thread/start",
+    {
+      ephemeral: true,
+      model: request.model,
+      cwd: request.workspacePath,
+      runtimeWorkspaceRoots: [request.workspacePath],
+      approvalPolicy: "never",
+      sandbox: "read-only",
+    },
+  );
+  const threadId = started?.thread?.id;
+  if (typeof threadId !== "string" || !threadId || started.thread.ephemeral !== true) {
+    throw new Error("Codex 未创建临时自动认领判断线程");
+  }
+
+  const completion = waitForRemoteAutomationDecision(request.codexHostId, threadId);
+  let turnStarted;
+  try {
+    turnStarted = await requestCodexAppServerViaCdp(
+      cdp,
+      undefined,
+      request.codexHostId,
+      "turn/start",
+      {
+        threadId,
+        input: [{
+          type: "text",
+          text: [
+            "你是 Codex Taskboard 自动认领 Agent。只判断下面的议题当前是否允许开始。",
+            "根据完整描述和最新评论做语义判断：若任一处明确要求等待、暂不执行或当前不应开始，decision 为 wait；否则 decision 为 start。不要调用工具，不要解释。",
+            JSON.stringify({
+              identifier: task.identifier,
+              title: task.title,
+              description: task.description,
+              latestComment: latestComment
+                ? {
+                    authorName: latestComment.authorName,
+                    createdAt: latestComment.createdAt,
+                    body: latestComment.body,
+                  }
+                : null,
+            }),
+          ].join("\n\n"),
+        }],
+        effort: request.reasoningEffort,
+        outputSchema: {
+          type: "object",
+          properties: {
+            decision: { type: "string", enum: ["start", "wait"] },
+          },
+          required: ["decision"],
+          additionalProperties: false,
+        },
+      },
+    );
+  } catch (error) {
+    completion.cancel();
+    throw error;
+  }
+  const turnId = turnStarted?.turn?.id;
+  if (typeof turnId !== "string" || !turnId) {
+    completion.cancel();
+    throw new Error("Codex 未返回自动认领判断 turn");
+  }
+  const answer = await completion.promise;
+  let decision;
+  try {
+    decision = JSON.parse(answer).decision;
+  } catch {}
+  if (decision !== "start" && decision !== "wait") {
+    throw new Error("Codex 未返回有效的自动认领判断");
+  }
+  return decision === "start";
+}
+
 async function runRemoteTaskboardAutomation(record) {
   const { request, version } = record;
   if (
@@ -1309,6 +1431,8 @@ async function runRemoteTaskboardAutomation(record) {
     taskboardRequest(attachmentsPath),
   ]);
   if (!eligibleRemoteAutomationTask(task) || task.projectId !== request.taskboardProjectId) return;
+  const cdp = currentQuotaPolicyCdp();
+  if (!(await remoteAutomationCanStart(cdp, request, task, comments))) return;
   const existingBinding = task.threadBinding?.codexProjectKind === "remote"
     ? task.threadBinding
     : null;
@@ -1321,7 +1445,6 @@ async function runRemoteTaskboardAutomation(record) {
     return;
   }
   const snapshot = remoteAutomationSnapshot(task, comments, attachments);
-  const cdp = currentQuotaPolicyCdp();
   const started = await requestCodexAppServerViaCdp(
     cdp,
     undefined,
@@ -2726,6 +2849,7 @@ async function main() {
     );
   };
   const forwardCodexAppServerNotification = (cdp, notification) => {
+    handleRemoteAutomationDecisionNotification(notification);
     if (remoteCodexConnections.get(notification.hostId) !== cdp) return;
     if (!taskboardChild?.connected) return;
     taskboardChild.send({

--- a/server/ai-chat-catalog.mjs
+++ b/server/ai-chat-catalog.mjs
@@ -337,6 +337,49 @@ function sanitizeModels(value) {
   });
 }
 
+function sanitizeAppServerModels(value) {
+  if (!Array.isArray(value)) throw new Error("Codex returned an invalid model catalog");
+  return value.flatMap((model) => {
+    if (
+      !model
+      || typeof model !== "object"
+      || model.hidden === true
+      || typeof model.model !== "string"
+      || !model.model.trim()
+    ) return [];
+    const slug = model.model.trim();
+    const efforts = Array.isArray(model.supportedReasoningEfforts)
+      ? [...new Set(model.supportedReasoningEfforts.flatMap((entry) => (
+          typeof entry?.reasoningEffort === "string" && entry.reasoningEffort.trim()
+            ? [entry.reasoningEffort.trim()]
+            : []
+        )))]
+      : [];
+    const serviceTiers = Array.isArray(model.serviceTiers)
+      ? model.serviceTiers.flatMap((tier) => (
+          typeof tier?.id === "string"
+          && tier.id.trim()
+          && typeof tier.name === "string"
+          && tier.name.trim()
+            ? [{ id: tier.id.trim(), name: tier.name.trim() }]
+            : []
+        ))
+      : [];
+    return [{
+      slug,
+      displayName: typeof model.displayName === "string" && model.displayName.trim()
+        ? model.displayName.trim()
+        : slug,
+      description: typeof model.description === "string" ? model.description : "",
+      defaultReasoningEffort: typeof model.defaultReasoningEffort === "string"
+        ? model.defaultReasoningEffort.trim()
+        : "",
+      supportedReasoningEfforts: efforts,
+      serviceTiers,
+    }];
+  });
+}
+
 function listSkills(codexExecutable, workspacePath, processEnv) {
   return new Promise((resolve, reject) => {
     const command = executableCommand(codexExecutable, ["app-server", "--stdio"]);
@@ -608,13 +651,14 @@ function referenceUnavailable(nodeIndex, reasonCode = "SOURCE_UNAVAILABLE") {
 }
 
 export class ComposerCatalog {
-  constructor({ appServer, agentsDirectory, codexHome, issueSlashCommands } = {}) {
+  constructor({ appServer, agentsDirectory, codexHome, issueSlashCommands, configuredAgents } = {}) {
     this.appServer = appServer;
     this.codexHome = codexHome
       ?? (agentsDirectory ? path.dirname(agentsDirectory) : process.env.CODEX_HOME)
       ?? path.join(os.homedir(), ".codex");
     this.agentsDirectory = agentsDirectory ?? path.join(this.codexHome, "agents");
     this.issueSlashCommands = issueSlashCommands ?? null;
+    this.configuredAgents = configuredAgents ?? listConfiguredAgents;
     this.workspaces = new Map();
     this.unsubscribe = appServer.subscribe((notification) => {
       if (notification?.method === "skills/changed") this.invalidate();
@@ -670,7 +714,7 @@ export class ComposerCatalog {
         skillsAvailable = true;
       } catch {}
     }
-    const { agents, available: agentsAvailable } = await listConfiguredAgents({
+    const { agents, available: agentsAvailable } = await this.configuredAgents({
       codexHome: this.codexHome,
       agentsDirectory: this.agentsDirectory,
       workspacePath,
@@ -771,7 +815,7 @@ export class ComposerCatalog {
       entries = await this.appServer.listSkills(workspacePath, { forceReload: true });
       skillsAvailable = true;
     } catch {}
-    const { agents, available: agentsAvailable } = await listConfiguredAgents({
+    const { agents, available: agentsAvailable } = await this.configuredAgents({
       codexHome: this.codexHome,
       agentsDirectory: this.agentsDirectory,
       workspacePath,
@@ -877,7 +921,7 @@ export class ComposerCatalog {
       ));
       throw referenceUnavailable(Math.max(firstReferenceIndex, 0));
     }
-    const { agents } = await listConfiguredAgents({
+    const { agents } = await this.configuredAgents({
       codexHome: this.codexHome,
       agentsDirectory: this.agentsDirectory,
       workspacePath,
@@ -966,6 +1010,20 @@ export async function discoverAiCatalog({
   const modelCatalog = JSON.parse(modelResult.stdout);
   return {
     models: sanitizeModels(modelCatalog?.models),
+    skills: sanitizeSkills(skillEntries),
+    commands,
+    sandboxes: ["read-only", "workspace-write", "danger-full-access"],
+  };
+}
+
+export async function discoverAppServerAiCatalog({ appServer, workspacePath }) {
+  const [modelResult, skillEntries, commands] = await Promise.all([
+    appServer.request("model/list", { cursor: null, limit: 100, includeHidden: false }),
+    appServer.listSkills(workspacePath, { forceReload: false }),
+    loadSlashCommands(),
+  ]);
+  return {
+    models: sanitizeAppServerModels(modelResult?.data),
     skills: sanitizeSkills(skillEntries),
     commands,
     sandboxes: ["read-only", "workspace-write", "danger-full-access"],

--- a/server/ai-chat.mjs
+++ b/server/ai-chat.mjs
@@ -6,11 +6,12 @@ import { signalProcessTree } from "../shared/process-tree.mjs";
 import { ApiError } from "./database.mjs";
 import {
   ComposerCatalog,
+  discoverAppServerAiCatalog,
   discoverAiCatalog,
   loadSlashCommands,
   resolveAiWorkspace,
 } from "./ai-chat-catalog.mjs";
-import { CodexAppServer } from "./codex-app-server.mjs";
+import { CodexAppServer, CodexHostAppServer } from "./codex-app-server.mjs";
 import {
   buildCodexArgs,
   buildCodexPrompt,
@@ -21,6 +22,7 @@ import {
 const SANDBOXES = new Set(["read-only", "workspace-write", "danger-full-access"]);
 const ERROR_CONTENT_LIMIT = 65_536;
 const AGENT_DISPATCH_PROTOCOL = "taskboard.agent.v1";
+const SKILL_MARKER = "\uFFFC";
 const CODEX_IMAGE_TYPES = new Set([
   "image/gif",
   "image/jpeg",
@@ -63,6 +65,21 @@ function appServerThreadSettings(thread, resolved) {
       ? {}
       : { approvalsReviewer: thread.sandbox === "read-only" ? "user" : "auto_review" }),
     sandbox: thread.sandbox,
+  };
+}
+
+function codexTargetFromOrigin(origin) {
+  if (
+    origin?.codexProjectKind !== "remote"
+    || !origin.codexProjectId
+    || !origin.codexHostId
+    || !origin.workspacePath
+  ) return undefined;
+  return {
+    codexProjectId: origin.codexProjectId,
+    codexProjectKind: "remote",
+    codexHostId: origin.codexHostId,
+    workspacePath: origin.workspacePath,
   };
 }
 
@@ -137,6 +154,9 @@ export class AiChatService {
       appServer: this.appServer,
       issueSlashCommands: () => loadSlashCommands(),
     });
+    this.remoteAppServerFactory = options.remoteAppServerFactory
+      ?? ((hostId) => new CodexHostAppServer({ hostId }));
+    this.remoteRuntimes = new Map();
     this.resolveContext = options.resolveContext ?? (async (projectId, issueId) => {
       const resolved = await resolveAiWorkspace(projectId, this.codexStatePath, this.database);
       let issue;
@@ -156,8 +176,32 @@ export class AiChatService {
     this.listeners = new Map();
     this.completions = new Map();
     this.unsubscribeAppServer = this.appServer.subscribe((notification) => {
-      this.#handleAppServerNotification(notification);
+      this.#handleAppServerNotification(this.appServer, notification);
     });
+  }
+
+  #runtimeForTarget(target) {
+    if (target?.codexProjectKind !== "remote") {
+      return { appServer: this.appServer, composerCatalog: this.composerCatalog };
+    }
+    let runtime = this.remoteRuntimes.get(target.codexHostId);
+    if (runtime) return runtime;
+    const appServer = this.remoteAppServerFactory(target.codexHostId);
+    const composerCatalog = new ComposerCatalog({
+      appServer,
+      issueSlashCommands: () => loadSlashCommands(),
+      configuredAgents: async () => ({ agents: [], available: false }),
+    });
+    const unsubscribe = appServer.subscribe((notification) => {
+      this.#handleAppServerNotification(appServer, notification);
+    });
+    runtime = { appServer, composerCatalog, unsubscribe };
+    this.remoteRuntimes.set(target.codexHostId, runtime);
+    return runtime;
+  }
+
+  #runtimeForThread(thread) {
+    return this.#runtimeForTarget(codexTargetFromOrigin(thread.origin));
   }
 
   listThreads() {
@@ -183,6 +227,10 @@ export class AiChatService {
       events: this.database.listAiChatEvents(threadId),
       runs: this.database.listAiChatRuns(threadId),
     };
+  }
+
+  composerCatalogForThread(thread) {
+    return this.#runtimeForThread(thread).composerCatalog;
   }
 
   getRun(runId) {
@@ -214,13 +262,29 @@ export class AiChatService {
     });
   }
 
-  async getCatalog(projectId, resolvedContext) {
-    const resolved = resolvedContext ?? await this.resolveContext(projectId);
+  async getCatalog(projectId, resolvedContext, codexTarget) {
+    const resolved = resolvedContext ?? await this.resolveContext(projectId, undefined, codexTarget);
+    if (resolved.codexProjectKind === "remote") {
+      const { appServer } = this.#runtimeForTarget(resolved);
+      return discoverAppServerAiCatalog({ appServer, workspacePath: resolved.workspacePath });
+    }
     return this.#catalogForWorkspace(resolved.workspacePath);
   }
 
-  async getComposerCandidates({ projectId, threadId, trigger, query }) {
+  async getComposerCandidates({
+    projectId,
+    threadId,
+    trigger,
+    query,
+    codexProjectId,
+    codexProjectKind,
+    codexHostId,
+    workspacePath,
+  }) {
     let thread;
+    let codexTarget = codexProjectKind === "remote"
+      ? { codexProjectId, codexProjectKind, codexHostId, workspacePath }
+      : undefined;
     if (threadId !== undefined) {
       try {
         thread = this.getThread(threadId);
@@ -242,6 +306,7 @@ export class AiChatService {
         );
       }
       projectId = thread.origin.projectId;
+      codexTarget = codexTargetFromOrigin(thread.origin);
     }
 
     if (projectId === undefined) {
@@ -253,7 +318,7 @@ export class AiChatService {
 
     let resolved;
     try {
-      resolved = await this.resolveContext(projectId, thread?.origin.issueId);
+      resolved = await this.resolveContext(projectId, thread?.origin.issueId, codexTarget);
     } catch (error) {
       if (error instanceof ApiError && ["PROJECT_NOT_FOUND", "AI_CHAT_ISSUE_NOT_FOUND"].includes(error.code)) {
         throw new ApiError(400, "INVALID_COMPOSER_QUERY", "Composer project is invalid");
@@ -267,7 +332,8 @@ export class AiChatService {
         "Composer thread workspace no longer matches the selected project",
       );
     }
-    const response = await this.composerCatalog.candidates({
+    const { composerCatalog } = this.#runtimeForTarget(resolved);
+    const response = await composerCatalog.candidates({
       workspacePath: resolved.workspacePath,
       trigger,
       query,
@@ -289,13 +355,14 @@ export class AiChatService {
     if (!thread.codexThreadId) {
       throw new ApiError(409, "AI_CHAT_THREAD_NOT_STARTED", "Conversation has not started");
     }
-    await this.appServer.compactThread(thread.codexThreadId);
+    await this.#runtimeForThread(thread).appServer.compactThread(thread.codexThreadId);
     return this.getThread(threadId);
   }
 
   async createThread(input) {
-    const resolved = await this.resolveContext(input.projectId, input.issueId);
-    const catalog = await this.getCatalog(input.projectId, resolved);
+    const codexTarget = input.codexProjectKind === "remote" ? input : undefined;
+    const resolved = await this.resolveContext(input.projectId, input.issueId, codexTarget);
+    const catalog = await this.getCatalog(input.projectId, resolved, codexTarget);
     const model = this.#resolveModel(catalog, input.model);
     const reasoningEffort = input.reasoningEffort ?? model.defaultReasoningEffort;
     this.#validateReasoningEffort(model, reasoningEffort);
@@ -310,6 +377,11 @@ export class AiChatService {
         projectId: resolved.project.id,
         projectName: resolved.project.name,
         workspacePath: resolved.workspacePath,
+        ...(resolved.codexProjectKind === "remote" ? {
+          codexProjectId: resolved.codexProjectId,
+          codexProjectKind: resolved.codexProjectKind,
+          codexHostId: resolved.codexHostId,
+        } : {}),
         ...(issue ? { issueId: issue.id, issueIdentifier: issue.identifier } : {}),
       },
       model: model.slug,
@@ -327,7 +399,11 @@ export class AiChatService {
 
     if (Object.hasOwn(changes, "sandbox")) this.#validateSandbox(changes.sandbox);
     if (Object.hasOwn(changes, "model") || Object.hasOwn(changes, "reasoningEffort")) {
-      const catalog = await this.getCatalog(thread.origin.projectId);
+      const catalog = await this.getCatalog(
+        thread.origin.projectId,
+        undefined,
+        codexTargetFromOrigin(thread.origin),
+      );
       thread = this.getThread(threadId);
       const model = this.#resolveModel(catalog, changes.model ?? thread.model);
       const reasoningEffort = changes.reasoningEffort ?? thread.reasoningEffort;
@@ -377,11 +453,13 @@ export class AiChatService {
       );
     }
 
+    const codexTarget = codexTargetFromOrigin(thread.origin);
     const resolved = await this.resolveContext(
       thread.origin.projectId,
       thread.origin.issueId,
+      codexTarget,
     );
-    const catalog = await this.getCatalog(thread.origin.projectId, resolved);
+    const catalog = await this.getCatalog(thread.origin.projectId, resolved, codexTarget);
 
     thread = this.getThread(threadId);
     if (this.#threadIsActive(thread)) {
@@ -420,6 +498,10 @@ export class AiChatService {
       }
     }
     const selectedSkills = skillIds.map((skillId) => availableSkills.get(skillId));
+
+    if (resolved.codexProjectKind === "remote") {
+      return this.#startRemoteTurn(thread, input, resolved, selectedSkills);
+    }
 
     const attachments = input.attachments ?? [];
     const {
@@ -557,7 +639,7 @@ export class AiChatService {
     if (active.kind === "app-server") {
       if (active.turnId) {
         try {
-          await this.appServer.interruptTurn({
+          await active.appServer.interruptTurn({
             threadId: active.appServerThreadId,
             turnId: active.turnId,
           });
@@ -589,7 +671,7 @@ export class AiChatService {
       active.interrupted = true;
       if (active.kind === "app-server") {
         if (active.turnId) {
-          void this.appServer.interruptTurn({
+          void active.appServer.interruptTurn({
             threadId: active.appServerThreadId,
             turnId: active.turnId,
           }).catch(() => {});
@@ -625,6 +707,12 @@ export class AiChatService {
     this.unsubscribeAppServer();
     this.composerCatalog.close();
     await this.appServer.close();
+    for (const runtime of this.remoteRuntimes.values()) {
+      runtime.unsubscribe();
+      runtime.composerCatalog.close();
+      await runtime.appServer.close();
+    }
+    this.remoteRuntimes.clear();
     this.listeners.clear();
   }
 
@@ -696,6 +784,120 @@ export class AiChatService {
     }
   }
 
+  async #startAppServerRun({
+    thread,
+    resolved,
+    appServer,
+    userInput,
+    userEvent,
+    temporaryDirectory = null,
+  }) {
+    const settings = appServerThreadSettings(thread, resolved);
+    let appServerThreadId = thread.codexThreadId;
+    if (appServerThreadId) {
+      const resumed = await appServer.resumeThread({
+        threadId: appServerThreadId,
+        ...settings,
+      });
+      if (resumed?.thread?.id !== appServerThreadId) {
+        throw new Error("Codex returned an unexpected resumed thread id");
+      }
+    } else {
+      const started = await appServer.startThread(settings);
+      appServerThreadId = started?.thread?.id;
+      if (typeof appServerThreadId !== "string" || !appServerThreadId) {
+        throw new Error("Codex did not provide a thread id");
+      }
+      this.database.updateAiChatThread(thread.id, { codexThreadId: appServerThreadId });
+    }
+
+    const run = this.database.createAiChatRun({ threadId: thread.id });
+    this.#emit(thread.id, { type: "ai.run", run });
+    const storedUserEvent = this.database.insertAiChatEvent({
+      threadId: thread.id,
+      runId: run.id,
+      type: "user_message",
+      role: "user",
+      ...userEvent,
+    });
+    this.#emit(thread.id, { type: "ai.event", event: storedUserEvent });
+
+    let resolveCompletion;
+    const completion = new Promise((resolve) => { resolveCompletion = resolve; });
+    const active = {
+      kind: "app-server",
+      run,
+      threadId: thread.id,
+      appServer,
+      appServerThreadId,
+      turnId: null,
+      interrupted: false,
+      temporaryDirectory,
+      resolveCompletion,
+    };
+    this.active.set(run.id, active);
+    const finalization = completion.finally(() => this.completions.delete(run.id));
+    this.completions.set(run.id, finalization);
+    try {
+      const started = await appServer.startTurn({
+        threadId: appServerThreadId,
+        input: userInput,
+        effort: thread.reasoningEffort,
+      });
+      const turnId = started?.turn?.id;
+      if (typeof turnId !== "string" || !turnId) {
+        throw new Error("Codex did not provide a turn id");
+      }
+      active.turnId = turnId;
+    } catch (error) {
+      await this.#finishAppServerRun(active, "failed", error);
+      throw error;
+    }
+    return run;
+  }
+
+  #remoteAttachmentInput(attachment) {
+    const url = `data:${attachment.contentType};base64,${attachment.data.toString("base64")}`;
+    if (CODEX_IMAGE_TYPES.has(attachment.contentType)) return { type: "image", url };
+    if (attachment.contentType.startsWith("audio/")) return { type: "audio", url };
+    return {
+      type: "text",
+      text: `\n\nAttached file ${attachment.filename}: ${url}`,
+    };
+  }
+
+  async #startRemoteTurn(thread, input, resolved, selectedSkills) {
+    const userInput = [];
+    const messageParts = input.message.split(SKILL_MARKER);
+    for (const [index, text] of messageParts.entries()) {
+      if (text) userInput.push({ type: "text", text });
+      const skill = selectedSkills[index];
+      if (skill) userInput.push({ type: "skill", name: skill.id, path: skill.path });
+    }
+    for (const attachment of input.attachments ?? []) {
+      userInput.push(this.#remoteAttachmentInput(attachment));
+    }
+    const userEventData = {};
+    if (selectedSkills.length > 0) userEventData.skillIds = selectedSkills.map((skill) => skill.id);
+    if ((input.attachments ?? []).length > 0) {
+      userEventData.attachments = input.attachments.map(({ filename, contentType, size }) => ({
+        filename,
+        contentType,
+        size,
+      }));
+    }
+    return this.#startAppServerRun({
+      thread,
+      resolved,
+      appServer: this.#runtimeForTarget(resolved).appServer,
+      userInput,
+      userEvent: {
+        content: input.message,
+        data: Object.keys(userEventData).length > 0 ? userEventData : undefined,
+      },
+    });
+  }
+
   async #startComposerTurn(thread, input) {
     if (thread.sandbox === "danger-full-access" && input.dangerFullAccessConfirmed !== true) {
       throw new ApiError(
@@ -705,10 +907,13 @@ export class AiChatService {
       );
     }
 
+    const codexTarget = codexTargetFromOrigin(thread.origin);
     const resolved = await this.resolveContext(
       thread.origin.projectId,
       thread.origin.issueId,
+      codexTarget,
     );
+    const runtime = this.#runtimeForTarget(resolved);
     thread = this.getThread(thread.id);
     if (this.#threadIsActive(thread)) {
       throw new ApiError(409, "THREAD_BUSY", `AI chat thread '${thread.id}' has a running turn`);
@@ -732,7 +937,7 @@ export class AiChatService {
       );
     }
     const resolvedReferences = nodes.some((node) => node.type === "skill" || node.type === "agent")
-      ? await this.composerCatalog.resolveReferences({
+      ? await runtime.composerCatalog.resolveReferences({
           workspacePath: resolved.workspacePath,
           revision: input.revision,
           nodes,
@@ -751,27 +956,10 @@ export class AiChatService {
       );
     }
 
-    const { temporaryDirectory, attachmentPaths } = await this.#writeTurnAttachments(attachments);
+    const { temporaryDirectory, attachmentPaths } = resolved.codexProjectKind === "remote"
+      ? { temporaryDirectory: null, attachmentPaths: [] }
+      : await this.#writeTurnAttachments(attachments);
     try {
-      const settings = appServerThreadSettings(thread, resolved);
-      let appServerThreadId = thread.codexThreadId;
-      if (appServerThreadId) {
-        const resumed = await this.appServer.resumeThread({
-          threadId: appServerThreadId,
-          ...settings,
-        });
-        if (resumed?.thread?.id !== appServerThreadId) {
-          throw new Error("Codex returned an unexpected resumed thread id");
-        }
-      } else {
-        const started = await this.appServer.startThread(settings);
-        appServerThreadId = started?.thread?.id;
-        if (typeof appServerThreadId !== "string" || !appServerThreadId) {
-          throw new Error("Codex did not provide a thread id");
-        }
-        this.database.updateAiChatThread(thread.id, { codexThreadId: appServerThreadId });
-      }
-
       const userInput = nodes.flatMap((node, nodeIndex) => {
         if (node.type === "text") return { type: "text", text: node.text };
         const reference = resolvedReferences[nodeIndex];
@@ -784,6 +972,10 @@ export class AiChatService {
         return { type: "text", text: agentDispatchText(reference) };
       });
       for (const [index, attachment] of attachments.entries()) {
+        if (resolved.codexProjectKind === "remote") {
+          userInput.push(this.#remoteAttachmentInput(attachment));
+          continue;
+        }
         const attachmentPath = attachmentPaths[index];
         if (CODEX_IMAGE_TYPES.has(attachment.contentType)) {
           userInput.push({ type: "localImage", path: attachmentPath });
@@ -792,18 +984,18 @@ export class AiChatService {
         }
       }
 
-      const run = this.database.createAiChatRun({ threadId: thread.id });
-      this.#emit(thread.id, { type: "ai.run", run });
       const agentDispatches = nodes.flatMap((node, nodeIndex) => {
         if (node.type !== "agent") return [];
         const reference = resolvedReferences[nodeIndex];
         return [{ nodeIndex, id: reference.id, name: reference.name }];
       });
-      const userEvent = this.database.insertAiChatEvent({
-        threadId: thread.id,
-        runId: run.id,
-        type: "user_message",
-        role: "user",
+      const run = await this.#startAppServerRun({
+        thread,
+        resolved,
+        appServer: runtime.appServer,
+        userInput,
+        temporaryDirectory,
+        userEvent: {
         content: nodes.map((node) => (
           node.type === "text" ? node.text : `@${node.label}`
         )).join(""),
@@ -826,40 +1018,9 @@ export class AiChatService {
                 })),
               }
             : {}),
+          },
         },
       });
-      this.#emit(thread.id, { type: "ai.event", event: userEvent });
-
-      let resolveCompletion;
-      const completion = new Promise((resolve) => { resolveCompletion = resolve; });
-      const active = {
-        kind: "app-server",
-        run,
-        threadId: thread.id,
-        appServerThreadId,
-        turnId: null,
-        interrupted: false,
-        temporaryDirectory,
-        resolveCompletion,
-      };
-      this.active.set(run.id, active);
-      const finalization = completion.finally(() => this.completions.delete(run.id));
-      this.completions.set(run.id, finalization);
-      try {
-        const started = await this.appServer.startTurn({
-          threadId: appServerThreadId,
-          input: userInput,
-          effort: thread.reasoningEffort,
-        });
-        const turnId = started?.turn?.id;
-        if (typeof turnId !== "string" || !turnId) {
-          throw new Error("Codex did not provide a turn id");
-        }
-        active.turnId = turnId;
-      } catch (error) {
-        await this.#finishAppServerRun(active, "failed", error);
-        throw error;
-      }
       return run;
     } catch (error) {
       if (temporaryDirectory && ![...this.active.values()].some(
@@ -871,11 +1032,12 @@ export class AiChatService {
     }
   }
 
-  #handleAppServerNotification(notification) {
+  #handleAppServerNotification(appServer, notification) {
     const params = notification?.params;
     if (!params || typeof params !== "object") return;
     const active = [...this.active.values()].find((candidate) => (
       candidate.kind === "app-server"
+      && candidate.appServer === appServer
       && candidate.appServerThreadId === params.threadId
       && (!candidate.turnId || !params.turnId || candidate.turnId === params.turnId)
     ));

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -903,6 +903,43 @@ function parseAiSetting(value, name, maxLength) {
   return setting;
 }
 
+function parseAiExecutionTarget(value) {
+  const fields = [
+    "codexProjectId",
+    "codexProjectKind",
+    "codexHostId",
+    "workspacePath",
+  ];
+  const present = fields.filter((field) => value[field] !== undefined);
+  if (present.length === 0) return undefined;
+  if (present.length !== fields.length) {
+    throw new ApiError(400, "INVALID_CODEX_TARGET", "Codex project identity must contain all four fields");
+  }
+  const codexProjectKind = parseAiSetting(value.codexProjectKind, "codexProjectKind", 16);
+  if (codexProjectKind !== "local" && codexProjectKind !== "remote") {
+    throw new ApiError(400, "INVALID_CODEX_TARGET", "'codexProjectKind' must be local or remote");
+  }
+  const workspacePath = parseAiSetting(value.workspacePath, "workspacePath", 4096);
+  if (workspacePath.includes("\0")) {
+    throw new ApiError(400, "INVALID_CODEX_TARGET", "'workspacePath' cannot contain null bytes");
+  }
+  return {
+    codexProjectId: parseAiSetting(value.codexProjectId, "codexProjectId", 256),
+    codexProjectKind,
+    codexHostId: parseAiSetting(value.codexHostId, "codexHostId", 512),
+    workspacePath,
+  };
+}
+
+function aiExecutionTargetFromQuery(searchParams) {
+  return parseAiExecutionTarget({
+    codexProjectId: searchParams.get("codexProjectId") ?? undefined,
+    codexProjectKind: searchParams.get("codexProjectKind") ?? undefined,
+    codexHostId: searchParams.get("codexHostId") ?? undefined,
+    workspacePath: searchParams.get("workspacePath") ?? undefined,
+  });
+}
+
 function parseAiThreadCreate(body) {
   assertPlainObject(body);
   assertAllowedKeys(body, new Set([
@@ -912,6 +949,10 @@ function parseAiThreadCreate(body) {
     "model",
     "reasoningEffort",
     "sandbox",
+    "codexProjectId",
+    "codexProjectKind",
+    "codexHostId",
+    "workspacePath",
   ]));
   return {
     projectId: validateProjectId(body.projectId),
@@ -920,6 +961,7 @@ function parseAiThreadCreate(body) {
     model: parseAiSetting(body.model, "model", 128),
     reasoningEffort: parseAiSetting(body.reasoningEffort, "reasoningEffort", 64),
     sandbox: parseAiSandbox(body.sandbox),
+    ...parseAiExecutionTarget(body),
   };
 }
 
@@ -1044,7 +1086,17 @@ function parseAiTurn(body) {
 function parseComposerCandidateQuery(searchParams) {
   assertAllowedQuery(
     searchParams,
-    new Set(["projectId", "threadId", "trigger", "query", "surface"]),
+    new Set([
+      "projectId",
+      "threadId",
+      "trigger",
+      "query",
+      "surface",
+      "codexProjectId",
+      "codexProjectKind",
+      "codexHostId",
+      "workspacePath",
+    ]),
     "GET /api/local/ai/composer/candidates",
   );
   let projectId;
@@ -1074,7 +1126,14 @@ function parseComposerCandidateQuery(searchParams) {
   if (!new Set(["ai-chat", "issue-description", "comment"]).has(surface)) {
     throw new ApiError(400, "INVALID_COMPOSER_QUERY", "Composer surface is invalid");
   }
-  return { projectId, threadId, trigger, query, surface };
+  return {
+    projectId,
+    threadId,
+    trigger,
+    query,
+    surface,
+    ...aiExecutionTargetFromQuery(searchParams),
+  };
 }
 
 function invalidComposerRebindRequest(message) {
@@ -1260,16 +1319,21 @@ async function resolveComposerRebindWorkspace(aiChat, input) {
         "Composer thread does not belong to the selected project",
       );
     }
-    try {
-      if (!(await stat(thread.origin.workspacePath)).isDirectory()) throw new Error("not a directory");
-    } catch {
-      throw new ApiError(
-        409,
-        "PROJECT_WORKSPACE_UNAVAILABLE",
-        "The conversation workspace is not available on this device",
-      );
+    if (thread.origin.codexProjectKind !== "remote") {
+      try {
+        if (!(await stat(thread.origin.workspacePath)).isDirectory()) throw new Error("not a directory");
+      } catch {
+        throw new ApiError(
+          409,
+          "PROJECT_WORKSPACE_UNAVAILABLE",
+          "The conversation workspace is not available on this device",
+        );
+      }
     }
-    return thread.origin.workspacePath;
+    return {
+      workspacePath: thread.origin.workspacePath,
+      composerCatalog: aiChat.composerCatalogForThread(thread),
+    };
   }
   let resolved;
   try {
@@ -1283,7 +1347,7 @@ async function resolveComposerRebindWorkspace(aiChat, input) {
     }
     throw error;
   }
-  return resolved.workspacePath;
+  return { workspacePath: resolved.workspacePath, composerCatalog: aiChat.composerCatalog };
 }
 
 function parseComposerDocument(value) {
@@ -1765,9 +1829,27 @@ export function createTaskboardServer(options = {}) {
     return payload;
   }
 
-  async function resolveAiChatContext(projectId, issueId) {
+  async function resolveAiChatContext(projectId, issueId, codexTarget) {
     const config = await cloudConfig.read();
     if (!config.remoteUrl) {
+      if (codexTarget?.codexProjectKind === "remote") {
+        const project = database.getProject(projectId);
+        if (!project) {
+          throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${projectId}' does not exist`);
+        }
+        let issue;
+        if (issueId !== undefined) {
+          issue = database.getTask(issueId);
+          if (!issue || issue.projectId !== projectId || issue.archivedAt != null) {
+            throw new ApiError(
+              404,
+              "AI_CHAT_ISSUE_NOT_FOUND",
+              `Task '${issueId}' is not an active task in project '${projectId}'`,
+            );
+          }
+        }
+        return { project, issue, addDirectories: [], ...codexTarget };
+      }
       let resolvedWorkspace;
       try {
         resolvedWorkspace = await resolveAiWorkspace(
@@ -1824,6 +1906,10 @@ export function createTaskboardServer(options = {}) {
       }
     }
 
+    if (codexTarget?.codexProjectKind === "remote") {
+      return { project, issue, addDirectories: [], ...codexTarget };
+    }
+
     const resolvedWorkspace = await resolveMappedAiWorkspace(
       projectId,
       project,
@@ -1839,6 +1925,7 @@ export function createTaskboardServer(options = {}) {
     manageTaskboardSkillPath: resolved.skillPath,
     processEnv: codexProcessEnvironment,
     resolveContext: resolveAiChatContext,
+    remoteAppServerFactory: options.remoteAppServerFactory,
   });
   const projectSummary = new ProjectSummaryService({
     database,
@@ -2309,9 +2396,19 @@ export function createTaskboardServer(options = {}) {
 
       if (pathname === "/api/local/ai/catalog") {
         if (request.method !== "GET") return methodNotAllowed(response, ["GET"]);
-        assertAllowedQuery(url.searchParams, new Set(["projectId"]), "GET /api/local/ai/catalog");
+        assertAllowedQuery(url.searchParams, new Set([
+          "projectId",
+          "codexProjectId",
+          "codexProjectKind",
+          "codexHostId",
+          "workspacePath",
+        ]), "GET /api/local/ai/catalog");
         const projectId = validateProjectId(url.searchParams.get("projectId") ?? undefined);
-        return sendJson(response, 200, await aiChat.getCatalog(projectId));
+        return sendJson(
+          response,
+          200,
+          await aiChat.getCatalog(projectId, undefined, aiExecutionTargetFromQuery(url.searchParams)),
+        );
       }
 
       if (pathname === "/api/local/ai/composer/candidates") {
@@ -2331,11 +2428,11 @@ export function createTaskboardServer(options = {}) {
         if (request.method !== "POST") return methodNotAllowed(response, ["POST"]);
         assertNoQuery(url.searchParams, "POST /api/local/ai/composer/rebind");
         const input = parseComposerRebindRequest(await readJson(request));
-        const workspacePath = await resolveComposerRebindWorkspace(aiChat, input);
+        const { workspacePath, composerCatalog } = await resolveComposerRebindWorkspace(aiChat, input);
         return sendJson(
           response,
           200,
-          await aiChat.composerCatalog.rebindPersistedReferences({
+          await composerCatalog.rebindPersistedReferences({
             workspacePath,
             nodes: input.document.nodes,
           }),

--- a/server/codex-app-server.mjs
+++ b/server/codex-app-server.mjs
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 
 import { withoutTaskboardLauncherEnvironment } from "../shared/codex-environment.mjs";
 import { executableCommand } from "../shared/executable-command.mjs";
@@ -228,6 +229,125 @@ export class CodexAppServer {
   #handleExit(error) {
     if (this.child && this.child.exitCode !== null) this.child = null;
     this.#rejectPending(error);
+  }
+
+  #rejectPending(error) {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}
+
+export class CodexHostAppServer {
+  constructor({ hostId, ipc = process, requestTimeoutMs } = {}) {
+    this.hostId = hostId;
+    this.ipc = ipc;
+    this.requestTimeoutMs = requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.pending = new Map();
+    this.listeners = new Set();
+    this.closed = false;
+    this.handleMessage = (message) => this.#handleMessage(message);
+    this.ipc.on?.("message", this.handleMessage);
+  }
+
+  subscribe(listener) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  async listSkills(workspacePath, { forceReload = false } = {}) {
+    const result = await this.request("skills/list", {
+      cwds: [workspacePath],
+      forceReload,
+    });
+    return Array.isArray(result?.data) ? result.data : [];
+  }
+
+  startThread(params) {
+    return this.request("thread/start", params);
+  }
+
+  resumeThread(params) {
+    return this.request("thread/resume", params);
+  }
+
+  startTurn(params) {
+    return this.request("turn/start", params);
+  }
+
+  interruptTurn(params) {
+    return this.request("turn/interrupt", params);
+  }
+
+  compactThread(threadId) {
+    return this.request("thread/compact/start", { threadId });
+  }
+
+  request(method, params) {
+    if (this.closed || typeof this.ipc.send !== "function" || this.ipc.connected === false) {
+      return Promise.reject(new CodexAppServerError("Codex host bridge is unavailable"));
+    }
+    const requestId = randomUUID();
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(requestId);
+        reject(new CodexAppServerError(`Codex host request '${method}' timed out`));
+      }, this.requestTimeoutMs);
+      timer.unref();
+      this.pending.set(requestId, { method, resolve, reject, timer });
+      this.ipc.send({
+        type: "taskboard:codex-app-server-request",
+        requestId,
+        hostId: this.hostId,
+        method,
+        params,
+      }, (error) => {
+        if (!error) return;
+        clearTimeout(timer);
+        this.pending.delete(requestId);
+        reject(error);
+      });
+    });
+  }
+
+  async close() {
+    if (this.closed) return;
+    this.closed = true;
+    this.ipc.off?.("message", this.handleMessage);
+    this.#rejectPending(new CodexAppServerError("Codex host bridge closed"));
+    this.listeners.clear();
+  }
+
+  #handleMessage(message) {
+    if (!message || typeof message !== "object" || message.hostId !== this.hostId) return;
+    if (message.type === "taskboard:codex-app-server-response") {
+      const pending = this.pending.get(message.requestId);
+      if (!pending) return;
+      this.pending.delete(message.requestId);
+      clearTimeout(pending.timer);
+      if (message.error) {
+        pending.reject(new CodexAppServerError(
+          `Codex host rejected '${pending.method}': ${message.error}`,
+        ));
+      } else {
+        pending.resolve(message.result);
+      }
+      return;
+    }
+    if (
+      message.type !== "taskboard:codex-app-server-notification"
+      || typeof message.method !== "string"
+    ) return;
+    const notification = { method: message.method, params: message.params };
+    for (const listener of this.listeners) {
+      try {
+        listener(notification);
+      } catch (error) {
+        console.error("Codex host notification handler failed", error);
+      }
+    }
   }
 
   #rejectPending(error) {

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -408,6 +408,9 @@ function aiChatThreadFromRow(row) {
       projectId: row.origin_project_id,
       projectName: row.origin_project_name,
       workspacePath: row.origin_workspace_path,
+      ...(row.origin_codex_project_id ? { codexProjectId: row.origin_codex_project_id } : {}),
+      ...(row.origin_codex_project_kind ? { codexProjectKind: row.origin_codex_project_kind } : {}),
+      ...(row.origin_codex_host_id ? { codexHostId: row.origin_codex_host_id } : {}),
       ...(row.origin_issue_id ? { issueId: row.origin_issue_id } : {}),
       ...(row.origin_issue_identifier ? { issueIdentifier: row.origin_issue_identifier } : {}),
     },
@@ -599,6 +602,9 @@ export class TaskboardDatabase {
         origin_project_id TEXT NOT NULL,
         origin_project_name TEXT NOT NULL,
         origin_workspace_path TEXT NOT NULL,
+        origin_codex_project_id TEXT,
+        origin_codex_project_kind TEXT,
+        origin_codex_host_id TEXT,
         origin_issue_id TEXT,
         origin_issue_identifier TEXT,
         codex_thread_id TEXT,
@@ -652,6 +658,17 @@ export class TaskboardDatabase {
     const projectColumns = this.database.prepare("PRAGMA table_info(projects)").all();
     if (!projectColumns.some((column) => column.name === "workspace_path")) {
       this.database.exec("ALTER TABLE projects ADD COLUMN workspace_path TEXT");
+    }
+
+    const aiChatThreadColumns = this.database.prepare("PRAGMA table_info(ai_chat_threads)").all();
+    for (const column of [
+      "origin_codex_project_id",
+      "origin_codex_project_kind",
+      "origin_codex_host_id",
+    ]) {
+      if (!aiChatThreadColumns.some((candidate) => candidate.name === column)) {
+        this.database.exec(`ALTER TABLE ai_chat_threads ADD COLUMN ${column} TEXT`);
+      }
     }
 
     const taskColumns = this.database.prepare("PRAGMA table_info(tasks)").all();
@@ -1619,10 +1636,11 @@ export class TaskboardDatabase {
       INSERT INTO ai_chat_threads (
         id, title, status,
         origin_project_id, origin_project_name, origin_workspace_path,
+        origin_codex_project_id, origin_codex_project_kind, origin_codex_host_id,
         origin_issue_id, origin_issue_identifier,
         codex_thread_id, model, reasoning_effort, sandbox,
         created_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       id,
       input.title,
@@ -1630,6 +1648,9 @@ export class TaskboardDatabase {
       input.origin.projectId,
       input.origin.projectName,
       input.origin.workspacePath,
+      input.origin.codexProjectId ?? null,
+      input.origin.codexProjectKind ?? null,
+      input.origin.codexHostId ?? null,
       input.origin.issueId ?? null,
       input.origin.issueIdentifier ?? null,
       input.codexThreadId ?? null,

--- a/test/ai-chat-ui.test.mjs
+++ b/test/ai-chat-ui.test.mjs
@@ -201,7 +201,7 @@ test("submission stays disabled while a snapshot is loading", () => {
 test("new threads normalize inherited settings against the target project catalog", () => {
   assert.match(chatSource, /catalogProjectId/);
   assert.match(chatSource, /catalogLoadedProjectId/);
-  assert.match(chatSource, /const targetCatalog = catalogLoadedProjectId === input\.projectId[\s\S]*?getAiChatCatalog\(input\.projectId\)/);
+  assert.match(chatSource, /const targetCatalog = catalogLoadedProjectId === input\.projectId[\s\S]*?getAiChatCatalog\(input\.projectId, undefined, origin\?\.codexProjectIdentity\)/);
   assert.match(chatSource, /normalizeChatSelection\(\s*targetCatalog\.models,\s*inheritedSettings\.model,\s*inheritedSettings\.reasoningEffort/);
   assert.match(chatSource, /createAiChatThread\(\{[\s\S]*?\.\.\.settings/);
 });

--- a/test/inject.test.mjs
+++ b/test/inject.test.mjs
@@ -421,6 +421,7 @@ test("Codex bootstrap metadata resolves local roots and SSH remote roots asynchr
         projectKind: "remote",
         workspacePath: "/srv/example/project",
         hostId: "remote-ssh-discovered:example",
+        name: "remote-project",
       }],
     ],
   );

--- a/test/project-automation-settings.test.mjs
+++ b/test/project-automation-settings.test.mjs
@@ -30,7 +30,7 @@ test("project automation state is device-local and scoped by taskboard project",
   assert.match(appSource, /codexHostId: string/);
   assert.match(appSource, /workspacePath: string/);
   assert.match(appSource, /type AutomationIntervalMinutes = 5 \| 10 \| 15 \| 30 \| 60/);
-  assert.match(appSource, /getAiChatCatalog\(selectedProject\.id, controller\.signal\)/);
+  assert.match(appSource, /getAiChatCatalog\(\s*selectedProject\.id,\s*controller\.signal,\s*selectedCodexProjectIdentity,\s*\)/);
   assert.match(appSource, /defaultModel\.slug/);
   assert.match(appSource, /defaultModel\.defaultReasoningEffort/);
   assert.match(appSource, /taskboardStorage\.getItem\(PROJECT_AUTOMATIONS_KEY\)/);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -865,6 +865,10 @@ export function App() {
   }, []);
 
   const selectedProject = projects.find((project) => project.id === selectedProjectId) ?? null;
+  const selectedCodexProjectIdentity = useMemo(
+    () => selectedProject ? codexProjectContextForTaskProject(selectedProject.id) : null,
+    [deviceWorkspacePaths, hostContext, projectCodexIdentities, projects, selectedProject?.id],
+  );
   const isAllProjects = selectedProjectId === ALL_PROJECTS_ID;
   const isJiraProject = selectedProject?.source === "jira";
   const boardDisplaySettings = projectBoardDisplaySettings[selectedProjectId]
@@ -881,7 +885,11 @@ export function App() {
     }
     const controller = new AbortController();
     setAutomationCatalogLoading(true);
-    void getAiChatCatalog(selectedProject.id, controller.signal).then(
+    void getAiChatCatalog(
+      selectedProject.id,
+      controller.signal,
+      selectedCodexProjectIdentity,
+    ).then(
       (catalog) => {
         if (controller.signal.aborted) return;
         setAutomationCatalog({ projectId: selectedProject.id, models: catalog.models });
@@ -896,7 +904,15 @@ export function App() {
       },
     );
     return () => controller.abort();
-  }, [localAiChatAvailable, selectedProject?.id, text]);
+  }, [
+    localAiChatAvailable,
+    selectedCodexProjectIdentity?.codexHostId,
+    selectedCodexProjectIdentity?.codexProjectId,
+    selectedCodexProjectIdentity?.codexProjectKind,
+    selectedCodexProjectIdentity?.workspacePath,
+    selectedProject?.id,
+    text,
+  ]);
   const aiImportProjectId = hasLoadedTasks
     && tasks.length === 0
     && selectedProject
@@ -909,13 +925,19 @@ export function App() {
     setAiImportReadyProjectId(null);
     if (!aiImportProjectId) return;
     const controller = new AbortController();
-    void getAiChatCatalog(aiImportProjectId, controller.signal)
+    void getAiChatCatalog(aiImportProjectId, controller.signal, selectedCodexProjectIdentity)
       .then(() => {
         if (!controller.signal.aborted) setAiImportReadyProjectId(aiImportProjectId);
       })
       .catch(() => {});
     return () => controller.abort();
-  }, [aiImportProjectId, selectedProject]);
+  }, [
+    aiImportProjectId,
+    selectedCodexProjectIdentity?.codexHostId,
+    selectedCodexProjectIdentity?.codexProjectId,
+    selectedCodexProjectIdentity?.codexProjectKind,
+    selectedCodexProjectIdentity?.workspacePath,
+  ]);
   useLayoutEffect(() => {
     if (selectedProject) rememberProjectOpen(selectedProject.id);
   }, [rememberProjectOpen, selectedProject]);
@@ -4100,6 +4122,7 @@ export function App() {
             available
             projectId={selectedProjectId || null}
             issueId={detailTaskId}
+            codexProjectIdentity={selectedCodexProjectIdentity}
             onThreadsChange={setAiThreads}
             openThreadRequest={aiOpenThreadRequest}
           />

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -13,6 +13,7 @@ import type {
   ComposerRebindRequest,
   ComposerRebindResponse,
   ComposerTurnInput,
+  CodexProjectIdentity,
   CodexThreadBinding,
   DevelopmentScan,
   HostContext,
@@ -281,9 +282,17 @@ export async function publishHostRuntime(context: HostContext): Promise<void> {
 export async function getAiChatCatalog(
   projectId: string,
   signal?: AbortSignal,
+  codexProjectIdentity?: CodexProjectIdentity | null,
 ): Promise<AiChatCatalog> {
+  const query = new URLSearchParams({ projectId });
+  if (codexProjectIdentity) {
+    query.set("codexProjectId", codexProjectIdentity.codexProjectId);
+    query.set("codexProjectKind", codexProjectIdentity.codexProjectKind);
+    query.set("codexHostId", codexProjectIdentity.codexHostId);
+    query.set("workspacePath", codexProjectIdentity.workspacePath);
+  }
   return request<AiChatCatalog>(
-    `/api/local/ai/catalog?projectId=${encodeURIComponent(projectId)}`,
+    `/api/local/ai/catalog?${query}`,
     { signal },
   );
 }
@@ -299,6 +308,10 @@ export async function getAiChatComposerCandidates(
   if (input.projectId) query.set("projectId", input.projectId);
   if (input.threadId) query.set("threadId", input.threadId);
   if (input.surface) query.set("surface", input.surface);
+  if (input.codexProjectId) query.set("codexProjectId", input.codexProjectId);
+  if (input.codexProjectKind) query.set("codexProjectKind", input.codexProjectKind);
+  if (input.codexHostId) query.set("codexHostId", input.codexHostId);
+  if (input.workspacePath) query.set("workspacePath", input.workspacePath);
   return request<ComposerCandidatesResponse>(`/api/local/ai/composer/candidates?${query}`, { signal });
 }
 
@@ -323,7 +336,7 @@ export async function createAiChatThread(input: {
   model?: string;
   reasoningEffort?: string;
   sandbox?: AiChatSandbox;
-}): Promise<AiChatThread> {
+} & Partial<CodexProjectIdentity>): Promise<AiChatThread> {
   const data = await request<{ thread: AiChatThread }>("/api/local/ai/threads", {
     method: "POST",
     body: JSON.stringify(input),

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -284,7 +284,7 @@ export async function getAiChatCatalog(
   signal?: AbortSignal,
   codexProjectIdentity?: CodexProjectIdentity | null,
 ): Promise<AiChatCatalog> {
-  const query = new URLSearchParams({ projectId });
+  const query = new URLSearchParams();
   if (codexProjectIdentity) {
     query.set("codexProjectId", codexProjectIdentity.codexProjectId);
     query.set("codexProjectKind", codexProjectIdentity.codexProjectKind);
@@ -292,7 +292,7 @@ export async function getAiChatCatalog(
     query.set("workspacePath", codexProjectIdentity.workspacePath);
   }
   return request<AiChatCatalog>(
-    `/api/local/ai/catalog?${query}`,
+    `/api/local/ai/catalog?projectId=${encodeURIComponent(projectId)}${query.size ? `&${query}` : ""}`,
     { signal },
   );
 }

--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -60,6 +60,7 @@ import type {
   AiChatSkill,
   AiChatThread,
   AiChatThreadSnapshot,
+  CodexProjectIdentity,
   ComposerCandidatesResponse,
   ComposerDocument,
   ComposerPersistedDocument,
@@ -111,6 +112,7 @@ interface AiChatProps {
   available: boolean;
   projectId: string | null;
   issueId: string | null;
+  codexProjectIdentity: CodexProjectIdentity | null;
   onThreadsChange?: (threads: AiChatThread[]) => void;
   openThreadRequest?: AiChatOpenThreadRequest | null;
 }
@@ -171,6 +173,7 @@ type ComposerBeforeInput = {
 type DraftThreadOrigin = {
   projectId: string;
   issueId: string | null;
+  codexProjectIdentity: CodexProjectIdentity | null;
 };
 type PanelResizeEdge = "top" | "left" | "top-left";
 type PanelGeometry = {
@@ -1299,6 +1302,7 @@ export function AiChat({
   available,
   projectId,
   issueId,
+  codexProjectIdentity,
   onThreadsChange,
   openThreadRequest,
 }: AiChatProps) {
@@ -1648,6 +1652,21 @@ export function AiChat({
     ?? selectedThreadSummary?.origin.projectId
     ?? draftOrigin?.projectId
     ?? projectId;
+  const catalogThreadOrigin = snapshot?.thread.origin ?? selectedThreadSummary?.origin;
+  const catalogCodexProjectIdentity = catalogThreadOrigin?.codexProjectKind === "remote"
+    && catalogThreadOrigin.codexProjectId
+    && catalogThreadOrigin.codexHostId
+      ? {
+          codexProjectId: catalogThreadOrigin.codexProjectId,
+          codexProjectKind: "remote" as const,
+          codexHostId: catalogThreadOrigin.codexHostId,
+          workspacePath: catalogThreadOrigin.workspacePath,
+        }
+      : draftOrigin?.projectId === catalogProjectId
+        ? draftOrigin.codexProjectIdentity
+        : projectId === catalogProjectId
+          ? codexProjectIdentity
+          : null;
   const activeCatalog = catalogLoadedProjectId === catalogProjectId ? catalog : null;
   useEffect(() => {
     if (!available || !catalogProjectId) {
@@ -1660,7 +1679,7 @@ export function AiChat({
     setCatalog(null);
     setCatalogLoadedProjectId(null);
     setCatalogError(null);
-    void getAiChatCatalog(catalogProjectId, controller.signal).then(
+    void getAiChatCatalog(catalogProjectId, controller.signal, catalogCodexProjectIdentity).then(
       (next) => {
         if (controller.signal.aborted) return;
         setCatalog(next);
@@ -1677,7 +1696,14 @@ export function AiChat({
       },
     );
     return () => controller.abort();
-  }, [available, catalogProjectId]);
+  }, [
+    available,
+    catalogProjectId,
+    catalogCodexProjectIdentity?.codexHostId,
+    catalogCodexProjectIdentity?.codexProjectId,
+    catalogCodexProjectIdentity?.codexProjectKind,
+    catalogCodexProjectIdentity?.workspacePath,
+  ]);
 
   const composerRequestQuery = useMemo(() => {
     if (!composerQueryState) return "";
@@ -1700,6 +1726,7 @@ export function AiChat({
     void getAiChatComposerCandidates({
       ...(catalogProjectId ? { projectId: catalogProjectId } : {}),
       ...(selectedThreadId ? { threadId: selectedThreadId } : {}),
+      ...(!selectedThreadId && catalogCodexProjectIdentity ? catalogCodexProjectIdentity : {}),
       trigger: composerQueryState.trigger,
       query: composerRequestQuery,
     }, controller.signal).then(
@@ -1718,7 +1745,16 @@ export function AiChat({
       },
     );
     return () => controller.abort();
-  }, [catalogProjectId, composerQueryState, composerRequestQuery, selectedThreadId]);
+  }, [
+    catalogProjectId,
+    catalogCodexProjectIdentity?.codexHostId,
+    catalogCodexProjectIdentity?.codexProjectId,
+    catalogCodexProjectIdentity?.codexProjectKind,
+    catalogCodexProjectIdentity?.workspacePath,
+    composerQueryState,
+    composerRequestQuery,
+    selectedThreadId,
+  ]);
 
   const restoreDraftSettings = useCallback((thread: AiChatThread) => {
     setDraftModel(thread.model);
@@ -1864,10 +1900,16 @@ export function AiChat({
       setDraftOrigin({
         projectId: openThreadRequest.projectId,
         issueId: openThreadRequest.issueId,
+        codexProjectIdentity: openThreadRequest.projectId === projectId
+          ? codexProjectIdentity
+          : null,
       });
       taskComposerDraftOriginRef.current = {
         projectId: openThreadRequest.projectId,
         issueId: openThreadRequest.issueId,
+        codexProjectIdentity: openThreadRequest.projectId === projectId
+          ? codexProjectIdentity
+          : null,
       };
       setSnapshot(null);
       selectThread(null);
@@ -2028,6 +2070,7 @@ export function AiChat({
     setDraftOrigin({
       projectId: input.projectId,
       issueId: input.issueId ?? null,
+      codexProjectIdentity,
     });
     setSnapshot(null);
     selectThread(null);
@@ -2038,7 +2081,7 @@ export function AiChat({
 
   async function createThreadForDraftOrigin(): Promise<AiChatThread | null> {
     const origin = draftOrigin ?? (
-      projectId ? { projectId, issueId } : null
+      projectId ? { projectId, issueId, codexProjectIdentity } : null
     );
     const input = buildThreadCreateInput(origin?.projectId ?? "", origin?.issueId ?? null);
     if (!input) {
@@ -2057,7 +2100,7 @@ export function AiChat({
     try {
       const targetCatalog = catalogLoadedProjectId === input.projectId && activeCatalog
         ? activeCatalog
-        : await getAiChatCatalog(input.projectId);
+        : await getAiChatCatalog(input.projectId, undefined, origin?.codexProjectIdentity);
       const normalized = normalizeChatSelection(
         targetCatalog.models,
         inheritedSettings.model,
@@ -2076,6 +2119,7 @@ export function AiChat({
       const thread = await createAiChatThread({
         ...input,
         ...settings,
+        ...(origin?.codexProjectIdentity ?? {}),
       });
       replaceThread(thread);
       selectThread(thread.id);
@@ -2488,6 +2532,7 @@ export function AiChat({
         try {
           const candidates = await getAiChatComposerCandidates({
             projectId: taskComposerDraftOriginRef.current?.projectId,
+            ...(catalogCodexProjectIdentity ?? {}),
             trigger: "@",
             query: "",
           });

--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -1653,20 +1653,22 @@ export function AiChat({
     ?? draftOrigin?.projectId
     ?? projectId;
   const catalogThreadOrigin = snapshot?.thread.origin ?? selectedThreadSummary?.origin;
-  const catalogCodexProjectIdentity = catalogThreadOrigin?.codexProjectKind === "remote"
-    && catalogThreadOrigin.codexProjectId
-    && catalogThreadOrigin.codexHostId
-      ? {
-          codexProjectId: catalogThreadOrigin.codexProjectId,
-          codexProjectKind: "remote" as const,
-          codexHostId: catalogThreadOrigin.codexHostId,
-          workspacePath: catalogThreadOrigin.workspacePath,
-        }
-      : draftOrigin?.projectId === catalogProjectId
-        ? draftOrigin.codexProjectIdentity
-        : projectId === catalogProjectId
-          ? codexProjectIdentity
-          : null;
+  const catalogCodexProjectIdentity = catalogThreadOrigin
+    ? catalogThreadOrigin.codexProjectKind === "remote"
+      && catalogThreadOrigin.codexProjectId
+      && catalogThreadOrigin.codexHostId
+        ? {
+            codexProjectId: catalogThreadOrigin.codexProjectId,
+            codexProjectKind: "remote" as const,
+            codexHostId: catalogThreadOrigin.codexHostId,
+            workspacePath: catalogThreadOrigin.workspacePath,
+          }
+        : null
+    : draftOrigin?.projectId === catalogProjectId
+      ? draftOrigin.codexProjectIdentity
+      : projectId === catalogProjectId
+        ? codexProjectIdentity
+        : null;
   const activeCatalog = catalogLoadedProjectId === catalogProjectId ? catalog : null;
   useEffect(() => {
     if (!available || !catalogProjectId) {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -165,6 +165,10 @@ export interface ComposerCandidatesQuery {
   surface?: ComposerSurface;
   trigger: ComposerTrigger;
   query: string;
+  codexProjectId?: string;
+  codexProjectKind?: "local" | "remote";
+  codexHostId?: string;
+  workspacePath?: string;
 }
 
 export interface ComposerCandidatesResponse {
@@ -265,6 +269,9 @@ export interface AiChatOrigin {
   projectId: string;
   projectName: string;
   workspacePath: string;
+  codexProjectId?: string;
+  codexProjectKind?: "local" | "remote";
+  codexHostId?: string;
   issueId?: string;
   issueIdentifier?: string;
 }


### PR DESCRIPTION
## Summary

- Route built-in AI chat for an online Codex SSH project through that project's registered remote host and remote working directory.
- Keep Taskboard todo reads, claims, comments, and status writes on the Taskboard host, while dispatching only code execution to the matched remote Codex project.
- Preserve the existing local-project AI chat and automation workspace path.

## Direct verification

- Real SSH AI chat ran in `C:\Users\admin\Documents\dashi-taskboard`.
- Host-side automation claimed a real isolated `todo`, wrote the Taskboard lifecycle locally, and ran its Codex thread in the same remote directory.
- The existing local comparison project kept `/Users/jadon7/.codex/worktrees/de03/codex-taskboard`.
- `npm run typecheck`, `npm run build:web`, focused Node syntax checks, and `git diff --check` passed.

Related to #256. Keep #256 open until a release containing this change is published and verified.