### PR TITLE
LOCAL-328 Keep Markdown video nodes stable

### DIFF
--- a/web/src/components/MarkdownDocument.tsx
+++ b/web/src/components/MarkdownDocument.tsx
@@ -1,6 +1,8 @@
 import {
   Children,
+  createContext,
   isValidElement,
+  useContext,
   useEffect,
   useId,
   useState,
@@ -12,7 +14,7 @@ import {
 } from "react";
 import { JSON_SCHEMA, load as loadYaml } from "js-yaml";
 import type { UponSanitizeAttributeHook, UponSanitizeElementHook } from "dompurify";
-import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
+import ReactMarkdown, { defaultUrlTransform, type ExtraProps } from "react-markdown";
 import { decodeString } from "micromark-util-decode-string";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
@@ -502,6 +504,50 @@ function MarkdownPre({ children, ...props }: ComponentPropsWithoutRef<"pre">) {
   return <pre {...props}>{children}</pre>;
 }
 
+interface MarkdownLinkContextValue {
+  value: string;
+  onLinkClick?: (event: MouseEvent<HTMLAnchorElement>, href?: string) => void;
+  renderLink?: (href: string | undefined, children: ReactNode) => ReactNode | null;
+}
+
+const MarkdownLinkContext = createContext<MarkdownLinkContextValue | null>(null);
+
+function MarkdownLink({
+  node,
+  href,
+  children,
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"a"> & ExtraProps) {
+  const { value, onLinkClick, renderLink } = useContext(MarkdownLinkContext)!;
+  const renderedLink = renderLink?.(href, children);
+  const isRenderedLink = renderedLink !== null && renderedLink !== undefined;
+  const start = node?.position?.start.offset;
+  const end = node?.position?.end.offset;
+  const markdown = typeof start === "number" && typeof end === "number"
+    ? value.slice(start, end)
+    : undefined;
+  const isComposerReference = Boolean(
+    markdown && /^\[[\s\S]*\]\(taskboard:\/\/composer-reference\/[^)]+\)$/.test(markdown),
+  );
+  if (isValidElement(renderedLink) && renderedLink.type === "video") {
+    return renderedLink;
+  }
+  return (
+    <a
+      {...props}
+      className={[className, isRenderedLink ? "issue-reference-link" : ""].filter(Boolean).join(" ") || undefined}
+      data-taskboard-inline-media-markdown={isRenderedLink || isComposerReference ? markdown : undefined}
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      onClick={(event) => onLinkClick?.(event, href)}
+    >
+      {isRenderedLink ? renderedLink : children}
+    </a>
+  );
+}
+
 export function MarkdownDocument({
   value,
   onCopy,
@@ -517,62 +563,37 @@ export function MarkdownDocument({
 }) {
   return (
     <div className="issue-description-document" onCopy={onCopy}>
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm, remarkStripMarkdownComments, remarkBreaks]}
-        urlTransform={(url) => defaultUrlTransform(resolvePersistedAttachmentUrl(url))}
-        components={{
-          a: ({ node, href, children, className, ...props }) => {
-            const renderedLink = renderLink?.(href, children);
-            const isRenderedLink = renderedLink !== null && renderedLink !== undefined;
-            const start = node?.position?.start.offset;
-            const end = node?.position?.end.offset;
-            const markdown = typeof start === "number" && typeof end === "number"
-              ? value.slice(start, end)
-              : undefined;
-            const isComposerReference = Boolean(
-              markdown && /^\[[\s\S]*\]\(taskboard:\/\/composer-reference\/[^)]+\)$/.test(markdown),
-            );
-            if (isValidElement(renderedLink) && renderedLink.type === "video") {
-              return renderedLink;
-            }
-            return (
-              <a
-                {...props}
-                className={[className, isRenderedLink ? "issue-reference-link" : ""].filter(Boolean).join(" ") || undefined}
-                data-taskboard-inline-media-markdown={isRenderedLink || isComposerReference ? markdown : undefined}
-                href={href}
-                target="_blank"
-                rel="noreferrer"
-                onClick={(event) => onLinkClick?.(event, href)}
-              >
-                {isRenderedLink ? renderedLink : children}
-              </a>
-            );
-          },
-          img: ({ node, ...props }) => {
-            const start = node?.position?.start.offset;
-            const end = node?.position?.end.offset;
-            const markdown = typeof start === "number" && typeof end === "number"
-              ? value.slice(start, end)
-              : undefined;
-            const selfContainedMarkdown = markdown
-              && /^!\[(?:\\.|[^\]])*\]\(/.test(markdown)
-              ? markdown
-              : undefined;
-            return (
-              <img
-                {...props}
-                className={[props.className, onImageClick ? "is-previewable" : ""].filter(Boolean).join(" ") || undefined}
-                data-taskboard-inline-media-markdown={selfContainedMarkdown}
-                onClick={onImageClick}
-              />
-            );
-          },
-          pre: MarkdownPre,
-        }}
-      >
-        {value}
-      </ReactMarkdown>
+      <MarkdownLinkContext.Provider value={{ value, onLinkClick, renderLink }}>
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm, remarkStripMarkdownComments, remarkBreaks]}
+          urlTransform={(url) => defaultUrlTransform(resolvePersistedAttachmentUrl(url))}
+          components={{
+            a: MarkdownLink,
+            img: ({ node, ...props }) => {
+              const start = node?.position?.start.offset;
+              const end = node?.position?.end.offset;
+              const markdown = typeof start === "number" && typeof end === "number"
+                ? value.slice(start, end)
+                : undefined;
+              const selfContainedMarkdown = markdown
+                && /^!\[(?:\\.|[^\]])*\]\(/.test(markdown)
+                ? markdown
+                : undefined;
+              return (
+                <img
+                  {...props}
+                  className={[props.className, onImageClick ? "is-previewable" : ""].filter(Boolean).join(" ") || undefined}
+                  data-taskboard-inline-media-markdown={selfContainedMarkdown}
+                  onClick={onImageClick}
+                />
+              );
+            },
+            pre: MarkdownPre,
+          }}
+        >
+          {value}
+        </ReactMarkdown>
+      </MarkdownLinkContext.Provider>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Keep the ReactMarkdown link renderer component type stable across normal Taskboard re-renders.
- Prevent description and comment `<video>` nodes from remounting every second while a task conversation is running.
- Preserve native controls, Markdown, links, issue references, attachments, images, and editor/save paths.

## E3 path
Issue detail → play a description or comment video → normal one-second Taskboard re-render → `MarkdownDocument` retains the same `MarkdownLink` component type → the same video DOM node remains mounted → playback continues instead of resetting.

## Verification
- Real isolated Codex App with dedicated profile, runtime, and CDP.
- Description and comment videos each played beyond 8 seconds with the same DOM node, 0 mounts, and 0 unmounts.
- Pause and resume preserved playback time.
- Normal link behavior remained unchanged.
- `npm run typecheck`, `npm run build:web`, and `git diff --check` passed.

## Scope
One source file. No new dependency, player, state machine, compatibility layer, test, or unrelated refactor.