### PR TITLE
Fix current user avatar in published comments

### DIFF
--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -1309,6 +1309,15 @@ export function TaskDetail({
                     );
                   }
                   const comment = item.comment;
+                  const commentActor: ActorIdentity = comment.authorType === currentUser.type
+                    && comment.authorId === currentUser.id
+                    ? currentUser
+                    : {
+                        type: comment.authorType,
+                        id: comment.authorId,
+                        name: comment.authorName,
+                        avatarUrl: comment.authorAvatarUrl,
+                      };
                   return (
                   <article
                     className={`comment-entry is-${comment.authorType}`}
@@ -1319,14 +1328,9 @@ export function TaskDetail({
                       <header className="comment-header">
                         <ActorAvatar
                           className="comment-avatar"
-                          actor={{
-                            type: comment.authorType,
-                            id: comment.authorId,
-                            name: comment.authorName,
-                            avatarUrl: comment.authorAvatarUrl,
-                          }}
+                          actor={commentActor}
                         />
-                        <strong>{comment.authorName}</strong>
+                        <strong>{commentActor.name}</strong>
                         <time title={exactTime(comment.createdAt, locale)}>{relativeTime(comment.createdAt, locale)}</time>
                         {comment.version > 1 && (
                           <span


### PR DESCRIPTION
## Product result

- Keep the signed-in user’s avatar consistent before and after publishing a comment.
- Render the current user’s live name and avatar when the stored comment author identity matches the current user.
- Keep stored author snapshots unchanged for other commenters.

## Scope

- `web/src/components/TaskDetail.tsx` only.
- Preserves the LOCAL-363 provider identity behavior and does not add source labels to user IDs.

## Verification

- `npm run typecheck`
- `npm run build:web`
- Isolated real Taskboard comment publish path: avatar remains identical before and after publishing; users without an avatar keep the same initial fallback.