### PR TITLE
fix: align task checkbox preview spacing

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3134,16 +3134,18 @@ kbd {
 }
 
 .issue-description-document .task-list-item {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1fr);
+  column-gap: 7px;
   list-style: none;
 }
 
 .issue-description-document input[type="checkbox"] {
   width: 14px;
   height: 14px;
-  margin: 0 7px 0 0;
+  margin: 4px 0 0;
   accent-color: var(--accent);
   pointer-events: none;
-  vertical-align: -2px;
 }
 
 .issue-description-document blockquote {


### PR DESCRIPTION
## Summary

- make reading-state task list items use the same 14px checkbox column and 7px text gap as the editor
- align the reading-state checkbox with the editor using the existing 4px top offset
- keep Markdown parsing, DOM structure, task toggling, serialization, and saving unchanged

## Verification

- real LOCAL-319 isolated demo: description read/edit and comment read/edit visual comparisons
- normal description task-checkbox edit, save, reload, and restore path
- `npm run typecheck`
- `npm run build:web`
- `git diff --check`

Exact head: `c19e48dbe4952c7f299828c7e7ca49e24e3fd86f`