### PR TITLE
Use stable Codex user identity and avatar

### DIFF
--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -88,6 +88,7 @@
   let pendingThreadCreation = null;
   let lastNativeThreadId = "";
   let lastNativeProjectId = "";
+  let currentCodexUserId = "";
   let suspendedNativeBrowserPanel = null;
   let active = false;
   let destroyed = false;
@@ -615,10 +616,12 @@
 
   async function captureHostContext() {
     const todoProgress = nativeTodoProgress();
-    const [selectedProjectId, projectMetadata] = await Promise.all([
+    const [selectedProjectId, projectMetadata, currentUser] = await Promise.all([
       selectedNativeProjectId(),
       readCodexProjectMetadata(),
+      requestHost("read-current-user"),
     ]);
+    currentCodexUserId = typeof currentUser.userId === "string" ? currentUser.userId : "";
     codexProjectMetadata = projectMetadata;
     if (selectedProjectId) lastNativeProjectId = selectedProjectId;
     let projects = readCodexProjects(projectMetadata);
@@ -755,35 +758,18 @@
     window.setTimeout(postHostContext, REATTACH_DELAY_MS);
   }
 
-  function userIdFromName(name) {
-    const slug = name.normalize("NFKD")
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "")
-      .slice(0, 96);
-    if (slug) return slug;
-    let hash = 2166136261;
-    for (const character of name) {
-      hash ^= character.codePointAt(0);
-      hash = Math.imul(hash, 16777619);
-    }
-    return `codex-user-${(hash >>> 0).toString(36)}`;
-  }
-
   function readCodexUser() {
-    const avatar = Array.from(document.querySelectorAll("img"))
-      .find((image) => image.src.includes("cdn.auth0.com/avatars/"));
-    const profileButton = avatar?.closest("button")
-      || Array.from(document.querySelectorAll('button[aria-haspopup="menu"]')).find((button) => (
-        normalizedLabel(button.getAttribute("aria-label")).includes("profile")
-        || normalizedLabel(button.getAttribute("aria-label")).includes("个人资料")
-      ));
+    const profileButton = Array.from(document.querySelectorAll('button[aria-haspopup="menu"]')).find((button) => (
+      normalizedLabel(button.getAttribute("aria-label")).includes("profile")
+      || normalizedLabel(button.getAttribute("aria-label")).includes("个人资料")
+    ));
     const name = profileButton?.textContent?.replace(/\s+/g, " ").trim();
-    if (!name) return null;
+    if (!currentCodexUserId || !name) return null;
+    const avatar = profileButton.querySelector("img");
     const avatarUrl = avatar?.currentSrc || avatar?.src || null;
     return {
       type: "user",
-      id: userIdFromName(name),
+      id: currentCodexUserId,
       name,
       avatarUrl,
     };

--- a/scripts/codex-injector-runtime.mjs
+++ b/scripts/codex-injector-runtime.mjs
@@ -20,6 +20,7 @@ function parseHostRequest(payload, parseAutomationRequest) {
   ) ? request.id : null;
   if (!id) return { id: null, request: null, error: HOST_REQUEST_ERROR };
   if (request.action === "ensure") return { id, request, error: null };
+  if (request.action === "read-current-user") return { id, request, error: null };
   if (
     request.action === "load-frame"
     && typeof request.frameName === "string"
@@ -114,6 +115,8 @@ export async function handleHostBindingPayload(params, handlers) {
     let result;
     if (parsed.request.action === "ensure") {
       result = await handlers.ensure();
+    } else if (parsed.request.action === "read-current-user") {
+      result = await handlers.readCurrentUser();
     } else if (parsed.request.action === "load-frame") {
       result = await handlers.loadFrame(parsed.request);
     } else if (parsed.request.action === "open-external") {

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -108,6 +108,19 @@ let quotaPoliciesWritePromise = Promise.resolve();
 const taskConversationAppServerTimeoutMs = 30_000;
 const remoteAutomationTurnTimeoutMs = 30 * 60_000;
 
+function stableCodexUserId(account) {
+  const email = account?.account?.type === "chatgpt"
+    && typeof account.account.email === "string"
+    ? account.account.email.trim().toLowerCase()
+    : "";
+  if (!email) throw new Error("The current Codex ChatGPT account email is unavailable");
+  const digest = createHash("sha256")
+    .update("codex-taskboard-user\0")
+    .update(email)
+    .digest("hex");
+  return `codex-user-${digest}`;
+}
+
 function parseArgs(argv) {
   const options = {
     port: defaultCodexDebuggingPort,
@@ -2271,6 +2284,15 @@ function installTaskboardHostBinding(
       isAuthorizedContext: (executionContextId) => executionContextId === activeContextId,
       parseAutomationRequest: parseTaskboardAutomationHostRequest,
       ensure: () => supervisor.ensure({ force: true }),
+      readCurrentUser: async () => ({
+        userId: stableCodexUserId(await requestCodexAppServerViaCdp(
+          cdp,
+          undefined,
+          "local",
+          "account/read",
+          { refreshToken: false },
+        )),
+      }),
       loadFrame: (request) => loadTaskboardFrameViaCdp(
         cdp,
         request.frameName,

--- a/test/actor-identity.test.mjs
+++ b/test/actor-identity.test.mjs
@@ -72,7 +72,10 @@ test("comment metadata separators never become avatar content", () => {
 
 test("Codex host identity is forwarded to user-authored taskboard mutations", () => {
   assert.match(injectSource, /function readCodexUser\(\)/);
-  assert.match(injectSource, /cdn\.auth0\.com\/avatars/);
+  assert.match(
+    injectSource,
+    /button\[aria-haspopup="menu"\][\s\S]*?profileButton\.querySelector\("img"\)[\s\S]*?avatar\?\.currentSrc \|\| avatar\?\.src \|\| null/,
+  );
   assert.match(injectSource, /user: readCodexUser\(\)/);
   assert.match(typesSource, /user\?: ActorIdentity/);
   assert.match(apiSource, /export function setCurrentUserActor/);

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -337,7 +337,7 @@ function DueDateControl({
 
 function AssigneeControl({
   task,
-  participants,
+  participants: persistedParticipants,
   currentUser,
   disabled,
   open,
@@ -356,7 +356,7 @@ function AssigneeControl({
   const displayIdentifier = task.externalKey ?? task.identifier;
   const currentUserKey = actorKey(currentUser);
   const assignee = actorKey(task.assignee) === currentUserKey ? currentUser : task.assignee;
-  const displayParticipants = participants.map((participant) => (
+  const participants = persistedParticipants.map((participant) => (
     actorKey(participant) === currentUserKey ? currentUser : participant
   ));
   const options = [assignee, currentUser, CODEX_AGENT_ACTOR]
@@ -365,7 +365,7 @@ function AssigneeControl({
     ));
   return (
     <TaskPropertyPicker
-      value={actorKey(assignee)}
+      value={actorKey(task.assignee)}
       options={options.map((actor) => ({
         value: actorKey(actor),
         label: actorKey(actor) === currentUserKey ? text(`${actor.name}（我）`, `${actor.name} (me)`) : actor.name,
@@ -375,7 +375,7 @@ function AssigneeControl({
       disabled={disabled}
       className="task-participants-control card-property-control"
       triggerClassName="task-assignee-trigger"
-      triggerContent={<ParticipantAvatars participants={displayParticipants} />}
+      triggerContent={<ParticipantAvatars participants={participants} />}
       ariaLabel={text(`${displayIdentifier} 负责人`, `${displayIdentifier} assignee`)}
       title={text(`负责人：${assignee.name}`, `Assignee: ${assignee.name}`)}
       onOpenChange={onOpenChange}

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -354,25 +354,30 @@ function AssigneeControl({
 }) {
   const { text } = useTaskboardI18n();
   const displayIdentifier = task.externalKey ?? task.identifier;
-  const options = [task.assignee, currentUser, CODEX_AGENT_ACTOR]
+  const currentUserKey = actorKey(currentUser);
+  const assignee = actorKey(task.assignee) === currentUserKey ? currentUser : task.assignee;
+  const displayParticipants = participants.map((participant) => (
+    actorKey(participant) === currentUserKey ? currentUser : participant
+  ));
+  const options = [assignee, currentUser, CODEX_AGENT_ACTOR]
     .filter((actor, index, actors) => (
       actors.findIndex((candidate) => actorKey(candidate) === actorKey(actor)) === index
     ));
   return (
     <TaskPropertyPicker
-      value={actorKey(task.assignee)}
+      value={actorKey(assignee)}
       options={options.map((actor) => ({
         value: actorKey(actor),
-        label: actor.id === currentUser.id ? text(`${actor.name}（我）`, `${actor.name} (me)`) : actor.name,
+        label: actorKey(actor) === currentUserKey ? text(`${actor.name}（我）`, `${actor.name} (me)`) : actor.name,
         icon: <ActorAvatar actor={actor} className="task-property-assignee-avatar" />,
       }))}
       open={open}
       disabled={disabled}
       className="task-participants-control card-property-control"
       triggerClassName="task-assignee-trigger"
-      triggerContent={<ParticipantAvatars participants={participants} />}
+      triggerContent={<ParticipantAvatars participants={displayParticipants} />}
       ariaLabel={text(`${displayIdentifier} 负责人`, `${displayIdentifier} assignee`)}
-      title={text(`负责人：${task.assignee.name}`, `Assignee: ${task.assignee.name}`)}
+      title={text(`负责人：${assignee.name}`, `Assignee: ${assignee.name}`)}
       onOpenChange={onOpenChange}
       onChange={(value) => {
         const selected = options.find((actor) => actorKey(actor) === value);

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -1007,7 +1007,10 @@ export function TaskDetail({
   ) {
     developmentOptions.unshift(currentTask.developmentContext);
   }
-  const assigneeOptions = [currentTask.assignee, currentUser, CODEX_AGENT_ACTOR]
+  const displayAssignee = actorKey(currentTask.assignee) === actorKey(currentUser)
+    ? currentUser
+    : currentTask.assignee;
+  const assigneeOptions = [displayAssignee, currentUser, CODEX_AGENT_ACTOR]
     .filter((actor, index, actors) => (
       actors.findIndex((candidate) => actorKey(candidate) === actorKey(actor)) === index
     ));
@@ -1730,10 +1733,10 @@ export function TaskDetail({
             <div className="detail-property-row assignee-property">
               <span className="detail-property-label">{text("负责人", "Assignee")}</span>
               <TaskPropertyPicker
-                value={actorKey(currentTask.assignee)}
+                value={actorKey(displayAssignee)}
                 options={assigneeOptions.map((actor) => ({
                   value: actorKey(actor),
-                  label: actor.id === currentUser.id
+                  label: actorKey(actor) === actorKey(currentUser)
                     ? `${actor.name}${text("（我）", " (me)")}`
                     : actor.name,
                   icon: <ActorAvatar actor={actor} className="task-property-assignee-avatar" />,

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -1007,7 +1007,8 @@ export function TaskDetail({
   ) {
     developmentOptions.unshift(currentTask.developmentContext);
   }
-  const displayAssignee = actorKey(currentTask.assignee) === actorKey(currentUser)
+  const displayAssignee = currentTask.assignee.type === currentUser.type
+    && currentTask.assignee.id === currentUser.id
     ? currentUser
     : currentTask.assignee;
   const assigneeOptions = [displayAssignee, currentUser, CODEX_AGENT_ACTOR]


### PR DESCRIPTION
## Summary

- derive the local Codex user ID from `account/read` email, normalized and hashed inside the privileged host
- read the current display name and avatar from the Codex profile button without exposing the email
- use live current-user name/avatar for matching persisted participants and assignees by `type:id`

## Verification

- `npm run typecheck`
- `npm run build:web`
- `node --check` for the injector, injector runtime, and userscript
- `git diff --check`
- isolated `--cdp-pipe` runtime with a task-owned profile/runtime confirmed the signed-in renderer, Taskboard host-context project sync, and successful `account/read`
- real isolated Taskboard API path confirmed one participant after same-ID name changes, ordinary comment creation, and current-user claim
- direct `ActorAvatar` render confirmed image output with an avatar and initial fallback without one

The platform did not permit visible Codex UI capture, so no unsupported UI-control workaround was used. The task-owned runtime and temporary login database copies were removed after verification.

Taskboard: LOCAL-352