### PR TITLE
Fix account fallback when Codex email is unavailable

### DIFF
--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -112,8 +112,7 @@ function stableCodexUserId(account) {
     && typeof account.account.email === "string"
     ? account.account.email.trim().toLowerCase()
     : "";
-  if (!email && account?.account?.type === "chatgpt") return "";
-  if (!email) throw new Error("The current Codex ChatGPT account email is unavailable");
+  if (!email) return "";
   const digest = createHash("sha256")
     .update("codex-taskboard-user\0")
     .update(email)


### PR DESCRIPTION
## Product result

When Codex does not expose the current ChatGPT account email, Taskboard now continues with the existing profile-name identity fallback instead of blocking the board.

- Email available: keeps the stable `codex-user-<sha256>` identity.
- Email unavailable: returns to the existing name-based identity path.
- User IDs do not contain email/no-email labels.

## Direct verification

The locally installed candidate was opened and verified by the user: the prior account-email-unavailable blocking page no longer appears and the board loads normally.

Fixes #328.