### PR TITLE
fix: keep create description height stable

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5703,10 +5703,6 @@ kbd {
   line-height: 27px;
 }
 
-.inline-media-description[data-empty="true"] {
-  min-height: 100px;
-}
-
 .composer-title textarea::placeholder,
 .composer-description textarea::placeholder,
 .property-control input::placeholder,


### PR DESCRIPTION
## Summary

- keep the create-issue description editor at the existing 118px minimum height in both empty and populated states
- preserve natural growth for multiline content

## Verification

- real isolated ChatGPT/Codex App: empty 118px, first character 118px, cleared 118px, eight lines 339px, back to one line 118px
- `npm run build:web`
- `git diff --check origin/main...HEAD`
- clean virtual merge with current `origin/main` (`088c1199`), with no overlapping file or hunk

Taskboard: LOCAL-319