### PR TITLE
fix: align creation checklist checkboxes

### DIFF
--- a/web/src/components/InlineMediaComposer.css
+++ b/web/src/components/InlineMediaComposer.css
@@ -224,6 +224,10 @@
   cursor: pointer;
 }
 
+.inline-media-description.ProseMirror li.task-list-item > input[type="checkbox"] {
+  margin-top: 6.5px;
+}
+
 .inline-media-composer.ProseMirror .inline-media-task-content {
   min-width: 0;
 }


### PR DESCRIPTION
## 变更

- 仅在新建议题描述编辑器中，把 14px 任务复选框按 27px 首行文字行盒垂直居中
- 不改 Markdown 解析、任务项 DOM、复选框外观或其他编辑器

## 真实路径

新建议题 -> 描述中输入已完成和未完成 Markdown 任务 -> ProseMirror 任务项 -> checkbox 与首行文字可见对齐

## 验证

- 修复前：普通宽度和窄宽度的中心偏差均为 -2.5px
- 修复后：750px 普通弹窗中两项偏差均为 0px
- 修复后：488px 窄弹窗中两项偏差均为 0px；第二项换行 2 行，仍按首行对齐
- `npm run build:web` 通过

按本次要求未新增测试。