### PR TITLE
Add beta release channel

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -20,6 +20,8 @@ jobs:
     outputs:
       release_tag: ${{ steps.validate.outputs.release_tag }}
       package_version: ${{ steps.validate.outputs.package_version }}
+      release_version: ${{ steps.validate.outputs.release_version }}
+      prerelease: ${{ steps.validate.outputs.prerelease }}
 
     steps:
       - name: Checkout
@@ -71,8 +73,29 @@ jobs:
             echo "package.json、Cargo.toml 和 tauri.conf.json 的版本必须一致。" >&2
             exit 1
           fi
-          if [[ "$RELEASE_TAG" != "v$PACKAGE_VERSION" ]]; then
-            echo "发布标签必须与应用版本一致。" >&2
+          if [[ ! "$PACKAGE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Apple-facing 应用版本必须是纯数字 major.minor.patch。" >&2
+            exit 1
+          fi
+
+          STABLE_TAG="v$PACKAGE_VERSION"
+          BETA_PREFIX="$STABLE_TAG-beta."
+          if [[ "$RELEASE_TAG" == "$STABLE_TAG" ]]; then
+            RELEASE_VERSION="$PACKAGE_VERSION"
+            RELEASE_CHANNEL="stable"
+            PRERELEASE=false
+            BETA_NUMBER=""
+          elif [[ "$RELEASE_TAG" == "$BETA_PREFIX"* ]]; then
+            BETA_NUMBER="${RELEASE_TAG#"$BETA_PREFIX"}"
+            if [[ ! "$BETA_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+              echo "Beta 标签必须是 $BETA_PREFIX 加正整数。" >&2
+              exit 1
+            fi
+            RELEASE_VERSION="$PACKAGE_VERSION-beta.$BETA_NUMBER"
+            RELEASE_CHANNEL="beta"
+            PRERELEASE=true
+          else
+            echo "发布标签必须是 $STABLE_TAG 或 $BETA_PREFIX<正整数>。" >&2
             exit 1
           fi
 
@@ -99,11 +122,34 @@ jobs:
               ;;
           esac
 
-          RELEASE_TAGS="$RUNNER_TEMP/release-tags.txt"
-          gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100" --jq '.[].tag_name' > "$RELEASE_TAGS"
-          PACKAGE_VERSION="$PACKAGE_VERSION" RELEASE_TAGS="$RELEASE_TAGS" node <<'NODE'
+          RELEASES="$RUNNER_TEMP/releases.tsv"
+          gh api \
+            --header "X-GitHub-Api-Version: 2026-03-10" \
+            --paginate \
+            "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+            --jq '.[] | [.tag_name, .draft, .prerelease, (.immutable // false), .target_commitish] | @tsv' \
+            > "$RELEASES"
+          PACKAGE_VERSION="$PACKAGE_VERSION" \
+          RELEASE_CHANNEL="$RELEASE_CHANNEL" \
+          BETA_NUMBER="$BETA_NUMBER" \
+          RELEASES="$RELEASES" \
+          GITHUB_SHA="$GITHUB_SHA" \
+          node <<'NODE'
           const fs = require("node:fs");
           const current = process.env.PACKAGE_VERSION.split(".").map(Number);
+          const releases = fs.readFileSync(process.env.RELEASES, "utf8")
+            .split(/\r?\n/)
+            .filter(Boolean)
+            .map((line) => {
+              const [tag, draft, prerelease, immutable, target] = line.split("\t");
+              return {
+                tag,
+                draft: draft === "true",
+                prerelease: prerelease === "true",
+                immutable: immutable === "true",
+                target,
+              };
+            });
           const compare = (left, right) => {
             for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
               const difference = (left[index] ?? 0) - (right[index] ?? 0);
@@ -111,10 +157,37 @@ jobs:
             }
             return 0;
           };
-          for (const tag of fs.readFileSync(process.env.RELEASE_TAGS, "utf8").split(/\r?\n/)) {
-            const match = /^(?:app-)?v(\d+(?:\.\d+)*)$/.exec(tag);
+          for (const release of releases) {
+            const match = /^(?:app-)?v(\d+(?:\.\d+)*)$/.exec(release.tag);
             if (match && compare(match[1].split(".").map(Number), current) >= 0) {
-              console.error(`已有相同或更高版本的 Release：${tag}`);
+              console.error(`已有相同或更高版本的稳定 Release：${release.tag}`);
+              process.exit(1);
+            }
+
+            if (process.env.RELEASE_CHANNEL === "beta") {
+              const betaMatch = /^v(\d+(?:\.\d+)*)-beta\.([1-9]\d*)$/.exec(release.tag);
+              if (betaMatch) {
+                const baseComparison = compare(betaMatch[1].split(".").map(Number), current);
+                const betaComparison = BigInt(betaMatch[2]) >= BigInt(process.env.BETA_NUMBER);
+                if (baseComparison > 0 || (baseComparison === 0 && betaComparison)) {
+                  console.error(`已有相同或更高版本的 Beta Release：${release.tag}`);
+                  process.exit(1);
+                }
+              }
+            }
+          }
+
+          if (process.env.RELEASE_CHANNEL === "stable") {
+            const confirmedBeta = releases.some((release) => {
+              const betaMatch = /^v(\d+(?:\.\d+)*)-beta\.([1-9]\d*)$/.exec(release.tag);
+              return betaMatch?.[1] === process.env.PACKAGE_VERSION
+                && release.draft === false
+                && release.prerelease === true
+                && release.immutable === true
+                && release.target === process.env.GITHUB_SHA;
+            });
+            if (!confirmedBeta) {
+              console.error("正式发布前必须先发布同一提交、同一版本的 immutable Beta Release。");
               process.exit(1);
             }
           }
@@ -123,12 +196,16 @@ jobs:
           echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
           echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           echo "package_version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
 
   release-linux:
     name: Build Ubuntu 24.04 x64 packages
     needs: release-preflight
     runs-on: ubuntu-24.04
     timeout-minutes: 40
+    env:
+      CODEX_TASKBOARD_RELEASE_VERSION: ${{ needs['release-preflight'].outputs.release_version }}
 
     steps:
       - name: Checkout
@@ -209,6 +286,8 @@ jobs:
     needs: release-preflight
     runs-on: windows-2025
     timeout-minutes: 40
+    env:
+      CODEX_TASKBOARD_RELEASE_VERSION: ${{ needs['release-preflight'].outputs.release_version }}
 
     steps:
       - name: Checkout
@@ -246,6 +325,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 90
     env:
+      CODEX_TASKBOARD_RELEASE_VERSION: ${{ needs['release-preflight'].outputs.release_version }}
       RELEASE_TAG: ${{ needs['release-preflight'].outputs.release_tag }}
       PACKAGE_VERSION: ${{ needs['release-preflight'].outputs.package_version }}
 
@@ -434,6 +514,7 @@ jobs:
     env:
       RELEASE_TAG: ${{ needs['release-preflight'].outputs.release_tag }}
       PACKAGE_VERSION: ${{ needs['release-preflight'].outputs.package_version }}
+      PRERELEASE: ${{ needs['release-preflight'].outputs.prerelease }}
 
     steps:
       - name: Checkout
@@ -538,12 +619,20 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           RELEASE_ASSETS="$RUNNER_TEMP/release-assets"
+          RELEASE_FLAGS=(--draft)
+          if [[ "$PRERELEASE" == "true" ]]; then
+            RELEASE_FLAGS+=(--prerelease --latest=false)
+          elif [[ "$PRERELEASE" != "false" ]]; then
+            echo "无效的 prerelease 状态：$PRERELEASE" >&2
+            exit 1
+          fi
           gh release create "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --verify-tag \
             --target "$GITHUB_SHA" \
-            --draft \
+            "${RELEASE_FLAGS[@]}" \
             --title "Codex Taskboard $RELEASE_TAG" \
             --generate-notes \
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg"
@@ -600,10 +689,25 @@ jobs:
           set -euo pipefail
           API_VERSION_HEADER="X-GitHub-Api-Version: 2026-03-10"
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
-          if [[ "$(git rev-parse HEAD)" != "$GITHUB_SHA" || "$RELEASE_TAG" != "v$PACKAGE_VERSION" ]]; then
+          EXPECTED_PRERELEASE=false
+          if [[ "$RELEASE_TAG" == "v$PACKAGE_VERSION" ]]; then
+            :
+          elif [[ "$RELEASE_TAG" == "v$PACKAGE_VERSION-beta."* ]]; then
+            BETA_NUMBER="${RELEASE_TAG#"v$PACKAGE_VERSION-beta."}"
+            if [[ ! "$BETA_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+              echo "promotion 收到无效的 Beta 标签。" >&2
+              exit 1
+            fi
+            EXPECTED_PRERELEASE=true
+          else
+            echo "promotion 标签与应用版本不一致。" >&2
+            exit 1
+          fi
+          if [[ "$(git rev-parse HEAD)" != "$GITHUB_SHA" ]]; then
             echo "promotion checkout、标签和应用版本不一致。" >&2
             exit 1
           fi
+          echo "EXPECTED_PRERELEASE=$EXPECTED_PRERELEASE" >> "$GITHUB_ENV"
 
           if [[ -z "$RULESET_TOKEN" ]]; then
             echo "缺少 RELEASE_RULESET_TOKEN，无法确认标签 Ruleset 的绕过者。" >&2
@@ -700,9 +804,13 @@ jobs:
           if ! jq -e \
             --arg tag "$RELEASE_TAG" \
             --arg target "$GITHUB_SHA" \
-            '.tag_name == $tag and .target_commitish == $target and .draft == true' \
+            --argjson prerelease "$EXPECTED_PRERELEASE" \
+            '.tag_name == $tag and
+             .target_commitish == $target and
+             .draft == true and
+             .prerelease == $prerelease' \
             <<< "$DRAFT_RELEASE" >/dev/null; then
-            echo "promotion 只能处理指向构建提交的 Draft Release。" >&2
+            echo "promotion 只能处理指向构建提交且通道状态正确的 Draft Release。" >&2
             exit 1
           fi
 
@@ -771,10 +879,12 @@ jobs:
           if ! jq -e \
             --arg tag "$RELEASE_TAG" \
             --arg target "$GITHUB_SHA" \
+            --argjson prerelease "$EXPECTED_PRERELEASE" \
             --argjson asset_count "$EXPECTED_ASSET_COUNT" \
             '.tag_name == $tag and
              .target_commitish == $target and
              .draft == true and
+             .prerelease == $prerelease and
              (.assets | length) == $asset_count and
              all(.assets[]; .state == "uploaded")' \
             <<< "$DRAFT_RELEASE" >/dev/null; then
@@ -818,19 +928,37 @@ jobs:
           MANIFEST_PATH="$RUNNER_TEMP/trusted-release-manifest/release-assets.sha256"
           FINAL_RELEASE="$(gh api --header "$API_VERSION_HEADER" \
             "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG")"
+          LATEST_RELEASE="$(gh api --header "$API_VERSION_HEADER" \
+            "repos/$GITHUB_REPOSITORY/releases/latest")"
           EXPECTED_ASSET_COUNT="$(wc -l < "$MANIFEST_PATH" | tr -d ' ')"
 
           if ! jq -e \
             --arg tag "$RELEASE_TAG" \
             --arg target "$GITHUB_SHA" \
+            --argjson prerelease "$EXPECTED_PRERELEASE" \
             --argjson asset_count "$EXPECTED_ASSET_COUNT" \
             '.tag_name == $tag and
              .target_commitish == $target and
              .draft == false and
+             .prerelease == $prerelease and
              .immutable == true and
              (.assets | length) == $asset_count' \
             <<< "$FINAL_RELEASE" >/dev/null; then
-            echo "最终 Release 未发布、未锁定或资产集合不正确。" >&2
+            echo "最终 Release 的发布、通道、锁定或资产状态不正确。" >&2
+            exit 1
+          fi
+
+          if [[ "$EXPECTED_PRERELEASE" == "true" ]]; then
+            if ! jq -e --arg tag "$RELEASE_TAG" \
+              '.draft == false and .prerelease == false and .tag_name != $tag' \
+              <<< "$LATEST_RELEASE" >/dev/null; then
+              echo "Beta Release 不得成为 GitHub latest。" >&2
+              exit 1
+            fi
+          elif ! jq -e --arg tag "$RELEASE_TAG" \
+            '.draft == false and .prerelease == false and .tag_name == $tag' \
+            <<< "$LATEST_RELEASE" >/dev/null; then
+            echo "正式 Release 必须成为 GitHub latest。" >&2
             exit 1
           fi
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-taskboard",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-taskboard",
-      "version": "1.1.20",
+      "version": "1.1.21",
       "dependencies": {
         "dhtmlx-gantt": "^10.0.0",
         "dompurify": "^3.4.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-taskboard",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "private": true,
   "type": "module",
   "engines": {

--- a/scripts/create-macos-updater.mjs
+++ b/scripts/create-macos-updater.mjs
@@ -16,9 +16,15 @@ if (!appPath || !outputDirectory || !releaseTag) {
 }
 
 const packageJson = JSON.parse(await readFile(path.join(projectRoot, "package.json"), "utf8"));
-if (releaseTag !== `v${packageJson.version}`) {
+const stableTag = `v${packageJson.version}`;
+const betaPrefix = `${stableTag}-beta.`;
+const betaNumber = releaseTag.startsWith(betaPrefix)
+  ? releaseTag.slice(betaPrefix.length)
+  : "";
+if (releaseTag !== stableTag && !/^[1-9]\d*$/.test(betaNumber)) {
   throw new Error("Release tag does not match package.json version");
 }
+const releaseVersion = releaseTag.slice(1);
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, { encoding: "utf8", ...options });
@@ -39,8 +45,8 @@ const signature = await readFile(`${artifactPath}.sig`, "utf8");
 const downloadUrl = `https://github.com/chuspeeism/dashi-taskboard/releases/download/${releaseTag}/${artifactName}`;
 const platform = { signature, url: downloadUrl };
 const latest = {
-  version: packageJson.version,
-  notes: `Codex Taskboard ${packageJson.version}`,
+  version: releaseVersion,
+  notes: `Codex Taskboard ${releaseVersion}`,
   pub_date: new Date().toISOString(),
   platforms: {
     "darwin-aarch64": platform,

--- a/scripts/verify-linux-updater.mjs
+++ b/scripts/verify-linux-updater.mjs
@@ -23,12 +23,18 @@ const tauriConfig = JSON.parse(await readFile(
   path.join(projectRoot, "src-tauri", "tauri.conf.json"),
   "utf8",
 ));
-if (releaseTag !== `v${packageJson.version}`) {
+const stableTag = `v${packageJson.version}`;
+const betaPrefix = `${stableTag}-beta.`;
+const betaNumber = releaseTag.startsWith(betaPrefix)
+  ? releaseTag.slice(betaPrefix.length)
+  : "";
+if (releaseTag !== stableTag && !/^[1-9]\d*$/.test(betaNumber)) {
   throw new Error("Release tag does not match package.json version");
 }
+const releaseVersion = releaseTag.slice(1);
 
 const latest = JSON.parse(await readFile(latestPath, "utf8"));
-if (latest.version !== packageJson.version) throw new Error("latest.json version is incorrect");
+if (latest.version !== releaseVersion) throw new Error("latest.json version is incorrect");
 if (latest.platforms?.["linux-x86_64"]) {
   throw new Error("latest.json must use installer-specific Linux updater entries");
 }

--- a/scripts/verify-macos-release.mjs
+++ b/scripts/verify-macos-release.mjs
@@ -36,9 +36,15 @@ const releasePolicy = JSON.parse(await readFile(
   path.join(projectRoot, "src-tauri", "release.json"),
   "utf8",
 ));
-if (releaseTag !== `v${packageJson.version}`) {
+const stableTag = `v${packageJson.version}`;
+const betaPrefix = `${stableTag}-beta.`;
+const betaNumber = releaseTag.startsWith(betaPrefix)
+  ? releaseTag.slice(betaPrefix.length)
+  : "";
+if (releaseTag !== stableTag && !/^[1-9]\d*$/.test(betaNumber)) {
   throw new Error("Release tag does not match package.json version");
 }
+const releaseVersion = releaseTag.slice(1);
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, { encoding: "utf8", ...options });
@@ -72,13 +78,22 @@ function verifyApp(targetPath) {
   if (plistValue(infoPath, "CFBundleIdentifier") !== tauriConfig.identifier) {
     throw new Error("Updater App bundle identifier does not match tauri.conf.json");
   }
-  if (plistValue(infoPath, "CFBundleShortVersionString") !== packageJson.version) {
-    throw new Error("Updater App version does not match package.json");
+  for (const versionKey of ["CFBundleShortVersionString", "CFBundleVersion"]) {
+    if (plistValue(infoPath, versionKey) !== packageJson.version) {
+      throw new Error(`Updater App ${versionKey} does not match package.json`);
+    }
   }
   if (!signingDetails(targetPath).includes(`TeamIdentifier=${releasePolicy.appleTeamId}`)) {
     throw new Error(`App does not use Apple Team ${releasePolicy.appleTeamId}`);
   }
   const launcherPath = path.join(targetPath, "Contents", "MacOS", "codex-taskboard-launcher");
+  const embeddedVersion = spawnSync(
+    "/usr/bin/grep",
+    ["-a", "-F", "-q", releaseVersion, launcherPath],
+  );
+  if (embeddedVersion.status !== 0) {
+    throw new Error(`Launcher does not embed release version ${releaseVersion}`);
+  }
   if (!signingDetails(launcherPath).includes(`TeamIdentifier=${releasePolicy.appleTeamId}`)) {
     throw new Error(`Launcher does not use Apple Team ${releasePolicy.appleTeamId}`);
   }
@@ -133,7 +148,7 @@ await verifyUpdaterSignature({
 });
 
 const latest = JSON.parse(await readFile(path.join(releaseDirectory, "latest.json"), "utf8"));
-if (latest.version !== packageJson.version) throw new Error("latest.json version is incorrect");
+if (latest.version !== releaseVersion) throw new Error("latest.json version is incorrect");
 const expectedUrl = `https://github.com/chuspeeism/dashi-taskboard/releases/download/${releaseTag}/${artifactName}`;
 const expectedPlatforms = [
   "darwin-aarch64",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "codex-taskboard-launcher"
-version = "1.1.20"
+version = "1.1.21"
 dependencies = [
  "base64 0.22.1",
  "dispatch2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-taskboard-launcher"
-version = "1.1.20"
+version = "1.1.21"
 description = "Codex Taskboard launcher"
 edition = "2021"
 rust-version = "1.88"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -87,6 +87,14 @@ const TASKBOARD_PREFERRED_PORT: u16 = 47823;
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 const TASKBOARD_LISTEN_FD: i32 = 5;
 
+fn release_version() -> &'static str {
+    option_env!("CODEX_TASKBOARD_RELEASE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))
+}
+
+fn is_beta_release() -> bool {
+    release_version().contains("-beta.")
+}
+
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct LauncherSnapshot {
@@ -1625,7 +1633,15 @@ async fn check_for_startup_update(
         snapshot.update_available = false;
     });
     let update = app
-        .updater()
+        .updater_builder()
+        .version_comparator(|current, release| {
+            if is_beta_release() {
+                release.version >= current
+            } else {
+                release.version > current
+            }
+        })
+        .build()
         .map_err(|error| error.to_string())?
         .check()
         .await
@@ -1642,7 +1658,8 @@ async fn check_for_startup_update(
         None => {
             append_log(state, "No update is available");
             update_snapshot(app, state, |snapshot| {
-                snapshot.update_message = "当前已是最新版本。".into();
+                snapshot.update_message =
+                    format!("当前版本 {} 已是最新版本。", snapshot.version.as_str());
                 snapshot.update_available = false;
             });
         }
@@ -1928,8 +1945,9 @@ async fn offer_update(
     };
     let Some(update) = update else {
         if show_current_version {
+            let current_version = state.snapshot.lock().unwrap().version.clone();
             app.dialog()
-                .message("当前已是最新版本。")
+                .message(format!("当前版本 {current_version} 已是最新版本。"))
                 .title("Codex Taskboard 更新")
                 .buttons(MessageDialogButtons::Ok)
                 .blocking_show();
@@ -2060,7 +2078,7 @@ fn main() {
                 app.handle().exit(0);
                 return Ok(());
             };
-            let version = app.package_info().version.to_string();
+            let version = release_version().to_string();
             let state = Arc::new(LauncherState::new(
                 data_directory,
                 log_directory,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex Taskboard",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "identifier": "com.chuspeeism.codex-taskboard",
   "app": {
     "windows": []


### PR DESCRIPTION
## Summary

- add a Beta release tag format: `v<version>-beta.<n>`
- keep Apple bundle versions numeric while showing the full Beta version in the Taskboard tray and update state
- publish Beta builds as GitHub prereleases without changing the stable `releases/latest` updater channel
- require an immutable Beta from the same commit before publishing the corresponding stable version
- rebuild the stable application from the confirmed source commit without the Beta label

Taskboard: LOCAL-370

## Verification

- Pro implementation: https://chatgpt.com/c/6a96cafa-aa6c-83e8-84c9-df8fdf001500
- typecheck, Web build, workflow YAML parse, changed-script syntax checks, and focused launcher release tests passed
- full Node suite passed: 371 pass, 0 fail, 1 platform skip; component tests 9/9
- local arm64 Beta and stable application builds completed from the same source
- both bundles use numeric `CFBundleShortVersionString=1.1.21` and `CFBundleVersion=1.1.21`
- Beta binary embeds `1.1.21-beta.1`; stable binary excludes that Beta version and embeds `1.1.21`
- release preflight fixtures cover first/next Beta, duplicate Beta rejection, matching immutable Beta promotion, and wrong-SHA/non-immutable rejection