### PR TITLE
Fix live Codex project mapping

### DIFF
--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -485,8 +485,12 @@
       (Array.isArray(bootstrap?.globalStateEntries) ? bootstrap.globalStateEntries : [])
         .map((entry) => [entry?.key, entry?.value]),
     );
+    const [currentLocalProjects, currentRemoteProjects] = await Promise.all([
+      requestNativeFetch("get-global-state", { key: "local-projects" }),
+      requestNativeFetch("get-global-state", { key: "remote-projects" }),
+    ]);
     const metadata = new Map();
-    const localProjects = entries.get("local-projects");
+    const localProjects = currentLocalProjects?.value ?? entries.get("local-projects");
     if (localProjects && typeof localProjects === "object" && !Array.isArray(localProjects)) {
       Object.entries(localProjects).forEach(([projectId, project]) => {
         const id = projectId.trim();
@@ -501,7 +505,7 @@
         });
       });
     }
-    const remoteProjects = entries.get("remote-projects");
+    const remoteProjects = currentRemoteProjects?.value ?? entries.get("remote-projects");
     if (Array.isArray(remoteProjects)) {
       remoteProjects.forEach((project) => {
         const id = typeof project?.id === "string" ? project.id.trim() : "";
@@ -989,7 +993,13 @@
   async function nativeProjectContext() {
     const bootstrap = await window.electronBridge?.getInitialSidebarBootstrap?.();
     const entries = bootstrap?.globalStateEntries ?? [];
-    const localProjects = entries.find((entry) => entry.key === "local-projects")?.value ?? {};
+    const currentLocalProjects = await requestNativeFetch(
+      "get-global-state",
+      { key: "local-projects" },
+    );
+    const localProjects = currentLocalProjects?.value
+      ?? entries.find((entry) => entry.key === "local-projects")?.value
+      ?? {};
     return {
       projects: Object.entries(localProjects).flatMap(([id, project]) => (
         project && Array.isArray(project.rootPaths)

--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -430,11 +430,11 @@
 
   function requestNativeFetch(path, body) {
     const bridge = window.electronBridge;
-    if (!bridge || typeof bridge.sendMessageFromView !== "function") return Promise.resolve(null);
+    if (!bridge || typeof bridge.sendMessageFromView !== "function") return Promise.resolve(undefined);
     return new Promise((resolve) => {
       const requestId = `taskboard-native-fetch-${crypto.randomUUID()}`;
       let settled = false;
-      const finish = (value = null) => {
+      const finish = (value) => {
         if (settled) return;
         settled = true;
         window.clearTimeout(timeout);
@@ -449,13 +449,17 @@
           || message.type !== "fetch-response"
           || message.requestId !== requestId
         ) return;
+        if (!Number.isInteger(message.status) || message.status < 200 || message.status >= 300) {
+          finish(undefined);
+          return;
+        }
         try {
           finish(JSON.parse(message.bodyJsonString || "null"));
         } catch (_) {
-          finish();
+          finish(undefined);
         }
       };
-      const timeout = window.setTimeout(finish, 1_000);
+      const timeout = window.setTimeout(() => finish(undefined), 1_000);
       window.addEventListener("message", onMessage);
       try {
         bridge.sendMessageFromView({
@@ -466,7 +470,7 @@
           body: JSON.stringify(body),
         });
       } catch (_) {
-        finish();
+        finish(undefined);
       }
     });
   }
@@ -490,7 +494,9 @@
       requestNativeFetch("get-global-state", { key: "remote-projects" }),
     ]);
     const metadata = new Map();
-    const localProjects = currentLocalProjects?.value ?? entries.get("local-projects");
+    const localProjects = currentLocalProjects === undefined
+      ? entries.get("local-projects")
+      : currentLocalProjects?.value;
     if (localProjects && typeof localProjects === "object" && !Array.isArray(localProjects)) {
       Object.entries(localProjects).forEach(([projectId, project]) => {
         const id = projectId.trim();
@@ -505,7 +511,9 @@
         });
       });
     }
-    const remoteProjects = currentRemoteProjects?.value ?? entries.get("remote-projects");
+    const remoteProjects = currentRemoteProjects === undefined
+      ? entries.get("remote-projects")
+      : currentRemoteProjects?.value;
     if (Array.isArray(remoteProjects)) {
       remoteProjects.forEach((project) => {
         const id = typeof project?.id === "string" ? project.id.trim() : "";
@@ -545,10 +553,24 @@
     const normalizedSlashes = windowsPath ? path.replace(/\\/g, "/") : path;
     const withoutTrailingSlash = normalizedSlashes.replace(/\/+$/, "")
       || (normalizedSlashes.startsWith("/") ? "/" : normalizedSlashes);
-    const macPath = /Mac/i.test(String(navigator.platform || navigator.userAgent || ""));
-    if (macPath) return withoutTrailingSlash.toLowerCase();
     if (!windowsPath || !/^[A-Za-z]:/.test(withoutTrailingSlash)) return withoutTrailingSlash;
     return `${withoutTrailingSlash[0].toLowerCase()}${withoutTrailingSlash.slice(1)}`;
+  }
+
+  async function canonicalNativeRootPaths(roots) {
+    const normalizedRoots = roots.map((root) => normalizeNativeRootPath(root));
+    const response = await requestNativeFetch("workspace-root-options", {
+      hostId: "local",
+      canonicalizeRoots: roots,
+    });
+    const canonicalPathByRoot = response?.canonicalPathByRoot;
+    if (!canonicalPathByRoot || typeof canonicalPathByRoot !== "object") return normalizedRoots;
+    const canonicalRoots = roots.map((root) => (
+      typeof canonicalPathByRoot[root] === "string"
+        ? normalizeNativeRootPath(canonicalPathByRoot[root])
+        : ""
+    ));
+    return canonicalRoots.every(Boolean) ? canonicalRoots : normalizedRoots;
   }
 
   function readCodexProjects(metadata = codexProjectMetadata) {
@@ -1005,11 +1027,16 @@
       "get-global-state",
       { key: "local-projects" },
     );
-    const localProjects = currentLocalProjects?.value
-      ?? entries.find((entry) => entry.key === "local-projects")?.value
-      ?? {};
+    const localProjects = currentLocalProjects === undefined
+      ? entries.find((entry) => entry.key === "local-projects")?.value
+      : currentLocalProjects?.value;
+    const projectEntries = localProjects
+      && typeof localProjects === "object"
+      && !Array.isArray(localProjects)
+      ? Object.entries(localProjects)
+      : [];
     return {
-      projects: Object.entries(localProjects).flatMap(([id, project]) => (
+      projects: projectEntries.flatMap(([id, project]) => (
         project && Array.isArray(project.rootPaths)
           ? [{ ...project, id }]
           : []
@@ -1020,12 +1047,22 @@
   async function resolveNativeProject(requestedProjectId, workspacePath) {
     const context = await nativeProjectContext();
     const normalizedWorkspacePath = normalizeNativeRootPath(workspacePath);
-    const project = context.projects.find((candidate) => (
-      candidate.id === requestedProjectId
-      || candidate.rootPaths.some((root) => (
-        normalizeNativeRootPath(root) === normalizedWorkspacePath
-      ))
-    )) ?? null;
+    let project = context.projects.find((candidate) => candidate.id === requestedProjectId) ?? null;
+    if (!project && normalizedWorkspacePath) {
+      const projectRoots = context.projects.flatMap((candidate) => candidate.rootPaths.flatMap((root) => (
+        typeof root === "string" && normalizeNativeRootPath(root)
+          ? [{ project: candidate, root }]
+          : []
+      )));
+      const canonicalRoots = await canonicalNativeRootPaths([
+        workspacePath,
+        ...projectRoots.map(({ root }) => root),
+      ]);
+      const matchingRootIndex = canonicalRoots.slice(1).findIndex((root) => (
+        root === canonicalRoots[0]
+      ));
+      if (matchingRootIndex >= 0) project = projectRoots[matchingRootIndex].project;
+    }
     const targetRoot = normalizedWorkspacePath ? workspacePath : project?.rootPaths[0];
     return project && typeof targetRoot === "string" && normalizeNativeRootPath(targetRoot)
       ? { projectId: project.id, targetRoot }
@@ -1049,23 +1086,22 @@
 
   async function waitForNativeProject(targetRoot, expectedProjectId) {
     const deadline = Date.now() + 8_000;
-    const normalizedTargetRoot = normalizeNativeRootPath(targetRoot);
     while (Date.now() < deadline) {
       const [projectId, activeWorkspace] = await Promise.all([
         selectedNativeProjectId(),
         activeNativeWorkspaceRoots(),
       ]);
-      const targetRootIsActive = activeWorkspace.roots.some((root) => (
-        normalizeNativeRootPath(root) === normalizedTargetRoot
-      ));
-      if (
-        projectId
-        && projectId === expectedProjectId
+      if (projectId && projectId === expectedProjectId) {
         // Some Codex desktop builds no longer expose active-workspace-roots.
         // A confirmed selected project is still safe when that endpoint is unavailable;
         // keep rejecting an explicitly reported, mismatched workspace root.
-        && (!activeWorkspace.available || targetRootIsActive)
-      ) return projectId;
+        if (!activeWorkspace.available) return projectId;
+        const [canonicalTargetRoot, ...canonicalActiveRoots] = await canonicalNativeRootPaths([
+          targetRoot,
+          ...activeWorkspace.roots,
+        ]);
+        if (canonicalActiveRoots.some((root) => root === canonicalTargetRoot)) return projectId;
+      }
       await new Promise((resolve) => window.setTimeout(resolve, 80));
     }
     throw new Error(hostText(

--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -539,6 +539,8 @@
     const normalizedSlashes = windowsPath ? path.replace(/\\/g, "/") : path;
     const withoutTrailingSlash = normalizedSlashes.replace(/\/+$/, "")
       || (normalizedSlashes.startsWith("/") ? "/" : normalizedSlashes);
+    const macPath = /Mac/i.test(String(navigator.platform || navigator.userAgent || ""));
+    if (macPath) return withoutTrailingSlash.toLowerCase();
     if (!windowsPath || !/^[A-Za-z]:/.test(withoutTrailingSlash)) return withoutTrailingSlash;
     return `${withoutTrailingSlash[0].toLowerCase()}${withoutTrailingSlash.slice(1)}`;
   }

--- a/test/inject.test.mjs
+++ b/test/inject.test.mjs
@@ -266,17 +266,21 @@ test("issues open an unsent native Codex composer in the confirmed project", () 
   assert.match(source, /requestNativeFetch\("active-workspace-roots", \{\}\)/);
   assert.match(source, /available: Array\.isArray\(roots\)/);
   assert.match(source, /function normalizeNativeRootPath\(value\)/);
+  assert.match(source, /async function canonicalNativeRootPaths\(roots\)/);
+  assert.match(source, /requestNativeFetch\("workspace-root-options", \{\s*hostId: "local",\s*canonicalizeRoots: roots,/);
   assert.match(source, /async function resolveNativeProject\(requestedProjectId, workspacePath\)/);
-  assert.match(source, /candidate\.id === requestedProjectId\s*\|\|\s*candidate\.rootPaths\.some/);
+  assert.match(source, /let project = context\.projects\.find\(\(candidate\) => candidate\.id === requestedProjectId\) \?\? null/);
+  assert.match(source, /if \(!project && normalizedWorkspacePath\)/);
   assert.match(source, /const targetRoot = normalizedWorkspacePath \? workspacePath : project\?\.rootPaths\[0\]/);
   assert.match(source, /async function waitForNativeProject\(targetRoot, expectedProjectId\)/);
   const waitStart = source.indexOf("async function waitForNativeProject");
   const waitSource = source.slice(waitStart, source.indexOf("async function createThreadForTask", waitStart));
   assert.match(waitSource, /selectedNativeProjectId\(\)/);
   assert.match(waitSource, /activeNativeWorkspaceRoots\(\)/);
-  assert.match(waitSource, /projectId\s*&&\s*projectId === expectedProjectId/);
-  assert.match(waitSource, /activeWorkspace\.roots\.some/);
-  assert.match(waitSource, /!activeWorkspace\.available \|\| targetRootIsActive/);
+  assert.match(waitSource, /if \(projectId && projectId === expectedProjectId\)/);
+  assert.match(waitSource, /if \(!activeWorkspace\.available\) return projectId/);
+  assert.match(waitSource, /canonicalNativeRootPaths\(\[\s*targetRoot,\s*\.\.\.activeWorkspace\.roots,/);
+  assert.match(waitSource, /canonicalActiveRoots\.some\(\(root\) => root === canonicalTargetRoot\)/);
   assert.match(
     source,
     /bridge\.sendMessageFromView\(\{\s*type: "electron-add-new-workspace-root-option",\s*root: targetRoot,/,
@@ -360,13 +364,89 @@ test("the standalone web page always opens a project-scoped Codex composer", () 
   assert.match(webApp, /deepLink\.searchParams\.set\("prompt", embeddedInstruction\)/);
 });
 
+test("native fetch preserves successful null bodies and returns undefined when unavailable", async () => {
+  const functionSource = source.slice(
+    source.indexOf("function requestNativeFetch"),
+    source.indexOf("\n\n  async function selectedNativeProjectId"),
+  );
+  const loadRequestNativeFetch = (window) => vm.runInNewContext(`(${functionSource})`, {
+    crypto: { randomUUID: () => "request-id" },
+    window,
+  });
+  const responseWindow = (status, bodyJsonString) => {
+    let onMessage;
+    return {
+      electronBridge: {
+        sendMessageFromView(message) {
+          onMessage({
+            data: {
+              type: "fetch-response",
+              requestId: message.requestId,
+              status,
+              bodyJsonString,
+            },
+          });
+        },
+      },
+      setTimeout,
+      clearTimeout,
+      addEventListener(_type, listener) { onMessage = listener; },
+      removeEventListener() {},
+    };
+  };
+
+  assert.equal(await loadRequestNativeFetch({})("get-global-state", {}), undefined);
+  assert.equal(
+    await loadRequestNativeFetch(responseWindow(200, "null"))("get-global-state", {}),
+    null,
+  );
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(
+      await loadRequestNativeFetch(responseWindow(200, '{"value":null}'))("get-global-state", {}),
+    )),
+    { value: null },
+  );
+  assert.equal(
+    await loadRequestNativeFetch(responseWindow(500, '{"value":{}}'))("get-global-state", {}),
+    undefined,
+  );
+  assert.equal(
+    await loadRequestNativeFetch(responseWindow(200, "{"))("get-global-state", {}),
+    undefined,
+  );
+
+  let expire;
+  const timeoutWindow = {
+    electronBridge: { sendMessageFromView() {} },
+    setTimeout(callback) { expire = callback; return 1; },
+    clearTimeout() {},
+    addEventListener() {},
+    removeEventListener() {},
+  };
+  const timeoutRequest = loadRequestNativeFetch(timeoutWindow)("get-global-state", {});
+  expire();
+  assert.equal(await timeoutRequest, undefined);
+
+  const throwingWindow = {
+    electronBridge: { sendMessageFromView() { throw new Error("unavailable"); } },
+    setTimeout,
+    clearTimeout,
+    addEventListener() {},
+    removeEventListener() {},
+  };
+  assert.equal(
+    await loadRequestNativeFetch(throwingWindow)("get-global-state", {}),
+    undefined,
+  );
+});
+
 test("host context captures all Codex projects even when the sidebar section is collapsed", () => {
   assert.match(source, /async function readCodexProjectMetadata\(\)/);
   assert.match(source, /await window\.electronBridge\?\.getInitialSidebarBootstrap\?\.\(\)/);
   assert.match(source, /requestNativeFetch\("get-global-state", \{ key: "local-projects" \}\)/);
   assert.match(source, /requestNativeFetch\("get-global-state", \{ key: "remote-projects" \}\)/);
-  assert.match(source, /currentLocalProjects\?\.value \?\? entries\.get\("local-projects"\)/);
-  assert.match(source, /currentRemoteProjects\?\.value \?\? entries\.get\("remote-projects"\)/);
+  assert.match(source, /currentLocalProjects === undefined\s*\? entries\.get\("local-projects"\)\s*: currentLocalProjects\?\.value/);
+  assert.match(source, /currentRemoteProjects === undefined\s*\? entries\.get\("remote-projects"\)\s*: currentRemoteProjects\?\.value/);
   assert.match(source, /entries\.get\("local-projects"\)/);
   assert.match(source, /entries\.get\("remote-projects"\)/);
   assert.match(source, /projectKind: "remote"/);
@@ -444,27 +524,90 @@ test("Codex project metadata prefers the live global state over the startup boot
     requestNativeFetch: async (_path, body) => ({
       value: body.key === "local-projects"
         ? { live: { rootPaths: ["/Users/example/live"] } }
-        : [],
+        : [{
+          id: "live-remote",
+          hostId: "remote-ssh-discovered:live",
+          remotePath: "/srv/live",
+          label: "Live Remote",
+        }],
     }),
     window: {
       electronBridge: {
         getInitialSidebarBootstrap: async () => ({
-          globalStateEntries: [{
-            key: "local-projects",
-            value: { stale: { rootPaths: ["/Users/example/stale"] } },
-          }],
+          globalStateEntries: [
+            {
+              key: "local-projects",
+              value: { stale: { rootPaths: ["/Users/example/stale"] } },
+            },
+            {
+              key: "remote-projects",
+              value: [{
+                id: "stale-remote",
+                hostId: "remote-ssh-discovered:stale",
+                remotePath: "/srv/stale",
+              }],
+            },
+          ],
         }),
       },
     },
   });
   assert.deepEqual(
     JSON.parse(JSON.stringify([...(await readCodexProjectMetadata()).entries()])),
-    [["live", {
-      projectKind: "local",
-      hostId: "local",
-      workspacePath: "/Users/example/live",
-    }]],
+    [
+      ["live", {
+        projectKind: "local",
+        hostId: "local",
+        workspacePath: "/Users/example/live",
+      }],
+      ["live-remote", {
+        projectKind: "remote",
+        workspacePath: "/srv/live",
+        hostId: "remote-ssh-discovered:live",
+        name: "Live Remote",
+      }],
+    ],
   );
+});
+
+test("successful empty Codex project state does not revive startup metadata", async () => {
+  const functionSource = source.slice(
+    source.indexOf("async function readCodexProjectMetadata"),
+    source.indexOf("\n\n  async function activeNativeWorkspaceRoots"),
+  );
+  const bootstrap = {
+    globalStateEntries: [
+      {
+        key: "local-projects",
+        value: { stale: { rootPaths: ["/Users/example/stale"] } },
+      },
+      {
+        key: "remote-projects",
+        value: [{
+          id: "stale-remote",
+          hostId: "remote-ssh-discovered:stale",
+          remotePath: "/srv/stale",
+        }],
+      },
+    ],
+  };
+  const loadMetadata = (requestNativeFetch) => vm.runInNewContext(`(${functionSource})`, {
+    requestNativeFetch,
+    window: {
+      electronBridge: { getInitialSidebarBootstrap: async () => bootstrap },
+    },
+  });
+
+  for (const requestNativeFetch of [
+    async () => null,
+    async () => ({ value: null }),
+    async (_path, body) => ({ value: body.key === "local-projects" ? {} : [] }),
+  ]) {
+    assert.deepEqual(
+      JSON.parse(JSON.stringify([...(await loadMetadata(requestNativeFetch)()).entries()])),
+      [],
+    );
+  }
 });
 
 test("new Codex conversations resolve projects added after startup", async () => {
@@ -495,20 +638,208 @@ test("new Codex conversations resolve projects added after startup", async () =>
   );
 });
 
-test("macOS native project paths compare without case drift", () => {
+test("new Codex conversations only use startup projects when the live request is unavailable", async () => {
+  const functionSource = source.slice(
+    source.indexOf("async function nativeProjectContext"),
+    source.indexOf("\n\n  async function resolveNativeProject"),
+  );
+  const bootstrap = {
+    globalStateEntries: [{
+      key: "local-projects",
+      value: { stale: { rootPaths: ["/Users/example/stale"] } },
+    }],
+  };
+  const loadContext = (response) => vm.runInNewContext(`(${functionSource})`, {
+    requestNativeFetch: async () => response,
+    window: {
+      electronBridge: { getInitialSidebarBootstrap: async () => bootstrap },
+    },
+  });
+
+  for (const response of [null, { value: null }, { value: {} }, { value: [] }]) {
+    assert.deepEqual(
+      JSON.parse(JSON.stringify((await loadContext(response)()).projects)),
+      [],
+    );
+  }
+  assert.deepEqual(
+    JSON.parse(JSON.stringify((await loadContext(undefined)()).projects)),
+    [{ id: "stale", rootPaths: ["/Users/example/stale"] }],
+  );
+});
+
+test("native root canonicalization follows the filesystem's case sensitivity", async () => {
   const start = source.indexOf("function normalizeNativeRootPath");
   const functionSource = source.slice(
     start,
     source.indexOf("\n\n  function readCodexProjects", start),
   );
-  const normalizeNativeRootPath = vm.runInNewContext(`(${functionSource})`, {
-    navigator: { platform: "MacIntel", userAgent: "" },
+  const roots = [
+    "/private/tmp/LOCAL344-default/Project",
+    "/private/tmp/local344-default/project",
+    "/Volumes/LOCAL344CASE/Project",
+    "/Volumes/LOCAL344CASE/project",
+  ];
+  const loadCanonicalizer = (requestNativeFetch) => vm.runInNewContext(`(() => {
+    ${functionSource}
+    return { normalizeNativeRootPath, canonicalNativeRootPaths };
+  })()`, { requestNativeFetch });
+  const calls = [];
+  const canonicalizer = loadCanonicalizer(async (path, body) => {
+    calls.push({ path, body: JSON.parse(JSON.stringify(body)) });
+    return {
+      canonicalPathByRoot: {
+        [roots[0]]: roots[0],
+        [roots[1]]: roots[0],
+        [roots[2]]: roots[2],
+        [roots[3]]: roots[3],
+      },
+    };
+  });
+  const canonicalRoots = await canonicalizer.canonicalNativeRootPaths(roots);
+
+  assert.equal(canonicalRoots[0], canonicalRoots[1]);
+  assert.notEqual(canonicalRoots[2], canonicalRoots[3]);
+  assert.notEqual(
+    canonicalizer.normalizeNativeRootPath(roots[2]),
+    canonicalizer.normalizeNativeRootPath(roots[3]),
+  );
+  assert.deepEqual(calls, [{
+    path: "workspace-root-options",
+    body: { hostId: "local", canonicalizeRoots: roots },
+  }]);
+
+  const unavailable = loadCanonicalizer(async () => undefined);
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(await unavailable.canonicalNativeRootPaths([roots[2], roots[3]]))),
+    [roots[2], roots[3]],
+  );
+  const missingMapping = loadCanonicalizer(async () => ({
+    canonicalPathByRoot: { [roots[0]]: "/private/tmp/LOCAL344-default/Project" },
+  }));
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(await missingMapping.canonicalNativeRootPaths([roots[0], roots[1]]))),
+    [roots[0], roots[1]],
+  );
+});
+
+test("native project resolution gives the explicit project ID priority over path candidates", async () => {
+  const functionSource = source.slice(
+    source.indexOf("async function resolveNativeProject"),
+    source.indexOf("\n\n  async function ensureProjectRows"),
+  );
+  let canonicalCalls = 0;
+  const resolveNativeProject = vm.runInNewContext(`(${functionSource})`, {
+    nativeProjectContext: async () => ({
+      projects: [
+        { id: "wrong", rootPaths: ["/Volumes/LOCAL344CASE/project"] },
+        { id: "expected", rootPaths: ["/Volumes/LOCAL344CASE/Project"] },
+      ],
+    }),
+    normalizeNativeRootPath: (value) => String(value || "").replace(/\/+$/, ""),
+    canonicalNativeRootPaths: async () => { canonicalCalls += 1; return []; },
   });
 
-  assert.equal(
-    normalizeNativeRootPath("/Users/example/Developer/CHEERY-Knowledge/"),
-    normalizeNativeRootPath("/Users/example/Developer/Cheery-Knowledge"),
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(
+      await resolveNativeProject("expected", "/Volumes/LOCAL344CASE/project"),
+    )),
+    { projectId: "expected", targetRoot: "/Volumes/LOCAL344CASE/project" },
   );
+  assert.equal(canonicalCalls, 0);
+});
+
+test("native project confirmation composes exact IDs, root availability, and canonical roots", async () => {
+  const normalizeStart = source.indexOf("function normalizeNativeRootPath");
+  const canonicalSource = source.slice(
+    normalizeStart,
+    source.indexOf("\n\n  function readCodexProjects", normalizeStart),
+  );
+  const waitStart = source.indexOf("async function waitForNativeProject");
+  const waitSource = source.slice(
+    waitStart,
+    source.indexOf("\n\n  async function createThreadForTask", waitStart),
+  );
+  const loadWait = ({ projectId, activeWorkspace, canonicalPathByRoot }) => {
+    let now = 0;
+    const canonicalCalls = [];
+    const api = vm.runInNewContext(`(() => {
+      ${canonicalSource}
+      ${waitSource}
+      return { waitForNativeProject };
+    })()`, {
+      Date: { now: () => now },
+      activeNativeWorkspaceRoots: async () => activeWorkspace,
+      hostText: (_chinese, english) => english,
+      requestNativeFetch: async (path, body) => {
+        canonicalCalls.push({ path, body: JSON.parse(JSON.stringify(body)) });
+        return canonicalPathByRoot === undefined ? undefined : { canonicalPathByRoot };
+      },
+      selectedNativeProjectId: async () => projectId,
+      window: {
+        setTimeout(resolve) { now = 8_001; resolve(); },
+      },
+    });
+    return { waitForNativeProject: api.waitForNativeProject, canonicalCalls };
+  };
+
+  const unavailable = loadWait({
+    projectId: "expected",
+    activeWorkspace: { available: false, roots: [] },
+  });
+  assert.equal(
+    await unavailable.waitForNativeProject("/Volumes/LOCAL344CASE/Project", "expected"),
+    "expected",
+  );
+  assert.deepEqual(unavailable.canonicalCalls, []);
+
+  const defaultTarget = "/private/tmp/LOCAL344-default/Project";
+  const defaultActive = "/private/tmp/local344-default/project";
+  const canonicalMatch = loadWait({
+    projectId: "expected",
+    activeWorkspace: { available: true, roots: [defaultActive] },
+    canonicalPathByRoot: {
+      [defaultTarget]: defaultTarget,
+      [defaultActive]: defaultTarget,
+    },
+  });
+  assert.equal(
+    await canonicalMatch.waitForNativeProject(defaultTarget, "expected"),
+    "expected",
+  );
+  assert.deepEqual(canonicalMatch.canonicalCalls, [{
+    path: "workspace-root-options",
+    body: { hostId: "local", canonicalizeRoots: [defaultTarget, defaultActive] },
+  }]);
+
+  const emptyRoots = loadWait({
+    projectId: "expected",
+    activeWorkspace: { available: true, roots: [] },
+    canonicalPathByRoot: {},
+  });
+  await assert.rejects(
+    emptyRoots.waitForNativeProject("/Volumes/LOCAL344CASE/Project", "expected"),
+  );
+
+  const sensitiveTarget = "/Volumes/LOCAL344CASE/Project";
+  const sensitiveOther = "/Volumes/LOCAL344CASE/project";
+  const mismatch = loadWait({
+    projectId: "expected",
+    activeWorkspace: { available: true, roots: [sensitiveOther] },
+    canonicalPathByRoot: {
+      [sensitiveTarget]: sensitiveTarget,
+      [sensitiveOther]: sensitiveOther,
+    },
+  });
+  await assert.rejects(mismatch.waitForNativeProject(sensitiveTarget, "expected"));
+
+  const wrongProject = loadWait({
+    projectId: "wrong",
+    activeWorkspace: { available: true, roots: [defaultTarget] },
+    canonicalPathByRoot: { [defaultTarget]: defaultTarget },
+  });
+  await assert.rejects(wrongProject.waitForNativeProject(defaultTarget, "expected"));
+  assert.deepEqual(wrongProject.canonicalCalls, []);
 });
 
 test("SSH task project selection uses its stable ID and local project IDs use bootstrap keys", () => {

--- a/test/inject.test.mjs
+++ b/test/inject.test.mjs
@@ -492,6 +492,22 @@ test("new Codex conversations resolve projects added after startup", async () =>
   );
 });
 
+test("macOS native project paths compare without case drift", () => {
+  const start = source.indexOf("function normalizeNativeRootPath");
+  const functionSource = source.slice(
+    start,
+    source.indexOf("\n\n  function readCodexProjects", start),
+  );
+  const normalizeNativeRootPath = vm.runInNewContext(`(${functionSource})`, {
+    navigator: { platform: "MacIntel", userAgent: "" },
+  });
+
+  assert.equal(
+    normalizeNativeRootPath("/Users/example/Developer/CHEERY-Knowledge/"),
+    normalizeNativeRootPath("/Users/example/Developer/Cheery-Knowledge"),
+  );
+});
+
 test("SSH task project selection uses its stable ID and local project IDs use bootstrap keys", () => {
   assert.match(source, /row = projectRowById\(projectId\)/);
   assert.doesNotMatch(source, /projectRowForTask|projectRowByLabel/);

--- a/test/inject.test.mjs
+++ b/test/inject.test.mjs
@@ -360,6 +360,10 @@ test("the standalone web page always opens a project-scoped Codex composer", () 
 test("host context captures all Codex projects even when the sidebar section is collapsed", () => {
   assert.match(source, /async function readCodexProjectMetadata\(\)/);
   assert.match(source, /await window\.electronBridge\?\.getInitialSidebarBootstrap\?\.\(\)/);
+  assert.match(source, /requestNativeFetch\("get-global-state", \{ key: "local-projects" \}\)/);
+  assert.match(source, /requestNativeFetch\("get-global-state", \{ key: "remote-projects" \}\)/);
+  assert.match(source, /currentLocalProjects\?\.value \?\? entries\.get\("local-projects"\)/);
+  assert.match(source, /currentRemoteProjects\?\.value \?\? entries\.get\("remote-projects"\)/);
   assert.match(source, /entries\.get\("local-projects"\)/);
   assert.match(source, /entries\.get\("remote-projects"\)/);
   assert.match(source, /projectKind: "remote"/);
@@ -386,6 +390,7 @@ test("Codex bootstrap metadata resolves local roots and SSH remote roots asynchr
     source.indexOf("\n\n  async function activeNativeWorkspaceRoots"),
   );
   const readCodexProjectMetadata = vm.runInNewContext(`(${functionSource})`, {
+    requestNativeFetch: async () => undefined,
     window: {
       electronBridge: {
         getInitialSidebarBootstrap: async () => ({
@@ -424,6 +429,66 @@ test("Codex bootstrap metadata resolves local roots and SSH remote roots asynchr
         name: "remote-project",
       }],
     ],
+  );
+});
+
+test("Codex project metadata prefers the live global state over the startup bootstrap", async () => {
+  const functionSource = source.slice(
+    source.indexOf("async function readCodexProjectMetadata"),
+    source.indexOf("\n\n  async function activeNativeWorkspaceRoots"),
+  );
+  const readCodexProjectMetadata = vm.runInNewContext(`(${functionSource})`, {
+    requestNativeFetch: async (_path, body) => ({
+      value: body.key === "local-projects"
+        ? { live: { rootPaths: ["/Users/example/live"] } }
+        : [],
+    }),
+    window: {
+      electronBridge: {
+        getInitialSidebarBootstrap: async () => ({
+          globalStateEntries: [{
+            key: "local-projects",
+            value: { stale: { rootPaths: ["/Users/example/stale"] } },
+          }],
+        }),
+      },
+    },
+  });
+  assert.deepEqual(
+    JSON.parse(JSON.stringify([...(await readCodexProjectMetadata()).entries()])),
+    [["live", {
+      projectKind: "local",
+      hostId: "local",
+      workspacePath: "/Users/example/live",
+    }]],
+  );
+});
+
+test("new Codex conversations resolve projects added after startup", async () => {
+  const functionSource = source.slice(
+    source.indexOf("async function nativeProjectContext"),
+    source.indexOf("\n\n  async function resolveNativeProject"),
+  );
+  const nativeProjectContext = vm.runInNewContext(`(${functionSource})`, {
+    requestNativeFetch: async () => ({
+      value: {
+        "live-project": { rootPaths: ["/Users/example/live"] },
+      },
+    }),
+    window: {
+      electronBridge: {
+        getInitialSidebarBootstrap: async () => ({
+          globalStateEntries: [{
+            key: "local-projects",
+            value: { stale: { rootPaths: ["/Users/example/stale"] } },
+          }],
+        }),
+      },
+    },
+  });
+  assert.deepEqual(
+    JSON.parse(JSON.stringify((await nativeProjectContext()).projects)),
+    [{ id: "live-project", rootPaths: ["/Users/example/live"] }],
   );
 });
 


### PR DESCRIPTION
## Summary
- prefer the current Codex global-state project metadata over the startup bootstrap for local and remote projects
- use the same live lookup when opening a new local Codex conversation
- retain the startup bootstrap as a fallback when the native fetch is unavailable

## Problem
When a Codex project is added or mapped after the initial sidebar bootstrap, Taskboard can still read the stale startup snapshot. Clicking **Open in new conversation** then fails with `The target project or worktree is not mapped in Codex`, even though the workspace is present and mapped.

## Tests
- `node --test test/inject.test.mjs` (29/29 passed)
- `npm run typecheck`