### PR TITLE
Fix Taskboard entry across Codex locales

### DIFF
--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -264,18 +264,19 @@
   function findReferenceButton() {
     const scroll = document.querySelector("[data-app-action-sidebar-scroll]");
     if (!scroll) return null;
-    const buttons = Array.from(scroll.querySelectorAll("button"));
+    const buttons = Array.from(scroll.querySelectorAll("button"))
+      .filter((button) => button.getAttribute(OWNED_ATTRIBUTE) !== "true");
     const plugin = buttons.find((button) => buttonMatches(button, PLUGIN_LABELS));
     if (plugin?.parentElement) return plugin;
 
     const firstSection = scroll.querySelector("[data-app-action-sidebar-section]");
-    const sectionTop = firstSection?.getBoundingClientRect().top ?? Number.POSITIVE_INFINITY;
-    const groups = Array.from(scroll.querySelectorAll("div")).filter((element) => {
-      const directButtons = Array.from(element.children).filter((child) => child.tagName === "BUTTON");
-      return directButtons.length >= 3 && element.getBoundingClientRect().top < sectionTop;
-    });
-    const group = groups.sort((left, right) => right.children.length - left.children.length)[0];
-    return Array.from(group?.children || []).filter((child) => child.tagName === "BUTTON").at(-1) || null;
+    if (!firstSection) return null;
+    const sectionTop = firstSection.getBoundingClientRect().top;
+    return buttons.filter((button) => {
+      const rect = button.getBoundingClientRect();
+      return rect.height > 0
+        && rect.bottom <= sectionTop;
+    }).at(-1) || null;
   }
 
   function replaceEntryIcon(button) {

--- a/test/inject-fullheight-regression.test.mjs
+++ b/test/inject-fullheight-regression.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { createHmac } from "node:crypto";
 import { access, mkdtemp, readFile, rm } from "node:fs/promises";
 import http from "node:http";
@@ -8,6 +8,8 @@ import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
+
+import { CdpPipeBrowser } from "../scripts/codex-cdp-pipe.mjs";
 
 const execFileAsync = promisify(execFile);
 const projectRoot = fileURLToPath(new URL("..", import.meta.url));
@@ -271,30 +273,54 @@ test("Taskboard fills the workspace, opens HTTPS links and revokes hostile ifram
   const profile = await mkdtemp(path.join(os.tmpdir(), "taskboard-fullheight-chrome-"));
   t.after(() => rm(profile, { recursive: true, force: true }));
   const url = `http://127.0.0.1:${server.address().port}/fixture`;
-  let stdout;
+  const child = spawn(chrome, [
+    "--headless=new",
+    "--disable-gpu",
+    "--no-sandbox",
+    `--user-data-dir=${profile}`,
+    "--remote-debugging-pipe",
+    "about:blank",
+  ], {
+    stdio: ["ignore", "ignore", "ignore", "pipe", "pipe"],
+  });
+  const browser = new CdpPipeBrowser(child);
+  let session;
+  let encodedResult = "";
   try {
-    ({ stdout } = await execFileAsync(chrome, [
-      "--headless=new",
-      "--disable-gpu",
-      "--no-sandbox",
-      `--user-data-dir=${profile}`,
-      "--virtual-time-budget=12000",
-      "--dump-dom",
-      url,
-    ], { maxBuffer: 5 * 1024 * 1024, timeout: 20_000 }));
-  } catch (error) {
-    if (!String(error?.stdout ?? "").trim()) {
-      t.skip("Chrome or Chromium cannot run headless dump-dom in this environment");
-      return;
+    await browser.open();
+    const target = (await browser.targets()).find(({ type }) => type === "page");
+    assert.ok(target, "Chrome did not expose a page target");
+    session = await browser.connect(target.targetId);
+    await session.send("Page.enable");
+    await session.send("Runtime.enable");
+    const loaded = session.waitFor("Page.loadEventFired", 10_000);
+    await session.send("Page.navigate", { url });
+    await loaded;
+
+    const deadline = Date.now() + 20_000;
+    while (!encodedResult && Date.now() < deadline) {
+      const evaluation = await session.send("Runtime.evaluate", {
+        expression: 'document.getElementById("result")?.textContent || ""',
+        returnByValue: true,
+      });
+      encodedResult = evaluation.result.value;
+      if (!encodedResult) await new Promise((resolve) => setTimeout(resolve, 50));
     }
-    throw error;
-  }
-  if (!stdout.trim()) {
-    t.skip("Chrome or Chromium cannot run headless dump-dom in this environment");
-    return;
+  } finally {
+    session?.close();
+    browser.close();
+    if (child.exitCode === null && child.signalCode === null) {
+      const exited = new Promise((resolve) => child.once("exit", resolve));
+      child.kill("SIGTERM");
+      await Promise.race([
+        exited,
+        new Promise((resolve) => setTimeout(resolve, 2_000)),
+      ]);
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+      await exited;
+    }
   }
 
-  const encodedResult = stdout.match(/<output id="result">([^<]+)<\/output>/)?.[1];
   assert.ok(encodedResult, "fixture did not report an injection result");
   const result = JSON.parse(Buffer.from(encodedResult, "base64").toString("utf8"));
   assert.deepEqual(result, {

--- a/test/inject.test.mjs
+++ b/test/inject.test.mjs
@@ -38,7 +38,8 @@ test("embedded page uses the launcher URL inside an opaque sandbox", () => {
 test("entry clones the native Plugins row and the page covers the complete Codex workspace", () => {
   assert.match(source, /const PLUGIN_LABELS = \["插件", "plugins", "外掛程式", "プラグイン"\]/);
   assert.match(source, /if \(plugin\?\.parentElement\) return plugin;/);
-  assert.match(source, /return directButtons\.length >= 3/);
+  assert.match(source, /button\.getAttribute\(OWNED_ATTRIBUTE\) !== "true"/);
+  assert.match(source, /rect\.bottom <= sectionTop/);
   assert.match(source, /const button = reference\.cloneNode\(true\)/);
   assert.match(source, /reference\.after\(entry\)/);
   assert.match(source, /document\.querySelector\("\.app-shell-main-content-frame"\)/);
@@ -53,7 +54,7 @@ test("entry clones the native Plugins row and the page covers the complete Codex
   assert.doesNotMatch(source, /aria-modal/);
 });
 
-test("entry recognizes the reported localized Plugins labels and keeps Taskboard copy binary", () => {
+test("entry recognizes known Plugins labels and structurally anchors an unenumerated locale", () => {
   const normalizedLabelSource = source.slice(
     source.indexOf("function normalizedLabel"),
     source.indexOf("\n\n  function hostLanguage"),
@@ -62,13 +63,15 @@ test("entry recognizes the reported localized Plugins labels and keeps Taskboard
     source.indexOf("function buttonMatches"),
     source.indexOf("\n\n  function replaceEntryIcon"),
   );
-  let currentButton;
+  let currentButtons;
+  let currentSection;
   const scroll = {
-    querySelector: () => null,
-    querySelectorAll: (selector) => selector === "button" ? [currentButton] : [],
+    querySelector: (selector) => selector === "[data-app-action-sidebar-section]" ? currentSection : null,
+    querySelectorAll: (selector) => selector === "button" ? currentButtons : [],
   };
   const findReferenceButton = vm.runInNewContext(`(() => {
     const PLUGIN_LABELS = ["插件", "plugins", "外掛程式", "プラグイン"];
+    const OWNED_ATTRIBUTE = "data-codex-taskboard-owned";
     ${normalizedLabelSource}
     ${referenceSource}
     return findReferenceButton;
@@ -77,13 +80,32 @@ test("entry recognizes the reported localized Plugins labels and keeps Taskboard
   });
 
   for (const textContent of ["插件", "外掛程式", "プラグイン", "Plugins"]) {
-    currentButton = {
+    const currentButton = {
       textContent,
       getAttribute: () => null,
       parentElement: {},
     };
+    currentButtons = [currentButton];
+    currentSection = null;
     assert.equal(findReferenceButton(), currentButton);
   }
+
+  const topButton = (textContent, top, owned = false) => ({
+    textContent,
+    getAttribute: (name) => name === "data-codex-taskboard-owned" && owned ? "true" : null,
+    getBoundingClientRect: () => ({ top, bottom: top + 30, height: 30 }),
+    parentElement: {},
+  });
+  const unenumeratedPlugin = topButton("Приклучоци", 160);
+  currentButtons = [
+    topButton("Барања за повлекување", 100),
+    topButton("Локации", 120),
+    topButton("Закажано", 140),
+    unenumeratedPlugin,
+    topButton("Taskboard", 180, true),
+  ];
+  currentSection = { getBoundingClientRect: () => ({ top: 200 }) };
+  assert.equal(findReferenceButton(), unenumeratedPlugin);
 
   const languageDocument = { documentElement: { lang: "" } };
   const languageSource = source.slice(


### PR DESCRIPTION
## 产品问题

Codex 切换到未列入 Taskboard 固定文案表的语言后，左侧“任务面板”入口会消失。

## 根因与最小修复

- 入口定位原先依赖已知的 Plugins 文案或固定 DOM 层级。
- 现在仍优先匹配已知文案；无法匹配时，在第一个原生 section 前选择最后一个可见原生按钮。
- Taskboard 自有入口先被排除，重复刷新不会把自己当成定位参考。
- 中文仍显示“任务面板”，其他语言显示“Taskboard”。

## 真实路径

已在独立 ChatGPT App / profile / runtime / CDP 中验证：

- zh-CN：插件 → 任务面板
- zh-TW：外掛程式 → 任务面板
- en-US：Plugins → Taskboard
- sr：Приклучоци → Taskboard

四种语言均只有一个入口，入口紧随最后一个原生按钮；真实点击后 Taskboard 页面可见且 iframe ready。

## 验证

- `node --check inject/codex-taskboard.user.js`
- `node --check test/inject.test.mjs`
- `node --test test/inject.test.mjs`：36/36
- `git diff --check origin/main...HEAD`
- 独立 Agent 审查：无 blocker / non-blocker
- ChatGPT Pro 实现纠错结论：https://chatgpt.com/c/6a958bda-a668-83e8-8103-4deea4958413

关联：LOCAL-359 / GitHub Issue #325