### PR TITLE
LOCAL-329 Clip completed card transition within review column

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2403,6 +2403,15 @@ kbd {
   animation: task-card-settle 200ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
 }
 
+.board-column.status-in_review .column-list {
+  view-transition-name: review-task-list;
+  view-transition-group: contain;
+}
+
+::view-transition-group-children(review-task-list) {
+  overflow: clip;
+}
+
 ::view-transition-group(*) {
   animation-duration: 220ms;
   animation-timing-function: cubic-bezier(0.2, 0.8, 0.2, 1);


### PR DESCRIPTION
## Summary
- Follow up on merged PR #307 after the middle-card completion animation was observed escaping the review column.
- Nest the `in_review` column list's card transition groups under the list and clip those groups to the list boundary.
- Keep the existing completion request, status update, exit keyframe, and list reflow semantics unchanged.

## Root cause and direct path
`TaskCard` 完成按钮 → `App.moveTask` → 状态保存为 `done` → View Transition 生成目标卡片退出和相邻卡片补位快照 → `column-list` 裁剪 → 用户可见帧。

The card groups were flattened under the document-level View Transition pseudo-tree, so the real `.column-list` overflow did not clip their snapshots. This change gives the review list a containing transition group and clips its group children.

## Verification
- `npm run typecheck`
- `npm run build:web`
- `git diff --check`
- Agent review of exact head `1906b3936a06b3f0c991cbb160f79fd4792ab631`: No findings.
- Headed Chrome with isolated real data: at 80 ms, the target remains at opacity `0.377019` and scale `0.981311`; lower cards A and B continue their position transition; no snapshot crosses the list top or bottom.
- Before frame: `output/playwright/LOCAL-329-repro-mid-frame.png` in the retained task worktree.
- Fixed frame: `output/playwright/LOCAL-329-fixed-mid-frame.png` in the retained task worktree.
- Demo: http://127.0.0.1:53329/?project=local-329-rework-demo

## Scope and gate
One CSS file, nine added lines. No new animation system, settings, compatibility layer, delayed state machine, unrelated refactor, or tests. User visual confirmation of the retained Demo remains the merge gate.