### PR TITLE
Avoid duplicate Check runs for branch pushes and tags

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,6 +3,8 @@ name: Check
 on:
   pull_request:
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 产品结果

同一个功能分支提交只运行 pull_request 的一套 Check，不再同时运行 push 和 pull_request 两套打包检查。

- 功能分支 push：不触发 Check
- pull request：触发 Check
- main push：保留 Check
- `v*` 标签：只由现有 Release workflow 处理，不额外触发 Check
- `workflow_dispatch`：继续保留手动 Check

## E3

路径：分支 push / PR / main push / v* tag / workflow_dispatch → `.github/workflows/check.yml` 触发条件 → GitHub Actions jobs → 可见的工作流运行。

最小根治：仅把 Check workflow 的 `push` 限定为 `main`；没有改 jobs、concurrency、构建、产物或发布流程。

## 实现与验证

- source base: `d6bc9b88f44853402e70336f7d884c3d74f4b240`
- exact head: `8d7e2c17a14493701e781ad8e34aee6e72d2b961`
- changed file: `.github/workflows/check.yml`（+2 / -0）
- YAML parse: PASS
- `node --test test/launcher-release.test.mjs`: 5/5 PASS
- `git diff --check`: PASS
- ChatGPT Pro implementation: https://chatgpt.com/c/6a964ec7-5988-83e8-8350-5b4240eab701
- Pro source ZIP: 12,143 bytes, SHA-256 `54ca63152cfb577d11db18e113a6644d3b49fae79e78f845876b665132a0dd88`

PR 创建后的 exact-head Actions 触发结果将在本 PR 上继续核验。