### PR TITLE
Release Codex Taskboard v1.1.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-taskboard",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-taskboard",
-      "version": "1.1.19",
+      "version": "1.1.20",
       "dependencies": {
         "dhtmlx-gantt": "^10.0.0",
         "dompurify": "^3.4.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-taskboard",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "codex-taskboard-launcher"
-version = "1.1.19"
+version = "1.1.20"
 dependencies = [
  "base64 0.22.1",
  "dispatch2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-taskboard-launcher"
-version = "1.1.19"
+version = "1.1.20"
 description = "Codex Taskboard launcher"
 edition = "2021"
 rust-version = "1.88"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex Taskboard",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "identifier": "com.chuspeeism.codex-taskboard",
   "app": {
     "windows": []


### PR DESCRIPTION
## Product release

Release Codex Taskboard v1.1.20 with the verified fix for loading the board when the current Codex ChatGPT account email is unavailable.

## Scope

Version-only change in the five required version files. No product code or release workflow changes.