### PR TITLE
Release v1.1.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-taskboard",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-taskboard",
-      "version": "1.1.14",
+      "version": "1.1.15",
       "dependencies": {
         "dhtmlx-gantt": "^10.0.0",
         "dompurify": "^3.4.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-taskboard",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "codex-taskboard-launcher"
-version = "1.1.14"
+version = "1.1.15"
 dependencies = [
  "base64 0.22.1",
  "dispatch2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-taskboard-launcher"
-version = "1.1.14"
+version = "1.1.15"
 description = "Codex Taskboard launcher"
 edition = "2021"
 rust-version = "1.88"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex Taskboard",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "identifier": "com.chuspeeism.codex-taskboard",
   "app": {
     "windows": []


### PR DESCRIPTION
## Summary

- bump Codex Taskboard application version from 1.1.14 to 1.1.15
- keep the existing release workflow unchanged

## Verification

- all six application version fields are 1.1.15
- `git diff --check`
- only the five version files changed

Taskboard: LOCAL-353
Exact head: `b58b8a8`