### PR TITLE
Fix task property popovers and dashboard unread indicators

### DIFF
--- a/web/src/components/DashboardView.tsx
+++ b/web/src/components/DashboardView.tsx
@@ -578,7 +578,9 @@ export function DashboardView({
                   onClick={() => onOpenTask(task)}
                   key={task.id}
                 >
-                  <span className="dashboard-attention-mark" aria-hidden="true"><i /></span>
+                  <span className="dashboard-attention-mark" aria-hidden="true">
+                    {presentations[task.id]?.unread && <i />}
+                  </span>
                   <strong>{task.title}</strong>
                   <small>ID: {task.externalKey ?? task.identifier}</small>
                 </button>

--- a/web/src/components/TaskPropertyPicker.tsx
+++ b/web/src/components/TaskPropertyPicker.tsx
@@ -145,11 +145,14 @@ export function TaskPropertyPicker<Value extends string>({
 
     document.addEventListener("pointerdown", closeFromOutside);
     window.addEventListener("keydown", closeFromEscape);
-    window.addEventListener("resize", closeFromViewportChange);
-    window.addEventListener("scroll", closeFromViewportChange, true);
+    const viewportListenerFrame = requestAnimationFrame(() => {
+      window.addEventListener("resize", closeFromViewportChange);
+      window.addEventListener("scroll", closeFromViewportChange, true);
+    });
     return () => {
       document.removeEventListener("pointerdown", closeFromOutside);
       window.removeEventListener("keydown", closeFromEscape);
+      cancelAnimationFrame(viewportListenerFrame);
       window.removeEventListener("resize", closeFromViewportChange);
       window.removeEventListener("scroll", closeFromViewportChange, true);
     };


### PR DESCRIPTION
## Summary

- LOCAL-358: register task-property viewport listeners after the opening autofocus frame so a residual same-frame scroll does not immediately close the popover
- LOCAL-361: render the Dashboard attention dot only while the issue is unread, while keeping read blocked issues in the attention list

## Verification

- Real browser at 750×762: status, priority, assignee, and development-context popovers remain open; a trusted residual 1px scroll in the opening frame no longer closes the status popover; a new scroll after listener activation still closes it
- Property selection: status PATCH returned 200, the visible value updated, and the popover closed; recurrence open/close path remained normal
- Dashboard: opening an unread blocked issue kept the blocked row but removed its blue dot; opening an unread non-blocked review issue removed it from the attention list
- `npm run typecheck`
- `npm run build:web`
- Agent review: no findings