### PR TITLE
Keep description editor open while choosing attachments

### DIFF
--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -434,6 +434,7 @@ export function TaskDetail({
   const editingComposerRef = useRef<InlineMediaComposerHandle>(null);
   const editingCommentScrollPositionRef = useRef<{ element: HTMLElement; top: number } | null>(null);
   const attachmentInputRef = useRef<HTMLInputElement>(null);
+  const descriptionAttachmentPickerOpenRef = useRef(false);
   const commentAttachmentInputRef = useRef<HTMLInputElement>(null);
   const editCommentAttachmentInputRef = useRef<HTMLInputElement>(null);
   const editingUploadedAttachmentsRef = useRef<Map<string, Attachment>>(new Map());
@@ -1064,6 +1065,7 @@ export function TaskDetail({
                       ) event.preventDefault();
                     }}
                     onBlur={(event) => {
+                      if (descriptionAttachmentPickerOpenRef.current) return;
                       if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
                       void saveDescription();
                     }}
@@ -1102,20 +1104,34 @@ export function TaskDetail({
                       disabled={savingProperty === "description"}
                       aria-label={text("添加描述附件", "Add description attachments")}
                       title={text("添加附件", "Add attachments")}
-                      onClick={() => attachmentInputRef.current?.click()}
+                      onClick={() => {
+                        const input = attachmentInputRef.current;
+                        if (!input) return;
+                        descriptionAttachmentPickerOpenRef.current = true;
+                        input.click();
+                      }}
                     >
                       <AttachmentIcon color="currentColor" />
                     </button>
                     <input
-                      ref={attachmentInputRef}
+                      ref={(input) => {
+                        attachmentInputRef.current = input;
+                        if (!input) return;
+                        input.oncancel = () => {
+                          descriptionAttachmentPickerOpenRef.current = false;
+                          requestAnimationFrame(() => descriptionComposerRef.current?.focus());
+                        };
+                      }}
                       type="file"
                       multiple
                       hidden
                       onChange={(event) => {
+                        descriptionAttachmentPickerOpenRef.current = false;
                         if (event.currentTarget.files) {
                           descriptionComposerRef.current?.addFiles(event.currentTarget.files);
                         }
                         event.currentTarget.value = "";
+                        requestAnimationFrame(() => descriptionComposerRef.current?.focus());
                       }}
                     />
                   </div>


### PR DESCRIPTION
## Product path
Issue detail → click description → click attachment icon → native file picker → choose a file → description editor stays open and inserts the selected attachment.

## Root cause
Opening the native file picker moves focus away from the description composer. The shared blur handler interpreted that temporary focus change as an intent to exit edit mode.

## Change
Track only the active description file-picker interaction, defer the blur exit while it is open, then restore focus after selection or cancellation.

## Verification
- Reproduced the reported path in an isolated real Taskboard page.
- Selected `package.json`; the editor stayed open, the attachment appeared, and the saved description contained the attachment link.
- `npm run typecheck`
- `npm run build:web`
- `git diff --check`