### PR TITLE
Keep updater cancellation responsive during download

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1813,6 +1813,7 @@ async fn install_update(
     let finish_state = Arc::clone(state);
     let finish_dialog = update_dialog.clone();
     let mut downloaded = 0_u64;
+    let mut displayed_progress = None;
     let download_result = {
         let download = download_update(
             app,
@@ -1826,6 +1827,10 @@ async fn install_update(
                         .saturating_div(total)
                         .min(100)
                 });
+                if progress == displayed_progress {
+                    return;
+                }
+                displayed_progress = progress;
                 let snapshot = update_snapshot(&progress_app, &progress_state, |snapshot| {
                     snapshot.update_message = match progress {
                         Some(progress) => {


### PR DESCRIPTION
## Summary

- Coalesce native updater progress rendering to integer percentage changes.
- Preserve the existing cancellation, signature verification, install, and restart paths.

## Direct verification

- Rust 1.88 arm64 `cargo check --locked --target aarch64-apple-darwin` passed.
- Isolated signed updater path from 9.0.1 to 9.0.2.
- Cancel path: the server connection closed at 11,403,264 of 82,158,747 bytes; the app did not verify, install, stop its child, or restart.
- Success path: the full 82,158,747-byte archive completed; the app verified, installed, restarted, and reported 9.0.2.
- Production `/Applications` app was not used as an update target.

Taskboard: LOCAL-360