### PR TITLE
Fix Beta update channel

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -972,3 +972,44 @@ jobs:
               exit 1
             fi
           done < "$MANIFEST_PATH"
+
+      - name: Update Beta updater metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ "$EXPECTED_PRERELEASE" != "true" ]]; then
+            exit 0
+          fi
+
+          API_VERSION_HEADER="X-GitHub-Api-Version: 2026-03-10"
+          BETA_FEED_BRANCH="beta-updater"
+          BETA_FEED_PATH="latest.json"
+          LATEST_PATH="$RUNNER_TEMP/draft-release-assets/latest.json"
+
+          if ! gh api --header "$API_VERSION_HEADER" \
+            "repos/$GITHUB_REPOSITORY/git/ref/heads/$BETA_FEED_BRANCH" >/dev/null 2>&1; then
+            gh api --header "$API_VERSION_HEADER" \
+              --method POST \
+              -f ref="refs/heads/$BETA_FEED_BRANCH" \
+              -f sha="$GITHUB_SHA" \
+              "repos/$GITHUB_REPOSITORY/git/refs" >/dev/null
+          fi
+
+          FILE_SHA="$(gh api --header "$API_VERSION_HEADER" \
+            "repos/$GITHUB_REPOSITORY/contents/$BETA_FEED_PATH?ref=$BETA_FEED_BRANCH" \
+            --jq '.sha' 2>/dev/null || true)"
+          CONTENT="$(base64 < "$LATEST_PATH" | tr -d '\n')"
+          UPDATE_ARGS=(
+            --method PUT
+            -f "message=Update Beta updater metadata for $RELEASE_TAG"
+            -f "content=$CONTENT"
+            -f "branch=$BETA_FEED_BRANCH"
+          )
+          if [[ -n "$FILE_SHA" ]]; then
+            UPDATE_ARGS+=(-f "sha=$FILE_SHA")
+          fi
+          gh api --header "$API_VERSION_HEADER" \
+            "${UPDATE_ARGS[@]}" \
+            "repos/$GITHUB_REPOSITORY/contents/$BETA_FEED_PATH" >/dev/null

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -74,6 +74,8 @@ const STOP_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 const LAUNCHER_STOP_TIMEOUT: Duration = Duration::from_secs(36);
 const UPDATE_CHECK_INTERVAL: Duration = Duration::from_secs(30 * 60);
+const BETA_UPDATER_ENDPOINT: &str =
+    "https://raw.githubusercontent.com/chuspeeism/dashi-taskboard/beta-updater/latest.json";
 // Unique whole-directory snapshots shipped from app-v0.2.0 through v1.1.2.
 const KNOWN_TASKBOARD_SKILL_DIGESTS: [&str; 6] = [
     "eeaaa5d71a2c47688bf62a5eb9f45e9138fe49eb636a46cfd6af8a0f8853e2e0",
@@ -1632,11 +1634,27 @@ async fn check_for_startup_update(
         snapshot.update_message = "正在检查更新…".into();
         snapshot.update_available = false;
     });
-    let update = app
-        .updater_builder()
-        .version_comparator(|current, release| {
-            if is_beta_release() {
-                release.version >= current
+    let beta_release = is_beta_release();
+    let current_release_version = if beta_release {
+        release_version()
+            .parse()
+            .map_err(|error| format!("Invalid release version {}: {error}", release_version()))?
+    } else {
+        app.package_info().version.clone()
+    };
+    let mut updater_builder = app.updater_builder();
+    if beta_release {
+        let beta_endpoint = BETA_UPDATER_ENDPOINT
+            .parse()
+            .map_err(|error| format!("Invalid Beta updater endpoint: {error}"))?;
+        updater_builder = updater_builder
+            .endpoints(vec![beta_endpoint])
+            .map_err(|error| error.to_string())?;
+    }
+    let update = updater_builder
+        .version_comparator(move |current, release| {
+            if beta_release {
+                release.version > current_release_version
             } else {
                 release.version > current
             }


### PR DESCRIPTION
## Root cause

The app uses GitHub's stable `releases/latest` updater feed for every build. GitHub excludes pre-releases from that endpoint, so a Beta build cannot see a later Beta. Tauri also supplies the package version without the release-time Beta suffix to the default updater comparison.

## Change

- Route Beta builds to a fixed `beta-updater/latest.json` feed at runtime.
- Compare Beta updates against `release_version()` so the actual `-beta.N` suffix is retained.
- After a pre-release is verified, publish its signed `latest.json` to the `beta-updater` branch. Stable releases do not update this feed.
- Keep the stable updater endpoint and the existing confirm, pre-download, install, and restart path unchanged.

## Direct verification

- `cargo check --locked` passes for the default build and for `CODEX_TASKBOARD_RELEASE_VERSION=1.1.21-beta.1`.
- Real `v1.1.21-beta.2` metadata parses and SemVer comparison reports `beta.2 > beta.1`.
- Real stable metadata remains `v1.1.20` and stable builds keep the stable endpoint.
- The actual workflow step was simulated: stable is a no-op; the first Beta creates the branch and file; a later Beta updates the existing file by blob SHA.
- Workflow YAML and every Bash `run` block pass syntax checks.

## Transition

The already published `1.1.21-beta.1` build still contains the old hard-coded stable endpoint. It requires one manual installation of the first Beta containing this fix. Subsequent Beta builds can follow the dedicated feed.