### PR TITLE
Add In Review acceptance and exact-task return flow

### DIFF
--- a/docs/superpowers/plans/2026-09-01-in-review-acceptance.md
+++ b/docs/superpowers/plans/2026-09-01-in-review-acceptance.md
@@ -1,0 +1,723 @@
+# In Review Acceptance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an explicit In Review acceptance surface where users can complete an issue or save feedback and continue its exact bound Codex task without creating a new task.
+
+**Architecture:** Keep Taskboard persistence in `TaskDetail` and native Codex messaging in the existing authenticated iframe-to-launcher bridge. A return action saves the comment, re-reads the issue, asks the launcher to start one turn on the saved host/thread, and only after a confirmed turn updates the issue to `in_progress`; the launcher never calls `thread/start` for this path.
+
+**Tech Stack:** React 19, TypeScript, Node.js ESM, Codex App Server JSON-RPC, Node test runner, Vite.
+
+---
+
+## Boundaries and verified starting point
+
+- Base: `upstream/main` at `51fbec106e829dda9314d24d26cc0d06b01c7552`; design commit `a42fde52ef5ef5087932ccab06a1811b66884873`.
+- Branch: `codex/in-review-acceptance`.
+- Direct path: `TaskDetail` → Taskboard comment API → authenticated injected host bridge → exact Codex host/thread `turn/start` → Taskboard task update → visible `in_progress` state.
+- Risk: high because the path crosses the Codex App Server boundary. Do not install the app, publish, push, use the real Taskboard database, start auto-claim, or create a Codex task from product code.
+- Verification budget: one successful return path and the send-failure path. Add only the minimal TDD checks needed to drive these paths.
+
+## File map
+
+- `scripts/codex-injector-runtime.mjs`: validate the new authenticated host request and route it to its dedicated handler.
+- `scripts/codex-injector.mjs`: verify saved host/thread/workspace and start exactly one turn.
+- `inject/codex-taskboard.user.js`: forward a capability-checked iframe request to the resident launcher and return success/failure to the iframe.
+- `web/src/App.tsx`: own the iframe request/response promise and expose `onContinueThread` to the detail page.
+- `web/src/components/TaskDetail.tsx`: render the acceptance surface and sequence comment → send → status update.
+- `web/src/styles.css`: style the acceptance surface with existing Taskboard tokens.
+- `test/injector-host-runtime.test.mjs`, `test/inject.test.mjs`, `test/board-interactions.test.mjs`: focused RED/GREEN checks for the direct contract and UI wiring.
+
+### Task 1: Validate and execute the exact-thread host request
+
+**Files:**
+- Modify: `test/injector-host-runtime.test.mjs`
+- Modify: `scripts/codex-injector-runtime.mjs`
+- Modify: `scripts/codex-injector.mjs`
+
+- [ ] **Step 1: Add the failing host-contract test**
+
+Append a focused test to `test/injector-host-runtime.test.mjs` that proves a complete binding reaches only the new handler and returns its turn ID:
+
+```js
+test("review feedback reaches the exact bound Codex task", async () => {
+  const calls = [];
+  const responses = [];
+  const request = {
+    id: "continue-review-1",
+    action: "continue-task-thread",
+    identifier: "LOCAL-12",
+    feedback: "Please keep the original layout and fix the empty state.",
+    threadBinding: {
+      threadId: "01a00000-0000-7000-8000-000000000012",
+      codexProjectId: "project-12",
+      codexProjectKind: "local",
+      codexHostId: "local",
+      workspacePath: "/workspace/project-12",
+    },
+  };
+
+  const result = await handleHostBindingPayload({
+    payload: JSON.stringify(request),
+    executionContextId: 12,
+  }, {
+    parseAutomationRequest: () => null,
+    continueTaskThread: async (value) => {
+      calls.push(value);
+      return { turnId: "turn-12" };
+    },
+    startConversation: async () => assert.fail("must not create a task"),
+    sendResponse: async (_executionContextId, response) => responses.push(response),
+  });
+
+  assert.deepEqual(result, { responded: true, accepted: true });
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0].threadBinding, request.threadBinding);
+  assert.deepEqual(responses, [{ id: request.id, ok: true, turnId: "turn-12" }]);
+});
+```
+
+Add one malformed representative to the same test:
+
+```js
+  const rejected = [];
+  await handleHostBindingPayload({
+    payload: JSON.stringify({
+      ...request,
+      id: "continue-review-invalid",
+      threadBinding: { ...request.threadBinding, workspacePath: "" },
+    }),
+    executionContextId: 12,
+  }, {
+    parseAutomationRequest: () => null,
+    continueTaskThread: async () => assert.fail("invalid binding must not reach Codex"),
+    startConversation: async () => assert.fail("invalid binding must not create a task"),
+    sendResponse: async (_executionContextId, response) => rejected.push(response),
+  });
+  assert.equal(rejected.length, 1);
+  assert.equal(rejected[0].ok, false);
+```
+
+- [ ] **Step 2: Run the host test and verify RED**
+
+Run:
+
+```bash
+node --test test/injector-host-runtime.test.mjs
+```
+
+Expected: the new test fails because `continue-task-thread` is rejected or falls through to `startConversation`.
+
+- [ ] **Step 3: Add the minimal request parser and explicit route**
+
+In `scripts/codex-injector-runtime.mjs`, add one parser branch before `start-task-conversation`:
+
+```js
+  if (
+    request.action === "continue-task-thread"
+    && typeof request.identifier === "string"
+    && request.identifier.length > 0
+    && request.identifier.length <= 128
+    && typeof request.feedback === "string"
+    && request.feedback.trim().length > 0
+    && request.feedback.length <= 100_000
+    && request.threadBinding
+    && typeof request.threadBinding.threadId === "string"
+    && request.threadBinding.threadId.length > 0
+    && request.threadBinding.threadId.length <= 240
+    && typeof request.threadBinding.codexProjectId === "string"
+    && request.threadBinding.codexProjectId.length > 0
+    && request.threadBinding.codexProjectId.length <= 240
+    && (request.threadBinding.codexProjectKind === "local" || request.threadBinding.codexProjectKind === "remote")
+    && typeof request.threadBinding.codexHostId === "string"
+    && request.threadBinding.codexHostId.length > 0
+    && request.threadBinding.codexHostId.length <= 240
+    && typeof request.threadBinding.workspacePath === "string"
+    && request.threadBinding.workspacePath.length > 0
+    && request.threadBinding.workspacePath.length <= 4_096
+    && !/[\u0000-\u001f\u007f]/.test([
+      request.identifier,
+      request.threadBinding.threadId,
+      request.threadBinding.codexProjectId,
+      request.threadBinding.codexHostId,
+      request.threadBinding.workspacePath,
+    ].join(""))
+  ) return { id, request, error: null };
+```
+
+Route it explicitly in `handleHostBindingPayload`:
+
+```js
+    } else if (parsed.request.action === "continue-task-thread") {
+      result = await handlers.continueTaskThread(parsed.request, params.executionContextId);
+    } else {
+      result = await handlers.startConversation(parsed.request, params.executionContextId);
+```
+
+- [ ] **Step 4: Add the exact-thread App Server handler**
+
+In the handler object passed to `handleHostBindingPayload` in `scripts/codex-injector.mjs`, add:
+
+```js
+      continueTaskThread: async (request) => {
+        const { threadBinding } = request;
+        const read = await requestCodexAppServerViaCdp(
+          cdp,
+          undefined,
+          threadBinding.codexHostId,
+          "thread/read",
+          { threadId: threadBinding.threadId, includeTurns: false },
+        );
+        if (
+          read?.thread?.id !== threadBinding.threadId
+          || normalizeRemoteWorkspace(read.thread.cwd) !== normalizeRemoteWorkspace(threadBinding.workspacePath)
+        ) {
+          throw new Error("The bound Codex task no longer matches its saved workspace");
+        }
+        const started = await requestCodexAppServerViaCdp(
+          cdp,
+          undefined,
+          threadBinding.codexHostId,
+          "turn/start",
+          {
+            threadId: threadBinding.threadId,
+            input: [{
+              type: "text",
+              text: [
+                `用户在 Taskboard 退回 ${request.identifier}。`,
+                "",
+                request.feedback.trim(),
+                "",
+                "请在这个原任务中继续处理；不要创建新任务。完成直接验证后，按原任务约定回报结果。",
+              ].join("\n"),
+            }],
+          },
+        );
+        if (typeof started?.turn?.id !== "string" || !started.turn.id) {
+          throw new Error("Codex did not confirm the continued turn");
+        }
+        return { turnId: started.turn.id };
+      },
+```
+
+Do not add `thread/start`, retries, task creation, model overrides, or reasoning-effort overrides.
+
+- [ ] **Step 5: Verify GREEN and commit**
+
+Run:
+
+```bash
+node --test test/injector-host-runtime.test.mjs
+```
+
+Expected: all tests in the file pass with no warnings.
+
+Commit:
+
+```bash
+git add scripts/codex-injector-runtime.mjs scripts/codex-injector.mjs test/injector-host-runtime.test.mjs
+git commit -m "feat: continue exact bound Codex task"
+```
+
+### Task 2: Wire the iframe request and response
+
+**Files:**
+- Modify: `test/inject.test.mjs`
+- Modify: `inject/codex-taskboard.user.js`
+- Modify: `web/src/App.tsx`
+
+- [ ] **Step 1: Add the failing bridge-wiring test**
+
+Append this test to `test/inject.test.mjs`:
+
+```js
+test("review feedback crosses the authenticated host bridge without creating a task", () => {
+  assert.match(webApp, /type: "taskboard:continue-thread-request"/);
+  assert.match(source, /message\.type === "taskboard:continue-thread-request"/);
+  assert.match(source, /requestHost\("continue-task-thread",/);
+  assert.match(source, /type: "taskboard:continue-thread-response"/);
+  assert.match(webApp, /message\.type === "taskboard:continue-thread-response"/);
+
+  const handlerStart = source.indexOf("async function continueTaskThread");
+  const handlerEnd = source.indexOf("\n\n  function handleExternalOpen", handlerStart);
+  const handler = source.slice(handlerStart, handlerEnd);
+  assert.ok(handlerStart >= 0 && handlerEnd > handlerStart);
+  assert.doesNotMatch(handler, /createThreadForTask|taskboard:create-thread|thread\/start/);
+});
+```
+
+- [ ] **Step 2: Run the bridge test and verify RED**
+
+Run:
+
+```bash
+node --test test/inject.test.mjs
+```
+
+Expected: the new test fails because the request and response message types do not exist.
+
+- [ ] **Step 3: Forward the request in the injected host**
+
+Add this function before `handleExternalOpen` in `inject/codex-taskboard.user.js`:
+
+```js
+  async function continueTaskThread(payload) {
+    const requestId = typeof payload?.requestId === "string" ? payload.requestId : "";
+    if (!requestId) return;
+    try {
+      const response = await requestHost("continue-task-thread", {
+        identifier: payload.identifier,
+        feedback: payload.feedback,
+        threadBinding: payload.threadBinding,
+      });
+      postToFrame({
+        type: "taskboard:continue-thread-response",
+        payload: { requestId, ok: true, turnId: response.turnId },
+      });
+    } catch (error) {
+      postToFrame({
+        type: "taskboard:continue-thread-response",
+        payload: {
+          requestId,
+          ok: false,
+          error: error instanceof Error ? error.message : hostText(
+            "无法继续原 Codex 任务",
+            "Could not continue the original Codex task",
+          ),
+          uncertain: error?.uncertain === true,
+        },
+      });
+    }
+  }
+```
+
+Add this branch in `onFrameMessage` after `taskboard:open-thread`:
+
+```js
+    if (message.type === "taskboard:continue-thread-request") {
+      void continueTaskThread(message.payload);
+      return;
+    }
+```
+
+Extend the timeout branch in `requestHost` so `continue-task-thread` sets `error.uncertain = true` just like an uncertain conversation start. Do not retry automatically.
+
+- [ ] **Step 4: Add the App-owned promise**
+
+Near `AutomationHostResponse` in `web/src/App.tsx`, add:
+
+```ts
+interface ContinueThreadHostResponse {
+  requestId: string;
+  ok: boolean;
+  turnId?: string;
+  error?: string;
+  uncertain?: boolean;
+}
+
+interface PendingContinueThreadRequest {
+  resolve: (response: ContinueThreadHostResponse) => void;
+  reject: (error: Error) => void;
+  timeoutId: number;
+}
+```
+
+Create `pendingContinueThreadRequestsRef` next to `pendingAutomationRequestsRef`.
+
+Add this callback next to `openThread`:
+
+```ts
+  function continueTaskThread(task: Task, feedback: string): Promise<void> {
+    if (!embedded || window.parent === window || !task.threadBinding) {
+      return Promise.reject(new Error(textRef.current(
+        "当前议题没有可继续的完整 Codex 任务绑定。",
+        "This issue does not have a complete Codex task binding to continue.",
+      )));
+    }
+    const requestId = window.crypto.randomUUID();
+    const response = new Promise<ContinueThreadHostResponse>((resolve, reject) => {
+      const timeoutId = window.setTimeout(() => {
+        pendingContinueThreadRequestsRef.current.delete(requestId);
+        reject(new Error(textRef.current(
+          "Codex 响应超时，反馈可能已发送。请打开原任务确认后再决定是否重试。",
+          "Codex timed out and the feedback may have been sent. Check the original task before retrying.",
+        )));
+      }, 12_000);
+      pendingContinueThreadRequestsRef.current.set(requestId, { resolve, reject, timeoutId });
+    });
+    postEmbeddedHostMessage({
+      type: "taskboard:continue-thread-request",
+      payload: {
+        requestId,
+        identifier: task.identifier,
+        feedback,
+        threadBinding: task.threadBinding,
+      },
+    });
+    return response.then(() => undefined);
+  }
+```
+
+In `receiveHostMessage`, resolve or reject `taskboard:continue-thread-response` before the host-context fallback:
+
+```ts
+      if (message.type === "taskboard:continue-thread-response" && message.payload) {
+        const payload = message.payload as Partial<ContinueThreadHostResponse>;
+        if (typeof payload.requestId !== "string") return;
+        const pending = pendingContinueThreadRequestsRef.current.get(payload.requestId);
+        if (!pending) return;
+        window.clearTimeout(pending.timeoutId);
+        pendingContinueThreadRequestsRef.current.delete(payload.requestId);
+        if (payload.ok && typeof payload.turnId === "string") {
+          pending.resolve(payload as ContinueThreadHostResponse);
+        } else {
+          pending.reject(new Error(payload.uncertain
+            ? textRef.current(
+                "Codex 响应超时，反馈可能已发送。请打开原任务确认后再决定是否重试。",
+                "Codex timed out and the feedback may have been sent. Check the original task before retrying.",
+              )
+            : typeof payload.error === "string"
+              ? payload.error
+              : textRef.current(
+                  "无法继续原 Codex 任务。",
+                  "Could not continue the original Codex task.",
+                )));
+        }
+        return;
+      }
+```
+
+In the effect cleanup, reject and clear this pending map alongside automation requests:
+
+```ts
+      for (const pending of pendingContinueThreadRequestsRef.current.values()) {
+        window.clearTimeout(pending.timeoutId);
+        pending.reject(new Error(textRef.current(
+          "Taskboard 消息桥已关闭",
+          "The Taskboard host bridge was closed",
+        )));
+      }
+      pendingContinueThreadRequestsRef.current.clear();
+```
+
+Pass `onContinueThread={continueTaskThread}` and `canContinueThread={embedded && window.parent !== window}` to `TaskDetail`.
+
+- [ ] **Step 5: Verify GREEN and commit**
+
+Run:
+
+```bash
+node --test test/inject.test.mjs
+npm run typecheck
+```
+
+Expected: `test/inject.test.mjs` passes and TypeScript reports no errors.
+
+Commit:
+
+```bash
+git add inject/codex-taskboard.user.js web/src/App.tsx test/inject.test.mjs
+git commit -m "feat: bridge review feedback to Codex"
+```
+
+### Task 3: Add the In Review acceptance surface and return sequencing
+
+**Files:**
+- Modify: `test/board-interactions.test.mjs`
+- Modify: `web/src/components/TaskDetail.tsx`
+- Modify: `web/src/styles.css`
+
+- [ ] **Step 1: Add the failing direct-UI-path test**
+
+Append this test to `test/board-interactions.test.mjs`:
+
+```js
+test("in-review details expose acceptance and exact-task return actions", () => {
+  assert.match(detailSource, /currentTask\.status === "in_review"[\s\S]*?className="review-acceptance"/);
+  assert.match(detailSource, /comments[\s\S]*?authorType === "agent"[\s\S]*?等待你验收/);
+  assert.match(detailSource, /通过并完成[\s\S]*?onUpdate\(currentTask, \{ status: "done" \}\)/);
+  assert.match(detailSource, /写退回意见[\s\S]*?composerRef\.current\?\.focus\(\)/);
+  assert.match(detailSource, /createComment\([\s\S]*?getTask\([\s\S]*?onContinueThread\([\s\S]*?status: "in_progress"/);
+  assert.match(detailSource, /仅改为等待认领（不通知）/);
+  assert.match(detailSource, /退回并继续原任务/);
+  assert.match(styles, /\.review-acceptance/);
+});
+```
+
+- [ ] **Step 2: Run the UI test and verify RED**
+
+Run:
+
+```bash
+node --test test/board-interactions.test.mjs
+```
+
+Expected: the new test fails because the acceptance surface and return action are absent.
+
+- [ ] **Step 3: Add the acceptance props and derived delivery comment**
+
+Extend `TaskDetailProps` in `web/src/components/TaskDetail.tsx`:
+
+```ts
+  canContinueThread: boolean;
+  onContinueThread: (task: Task, feedback: string) => Promise<void>;
+```
+
+Add a `commentComposerFormRef` and a derived latest Agent comment before the return statement:
+
+```ts
+  const commentComposerFormRef = useRef<HTMLFormElement>(null);
+  const latestAgentDelivery = [...comments]
+    .reverse()
+    .find((comment) => comment.authorType === "agent" && comment.body.trim());
+```
+
+- [ ] **Step 4: Render the acceptance surface**
+
+Insert the surface between the issue editor/sub-issues block and the activity section:
+
+```tsx
+            {currentTask.status === "in_review" && (
+              <section className="review-acceptance" aria-labelledby="review-acceptance-heading">
+                <header>
+                  <div>
+                    <span>{text("等待你验收", "Waiting for your review")}</span>
+                    <h2 id="review-acceptance-heading">{currentTask.title}</h2>
+                  </div>
+                  <button
+                    className="button primary"
+                    type="button"
+                    disabled={savingProperty !== null || submitting}
+                    onClick={() => {
+                      setSavingProperty("review-complete");
+                      void onUpdate(currentTask, { status: "done" })
+                        .then(setCurrentTask)
+                        .catch((error) => onError(issueMessageFor(error)))
+                        .finally(() => setSavingProperty(null));
+                    }}
+                  >
+                    {text("通过并完成", "Approve and complete")}
+                  </button>
+                </header>
+                <div className="review-delivery">
+                  {latestAgentDelivery
+                    ? <DescriptionDocument
+                        value={latestAgentDelivery.body}
+                        referenceTasks={referenceTasks}
+                        onOpenTask={onOpenTask}
+                        attachments={latestAgentDelivery.attachments}
+                        enableImagePreview
+                        onOpenAttachment={handleAttachmentDownload}
+                      />
+                    : <p>{text(
+                        "暂无 Agent 交付说明，请打开处理对话查看结果。",
+                        "No Agent delivery note is available. Open the processing task to inspect the result.",
+                      )}</p>}
+                </div>
+                <footer>
+                  <span>{text("普通评论只保存记录，不会通知 Codex。", "Regular comments are recorded without notifying Codex.")}</span>
+                  <button
+                    className="button secondary"
+                    type="button"
+                    disabled={!canContinueThread || !currentTask.threadBinding}
+                    onClick={() => {
+                      commentComposerFormRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+                      requestAnimationFrame(() => composerRef.current?.focus());
+                    }}
+                  >
+                    {text("写退回意见", "Write return feedback")}
+                  </button>
+                </footer>
+              </section>
+            )}
+```
+
+Use existing `button`, text, surface, border, and radius tokens; do not import external colors, fonts, icons, or assets.
+
+- [ ] **Step 5: Sequence comment, exact send, and status update**
+
+Change `submitComment` to accept an intent:
+
+```ts
+  async function submitComment(intent: "record" | "return" = "record") {
+```
+
+Before setting `submitting`, reject a return without body, complete binding, embedded capability, or `in_review` status:
+
+```ts
+    if (
+      intent === "return"
+      && (!body || currentTask.status !== "in_review" || !currentTask.threadBinding || !canContinueThread)
+    ) return;
+```
+
+After comment creation/upload and `const relationAnchor = await getTask(currentTask.id)`, add the return branch before the existing Todo branch:
+
+```ts
+      if (intent === "return") {
+        if (relationAnchor.status !== "in_review" || !relationAnchor.threadBinding) {
+          throw new Error(text(
+            "议题或任务绑定已变化，请刷新后重试。",
+            "The issue or task binding changed. Refresh and try again.",
+          ));
+        }
+        await onContinueThread(relationAnchor, body);
+        try {
+          const saved = await onUpdate(relationAnchor, { status: "in_progress" });
+          setCurrentTask(saved);
+          relationAnchor = saved;
+        } catch (error) {
+          setCommentsError(text(
+            "反馈已发送，但状态更新失败。请刷新议题；不要再次发送反馈。",
+            "Feedback was sent, but the status update failed. Refresh the issue; do not send the feedback again.",
+          ));
+          return;
+        }
+      }
+```
+
+Keep comment creation first. Keep the comment when send fails. Do not call `onUpdate` when `onContinueThread` rejects. Do not automatically retry either operation.
+
+Give the form `ref={commentComposerFormRef}`. In Review, render both explicit submit buttons:
+
+```tsx
+                    <button className="button secondary" type="submit" disabled={...}>
+                      {submitting ? text("发布中…", "Posting…") : text("仅记录评论", "Record comment")}
+                    </button>
+                    <button
+                      className="button primary"
+                      type="button"
+                      disabled={!draft.trim() || submitting || !canContinueThread || !currentTask.threadBinding}
+                      onClick={() => void submitComment("return")}
+                    >
+                      {submitting
+                        ? text("发送中…", "Sending…")
+                        : text("退回并继续原任务", "Return and continue original task")}
+                    </button>
+```
+
+For non-review statuses, retain the current single Comment button. For the existing Todo switch, use `text("仅改为等待认领（不通知）", "Move to Todo only (no notification)")` while in review and preserve the existing copy elsewhere.
+
+- [ ] **Step 6: Add minimal styles**
+
+Add a `.review-acceptance` block near `.activity-section` in `web/src/styles.css` using only existing variables:
+
+```css
+.review-acceptance {
+  margin: 0 14px 18px;
+  padding: 16px;
+  border: var(--border-hairline) solid color-mix(in srgb, var(--accent) 24%, var(--border));
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--accent) 4%, var(--surface));
+}
+
+.review-acceptance > header,
+.review-acceptance > footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.review-acceptance > header span,
+.review-acceptance > footer span {
+  color: var(--text-tertiary);
+  font-size: 11px;
+}
+
+.review-acceptance h2 {
+  margin: 2px 0 0;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.review-delivery {
+  margin: 14px 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.review-delivery > :first-child { margin-top: 0; }
+.review-delivery > :last-child { margin-bottom: 0; }
+
+@media (max-width: 719px) {
+  .review-acceptance > header,
+  .review-acceptance > footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+```
+
+- [ ] **Step 7: Verify GREEN and commit**
+
+Run:
+
+```bash
+node --test test/board-interactions.test.mjs
+npm run typecheck
+npm run build:web
+```
+
+Expected: the focused test passes, TypeScript reports no errors, and Vite completes a Web build.
+
+Commit:
+
+```bash
+git add web/src/components/TaskDetail.tsx web/src/styles.css test/board-interactions.test.mjs
+git commit -m "feat: add in-review acceptance actions"
+```
+
+### Task 4: Direct-path verification and handoff
+
+**Files:**
+- No product files unless direct verification exposes a defect in the requested path.
+
+- [ ] **Step 1: Run the focused verification set**
+
+Run:
+
+```bash
+node --test test/injector-host-runtime.test.mjs test/inject.test.mjs test/board-interactions.test.mjs
+npm run typecheck
+npm run build:web
+git diff --check upstream/main...HEAD
+```
+
+Expected: all focused tests pass; typecheck and Web build succeed; diff check is clean.
+
+- [ ] **Step 2: Run simplify before completion**
+
+Inspect:
+
+```bash
+git diff --stat upstream/main...HEAD
+git diff upstream/main...HEAD -- scripts/codex-injector-runtime.mjs scripts/codex-injector.mjs inject/codex-taskboard.user.js web/src/App.tsx web/src/components/TaskDetail.tsx web/src/styles.css
+```
+
+Remove any new abstraction, retry, fallback, compatibility path, duplicate validation at the same boundary, or unrelated style change not required by the successful and failed direct paths. Retain authenticated-host validation, complete-binding validation, workspace matching, timeout uncertainty, and the comment/send/status ordering because they protect distinct trust or persistence boundaries.
+
+- [ ] **Step 3: Verify the isolated success and failure paths**
+
+Use a temporary Taskboard data directory and an isolated loopback port; never point at the active launcher runtime or real database. Seed one `in_review` fixture issue with an Agent delivery comment and a fake complete binding. Stub the authenticated host response for two cases:
+
+1. Success: return `{ ok: true, turnId: "turn-fixture" }`; verify one click records one comment, sends one continue request containing the saved host/thread and body, then shows `in_progress`.
+2. Failure: return `{ ok: false, error: "fixture send failure" }`; verify the comment remains visible, status remains `in_review`, and the error is visible.
+
+Capture screenshots of the acceptance surface at desktop width and below 719px. Confirm hierarchy, legibility, spacing, contrast, keyboard focus, bilingual copy, and that external Linear brand colors/fonts/assets are absent. Stop only the exact isolated processes started for this verification.
+
+- [ ] **Step 4: Prepare the working demo; do not push or open a PR yet**
+
+Record:
+
+- changed files and commits;
+- exact HEAD SHA;
+- RED then GREEN outputs;
+- isolated success/failure receipts;
+- screenshot paths;
+- known limitation: a confirmed Codex send followed by a Taskboard status failure cannot be atomic, so the UI warns not to resend;
+- review decision: Pro review is required after user confirmation because this changes the native host/Codex App Server external boundary.
+
+Return the evidence to the coordinator. Do not merge, release, install, mark anything `done`, submit to Pro, push, or create a PR before the coordinator presents the working demo and the user confirms it works.

--- a/docs/superpowers/specs/2026-09-01-in-review-acceptance-design.md
+++ b/docs/superpowers/specs/2026-09-01-in-review-acceptance-design.md
@@ -1,0 +1,111 @@
+# In Review 验收与退回原任务设计
+
+## 目标与范围
+
+让用户在议题详情页完成两条明确的 In Review 主路径：
+
+1. 查看最近一次 Agent 交付说明，确认后将议题标记为 `done`。
+2. 写下验收反馈，保存为 Taskboard 评论，并把同一反馈发送给议题已绑定的 Codex 任务；发送成功后将议题移回 `in_progress`。
+
+本阶段不修改自动领项、实时进度、状态模型、数据库结构或普通评论的通知语义，不创建新的 Codex 任务。
+
+## 已证明的现有操作链
+
+- 验收入口：`web/src/components/TaskCard.tsx` 在 `in_review` 卡片上显示“完成”，调用 `web/src/App.tsx` 的 `moveTask(task, "done")`，最终通过现有任务移动 API 更新状态，用户看到卡片进入完成状态。
+- 评论入口：`web/src/components/TaskDetail.tsx` 的 `submitComment()` 调用 `web/src/api.ts` 的 `createComment()`，服务端写入评论并通过实时事件刷新界面；该路径不会向 Codex 任务发送消息。
+- 绑定入口：`TaskDetail.tsx` 和 `App.tsx` 已能读取完整 `threadBinding` 并打开精确的本地或 SSH Codex 任务。
+- 原生边界：嵌入页消息经 `inject/codex-taskboard.user.js` 的 capability/challenge 校验进入固定宿主绑定；`scripts/codex-injector-runtime.mjs` 校验宿主请求，`scripts/codex-injector.mjs` 已通过 Codex App Server 的 `turn/start` 向精确 `threadId` 发起回合。
+
+## 方案比较
+
+### A. 详情页轻量验收区（采用）
+
+在现有详情页主栏中增加 In Review 专用验收区，显示最近一条非空 Agent 评论和两个明确动作。退回动作复用现有评论输入框，不新增编辑器或弹窗。
+
+优点：信息与动作同页；最少新增 UI；复用评论、状态更新和绑定数据。缺点：需要跨 Web、注入脚本和宿主请求边界发送反馈。
+
+### B. 验收弹窗
+
+点击卡片或详情页按钮后打开独立弹窗，集中展示交付说明、反馈框和动作。
+
+优点：流程聚焦。缺点：复制现有评论编辑能力，增加附件、焦点、响应式和错误状态处理，不符合当前最小主路径。
+
+### C. 扩展现有“改为等待认领”开关
+
+把现有评论开关改成“退回并通知”。
+
+优点：改动面小。缺点：继续混淆“回到待认领”和“继续原绑定任务”，且无法自然表达验收通过，因此不采用。
+
+## 交互设计
+
+### 验收区
+
+仅当 `currentTask.status === "in_review"` 时显示，位置在议题内容之后、活动时间线之前。
+
+- 标题：“等待你验收”。
+- 内容：按 `createdAt` 取最近一条 `authorType === "agent"` 且正文非空的评论，原样用现有 Markdown 渲染器展示；没有时显示“暂无 Agent 交付说明，请打开处理对话查看结果”。
+- 若议题有完整 `threadBinding`，保留现有对话链接。
+- 主按钮：“通过并完成”。调用现有任务更新路径把状态改为 `done`。
+- 次按钮：“写退回意见”。滚动并聚焦现有评论框，同时切换为“退回原任务”提交意图。
+
+### 评论框
+
+普通状态保持现状。In Review 时明确显示：
+
+- 普通“评论”仍只保存记录，不通知 Codex。
+- “退回并继续原任务”只在存在完整 `threadBinding` 且反馈正文非空时可用；附件不能替代正文，因为发送给 Codex 的是文本反馈。
+- 现有“改为等待认领”动作改写为“仅改为等待认领（不通知）”，保留原能力但消除语义误导。
+
+### 状态与错误
+
+- 通过成功：`in_review -> done`，不发送 Codex 消息。
+- 退回成功：先保存用户评论，再把反馈发送到完整 `threadBinding.threadId`；宿主确认 `turn/start` 成功后，使用最新议题版本执行 `in_review -> in_progress`，保留完整绑定。
+- 评论保存失败：停止，不发送、不改状态。
+- Codex 发送失败：评论保留，议题保持 `in_review`，展示明确错误；不创建新任务、不自动重试。
+- 发送已确认但状态更新失败：展示“反馈已发送，但状态更新失败”，刷新议题；不再次发送。该跨系统边界无法做数据库事务，本阶段不引入持久化幂等层。
+- 无完整绑定或仅有 legacy local thread：不提供自动退回按钮，提示用户打开原对话或改为等待认领；不得猜测项目或主机。
+
+## 组件与数据流
+
+### 通过并完成
+
+`TaskDetail` 验收区 → `onUpdate(currentTask, { status: "done" })` → 现有任务更新 API/数据库 → App 任务状态刷新 → 用户看到完成状态。
+
+### 退回并继续原任务
+
+`TaskDetail` 评论框 → `createComment()` 保存反馈 → 重新读取议题并核对 `in_review` 与完整绑定 → `App` 发出带 request ID 的嵌入宿主消息 → 注入层校验 frame capability/challenge → 固定宿主校验 thread binding 和反馈边界 → Codex App Server `turn/start` 精确发送到保存的 host/thread → 成功响应 → `onUpdate(..., { status: "in_progress" })` → 用户看到处理中状态。
+
+请求不包含新建任务参数，宿主处理器也不调用 `thread/start` 或 `create_thread`。
+
+## 安全与边界
+
+- 只接受完整五字段绑定：`threadId`、`codexProjectId`、`codexProjectKind`、`codexHostId`、`workspacePath`。
+- 宿主请求沿用现有 authenticated iframe capability、隔离 world binding 和 host ID 路由。
+- 反馈文本必须非空并限制在现有评论正文上限内；不读取任意文件，不操作附件内容。
+- 每次点击最多发起一个 `turn/start`；按钮在请求中禁用。未知结果不自动重试。
+- 不操作真实 Taskboard 数据；直接验证使用现有测试、fixture 和隔离宿主 stub。
+
+## 直接验证与验收标准
+
+风险等级：高。原因是改动跨越 UI、原生注入宿主和 Codex App Server 外部边界，但不涉及数据库迁移、进程生命周期、安装或发布。
+
+验证预算是退回失败路径加一条成功主路径：
+
+1. 测试先证明无完整绑定时不会显示/触发自动退回。
+2. 测试证明一条退回请求只携带保存的 host/thread 和正文，调用一次 `turn/start`，不包含创建任务调用。
+3. 隔离页面验证评论保存 → 精确发送 → 状态变 `in_progress`；模拟发送失败时评论保留、状态仍为 `in_review`。
+4. 真实 UI 预览只使用 fixture：能看到最近交付说明、“通过并完成”、“写退回意见”，普通评论的“不通知”含义清楚。
+
+完成定义：用户可在一个详情页通过或退回；退回只继续原绑定任务，不创建自动化或新任务；发送失败不会误改状态。
+
+## 视觉选择回执
+
+- 项目批准来源：未发现独立批准的设计规范；现有 `web/src/components/TaskDetail.tsx` 与 `web/src/styles.css` 作为运行中的主基线。
+- 记录的缺口：In Review 缺少清晰的交付摘要与主次验收动作层级。
+- 外部池：`/Users/lyon/Documents/Codex/VisualStyleLibrary/sources/awesome-design-md`。
+- 池提交：`8147538b4226ae41e2487a9179e3bcc1f68e8554`。
+- 选中条目：`design-md/linear.app/DESIGN.md`，权利标签 `public_reference_only`。
+- 来源陈述：参考条目使用单一强调色表达少量关键 CTA，次级按钮保持表面色，按钮采用紧凑间距与中等圆角。
+- 采用推断：只采用“一个明确主动作、一个次动作、静默辅助说明”的层级；颜色、字号、圆角和间距全部继续使用 Taskboard 现有 token。
+- 拒绝项：不采用 Linear 的品牌色、专有字体、Logo、深色营销画布或其他识别性元素；Notion 条目因彩色品牌表达超出此缺口而未采用。
+- 预览与 QA：实现完成后在隔离 fixture 页面检查信息层级、可读性、间距、对比度、键盘焦点、窄屏布局和中英文文案；在用户确认前不合并或发布。

--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -1244,6 +1244,35 @@
     }
   }
 
+  async function continueTaskThread(payload) {
+    const requestId = typeof payload?.requestId === "string" ? payload.requestId : "";
+    if (!requestId) return;
+    try {
+      const response = await requestHost("continue-task-thread", {
+        identifier: payload.identifier,
+        feedback: payload.feedback,
+        threadBinding: payload.threadBinding,
+      });
+      postToFrame({
+        type: "taskboard:continue-thread-response",
+        payload: { requestId, ok: true, turnId: response.turnId },
+      });
+    } catch (error) {
+      postToFrame({
+        type: "taskboard:continue-thread-response",
+        payload: {
+          requestId,
+          ok: false,
+          error: error instanceof Error ? error.message : hostText(
+            "无法继续原 Codex 任务",
+            "Could not continue the original Codex task",
+          ),
+          uncertain: error?.uncertain === true,
+        },
+      });
+    }
+  }
+
   function handleExternalOpen(payload) {
     try {
       const url = new URL(payload?.url);
@@ -1345,6 +1374,10 @@
     }
     if (message.type === "taskboard:open-thread") {
       void openThread(message.payload);
+      return;
+    }
+    if (message.type === "taskboard:continue-thread-request") {
+      void continueTaskThread(message.payload);
       return;
     }
     if (message.type === "taskboard:expand-sidebar") {
@@ -1601,7 +1634,9 @@
         : window.setTimeout(() => {
           hostRequests.delete(id);
           const error = hostError("任务面板启动器没有响应", "The Taskboard launcher did not respond");
-          if (action === "start-task-conversation") error.uncertain = true;
+          if (action === "start-task-conversation" || action === "continue-task-thread") {
+            error.uncertain = true;
+          }
           reject(error);
         }, timeoutMs);
       hostRequests.set(id, { resolve, reject, timeout });

--- a/scripts/codex-injector-runtime.mjs
+++ b/scripts/codex-injector-runtime.mjs
@@ -59,6 +59,36 @@ function parseHostRequest(payload, parseAutomationRequest) {
         };
   }
   if (
+    request.action === "continue-task-thread"
+    && typeof request.identifier === "string"
+    && request.identifier.length > 0
+    && request.identifier.length <= 128
+    && typeof request.feedback === "string"
+    && request.feedback.trim().length > 0
+    && request.feedback.length <= 100_000
+    && request.threadBinding
+    && typeof request.threadBinding.threadId === "string"
+    && request.threadBinding.threadId.length > 0
+    && request.threadBinding.threadId.length <= 240
+    && typeof request.threadBinding.codexProjectId === "string"
+    && request.threadBinding.codexProjectId.length > 0
+    && request.threadBinding.codexProjectId.length <= 240
+    && (request.threadBinding.codexProjectKind === "local" || request.threadBinding.codexProjectKind === "remote")
+    && typeof request.threadBinding.codexHostId === "string"
+    && request.threadBinding.codexHostId.length > 0
+    && request.threadBinding.codexHostId.length <= 240
+    && typeof request.threadBinding.workspacePath === "string"
+    && request.threadBinding.workspacePath.length > 0
+    && request.threadBinding.workspacePath.length <= 4_096
+    && !/[\u0000-\u001f\u007f]/.test([
+      request.identifier,
+      request.threadBinding.threadId,
+      request.threadBinding.codexProjectId,
+      request.threadBinding.codexHostId,
+      request.threadBinding.workspacePath,
+    ].join(""))
+  ) return { id, request, error: null };
+  if (
     request.action === "start-task-conversation"
     && typeof request.taskId === "string"
     && request.taskId.length > 0
@@ -125,6 +155,8 @@ export async function handleHostBindingPayload(params, handlers) {
       result = await handlers.openAttachment(parsed.request);
     } else if (parsed.request.action === "automation") {
       result = await handlers.runAutomation(parsed.request, params.executionContextId);
+    } else if (parsed.request.action === "continue-task-thread") {
+      result = await handlers.continueTaskThread(parsed.request, params.executionContextId);
     } else {
       result = await handlers.startConversation(parsed.request, params.executionContextId);
     }

--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -2351,6 +2351,45 @@ function installTaskboardHostBinding(
             : reconcileTaskboardAutomation(request, rpc);
         })()
       ),
+      continueTaskThread: async (request) => {
+        const { threadBinding } = request;
+        const read = await requestCodexAppServerViaCdp(
+          cdp,
+          undefined,
+          threadBinding.codexHostId,
+          "thread/read",
+          { threadId: threadBinding.threadId, includeTurns: false },
+        );
+        if (
+          read?.thread?.id !== threadBinding.threadId
+          || normalizeRemoteWorkspace(read.thread.cwd) !== normalizeRemoteWorkspace(threadBinding.workspacePath)
+        ) {
+          throw new Error("The bound Codex task no longer matches its saved workspace");
+        }
+        const started = await requestCodexAppServerViaCdp(
+          cdp,
+          undefined,
+          threadBinding.codexHostId,
+          "turn/start",
+          {
+            threadId: threadBinding.threadId,
+            input: [{
+              type: "text",
+              text: [
+                `用户在 Taskboard 退回 ${request.identifier}。`,
+                "",
+                request.feedback.trim(),
+                "",
+                "请在这个原任务中继续处理；不要创建新任务。完成直接验证后，按原任务约定回报结果。",
+              ].join("\n"),
+            }],
+          },
+        );
+        if (typeof started?.turn?.id !== "string" || !started.turn.id) {
+          throw new Error("Codex did not confirm the continued turn");
+        }
+        return { turnId: started.turn.id };
+      },
       startConversation: (request) => (
         getOrStartTaskConversation(cdp, undefined, request)
       ),

--- a/test/board-interactions.test.mjs
+++ b/test/board-interactions.test.mjs
@@ -165,6 +165,19 @@ test("comments upload and render their own attachments in the content flow", () 
   assert.match(composerSource, /className="inline-media-attachment"/);
 });
 
+test("in-review details expose acceptance and exact-task return actions", () => {
+  assert.match(detailSource, /currentTask\.status === "in_review"[\s\S]*?className="review-acceptance"/);
+  assert.match(detailSource, /comments[\s\S]*?authorType === "agent"[\s\S]*?等待你验收/);
+  assert.match(detailSource, /通过并完成/);
+  assert.match(detailSource, /onUpdate\(currentTask, \{ status: "done" \}\)/);
+  assert.match(detailSource, /写退回意见/);
+  assert.match(detailSource, /commentComposerFormRef\.current\?\.scrollIntoView[\s\S]*?composerRef\.current\?\.focus\(\)/);
+  assert.match(detailSource, /createComment\([\s\S]*?getTask\([\s\S]*?onContinueThread\([\s\S]*?status: "in_progress"/);
+  assert.match(detailSource, /仅改为等待认领（不通知）/);
+  assert.match(detailSource, /退回并继续原任务/);
+  assert.match(styles, /\.review-acceptance/);
+});
+
 test("issue creation and detail share one searchable, creatable label picker", () => {
   assert.match(editorSource, /<LabelPicker/);
   assert.match(detailSource, /<LabelPicker/);

--- a/test/board-interactions.test.mjs
+++ b/test/board-interactions.test.mjs
@@ -176,6 +176,9 @@ test("in-review details expose acceptance and exact-task return actions", () => 
   assert.match(detailSource, /仅改为等待认领（不通知）/);
   assert.match(detailSource, /退回并继续原任务/);
   assert.match(styles, /\.review-acceptance/);
+  assert.match(styles, /\.composer-footer > div:last-child \{[\s\S]*?flex: 1 1 100%/);
+  assert.match(styles, /\.comment-status-action \{[\s\S]*?flex: 1 1 100%/);
+  assert.match(styles, /\.composer-footer \.button \{[\s\S]*?white-space: nowrap/);
 });
 
 test("issue creation and detail share one searchable, creatable label picker", () => {

--- a/test/inject.test.mjs
+++ b/test/inject.test.mjs
@@ -923,3 +923,17 @@ test("host integration stays thin", () => {
   assert.doesNotMatch(source, /import\s*\(/);
   assert.doesNotMatch(source, /window\.fetch\s*=/);
 });
+
+test("review feedback crosses the authenticated host bridge without creating a task", () => {
+  assert.match(webApp, /type: "taskboard:continue-thread-request"/);
+  assert.match(source, /message\.type === "taskboard:continue-thread-request"/);
+  assert.match(source, /requestHost\("continue-task-thread",/);
+  assert.match(source, /type: "taskboard:continue-thread-response"/);
+  assert.match(webApp, /message\.type === "taskboard:continue-thread-response"/);
+
+  const handlerStart = source.indexOf("async function continueTaskThread");
+  const handlerEnd = source.indexOf("\n\n  function handleExternalOpen", handlerStart);
+  const handler = source.slice(handlerStart, handlerEnd);
+  assert.ok(handlerStart >= 0 && handlerEnd > handlerStart);
+  assert.doesNotMatch(handler, /createThreadForTask|taskboard:create-thread|thread\/start/);
+});

--- a/test/injector-host-runtime.test.mjs
+++ b/test/injector-host-runtime.test.mjs
@@ -265,3 +265,56 @@ test("refresh stops every stale resident before starting one token-verified repl
     ["ready", 9231, 9876, startupToken],
   ]);
 });
+
+test("review feedback reaches the exact bound Codex task", async () => {
+  const calls = [];
+  const responses = [];
+  const request = {
+    id: "continue-review-1",
+    action: "continue-task-thread",
+    identifier: "LOCAL-12",
+    feedback: "Please keep the original layout and fix the empty state.",
+    threadBinding: {
+      threadId: "01a00000-0000-7000-8000-000000000012",
+      codexProjectId: "project-12",
+      codexProjectKind: "local",
+      codexHostId: "local",
+      workspacePath: "/workspace/project-12",
+    },
+  };
+
+  const result = await handleHostBindingPayload({
+    payload: JSON.stringify(request),
+    executionContextId: 12,
+  }, {
+    parseAutomationRequest: () => null,
+    continueTaskThread: async (value) => {
+      calls.push(value);
+      return { turnId: "turn-12" };
+    },
+    startConversation: async () => assert.fail("must not create a task"),
+    sendResponse: async (_executionContextId, response) => responses.push(response),
+  });
+
+  assert.deepEqual(result, { responded: true, accepted: true });
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0].threadBinding, request.threadBinding);
+  assert.deepEqual(responses, [{ id: request.id, ok: true, turnId: "turn-12" }]);
+
+  const rejected = [];
+  await handleHostBindingPayload({
+    payload: JSON.stringify({
+      ...request,
+      id: "continue-review-invalid",
+      threadBinding: { ...request.threadBinding, workspacePath: "" },
+    }),
+    executionContextId: 12,
+  }, {
+    parseAutomationRequest: () => null,
+    continueTaskThread: async () => assert.fail("invalid binding must not reach Codex"),
+    startConversation: async () => assert.fail("invalid binding must not create a task"),
+    sendResponse: async (_executionContextId, response) => rejected.push(response),
+  });
+  assert.equal(rejected.length, 1);
+  assert.equal(rejected[0].ok, false);
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -294,6 +294,20 @@ interface PendingAutomationRequest {
   timeoutId: number;
 }
 
+interface ContinueThreadHostResponse {
+  requestId: string;
+  ok: boolean;
+  turnId?: string;
+  error?: string;
+  uncertain?: boolean;
+}
+
+interface PendingContinueThreadRequest {
+  resolve: (response: ContinueThreadHostResponse) => void;
+  reject: (error: Error) => void;
+  timeoutId: number;
+}
+
 const DEFAULT_USER_ACTOR: ActorIdentity = {
   type: "user",
   id: "local-user",
@@ -855,6 +869,7 @@ export function App() {
     );
   }
   const pendingAutomationRequestsRef = useRef(new Map<string, PendingAutomationRequest>());
+  const pendingContinueThreadRequestsRef = useRef(new Map<string, PendingContinueThreadRequest>());
   const automationRequestInFlightRef = useRef<"list" | "save" | null>(null);
   const loadedAutomationProjectIdsRef = useRef(new Set<string>());
   const queuedAutomationSavesRef = useRef(new Map<string, QueuedProjectAutomationSave>());
@@ -1760,6 +1775,31 @@ export function App() {
         return;
       }
 
+      if (message.type === "taskboard:continue-thread-response" && message.payload) {
+        const payload = message.payload as Partial<ContinueThreadHostResponse>;
+        if (typeof payload.requestId !== "string") return;
+        const pending = pendingContinueThreadRequestsRef.current.get(payload.requestId);
+        if (!pending) return;
+        window.clearTimeout(pending.timeoutId);
+        pendingContinueThreadRequestsRef.current.delete(payload.requestId);
+        if (payload.ok && typeof payload.turnId === "string") {
+          pending.resolve(payload as ContinueThreadHostResponse);
+        } else {
+          pending.reject(new Error(payload.uncertain
+            ? textRef.current(
+                "Codex 响应超时，反馈可能已发送。请打开原任务确认后再决定是否重试。",
+                "Codex timed out and the feedback may have been sent. Check the original task before retrying.",
+              )
+            : typeof payload.error === "string"
+              ? payload.error
+              : textRef.current(
+                  "无法继续原 Codex 任务。",
+                  "Could not continue the original Codex task.",
+                )));
+        }
+        return;
+      }
+
       if (message.type === "taskboard:theme" && isTheme(message.theme)) {
         setTheme(message.theme);
         return;
@@ -1810,6 +1850,14 @@ export function App() {
         )));
       }
       pendingAutomationRequestsRef.current.clear();
+      for (const pending of pendingContinueThreadRequestsRef.current.values()) {
+        window.clearTimeout(pending.timeoutId);
+        pending.reject(new Error(textRef.current(
+          "Taskboard 消息桥已关闭",
+          "The Taskboard host bridge was closed",
+        )));
+      }
+      pendingContinueThreadRequestsRef.current.clear();
     };
   }, [embedded, host]);
 
@@ -2925,6 +2973,36 @@ export function App() {
       return;
     }
     window.location.assign(`codex://threads/${encodeURIComponent(binding.threadId.trim())}`);
+  }
+
+  function continueTaskThread(task: Task, feedback: string): Promise<void> {
+    if (!embedded || window.parent === window || !task.threadBinding) {
+      return Promise.reject(new Error(textRef.current(
+        "当前议题没有可继续的完整 Codex 任务绑定。",
+        "This issue does not have a complete Codex task binding to continue.",
+      )));
+    }
+    const requestId = window.crypto.randomUUID();
+    const response = new Promise<ContinueThreadHostResponse>((resolve, reject) => {
+      const timeoutId = window.setTimeout(() => {
+        pendingContinueThreadRequestsRef.current.delete(requestId);
+        reject(new Error(textRef.current(
+          "Codex 响应超时，反馈可能已发送。请打开原任务确认后再决定是否重试。",
+          "Codex timed out and the feedback may have been sent. Check the original task before retrying.",
+        )));
+      }, 12_000);
+      pendingContinueThreadRequestsRef.current.set(requestId, { resolve, reject, timeoutId });
+    });
+    postEmbeddedHostMessage({
+      type: "taskboard:continue-thread-request",
+      payload: {
+        requestId,
+        identifier: task.identifier,
+        feedback,
+        threadBinding: task.threadBinding,
+      },
+    });
+    return response.then(() => undefined);
   }
 
   function openLegacyLocalThread(threadId: string) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3776,6 +3776,8 @@ export function App() {
               mutateTaskRelation("remove", current, type, relatedTaskId, origin)
             )}
             onOpenThread={openThread}
+            canContinueThread={embedded && window.parent !== window}
+            onContinueThread={continueTaskThread}
             onOpenLegacyLocalThread={openLegacyLocalThread}
             onOpenInThread={openTaskInThread}
             onCopy={(text, message) => void copyText(text, message)}

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -127,6 +127,8 @@ interface TaskDetailProps {
     origin?: IssueRelationOrigin,
   ) => Promise<RelationMutationResult>;
   onOpenThread: (binding: CodexThreadBinding) => void;
+  canContinueThread: boolean;
+  onContinueThread: (task: Task, feedback: string) => Promise<void>;
   onOpenLegacyLocalThread: (threadId: string) => void;
   onOpenInThread: (task: Task) => void;
   onCopy: (text: string, announcement: string) => void;
@@ -386,6 +388,8 @@ export function TaskDetail({
   onAddRelation,
   onRemoveRelation,
   onOpenThread,
+  canContinueThread,
+  onContinueThread,
   onOpenLegacyLocalThread,
   onOpenInThread,
   onCopy,
@@ -430,6 +434,7 @@ export function TaskDetail({
   const descriptionComposerRef = useRef<InlineMediaComposerHandle>(null);
   const descriptionScrollPositionRef = useRef<{ element: HTMLElement; top: number } | null>(null);
   const descriptionCaretRef = useRef<{ text: string; offset: number; occurrence: number } | null>(null);
+  const commentComposerFormRef = useRef<HTMLFormElement>(null);
   const composerRef = useRef<InlineMediaComposerHandle>(null);
   const editingComposerRef = useRef<InlineMediaComposerHandle>(null);
   const editingCommentScrollPositionRef = useRef<{ element: HTMLElement; top: number } | null>(null);
@@ -821,8 +826,12 @@ export function TaskDetail({
     }
   }
 
-  async function submitComment() {
+  async function submitComment(intent: "record" | "return" = "record") {
     const body = draft.trim();
+    if (
+      intent === "return"
+      && (!body || currentTask.status !== "in_review" || !currentTask.threadBinding || !canContinueThread)
+    ) return;
     if ((!body && commentInlineImages.length === 0 && commentInlineFiles.length === 0) || submitting) return;
     setSubmitting(true);
     setCommentsError(null);
@@ -850,7 +859,27 @@ export function TaskDetail({
       setCommentSegments(createInlineMediaSegments());
       if (commentAttachmentInputRef.current) commentAttachmentInputRef.current.value = "";
       let relationAnchor = await getTask(currentTask.id);
-      if (changeStatusToTodo) {
+      if (intent === "return") {
+        if (relationAnchor.status !== "in_review" || !relationAnchor.threadBinding) {
+          throw new Error(text(
+            "议题或任务绑定已变化，请刷新后重试。",
+            "The issue or task binding changed. Refresh and try again.",
+          ));
+        }
+        await onContinueThread(relationAnchor, body);
+        try {
+          const saved = await onUpdate(relationAnchor, { status: "in_progress" });
+          setCurrentTask(saved);
+          relationAnchor = saved;
+          setChangeStatusToTodo(false);
+        } catch {
+          setCommentsError(text(
+            "反馈已发送，但状态更新失败。请刷新议题；不要再次发送反馈。",
+            "Feedback was sent, but the status update failed. Refresh the issue; do not send the feedback again.",
+          ));
+          return;
+        }
+      } else if (changeStatusToTodo) {
         const saved = await onUpdate(relationAnchor, { status: "todo" });
         setCurrentTask(saved);
         relationAnchor = saved;
@@ -1016,6 +1045,16 @@ export function TaskDetail({
   ].sort((left, right) => (
     left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id)
   ));
+  const latestAgentDelivery = comments.reduce<Comment | null>((latest, comment) => {
+    if (comment.authorType === "agent" && comment.body.trim()) {
+      if (!latest) return comment;
+      return comment.createdAt.localeCompare(latest.createdAt) > 0
+        || (comment.createdAt === latest.createdAt && comment.id.localeCompare(latest.id) > 0)
+        ? comment
+        : latest;
+    }
+    return latest;
+  }, null);
 
   return (
     <section
@@ -1217,6 +1256,63 @@ export function TaskDetail({
                 () => onRemoveRelation(anchor, type, relatedTaskId),
               )}
             />
+
+            {currentTask.status === "in_review" && (
+              <section className="review-acceptance" aria-labelledby="review-acceptance-heading">
+                <header>
+                  <div>
+                    <span>{text("等待你验收", "Waiting for your review")}</span>
+                    <h2 id="review-acceptance-heading">{currentTask.title}</h2>
+                  </div>
+                  <button
+                    className="button primary"
+                    type="button"
+                    disabled={savingProperty !== null || submitting}
+                    onClick={() => {
+                      setSavingProperty("review-complete");
+                      void onUpdate(currentTask, { status: "done" })
+                        .then(setCurrentTask)
+                        .catch((error) => onError(issueMessageFor(error)))
+                        .finally(() => setSavingProperty(null));
+                    }}
+                  >
+                    {text("通过并完成", "Approve and complete")}
+                  </button>
+                </header>
+                <div className="review-delivery">
+                  {latestAgentDelivery
+                    ? <DescriptionDocument
+                        value={latestAgentDelivery.body}
+                        referenceTasks={referenceTasks}
+                        onOpenTask={onOpenTask}
+                        attachments={latestAgentDelivery.attachments}
+                        enableImagePreview
+                        onOpenAttachment={handleAttachmentDownload}
+                      />
+                    : <p>{text(
+                        "暂无 Agent 交付说明，请打开处理对话查看结果。",
+                        "No Agent delivery note is available. Open the processing task to inspect the result.",
+                      )}</p>}
+                </div>
+                <footer>
+                  <span>{text(
+                    "普通评论只保存记录，不会通知 Codex。",
+                    "Regular comments are recorded without notifying Codex.",
+                  )}</span>
+                  <button
+                    className="button secondary"
+                    type="button"
+                    disabled={!canContinueThread || !currentTask.threadBinding}
+                    onClick={() => {
+                      commentComposerFormRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+                      requestAnimationFrame(() => composerRef.current?.focus());
+                    }}
+                  >
+                    {text("写退回意见", "Write return feedback")}
+                  </button>
+                </footer>
+              </section>
+            )}
 
             <section className="activity-section" aria-labelledby="activity-heading">
               <header className="activity-heading">
@@ -1494,7 +1590,11 @@ export function TaskDetail({
                 </div>
               )}
 
-              <form className="comment-composer" onSubmit={(event) => { event.preventDefault(); void submitComment(); }}>
+              <form
+                ref={commentComposerFormRef}
+                className="comment-composer"
+                onSubmit={(event) => { event.preventDefault(); void submitComment(); }}
+              >
                 <div className="composer-author">
                   <ActorAvatar
                     className="comment-avatar"
@@ -1546,7 +1646,9 @@ export function TaskDetail({
                   </div>
                   <div>
                     <div className="comment-status-action">
-                      <span>{text("改变状态为-等待认领", "Change status to Todo")}</span>
+                      <span>{currentTask.status === "in_review"
+                        ? text("仅改为等待认领（不通知）", "Move to Todo only (no notification)")
+                        : text("改变状态为-等待认领", "Change status to Todo")}</span>
                       <button
                         type="button"
                         className={`board-setting-switch${changeStatusToTodo ? " is-on" : ""}`}
@@ -1558,17 +1660,43 @@ export function TaskDetail({
                         <span aria-hidden="true" />
                       </button>
                     </div>
-                    <button
-                      className="button primary"
-                      type="submit"
-                      disabled={(
-                        !draft.trim()
-                        && commentInlineImages.length === 0
-                        && commentInlineFiles.length === 0
-                      ) || submitting}
-                    >
-                      {submitting ? text("发布中…", "Posting…") : text("评论", "Comment")}
-                    </button>
+                    {currentTask.status === "in_review" ? (
+                      <>
+                        <button
+                          className="button secondary"
+                          type="submit"
+                          disabled={(
+                            !draft.trim()
+                            && commentInlineImages.length === 0
+                            && commentInlineFiles.length === 0
+                          ) || submitting}
+                        >
+                          {submitting ? text("发布中…", "Posting…") : text("仅记录评论", "Record comment")}
+                        </button>
+                        <button
+                          className="button primary"
+                          type="button"
+                          disabled={!draft.trim() || submitting || !canContinueThread || !currentTask.threadBinding}
+                          onClick={() => void submitComment("return")}
+                        >
+                          {submitting
+                            ? text("发送中…", "Sending…")
+                            : text("退回并继续原任务", "Return and continue original task")}
+                        </button>
+                      </>
+                    ) : (
+                      <button
+                        className="button primary"
+                        type="submit"
+                        disabled={(
+                          !draft.trim()
+                          && commentInlineImages.length === 0
+                          && commentInlineFiles.length === 0
+                        ) || submitting}
+                      >
+                        {submitting ? text("发布中…", "Posting…") : text("评论", "Comment")}
+                      </button>
+                    )}
                   </div>
                 </footer>
               </form>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8617,6 +8617,25 @@ kbd {
     margin-left: 0;
   }
 
+  .composer-footer {
+    flex-wrap: wrap;
+  }
+
+  .composer-footer > div:last-child {
+    flex: 1 1 100%;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .comment-status-action {
+    flex: 1 1 100%;
+    justify-content: flex-end;
+  }
+
+  .composer-footer .button {
+    white-space: nowrap;
+  }
+
   .composer-footer > span,
   .composer-footer kbd {
     display: none;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4041,6 +4041,53 @@ kbd {
   font-size: 10px;
 }
 
+.review-acceptance {
+  margin: 0 14px 18px;
+  padding: 16px;
+  border: var(--border-hairline) solid color-mix(in srgb, var(--accent) 24%, var(--border));
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--accent) 4%, var(--surface));
+}
+
+.review-acceptance > header,
+.review-acceptance > footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.review-acceptance > header span,
+.review-acceptance > footer span {
+  color: var(--text-tertiary);
+  font-size: 11px;
+}
+
+.review-acceptance h2 {
+  margin: 2px 0 0;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.review-delivery {
+  margin: 14px 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.55;
+}
+
+.review-delivery > :first-child { margin-top: 0; }
+.review-delivery > :last-child { margin-bottom: 0; }
+
+@media (max-width: 719px) {
+  .review-acceptance > header,
+  .review-acceptance > footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+
 .activity-section {
   position: relative;
   padding: 22px 14px 60px;


### PR DESCRIPTION
## Summary
- show the latest Agent delivery summary for In Review items
- approve through the existing completion update without notifying Codex
- save review feedback, revalidate the full binding, and continue the exact bound Codex task
- move back to in_progress only after a confirmed send; keep in_review on failure

## Verification
- node --test test/injector-host-runtime.test.mjs test/inject.test.mjs test/board-interactions.test.mjs (59 passed)
- isolated success/failure host bridge checks; no new Codex task created
- desktop and 390px visual fixture review
- git diff --check

## Boundaries
- no Taskboard schema, auto-claim, progress-system, install, release, or real-data mutation changes
- local full npm typecheck/build were unavailable because this worktree has no installed tsc/vite; PR CI runs npm ci and the repository check/build jobs