### PR TITLE
Restore profile identity when Codex account email is unavailable

### DIFF
--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -88,7 +88,7 @@
   let pendingThreadCreation = null;
   let lastNativeThreadId = "";
   let lastNativeProjectId = "";
-  let currentCodexUserId = "";
+  let currentCodexUserId = null;
   let suspendedNativeBrowserPanel = null;
   let active = false;
   let destroyed = false;
@@ -615,6 +615,7 @@
   }
 
   async function captureHostContext() {
+    currentCodexUserId = null;
     const todoProgress = nativeTodoProgress();
     const [selectedProjectId, projectMetadata, currentUser] = await Promise.all([
       selectedNativeProjectId(),
@@ -758,18 +759,33 @@
     window.setTimeout(postHostContext, REATTACH_DELAY_MS);
   }
 
+  function userIdFromName(name) {
+    const slug = name.normalize("NFKD")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 96);
+    if (slug) return slug;
+    let hash = 2166136261;
+    for (const character of name) {
+      hash ^= character.codePointAt(0);
+      hash = Math.imul(hash, 16777619);
+    }
+    return `codex-user-${(hash >>> 0).toString(36)}`;
+  }
+
   function readCodexUser() {
     const profileButton = Array.from(document.querySelectorAll('button[aria-haspopup="menu"]')).find((button) => (
       normalizedLabel(button.getAttribute("aria-label")).includes("profile")
       || normalizedLabel(button.getAttribute("aria-label")).includes("个人资料")
     ));
     const name = profileButton?.textContent?.replace(/\s+/g, " ").trim();
-    if (!currentCodexUserId || !name) return null;
+    if (currentCodexUserId === null || !name) return null;
     const avatar = profileButton.querySelector("img");
     const avatarUrl = avatar?.currentSrc || avatar?.src || null;
     return {
       type: "user",
-      id: currentCodexUserId,
+      id: currentCodexUserId || userIdFromName(name),
       name,
       avatarUrl,
     };

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -112,6 +112,7 @@ function stableCodexUserId(account) {
     && typeof account.account.email === "string"
     ? account.account.email.trim().toLowerCase()
     : "";
+  if (!email && account?.account?.type === "chatgpt") return "";
   if (!email) throw new Error("The current Codex ChatGPT account email is unavailable");
   const digest = createHash("sha256")
     .update("codex-taskboard-user\0")


### PR DESCRIPTION
## Product result

Taskboard now supports both Codex identity paths:

- When Codex provides a ChatGPT email, Taskboard keeps the existing normalized-email SHA-256 user ID.
- When a CC Switch or another third-party Provider still provides no email after the official refresh read, Taskboard falls back to the profile-name identity behavior used before email-based IDs were introduced.

A missing email no longer prevents Taskboard from opening. Switching from an email account to a no-email Provider clears the previous email identity before applying the name-based identity.

The ID value does not contain source labels such as email/no-email.

## Scope

Only two production files change:

- `scripts/codex-injector.mjs`
- `inject/codex-taskboard.user.js`

No credential, cookie, token, auth file, browser storage, manual email setting, new UI, or unrelated fallback is added.

## Direct verification

- email path: one `account/read({ refreshToken:false })` call → unchanged `codex-user-<sha256>`
- missing-email path: `false` then `true` reads → historical `userIdFromName(profileName)`
- Provider switch: reading state exposes no stale prior user; final identity is the name-derived ID
- non-ChatGPT behavior remains unchanged
- production syntax and diff checks pass

Fixes #328.