### PR TITLE
LOCAL-329 Animate completed card exit and board reflow

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3795,7 +3795,7 @@ export function App() {
                         onCreate={(initialStatus) => setEditor({ task: null, status: initialStatus })}
                         onEdit={openTaskDetail}
                         onUpdate={updateTaskProperties}
-                        onComplete={(task) => void moveTask(task, "done")}
+                        onComplete={(task) => moveTask(task, "done")}
                         onContextMenu={openTaskContextMenu}
                         onDragStart={startTaskDrag}
                         onDragEnd={endTaskDrag}

--- a/web/src/components/BoardColumn.tsx
+++ b/web/src/components/BoardColumn.tsx
@@ -42,7 +42,7 @@ interface BoardColumnProps {
   onCreate: (status: TaskStatus) => void;
   onEdit: (task: Task) => void;
   onUpdate: (task: Task, changes: Partial<TaskDraft>) => Promise<Task>;
-  onComplete: (task: Task) => void;
+  onComplete: (task: Task) => Promise<void>;
   onContextMenu: (task: Task, position: { x: number; y: number }) => void;
   onDragStart: (task: Task, height: number) => void;
   onDragEnd: () => void;

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -45,7 +45,7 @@ interface TaskCardProps {
   onCreateLabel: (label: string) => Promise<void>;
   onEdit: (task: Task) => void;
   onUpdate: (task: Task, changes: Partial<TaskDraft>) => Promise<Task>;
-  onComplete?: (task: Task) => void;
+  onComplete?: (task: Task) => Promise<void>;
   onContextMenu: (task: Task, position: { x: number; y: number }) => void;
   onDragStart: (task: Task, height: number) => void;
   onDragEnd: () => void;
@@ -446,7 +446,10 @@ export function TaskCard({
   return (
     <article
       className={`task-card task-card-${variant} status-${task.status}${processingCard ? " is-processing-card" : ""}${processingCard && presentation.processing.running ? " is-running-card" : ""}${image ? " has-media" : ""}${presentation.unread ? " is-unread" : ""}${isDragging ? " is-dragging" : ""}${dragShift ? " is-drag-shifted" : ""}${isMoving ? " is-moving" : ""}${isSettling ? " is-settling" : ""}${isContextMenuOpen ? " is-context-open" : ""}${propertyMenu ? " is-property-menu-open" : ""}`}
-      style={dragShift ? { transform: `translate3d(0, ${dragShift}px, 0)` } : undefined}
+      style={{
+        viewTransitionName: task.status === "in_review" ? `review-task-${task.id}` : "none",
+        ...(dragShift ? { transform: `translate3d(0, ${dragShift}px, 0)` } : {}),
+      }}
       draggable={!isMoving}
       aria-labelledby={`task-${task.id}-title`}
       data-task-id={task.id}
@@ -484,7 +487,13 @@ export function TaskCard({
             title={text("完成", "Complete")}
             onClick={(event) => {
               event.stopPropagation();
-              onComplete(task);
+              const card = event.currentTarget.closest<HTMLElement>(".task-card")!;
+              card.style.viewTransitionName = "completing-task";
+              const transition = document.startViewTransition(() => onComplete(task));
+              void transition.finished.then(
+                () => { card.style.viewTransitionName = `review-task-${task.id}`; },
+                () => { card.style.viewTransitionName = `review-task-${task.id}`; },
+              );
             }}
           >
             <img src={completeIcon} alt="" aria-hidden="true" />

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2403,6 +2403,29 @@ kbd {
   animation: task-card-settle 200ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
 }
 
+::view-transition-group(*) {
+  animation-duration: 220ms;
+  animation-timing-function: cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+::view-transition-group(root),
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+}
+
+::view-transition-old(completing-task) {
+  animation: task-card-complete-exit 180ms ease-out both;
+  transform-origin: center;
+}
+
+@keyframes task-card-complete-exit {
+  to {
+    opacity: 0;
+    transform: scale(0.97);
+  }
+}
+
 @keyframes task-card-settle {
   from {
     opacity: 0.38;


### PR DESCRIPTION
## Summary
- Fade and slightly scale the clicked card out after completing an `in_review` task.
- Smoothly move the remaining cards into their new positions.
- Keep the existing task-save and status-update semantics unchanged.

## Direct path
`TaskCard` 完成按钮 → `App.moveTask` → `POST /api/tasks/:id/move` → 状态保存为 `done` → 对应卡片退出且列表补位。

## Verification
- `npm run typecheck`
- `npm run build:web`
- `git diff --check origin/main...HEAD`
- Headed browser with isolated real data: target opacity `1 → 0`, scale `1 → 0.97` over 180 ms; two lower cards participate in the 220 ms position transition and move up one slot.
- Demo: http://127.0.0.1:53299/?project=local-329-demo

## Scope
No new settings, abstractions, compatibility layers, delayed state machine, unrelated refactor, or tests. User visual confirmation remains the merge gate.