### PR TITLE
Fix missing Codex account email after auth refresh

### DIFF
--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -2295,15 +2295,31 @@ function installTaskboardHostBinding(
       isAuthorizedContext: (executionContextId) => executionContextId === activeContextId,
       parseAutomationRequest: parseTaskboardAutomationHostRequest,
       ensure: () => supervisor.ensure({ force: true }),
-      readCurrentUser: async () => ({
-        userId: stableCodexUserId(await requestCodexAppServerViaCdp(
+      readCurrentUser: async () => {
+        let account = await requestCodexAppServerViaCdp(
           cdp,
           undefined,
           "local",
           "account/read",
           { refreshToken: false },
-        )),
-      }),
+        );
+        if (
+          account?.account?.type === "chatgpt"
+          && (
+            typeof account.account.email !== "string"
+            || !account.account.email.trim()
+          )
+        ) {
+          account = await requestCodexAppServerViaCdp(
+            cdp,
+            undefined,
+            "local",
+            "account/read",
+            { refreshToken: true },
+          );
+        }
+        return { userId: stableCodexUserId(account) };
+      },
       loadFrame: (request) => loadTaskboardFrameViaCdp(
         cdp,
         request.frameName,


### PR DESCRIPTION
## Product result

When Codex initially reports a ChatGPT account without an email, Taskboard now asks the official Codex App Server to refresh authentication once and then retries the same account read. If the refresh restores the email, Taskboard opens normally and keeps the existing email-derived user identity.

The existing fast path remains unchanged. If the official refresh still has no email, the existing error remains; this PR does not add local-user, cookie, DOM, token, or multi-source identity fallbacks.

## Direct verification

- missing email → one `refreshToken: true` retry → same stable email-derived user ID
- existing email → one `refreshToken: false` call only → unchanged user ID
- refresh still missing email → existing error
- `node --check scripts/codex-injector.mjs`
- `node --test test/injector.test.mjs` (11/11)
- `git diff --check`

Refs #328. Keep #328 open until a release containing this PR is published.