### PR TITLE
Fix description media actions

### DIFF
--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -1055,6 +1055,14 @@ export function TaskDetail({
                 {editingDescription ? (
                   <div
                     className="issue-description-composer"
+                    onMouseDownCapture={(event) => {
+                      if (
+                        event.target instanceof Element
+                        && event.target.closest(
+                          ".inline-media-image > button, .inline-media-attachment > button, .issue-description-attach-button",
+                        )
+                      ) event.preventDefault();
+                    }}
                     onBlur={(event) => {
                       if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
                       void saveDescription();


### PR DESCRIPTION
## Product change

Fix issue-description media controls so deleting an image or attachment and choosing a new attachment no longer exits editing before the action is applied.

## E3 path

Issue detail → edit description → delete media or add attachment → editor stays active → save on a real outside click → read view and API show the updated content.

## Scope

- `web/src/components/TaskDetail.tsx`
- 8 added lines
- Comment editing behavior is unchanged

## Verification

- Reproduced the reported failure before the change
- Description image removal and attachment selection now persist
- Comment attachment edit/save remains working
- `npm run typecheck`
- `npm run build:web`
- `git diff --check`

Taskboard: LOCAL-372
Exact head: `ce5189e7fb4f193b85c5090d1e3950c3bbe1de4b`