### PR TITLE
Fix project display settings sync

### DIFF
--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -7,6 +7,7 @@ const PROJECT_README_BODY_LIMIT = 3 * 1024 * 1024;
 const ATTACHMENT_BODY_LIMIT = 25 * 1024 * 1024;
 const DEFAULT_PROJECT_LABELS_JSON = JSON.stringify(DEFAULT_LABEL_NAMES);
 const PROJECT_ID_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
+const PROJECT_BOARD_DISPLAY_SETTINGS_KEY_PREFIX = "taskboard.project-board-display-settings.v3.";
 const TASK_STATUSES = [
   "backlog",
   "todo",
@@ -44,6 +45,25 @@ export class RealtimeHub extends DurableObject {
       const [client, server] = Object.values(pair);
       this.ctx.acceptWebSocket(server);
       return new Response(null, { status: 101, webSocket: client });
+    }
+
+    if (url.pathname === "/client-storage") {
+      if (request.method === "GET") {
+        return json(200, {
+          entries: Object.fromEntries(await this.ctx.storage.list({
+            prefix: PROJECT_BOARD_DISPLAY_SETTINGS_KEY_PREFIX,
+          })),
+        });
+      }
+      if (request.method === "PATCH") {
+        const { key, value } = await request.json();
+        if (value === null) await this.ctx.storage.delete(key);
+        else await this.ctx.storage.put(key, value);
+        return empty(204);
+      }
+      return json(405, {
+        error: { code: "METHOD_NOT_ALLOWED", message: "Method not allowed" },
+      }, { allow: "GET, PATCH" });
     }
 
     if (url.pathname === "/broadcast" && request.method === "POST") {
@@ -1275,6 +1295,26 @@ function parseProjectCreate(body) {
     }
   }
   return { id, name };
+}
+
+function parseClientStorageUpdate(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["key", "value"]));
+  const key = stringField(body.key, "key", { required: true, maxLength: 512 });
+  if (
+    !key.startsWith(PROJECT_BOARD_DISPLAY_SETTINGS_KEY_PREFIX)
+    || key.length === PROJECT_BOARD_DISPLAY_SETTINGS_KEY_PREFIX.length
+  ) {
+    throw new ApiError(
+      400,
+      "INVALID_FIELD",
+      "'key' must identify project board display settings",
+    );
+  }
+  return {
+    key,
+    value: stringField(body.value, "value", { nullable: true, maxLength: 100_000 }),
+  };
 }
 
 function parseProjectLabel(body) {
@@ -3035,6 +3075,30 @@ async function routeApi(request, env, actor, url) {
       },
       localCapabilities: { available: false },
     });
+  }
+
+  if (pathname === "/api/client-storage") {
+    requireNoQuery(url, "/api/client-storage");
+    if (request.method === "GET") {
+      return realtimeHub(env).fetch("https://realtime.internal/client-storage");
+    }
+    if (request.method === "PATCH") {
+      const update = parseClientStorageUpdate(await readJson(request));
+      const response = await realtimeHub(env).fetch(
+        "https://realtime.internal/client-storage",
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(update),
+        },
+      );
+      if (!response.ok) return response;
+      await env.DB.prepare(`
+        UPDATE global_revision SET revision = revision + 1 WHERE singleton = 1
+      `).run();
+      return response;
+    }
+    methodNotAllowed(["GET", "PATCH"]);
   }
 
   if (pathname === "/api/revisions") {

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -53,6 +53,7 @@ const INLINE_ATTACHMENT_TYPES = new Set([
   "text/plain",
 ]);
 const PROJECT_ID_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
+const PROJECT_BOARD_DISPLAY_SETTINGS_KEY_PREFIX = "taskboard.project-board-display-settings.v3.";
 const TRUSTED_EMBED_ORIGINS = new Set(["app://-"]);
 const TRUSTED_ORIGINS_ENV = "CODEX_TASKBOARD_TRUSTED_ORIGINS";
 const CODEX_AGENT_ACTOR = {
@@ -1729,11 +1730,15 @@ export function createTaskboardServer(options = {}) {
     }
   }
 
-  async function updateClientStorage(body) {
+  function parseClientStorageUpdate(body) {
     assertPlainObject(body);
     assertAllowedKeys(body, new Set(["key", "value"]));
     const key = stringField(body.key, "key", { required: true, maxLength: 512 });
     const value = stringField(body.value, "value", { nullable: true, maxLength: 100_000 });
+    return { key, value };
+  }
+
+  async function updateClientStorage({ key, value }) {
     clientStorageWrite = clientStorageWrite.catch(() => {}).then(async () => {
       const entries = await readClientStorage();
       if (value === null) delete entries[key];
@@ -2161,10 +2166,41 @@ export function createTaskboardServer(options = {}) {
       if (pathname === "/api/client-storage") {
         if (request.method === "GET") {
           await clientStorageWrite;
-          return sendJson(response, 200, { entries: await readClientStorage() });
+          const entries = await readClientStorage();
+          const config = await cloudConfig.read();
+          if (config.remoteUrl) {
+            assertLoopbackRequest(request);
+            const shared = await readCloudJson("/api/client-storage");
+            for (const key of Object.keys(entries)) {
+              if (key.startsWith(PROJECT_BOARD_DISPLAY_SETTINGS_KEY_PREFIX)) delete entries[key];
+            }
+            for (const [key, value] of Object.entries(shared.entries)) {
+              if (key.startsWith(PROJECT_BOARD_DISPLAY_SETTINGS_KEY_PREFIX)) entries[key] = value;
+            }
+          }
+          return sendJson(response, 200, { entries });
         }
         if (request.method === "PATCH") {
-          await updateClientStorage(await readJson(request));
+          const update = parseClientStorageUpdate(await readJson(request));
+          const config = await cloudConfig.read();
+          if (
+            config.remoteUrl
+            && update.key.startsWith(PROJECT_BOARD_DISPLAY_SETTINGS_KEY_PREFIX)
+          ) {
+            assertLoopbackRequest(request);
+            return sendFetchResponse(
+              response,
+              await cloudProxy.forward(new Request("http://127.0.0.1/api/client-storage", {
+                method: "PATCH",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify(update),
+              })),
+            );
+          }
+          await updateClientStorage(update);
+          if (update.key.startsWith(PROJECT_BOARD_DISPLAY_SETTINGS_KEY_PREFIX)) {
+            events.emit("client-storage.updated", { key: update.key });
+          }
           return sendEmpty(response, 204);
         }
         return methodNotAllowed(response, ["GET", "PATCH"]);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -85,7 +85,12 @@ import {
   type NewTaskEditorDraft,
 } from "./components/TaskEditor";
 import { TaskFilterMenu } from "./components/TaskFilterMenu";
-import { taskboardStorage } from "./storage";
+import {
+  PROJECT_BOARD_DISPLAY_SETTINGS_KEY_PREFIX,
+  projectBoardDisplaySettingsStorageEntries,
+  refreshProjectBoardDisplaySettingsStorage,
+  taskboardStorage,
+} from "./storage";
 import {
   installEmbeddedExternalLinkHandler,
   postEmbeddedHostMessage,
@@ -303,7 +308,6 @@ const PROJECT_VIEW_KEY_PREFIX = "taskboard.project-view.v1.";
 const DEVICE_WORKSPACE_PATHS_KEY = "taskboard.deviceWorkspacePaths.v1";
 const PROJECT_CODEX_IDENTITIES_KEY = "taskboard.projectCodexIdentities.v1";
 const PROJECT_AUTOMATIONS_KEY = "taskboard.projectAutomations.v1";
-const PROJECT_BOARD_DISPLAY_SETTINGS_KEY = "taskboard.project-board-display-settings.v3";
 const ISSUE_READ_KEY_PREFIX = "taskboard.issue-read.v1";
 const FIRST_USE_COMPLETE_KEY = "taskboard.first-use-complete.v1";
 function readIssueActivityKeys(storageKey: string): Record<string, string> {
@@ -326,12 +330,20 @@ function readProjectBoardView(projectId: string): BoardView {
 }
 
 function readProjectBoardDisplaySettings(): Record<string, BoardDisplaySettings> {
-  try {
-    const value = JSON.parse(taskboardStorage.getItem(PROJECT_BOARD_DISPLAY_SETTINGS_KEY) ?? "{}");
-    return value && typeof value === "object" && !Array.isArray(value) ? value : {};
-  } catch {
-    return {};
+  const settings: Record<string, BoardDisplaySettings> = {};
+  for (const [key, storedValue] of projectBoardDisplaySettingsStorageEntries()) {
+    const projectId = key.slice(PROJECT_BOARD_DISPLAY_SETTINGS_KEY_PREFIX.length);
+    if (!projectId) continue;
+    try {
+      const value = JSON.parse(storedValue);
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        settings[projectId] = value as BoardDisplaySettings;
+      }
+    } catch {
+      // Ignore malformed display settings without affecting other projects.
+    }
   }
+  return settings;
 }
 
 function readRecentProjectIds(): string[] {
@@ -361,6 +373,7 @@ const EVENT_NAMES = [
   "project.created",
   "project.labels.updated",
   "project.readme.updated",
+  "client-storage.updated",
 ] as const;
 
 function isTheme(value: unknown): value is Theme {
@@ -559,6 +572,7 @@ interface LocalRealtimeSyncProps {
     projectId: string,
     options?: { quiet?: boolean; signal?: AbortSignal },
   ) => Promise<void>;
+  refreshProjectBoardDisplaySettings: () => Promise<void>;
   setConnection: Dispatch<SetStateAction<ConnectionState>>;
   setCommentsRevision: Dispatch<SetStateAction<number>>;
   setAttachmentsRevision: Dispatch<SetStateAction<number>>;
@@ -570,6 +584,7 @@ function LocalRealtimeSync({
   detailTaskId,
   refreshProjectList,
   refreshTasks,
+  refreshProjectBoardDisplaySettings,
   setConnection,
   setCommentsRevision,
   setAttachmentsRevision,
@@ -597,15 +612,23 @@ function LocalRealtimeSync({
 
     const handleEvent = (event: Event) => {
       const message = event as MessageEvent<string>;
-      let payload: { projectId?: string; taskId?: string; project?: Project } = {};
+      let payload: { projectId?: string; taskId?: string; project?: Project; key?: string } = {};
       try {
         payload = JSON.parse(message.data) as {
           projectId?: string;
           taskId?: string;
           project?: Project;
+          key?: string;
         };
       } catch {
         // A malformed event should not interrupt later updates.
+      }
+      if (
+        event.type === "client-storage.updated"
+        && payload.key?.startsWith(PROJECT_BOARD_DISPLAY_SETTINGS_KEY_PREFIX)
+      ) {
+        void refreshProjectBoardDisplaySettings();
+        return;
       }
       const eventProjectId = payload.projectId ?? payload.project?.id;
       const affectsSelectedProject = Boolean(selectedProjectId)
@@ -649,6 +672,7 @@ function LocalRealtimeSync({
     EVENT_NAMES.forEach((name) => source.addEventListener(name, handleEvent));
     source.onopen = () => {
       setConnection("live");
+      void refreshProjectBoardDisplaySettings();
       scheduleRefresh({ projects: true, tasks: Boolean(selectedProjectId) });
       if (selectedProjectId && selectedProjectId !== ALL_PROJECTS_ID) {
         setReadmeRevision((current) => current + 1);
@@ -667,6 +691,7 @@ function LocalRealtimeSync({
     };
   }, [
     detailTaskId,
+    refreshProjectBoardDisplaySettings,
     refreshProjectList,
     refreshTasks,
     selectedProjectId,
@@ -732,6 +757,14 @@ export function App() {
   const [projectBoardDisplaySettings, setProjectBoardDisplaySettings] = useState(
     readProjectBoardDisplaySettings,
   );
+  const refreshProjectBoardDisplaySettings = useCallback(async () => {
+    try {
+      await refreshProjectBoardDisplaySettingsStorage();
+      setProjectBoardDisplaySettings(readProjectBoardDisplaySettings());
+    } catch (error) {
+      console.error(error);
+    }
+  }, []);
   const [dashboardSummaryAnimatedProjectId, setDashboardSummaryAnimatedProjectId] = useState<string | null>(null);
   const [ganttZoom, setGanttZoom] = useState<GanttZoom>("week");
   const [ganttHideCompleted, setGanttHideCompleted] = useState(false);
@@ -2037,6 +2070,7 @@ export function App() {
 
   const invalidateCloudData = useCallback(() => {
     void refreshProjectList();
+    void refreshProjectBoardDisplaySettings();
     const projectId = taskScopeProjectIdRef.current;
     if (projectId) {
       void refreshTasks(projectId, { quiet: true });
@@ -2044,7 +2078,7 @@ export function App() {
     setReadmeRevision((current) => current + 1);
     setCommentsRevision((current) => current + 1);
     setAttachmentsRevision((current) => current + 1);
-  }, [refreshProjectList, refreshTasks]);
+  }, [refreshProjectList, refreshProjectBoardDisplaySettings, refreshTasks]);
 
   useEffect(() => {
     if (revisionPollingInterval === null) return;
@@ -2303,7 +2337,10 @@ export function App() {
   function updateProjectBoardDisplaySettings(value: BoardDisplaySettings) {
     setProjectBoardDisplaySettings((current) => {
       const next = { ...current, [selectedProjectId]: value };
-      taskboardStorage.setItem(PROJECT_BOARD_DISPLAY_SETTINGS_KEY, JSON.stringify(next));
+      taskboardStorage.setItem(
+        `${PROJECT_BOARD_DISPLAY_SETTINGS_KEY_PREFIX}${selectedProjectId}`,
+        JSON.stringify(value),
+      );
       return next;
     });
   }
@@ -2312,7 +2349,9 @@ export function App() {
     setProjectBoardDisplaySettings((current) => {
       const next = { ...current };
       delete next[selectedProjectId];
-      taskboardStorage.setItem(PROJECT_BOARD_DISPLAY_SETTINGS_KEY, JSON.stringify(next));
+      taskboardStorage.removeItem(
+        `${PROJECT_BOARD_DISPLAY_SETTINGS_KEY_PREFIX}${selectedProjectId}`,
+      );
       return next;
     });
   }
@@ -3271,6 +3310,7 @@ export function App() {
           detailTaskId={detailTaskId}
           refreshProjectList={refreshProjectList}
           refreshTasks={refreshTasks}
+          refreshProjectBoardDisplaySettings={refreshProjectBoardDisplaySettings}
           setConnection={setConnection}
           setCommentsRevision={setCommentsRevision}
           setAttachmentsRevision={setAttachmentsRevision}

--- a/web/src/storage.ts
+++ b/web/src/storage.ts
@@ -1,9 +1,40 @@
 const memoryStorage = new Map<string, string>();
+export const PROJECT_BOARD_DISPLAY_SETTINGS_KEY_PREFIX = "taskboard.project-board-display-settings.v3.";
 const RETRY_DELAY_MS = 250;
 const MAX_RETRY_DELAY_MS = 5_000;
 let localStorageBackend: Storage | null = null;
 let serverBacked = false;
 let storageWrite = Promise.resolve();
+let storageRefresh = Promise.resolve();
+
+function isProjectBoardDisplaySettingsKey(key: string) {
+  return key.startsWith(PROJECT_BOARD_DISPLAY_SETTINGS_KEY_PREFIX);
+}
+
+async function readServerStorage() {
+  const response = await fetch(new URL("api/client-storage", document.baseURI));
+  if (!response.ok) throw new Error(`Taskboard storage returned ${response.status}`);
+  const payload = await response.json() as { entries: Record<string, string> };
+  if (localStorageBackend) {
+    for (const key of memoryStorage.keys()) {
+      if (isProjectBoardDisplaySettingsKey(key)) memoryStorage.delete(key);
+    }
+    for (const [key, value] of Object.entries(payload.entries)) {
+      if (isProjectBoardDisplaySettingsKey(key)) memoryStorage.set(key, value);
+    }
+    return;
+  }
+  memoryStorage.clear();
+  for (const [key, value] of Object.entries(payload.entries)) {
+    memoryStorage.set(key, value);
+  }
+  serverBacked = true;
+}
+
+async function refreshServerStorage() {
+  storageRefresh = storageRefresh.catch(() => {}).then(readServerStorage);
+  await storageRefresh;
+}
 
 function persist(key: string, value: string | null) {
   storageWrite = storageWrite.then(async () => {
@@ -37,23 +68,32 @@ function persist(key: string, value: string | null) {
 export async function initializeTaskboardStorage() {
   try {
     localStorageBackend = window.localStorage;
-    return;
   } catch {
-    const response = await fetch(new URL("api/client-storage", document.baseURI));
-    if (!response.ok) throw new Error(`Taskboard storage returned ${response.status}`);
-    const payload = await response.json() as { entries: Record<string, string> };
-    for (const [key, value] of Object.entries(payload.entries)) {
-      memoryStorage.set(key, value);
-    }
-    serverBacked = true;
+    localStorageBackend = null;
   }
+  await refreshServerStorage();
+}
+
+export async function refreshProjectBoardDisplaySettingsStorage() {
+  await storageWrite;
+  await refreshServerStorage();
+}
+
+export function projectBoardDisplaySettingsStorageEntries() {
+  return [...memoryStorage.entries()].filter(([key]) => isProjectBoardDisplaySettingsKey(key));
 }
 
 export const taskboardStorage: Pick<Storage, "getItem" | "setItem" | "removeItem"> = {
   getItem(key) {
+    if (isProjectBoardDisplaySettingsKey(key)) return memoryStorage.get(key) ?? null;
     return localStorageBackend?.getItem(key) ?? memoryStorage.get(key) ?? null;
   },
   setItem(key, value) {
+    if (isProjectBoardDisplaySettingsKey(key)) {
+      memoryStorage.set(key, value);
+      persist(key, value);
+      return;
+    }
     if (localStorageBackend) {
       localStorageBackend.setItem(key, value);
       return;
@@ -62,6 +102,11 @@ export const taskboardStorage: Pick<Storage, "getItem" | "setItem" | "removeItem
     if (serverBacked) persist(key, value);
   },
   removeItem(key) {
+    if (isProjectBoardDisplaySettingsKey(key)) {
+      memoryStorage.delete(key);
+      persist(key, null);
+      return;
+    }
     if (localStorageBackend) {
       localStorageBackend.removeItem(key);
       return;


### PR DESCRIPTION
## Summary

- Store board display settings per project through the shared client-storage endpoint.
- Refresh local windows through SSE and cloud clients through the existing revision path.
- Keep unrelated client preferences local.

## Verification

- `npm run typecheck`
- `npm run build:web`
- `node --check server/app.mjs`
- `node --check cloud/src/index.mjs`
- `node --test test/server.test.mjs` (30/30)
- `node --test test/cloud-shared-worker.test.mjs` (25/25)
- Real path: Alpha settings changed from two isolated Codex windows and one browser, synchronized live, and remained consistent after hard refresh.
- Project isolation: Alpha and Beta retained different settings.

Taskboard: LOCAL-327