### PR TITLE
Fix Codex task detail interactions

### DIFF
--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -1254,6 +1254,7 @@
       });
       input.remove();
     }, { once: true });
+    input.getBoundingClientRect();
     input.showPicker();
   }
 

--- a/web/src/components/DescriptionDocument.tsx
+++ b/web/src/components/DescriptionDocument.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ClipboardEvent, type MouseEvent } from "react";
+import { memo, useEffect, useState, type ClipboardEvent, type MouseEvent } from "react";
 import { createPortal } from "react-dom";
 import { attachmentContentUrl } from "../api";
 import { readIssueIdentifier } from "../issueRoute";
@@ -47,7 +47,7 @@ function fileSize(value: number): string {
   return `${(value / (1024 * 1024)).toFixed(value < 10 * 1024 * 1024 ? 1 : 0)} MB`;
 }
 
-export function DescriptionDocument({
+export const DescriptionDocument = memo(function DescriptionDocument({
   value,
   referenceTasks,
   onOpenTask,
@@ -113,7 +113,6 @@ export function DescriptionDocument({
                 src={attachmentContentUrl(attachment)}
                 aria-label={attachment.filename}
                 controls
-                onClick={(event) => event.stopPropagation()}
               />
             );
           }
@@ -207,4 +206,4 @@ export function DescriptionDocument({
       document.body,
     )}
   </>);
-}
+});

--- a/web/src/components/InlineMediaComposer.css
+++ b/web/src/components/InlineMediaComposer.css
@@ -188,7 +188,37 @@
 
 .issue-description-composer .inline-media-composer.ProseMirror li > p,
 .comment-inline-media.ProseMirror li > p {
-  margin-bottom: 4px;
+  margin-bottom: 3px;
+}
+
+.inline-media-composer.ProseMirror ul:has(> li.task-list-item),
+.inline-media-composer.ProseMirror ol:has(> li.task-list-item) {
+  padding-left: 2px;
+  list-style: none;
+}
+
+.inline-media-composer.ProseMirror li.task-list-item {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr);
+  column-gap: 7px;
+  list-style: none;
+}
+
+.inline-media-composer.ProseMirror li.task-list-item > input[type="checkbox"] {
+  width: 14px;
+  height: 14px;
+  margin: 4px 0 0;
+  padding: 0;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.inline-media-composer.ProseMirror .inline-media-task-content {
+  min-width: 0;
+}
+
+.inline-media-composer.ProseMirror .inline-media-task-content > p {
+  margin-bottom: 0;
 }
 
 .inline-media-composer.ProseMirror p:has(+ .inline-media-attachment-atom:not(.inline-media-video-atom)) {

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -1138,6 +1138,15 @@ function ComposerReferenceChip({
 const INLINE_MEDIA_NODE = "taskboard_inline_media";
 const INLINE_REFERENCE_NODE = "taskboard_inline_reference";
 const INLINE_MEDIA_PLACEHOLDER_PREFIX = "https://taskboard.invalid/inline-media/";
+const TASK_LIST_MARKER = /^\[([ xX])\][\t ]+/;
+
+function taskMarkerIsChecked(marker: string): boolean {
+  return /^\[[xX]\]/.test(marker);
+}
+
+function toggledTaskMarker(marker: string): string {
+  return marker.replace(/^\[[ xX]\]/, taskMarkerIsChecked(marker) ? "[ ]" : "[x]");
+}
 
 const markdownMarks = defaultMarkdownParser.schema.spec.marks.append({
   strike: {
@@ -1161,7 +1170,33 @@ const composerMarks = ["strong", "em", "code", "link", "strike"].reduce(
 );
 
 const markdownNodes = defaultMarkdownParser.schema.spec.nodes;
-const composerNodes = markdownNodes.update("heading", {
+const listItemNode = markdownNodes.get("list_item")!;
+const composerNodes = markdownNodes.update("list_item", {
+  ...listItemNode,
+  attrs: {
+    ...(listItemNode.attrs ?? {}),
+    taskMarker: { default: null },
+  },
+  toDOM(node) {
+    const taskMarker = typeof node.attrs.taskMarker === "string"
+      ? node.attrs.taskMarker
+      : null;
+    if (!taskMarker) return ["li", 0];
+    const checkboxAttributes: Record<string, string> = {
+      type: "checkbox",
+      contenteditable: "false",
+      tabindex: "-1",
+      "data-inline-media-task-checkbox": "true",
+    };
+    if (taskMarkerIsChecked(taskMarker)) checkboxAttributes.checked = "checked";
+    return [
+      "li",
+      { class: "task-list-item" },
+      ["input", checkboxAttributes],
+      ["div", { class: "inline-media-task-content" }, 0],
+    ];
+  },
+}).update("heading", {
   ...markdownNodes.get("heading")!,
   content: "inline*",
 }).append({
@@ -1374,8 +1409,21 @@ function editorNodesWithAtoms(
 
   const children: ProseMirrorNode[] = [];
   node.forEach((child) => children.push(...editorNodesWithAtoms(child, atomSegments)));
-  if (node.type.name === "list_item" && children[0]?.type.name !== "paragraph") {
-    children.unshift(composerSchema.nodes.paragraph.create());
+  if (node.type.name === "list_item") {
+    if (children[0]?.type.name !== "paragraph") {
+      children.unshift(composerSchema.nodes.paragraph.create());
+    }
+    if (typeof node.attrs.taskMarker !== "string") {
+      const taskMarker = TASK_LIST_MARKER.exec(children[0].textContent)?.[0];
+      if (taskMarker) {
+        children[0] = children[0].cut(taskMarker.length);
+        return [node.type.create(
+          { ...node.attrs, taskMarker },
+          Fragment.fromArray(children),
+          node.marks,
+        )];
+      }
+    }
   }
   return [node.copy(Fragment.fromArray(children))];
 }
@@ -1478,6 +1526,25 @@ function markInputRule(
   });
 }
 
+function taskListInputRule(): InputRule {
+  return new InputRule(/^\[([ xX])\][\t ]$/, (state, match, start, end) => {
+    const { $from } = state.selection;
+    if ($from.parent.type !== composerSchema.nodes.paragraph || $from.depth < 2) return null;
+    const listItemDepth = $from.depth - 1;
+    const listItem = $from.node(listItemDepth);
+    if (
+      listItem.type !== composerSchema.nodes.list_item
+      || start !== $from.start()
+    ) return null;
+    return state.tr
+      .delete(start, end)
+      .setNodeMarkup($from.before(listItemDepth), undefined, {
+        ...listItem.attrs,
+        taskMarker: match[0],
+      });
+  });
+}
+
 function composerPlugins(): Plugin[] {
   const rules: InputRule[] = [
     wrappingInputRule(/^\s*>\s$/, composerSchema.nodes.blockquote),
@@ -1488,6 +1555,7 @@ function composerPlugins(): Plugin[] {
       (match, node) => node.childCount + node.attrs.order === Number(match[1]),
     ),
     wrappingInputRule(/^\s*([-+*])\s$/, composerSchema.nodes.bullet_list),
+    taskListInputRule(),
     textblockTypeInputRule(/^```$/, composerSchema.nodes.code_block),
     textblockTypeInputRule(/^(#{1,6})\s$/, composerSchema.nodes.heading, (match) => ({
       level: match[1].length,
@@ -1535,12 +1603,17 @@ const editorMarkdownSerializer = new MarkdownSerializer({
     state.write("\n");
   },
   paragraph(state, node, parent, index) {
-    const taskMarker = parent.type === composerSchema.nodes.list_item && index === 0
-      ? /^\[([ xX])\][\t ]+/.exec(node.textContent)?.[0]
+    const storedTaskMarker = parent.type === composerSchema.nodes.list_item && index === 0
+      && typeof parent.attrs.taskMarker === "string"
+      ? parent.attrs.taskMarker
       : null;
+    const textTaskMarker = parent.type === composerSchema.nodes.list_item && index === 0
+      ? TASK_LIST_MARKER.exec(node.textContent)?.[0]
+      : null;
+    const taskMarker = storedTaskMarker ?? textTaskMarker;
     if (taskMarker) {
       state.write(taskMarker);
-      state.renderInline(node.cut(taskMarker.length), false);
+      state.renderInline(storedTaskMarker ? node : node.cut(taskMarker.length), false);
     } else {
       state.renderInline(node);
     }
@@ -2315,6 +2388,37 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
           return true;
         },
         handleDOMEvents: {
+          mousedown(_view, event) {
+            const target = event.target;
+            if (
+              !(target instanceof Element)
+              || !target.closest("[data-inline-media-task-checkbox]")
+            ) return false;
+            event.preventDefault();
+            return true;
+          },
+          click(view, event) {
+            const target = event.target;
+            if (!(target instanceof Element)) return false;
+            const checkbox = target.closest("[data-inline-media-task-checkbox]");
+            if (!checkbox) return false;
+            event.preventDefault();
+            if (disabledRef.current) return true;
+            const listItem = checkbox.closest("li.task-list-item");
+            if (!listItem) return false;
+            const nodePos = view.posAtDOM(listItem, 0) - 1;
+            const node = view.state.doc.nodeAt(nodePos);
+            if (
+              node?.type !== composerSchema.nodes.list_item
+              || typeof node.attrs.taskMarker !== "string"
+            ) return false;
+            view.dispatch(view.state.tr.setNodeMarkup(nodePos, undefined, {
+              ...node.attrs,
+              taskMarker: toggledTaskMarker(node.attrs.taskMarker),
+            }));
+            view.focus();
+            return true;
+          },
           dragover(_view, event) {
             if (disabledRef.current || !event.dataTransfer?.types.includes("Files")) return false;
             event.preventDefault();

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useLayoutEffect,
   useRef,
@@ -971,14 +972,17 @@ export function TaskDetail({
     }
   }
 
-  function handleAttachmentDownload(event: MouseEvent<HTMLAnchorElement>, attachment: Attachment) {
+  const handleAttachmentDownload = useCallback((
+    event: MouseEvent<HTMLAnchorElement>,
+    attachment: Attachment,
+  ) => {
     event.preventDefault();
     event.stopPropagation();
     setAttachmentsError(null);
     void downloadAttachmentFile(attachment).catch((error) => {
       setAttachmentsError(messageFor(error));
     });
-  }
+  }, []);
 
   const developmentOptions = [...developmentScan.contexts];
   if (
@@ -1110,6 +1114,7 @@ export function TaskDetail({
                     tabIndex={0}
                     aria-label={text("编辑议题描述", "Edit issue description")}
                     onClick={(event) => {
+                      if (event.target instanceof Element && event.target.closest("video")) return;
                       if (window.getSelection()?.isCollapsed === false) return;
                       descriptionCaretRef.current = null;
                       const range = event.currentTarget.ownerDocument.caretRangeFromPoint(


### PR DESCRIPTION
## Summary

- anchor the Codex-hosted date picker to the clicked start or due date field
- keep task, unordered, and ordered lists consistent between edit and read modes
- prevent unchanged description and comment documents from rerendering during title or comment draft input
- preserve native video mouse controls without entering description edit mode
- keep task checkbox focus inside the editor and persist the toggled Markdown state

## Direct verification

- real mouse checkbox path: editor stayed open, unchecked changed to checked, blur saved, read mode stayed checked, isolated issue version advanced
- ChatGPT Pro direct-development delivery and blocker analysis: https://chatgpt.com/c/6a92b923-3854-83e8-8996-fa62ebddc691
- `npm run typecheck`
- `node --test test/inject.test.mjs test/board-interactions.test.mjs test/issue-detail-markdown.test.mjs test/issue-detail-inline-focus.test.mjs` — 47 passed
- `npm run build:web`
- `git diff --check e0ceec39b6a9b8be96f84358896c959602b9001e..8491210d504a75cca58a3f7e6e8983ff563e36dd`

Exact head: `8491210d504a75cca58a3f7e6e8983ff563e36dd`
