### PR TITLE
Optimize verified release workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -15,7 +16,187 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  main-check-scope:
+    name: Select main Check scope
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      run_full: ${{ steps.scope.outputs.run_full }}
+    steps:
+      - name: Reuse successful PR Check for the exact tested merge tree
+        id: scope
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          API_VERSION_HEADER="X-GitHub-Api-Version: 2026-03-10"
+          ATTESTATION_SCHEMA="codex-taskboard.pr-check-tree.v1"
+          printf 'run_full=true\n' > "$GITHUB_OUTPUT"
+
+          if ! MAIN_COMMIT="$(gh api \
+            --header "$API_VERSION_HEADER" \
+            "repos/$GITHUB_REPOSITORY/git/commits/$GITHUB_SHA")"; then
+            echo "无法读取 main 提交；运行完整 Check。"
+            exit 0
+          fi
+          if [[ "$(jq -r '.parents | length' <<< "$MAIN_COMMIT")" != "2" ]]; then
+            echo "main 提交不是标准二父 merge；运行完整 Check。"
+            exit 0
+          fi
+
+          MAIN_TREE_SHA="$(jq -r '.tree.sha // empty' <<< "$MAIN_COMMIT")"
+          BASE_SHA="$(jq -r '.parents[0].sha // empty' <<< "$MAIN_COMMIT")"
+          PR_HEAD_SHA="$(jq -r '.parents[1].sha // empty' <<< "$MAIN_COMMIT")"
+          if [[ -z "$MAIN_TREE_SHA" || -z "$BASE_SHA" || -z "$PR_HEAD_SHA" ]]; then
+            echo "main merge 元数据不完整；运行完整 Check。"
+            exit 0
+          fi
+
+          CHECK_WORKFLOW_PATH=".github/workflows/check.yml"
+          if ! PR_COMPARE="$(gh api \
+            --header "$API_VERSION_HEADER" \
+            "repos/$GITHUB_REPOSITORY/compare/$BASE_SHA...$PR_HEAD_SHA?per_page=100&page=1")"; then
+            echo "无法比较 PR base/head；运行完整 Check。"
+            exit 0
+          fi
+          if ! jq -e \
+            --arg base "$BASE_SHA" \
+            --arg head "$PR_HEAD_SHA" \
+            '(.base_commit.sha == $base) and
+             ((.total_commits | type) == "number") and
+             (.total_commits > 0) and
+             (.total_commits <= 100) and
+             ((.total_commits | floor) == .total_commits) and
+             ((.commits | type) == "array") and
+             ((.commits | length) == .total_commits) and
+             all(.commits[]; (.sha | type) == "string") and
+             (.commits[-1].sha == $head) and
+             ((.files | type) == "array") and
+             ((.files | length) < 300) and
+             all(.files[];
+               ((.filename | type) == "string") and
+               ((has("previous_filename") | not) or
+                ((.previous_filename | type) == "string")))' \
+            <<< "$PR_COMPARE" >/dev/null; then
+            echo "PR compare 结果分页、不完整或无法唯一证明 base/head；运行完整 Check。"
+            exit 0
+          fi
+          if jq -e \
+            --arg workflow "$CHECK_WORKFLOW_PATH" \
+            'any(.files[];
+               .filename == $workflow or .previous_filename == $workflow)' \
+            <<< "$PR_COMPARE" >/dev/null; then
+            echo "PR 修改了 $CHECK_WORKFLOW_PATH；运行完整 Check。"
+            exit 0
+          fi
+
+          if ! PR_RUNS="$(gh api \
+            --header "$API_VERSION_HEADER" \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/check.yml/runs?event=pull_request&head_sha=$PR_HEAD_SHA&per_page=1")"; then
+            echo "无法读取 exact-head PR Check；运行完整 Check。"
+            exit 0
+          fi
+          PR_RUN_ID="$(jq -r '.workflow_runs[0].id // empty' <<< "$PR_RUNS")"
+          PR_RUN_EVENT="$(jq -r '.workflow_runs[0].event // empty' <<< "$PR_RUNS")"
+          PR_RUN_STATUS="$(jq -r '.workflow_runs[0].status // empty' <<< "$PR_RUNS")"
+          PR_RUN_HEAD_SHA="$(jq -r '.workflow_runs[0].head_sha // empty' <<< "$PR_RUNS")"
+          PR_RUN_CONCLUSION="$(jq -r '.workflow_runs[0].conclusion // empty' <<< "$PR_RUNS")"
+          if [[ -z "$PR_RUN_ID" || "$PR_RUN_EVENT" != "pull_request" || \
+                "$PR_RUN_STATUS" != "completed" || "$PR_RUN_HEAD_SHA" != "$PR_HEAD_SHA" || \
+                "$PR_RUN_CONCLUSION" != "success" ]]; then
+            echo "最新的 exact-head PR Check 未成功完成；运行完整 Check。"
+            exit 0
+          fi
+
+          if ! ARTIFACTS="$(gh api \
+            --header "$API_VERSION_HEADER" \
+            "repos/$GITHUB_REPOSITORY/actions/runs/$PR_RUN_ID/artifacts?per_page=100")"; then
+            echo "无法读取 PR Check 的 tested-tree 证据；运行完整 Check。"
+            exit 0
+          fi
+          ATTESTATION_NAME="pr-check-tree-$PR_HEAD_SHA"
+          ATTESTATION_ARTIFACT="$(jq -c \
+            --arg name "$ATTESTATION_NAME" \
+            '[.artifacts[]? | select(.name == $name and .expired == false)] | if length == 1 then .[0] else empty end' \
+            <<< "$ARTIFACTS")"
+          if [[ -z "$ATTESTATION_ARTIFACT" ]]; then
+            echo "找不到唯一且未过期的 tested-tree 证据；运行完整 Check。"
+            exit 0
+          fi
+          ATTESTATION_ARTIFACT_ID="$(jq -r '.id // empty' <<< "$ATTESTATION_ARTIFACT")"
+          if [[ -z "$ATTESTATION_ARTIFACT_ID" ]]; then
+            echo "tested-tree 证据缺少 artifact id；运行完整 Check。"
+            exit 0
+          fi
+
+          ATTESTATION_ZIP="$RUNNER_TEMP/pr-check-tree.zip"
+          ATTESTATION_PATH="$RUNNER_TEMP/pr-check-tree.json"
+          if ! gh api \
+            --header "$API_VERSION_HEADER" \
+            "repos/$GITHUB_REPOSITORY/actions/artifacts/$ATTESTATION_ARTIFACT_ID/zip" \
+            > "$ATTESTATION_ZIP"; then
+            echo "无法下载 tested-tree 证据；运行完整 Check。"
+            exit 0
+          fi
+          mapfile -t ATTESTATION_FILES < <(unzip -Z1 "$ATTESTATION_ZIP")
+          if [[ "${#ATTESTATION_FILES[@]}" != "1" || "${ATTESTATION_FILES[0]}" != "pr-check-tree.json" ]]; then
+            echo "tested-tree 证据归档结构无效；运行完整 Check。"
+            exit 0
+          fi
+          if ! unzip -p "$ATTESTATION_ZIP" pr-check-tree.json > "$ATTESTATION_PATH"; then
+            echo "无法读取 tested-tree 证据；运行完整 Check。"
+            exit 0
+          fi
+          if ! jq -e \
+            --arg schema "$ATTESTATION_SCHEMA" \
+            --arg base "$BASE_SHA" \
+            --arg head "$PR_HEAD_SHA" \
+            '.schema == $schema and .base_sha == $base and .head_sha == $head and
+             (.checked_sha | type == "string" and length > 0) and
+             (.checked_tree | type == "string" and length > 0)' \
+            "$ATTESTATION_PATH" >/dev/null; then
+            echo "tested-tree 证据与 main merge 的 base/head 不一致；运行完整 Check。"
+            exit 0
+          fi
+          CHECKED_SHA="$(jq -r '.checked_sha' "$ATTESTATION_PATH")"
+          ATTESTED_TREE_SHA="$(jq -r '.checked_tree' "$ATTESTATION_PATH")"
+          if [[ ! "$CHECKED_SHA" =~ ^[0-9a-f]{40,64}$ || ! "$ATTESTED_TREE_SHA" =~ ^[0-9a-f]{40,64}$ ]]; then
+            echo "tested-tree 证据中的 Git 对象 id 无效；运行完整 Check。"
+            exit 0
+          fi
+
+          if ! CHECKED_COMMIT="$(gh api \
+            --header "$API_VERSION_HEADER" \
+            "repos/$GITHUB_REPOSITORY/git/commits/$CHECKED_SHA")"; then
+            echo "无法读取 PR Check 实际 checkout 的 merge 提交；运行完整 Check。"
+            exit 0
+          fi
+          if ! jq -e \
+            --arg tree "$MAIN_TREE_SHA" \
+            --arg base "$BASE_SHA" \
+            --arg head "$PR_HEAD_SHA" \
+            '.tree.sha == $tree and
+             (.parents | length) == 2 and
+             .parents[0].sha == $base and
+             .parents[1].sha == $head' \
+            <<< "$CHECKED_COMMIT" >/dev/null; then
+            echo "PR Check 的 tested merge 与最终 main merge 不同；运行完整 Check。"
+            exit 0
+          fi
+          CHECKED_TREE_SHA="$(jq -r '.tree.sha // empty' <<< "$CHECKED_COMMIT")"
+          if [[ "$ATTESTED_TREE_SHA" != "$CHECKED_TREE_SHA" || "$CHECKED_TREE_SHA" != "$MAIN_TREE_SHA" ]]; then
+            echo "tested-tree 证据、GitHub merge commit 与 main tree 不一致；运行完整 Check。"
+            exit 0
+          fi
+
+          echo "复用 PR Check run $PR_RUN_ID 对 merge $CHECKED_SHA / tree $MAIN_TREE_SHA 的成功结果。"
+          printf 'run_full=false\n' > "$GITHUB_OUTPUT"
+
   check:
+    needs: main-check-scope
+    if: ${{ !cancelled() && (github.event_name != 'push' || needs['main-check-scope'].outputs.run_full != 'false') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -28,9 +209,39 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run check
+      - name: Record tested PR merge tree
+        if: github.event_name == 'pull_request'
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg schema "codex-taskboard.pr-check-tree.v1" \
+            --arg base_sha "$PR_BASE_SHA" \
+            --arg head_sha "$PR_HEAD_SHA" \
+            --arg checked_sha "$GITHUB_SHA" \
+            --arg checked_tree "$(git rev-parse 'HEAD^{tree}')" \
+            '{
+              schema: $schema,
+              base_sha: $base_sha,
+              head_sha: $head_sha,
+              checked_sha: $checked_sha,
+              checked_tree: $checked_tree
+            }' > "$RUNNER_TEMP/pr-check-tree.json"
+      - name: Preserve tested PR merge tree
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-check-tree-${{ github.event.pull_request.head.sha }}
+          path: ${{ runner.temp }}/pr-check-tree.json
+          if-no-files-found: error
+          overwrite: true
 
   macos-launcher:
     name: macOS launcher
+    needs: main-check-scope
+    if: ${{ !cancelled() && (github.event_name != 'push' || needs['main-check-scope'].outputs.run_full != 'false') }}
     runs-on: macos-latest
     timeout-minutes: 40
     steps:
@@ -65,6 +276,8 @@ jobs:
 
   windows-launcher:
     name: Windows x64 launcher
+    needs: main-check-scope
+    if: ${{ !cancelled() && (github.event_name != 'push' || needs['main-check-scope'].outputs.run_full != 'false') }}
     runs-on: windows-2025
     timeout-minutes: 40
     steps:
@@ -92,6 +305,8 @@ jobs:
 
   linux-launcher:
     name: Ubuntu 24.04 x64 launcher
+    needs: main-check-scope
+    if: ${{ !cancelled() && (github.event_name != 'push' || needs['main-check-scope'].outputs.run_full != 'false') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 40
     steps:

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -638,80 +638,56 @@ jobs:
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg"
           gh release upload "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb"
-          gh release upload "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb.sig"
-          gh release upload "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage"
-          gh release upload "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage.sig"
-          gh release upload "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_NSIS-x64-unsigned.exe"
-          gh release upload "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz"
-          gh release upload "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig"
-          gh release upload "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
+            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb" \
+            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb.sig" \
+            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage" \
+            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage.sig" \
+            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_NSIS-x64-unsigned.exe" \
+            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" \
+            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" \
             "$RELEASE_ASSETS/latest.json"
 
-  promote-release:
-    name: Verify and publish immutable macOS release
-    needs: draft-release
-    runs-on: macos-latest
-    timeout-minutes: 30
+  approve-stable-release:
+    name: Approve stable release
+    needs:
+      - release-preflight
+      - draft-release
+    if: ${{ needs['release-preflight'].outputs.prerelease == 'false' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     environment: macos-release
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          fetch-depth: 0
+      - name: Confirm protected stable promotion
+        env:
+          RELEASE_TAG: ${{ needs['release-preflight'].outputs.release_tag }}
+        run: echo "Approved stable promotion for $RELEASE_TAG"
 
-      - name: Set up Node.js 22
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
-        with:
-          node-version: 22
+  promote-release:
+    name: Verify and publish immutable release
+    needs:
+      - release-preflight
+      - draft-release
+      - approve-stable-release
+    if: ${{ !cancelled() && needs['release-preflight'].result == 'success' && needs['draft-release'].result == 'success' && (needs['release-preflight'].outputs.prerelease == 'true' || needs['approve-stable-release'].result == 'success') }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      RELEASE_TAG: ${{ needs['release-preflight'].outputs.release_tag }}
+      PACKAGE_VERSION: ${{ needs['release-preflight'].outputs.package_version }}
+      EXPECTED_PRERELEASE: ${{ needs['release-preflight'].outputs.prerelease }}
 
+    steps:
       - name: Validate protected release promotion
         env:
-          GH_TOKEN: ${{ github.token }}
           RULESET_TOKEN: ${{ secrets.RELEASE_RULESET_TOKEN }}
-          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           API_VERSION_HEADER="X-GitHub-Api-Version: 2026-03-10"
-          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
-          EXPECTED_PRERELEASE=false
-          APP_NAME="Codex Taskboard.app"
-          if [[ "$RELEASE_TAG" == "v$PACKAGE_VERSION" ]]; then
-            :
-          elif [[ "$RELEASE_TAG" == "v$PACKAGE_VERSION-beta."* ]]; then
-            BETA_NUMBER="${RELEASE_TAG#"v$PACKAGE_VERSION-beta."}"
-            if [[ ! "$BETA_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
-              echo "promotion 收到无效的 Beta 标签。" >&2
-              exit 1
-            fi
-            EXPECTED_PRERELEASE=true
-            APP_NAME="Codex Taskboard Beta.app"
-          else
-            echo "promotion 标签与应用版本不一致。" >&2
+          if [[ "$EXPECTED_PRERELEASE" != "true" && "$EXPECTED_PRERELEASE" != "false" ]]; then
+            echo "promotion 收到无效的 prerelease 状态。" >&2
             exit 1
           fi
-          if [[ "$(git rev-parse HEAD)" != "$GITHUB_SHA" ]]; then
-            echo "promotion checkout、标签和应用版本不一致。" >&2
-            exit 1
-          fi
-          echo "EXPECTED_PRERELEASE=$EXPECTED_PRERELEASE" >> "$GITHUB_ENV"
-          echo "APP_NAME=$APP_NAME" >> "$GITHUB_ENV"
-
           if [[ -z "$RULESET_TOKEN" ]]; then
             echo "缺少 RELEASE_RULESET_TOKEN，无法确认标签 Ruleset 的绕过者。" >&2
             exit 1
@@ -781,92 +757,15 @@ jobs:
           name: macos-release-${{ github.sha }}-sha256
           path: ${{ runner.temp }}/trusted-release-manifest
 
-      - name: Download and verify Draft Release assets
+      - name: Verify Draft Release digests and publish
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-          API_VERSION_HEADER="X-GitHub-Api-Version: 2026-03-10"
-          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
-          MANIFEST_PATH="$RUNNER_TEMP/trusted-release-manifest/release-assets.sha256"
-          DRAFT_ASSETS="$RUNNER_TEMP/draft-release-assets"
-          EXPECTED_ASSETS="$RUNNER_TEMP/expected-release-assets.txt"
-          ACTUAL_ASSETS="$RUNNER_TEMP/actual-release-assets.txt"
-
-          RELEASES="$(gh api --header "$API_VERSION_HEADER" \
-            "repos/$GITHUB_REPOSITORY/releases?per_page=100")"
-          DRAFT_RELEASE="$(jq -c \
-            --arg tag "$RELEASE_TAG" \
-            '[.[] | select(.tag_name == $tag and .draft == true)] | if length == 1 then .[0] else empty end' \
-            <<< "$RELEASES")"
-          if [[ -z "$DRAFT_RELEASE" ]]; then
-            echo "找不到唯一的目标 Draft Release。" >&2
-            exit 1
-          fi
-          if ! jq -e \
-            --arg tag "$RELEASE_TAG" \
-            --arg target "$GITHUB_SHA" \
-            --argjson prerelease "$EXPECTED_PRERELEASE" \
-            '.tag_name == $tag and
-             .target_commitish == $target and
-             .draft == true and
-             .prerelease == $prerelease' \
-            <<< "$DRAFT_RELEASE" >/dev/null; then
-            echo "promotion 只能处理指向构建提交且通道状态正确的 Draft Release。" >&2
-            exit 1
-          fi
-
-          mkdir -p "$DRAFT_ASSETS"
-          while IFS=$'\t' read -r ASSET_ID ASSET_NAME; do
-            gh api \
-              --header "$API_VERSION_HEADER" \
-              --header "Accept: application/octet-stream" \
-              "repos/$GITHUB_REPOSITORY/releases/assets/$ASSET_ID" \
-              > "$DRAFT_ASSETS/$ASSET_NAME"
-          done < <(jq -r '.assets[] | [.id, .name] | @tsv' <<< "$DRAFT_RELEASE")
-          sed -E 's/^[0-9a-f]{64}  //' "$MANIFEST_PATH" | LC_ALL=C sort > "$EXPECTED_ASSETS"
-          node -e \
-            'const fs=require("node:fs"); for (const name of fs.readdirSync(process.argv[1]).sort()) console.log(name)' \
-            "$DRAFT_ASSETS" > "$ACTUAL_ASSETS"
-          diff -u "$EXPECTED_ASSETS" "$ACTUAL_ASSETS"
-          (
-            cd "$DRAFT_ASSETS"
-            shasum -a 256 --check "$MANIFEST_PATH"
-          )
-
-          UPDATER_ROOT="$RUNNER_TEMP/remote-updater"
-          mkdir -p "$UPDATER_ROOT"
-          tar -xzf \
-            "$DRAFT_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" \
-            -C "$UPDATER_ROOT"
-          MACOS_RELEASE_ROOT="$RUNNER_TEMP/remote-macos-release"
-          mkdir -p "$MACOS_RELEASE_ROOT"
-          cp \
-            "$DRAFT_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" \
-            "$DRAFT_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" \
-            "$MACOS_RELEASE_ROOT/"
-          jq 'del(.platforms["linux-x86_64-deb"], .platforms["linux-x86_64-appimage"])' \
-            "$DRAFT_ASSETS/latest.json" > "$MACOS_RELEASE_ROOT/latest.json"
-          npm run app:verify-release -- \
-            "$UPDATER_ROOT/$APP_NAME" \
-            "$DRAFT_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg" \
-            "$MACOS_RELEASE_ROOT" \
-            "$RELEASE_TAG"
-          node scripts/verify-linux-updater.mjs \
-            "$DRAFT_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb" \
-            "$DRAFT_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage" \
-            "$DRAFT_ASSETS/latest.json" \
-            "$RELEASE_TAG"
-
-      - name: Publish verified Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           API_VERSION_HEADER="X-GitHub-Api-Version: 2026-03-10"
           MANIFEST_PATH="$RUNNER_TEMP/trusted-release-manifest/release-assets.sha256"
+          LATEST_PATH="$RUNNER_TEMP/release-latest.json"
+          FIRST_ASSET_NAME="Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg"
           RELEASES="$(gh api --header "$API_VERSION_HEADER" \
             "repos/$GITHUB_REPOSITORY/releases?per_page=100")"
           DRAFT_RELEASE="$(jq -c \
@@ -882,6 +781,7 @@ jobs:
           if ! jq -e \
             --arg tag "$RELEASE_TAG" \
             --arg target "$GITHUB_SHA" \
+            --arg first_asset "$FIRST_ASSET_NAME" \
             --argjson prerelease "$EXPECTED_PRERELEASE" \
             --argjson asset_count "$EXPECTED_ASSET_COUNT" \
             '.tag_name == $tag and
@@ -889,9 +789,10 @@ jobs:
              .draft == true and
              .prerelease == $prerelease and
              (.assets | length) == $asset_count and
+             .assets[0].name == $first_asset and
              all(.assets[]; .state == "uploaded")' \
             <<< "$DRAFT_RELEASE" >/dev/null; then
-            echo "发布前 Draft Release 或资产集合发生变化。" >&2
+            echo "发布前 Draft Release、通道、DMG 首位或资产集合发生变化。" >&2
             exit 1
           fi
 
@@ -906,14 +807,37 @@ jobs:
             fi
           done < "$MANIFEST_PATH"
 
-          REMOTE_TAG_COMMIT="$(git ls-remote origin "refs/tags/$RELEASE_TAG^{}" | awk 'NR == 1 { print $1 }')"
-          if [[ -z "$REMOTE_TAG_COMMIT" ]]; then
-            REMOTE_TAG_COMMIT="$(git ls-remote origin "refs/tags/$RELEASE_TAG" | awk 'NR == 1 { print $1 }')"
+          if ! REMOTE_TAG_COMMIT="$(gh api \
+            --header "$API_VERSION_HEADER" \
+            "repos/$GITHUB_REPOSITORY/commits/$RELEASE_TAG" \
+            --jq '.sha')"; then
+            echo "发布前无法重新读取远程标签。" >&2
+            exit 1
           fi
           if [[ "$REMOTE_TAG_COMMIT" != "$GITHUB_SHA" ]]; then
             echo "发布前远程标签与构建提交不一致。" >&2
             exit 1
           fi
+
+          LATEST_ASSET_ID="$(jq -r \
+            '[.assets[] | select(.name == "latest.json")] | if length == 1 then .[0].id else empty end' \
+            <<< "$DRAFT_RELEASE")"
+          EXPECTED_LATEST_SHA256="$(awk '$2 == "latest.json" { print $1 }' "$MANIFEST_PATH")"
+          if [[ -z "$LATEST_ASSET_ID" || -z "$EXPECTED_LATEST_SHA256" ]]; then
+            echo "Draft Release 或 manifest 缺少唯一的 latest.json。" >&2
+            exit 1
+          fi
+          gh api \
+            --header "$API_VERSION_HEADER" \
+            --header "Accept: application/octet-stream" \
+            "repos/$GITHUB_REPOSITORY/releases/assets/$LATEST_ASSET_ID" \
+            > "$LATEST_PATH"
+          ACTUAL_LATEST_SHA256="$(sha256sum "$LATEST_PATH" | awk '{ print $1 }')"
+          if [[ "$ACTUAL_LATEST_SHA256" != "$EXPECTED_LATEST_SHA256" ]]; then
+            echo "下载的 latest.json 与构建 manifest 不一致。" >&2
+            exit 1
+          fi
+          jq -e . "$LATEST_PATH" >/dev/null
 
           RELEASE_ID="$(jq -r '.id' <<< "$DRAFT_RELEASE")"
           gh api --header "$API_VERSION_HEADER" \
@@ -924,11 +848,11 @@ jobs:
       - name: Verify final immutable Release and assets
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           API_VERSION_HEADER="X-GitHub-Api-Version: 2026-03-10"
           MANIFEST_PATH="$RUNNER_TEMP/trusted-release-manifest/release-assets.sha256"
+          FIRST_ASSET_NAME="Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg"
           FINAL_RELEASE="$(gh api --header "$API_VERSION_HEADER" \
             "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG")"
           LATEST_RELEASE="$(gh api --header "$API_VERSION_HEADER" \
@@ -938,6 +862,7 @@ jobs:
           if ! jq -e \
             --arg tag "$RELEASE_TAG" \
             --arg target "$GITHUB_SHA" \
+            --arg first_asset "$FIRST_ASSET_NAME" \
             --argjson prerelease "$EXPECTED_PRERELEASE" \
             --argjson asset_count "$EXPECTED_ASSET_COUNT" \
             '.tag_name == $tag and
@@ -945,9 +870,11 @@ jobs:
              .draft == false and
              .prerelease == $prerelease and
              .immutable == true and
-             (.assets | length) == $asset_count' \
+             (.assets | length) == $asset_count and
+             .assets[0].name == $first_asset and
+             all(.assets[]; .state == "uploaded")' \
             <<< "$FINAL_RELEASE" >/dev/null; then
-            echo "最终 Release 的发布、通道、锁定或资产状态不正确。" >&2
+            echo "最终 Release 的发布、通道、锁定、DMG 首位或资产状态不正确。" >&2
             exit 1
           fi
 
@@ -976,20 +903,17 @@ jobs:
             fi
           done < "$MANIFEST_PATH"
 
-      - name: Update Beta updater metadata
+      - name: Update and verify Beta updater metadata
+        if: env.EXPECTED_PRERELEASE == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          if [[ "$EXPECTED_PRERELEASE" != "true" ]]; then
-            exit 0
-          fi
-
           API_VERSION_HEADER="X-GitHub-Api-Version: 2026-03-10"
           BETA_FEED_BRANCH="beta-updater"
           BETA_FEED_PATH="latest.json"
-          LATEST_PATH="$RUNNER_TEMP/draft-release-assets/latest.json"
+          LATEST_PATH="$RUNNER_TEMP/release-latest.json"
+          REMOTE_LATEST_PATH="$RUNNER_TEMP/beta-updater-latest.json"
 
           if ! gh api --header "$API_VERSION_HEADER" \
             "repos/$GITHUB_REPOSITORY/git/ref/heads/$BETA_FEED_BRANCH" >/dev/null 2>&1; then
@@ -1013,6 +937,26 @@ jobs:
           if [[ -n "$FILE_SHA" ]]; then
             UPDATE_ARGS+=(-f "sha=$FILE_SHA")
           fi
-          gh api --header "$API_VERSION_HEADER" \
+          UPDATE_RESULT="$(gh api --header "$API_VERSION_HEADER" \
             "${UPDATE_ARGS[@]}" \
-            "repos/$GITHUB_REPOSITORY/contents/$BETA_FEED_PATH" >/dev/null
+            "repos/$GITHUB_REPOSITORY/contents/$BETA_FEED_PATH")"
+          UPDATED_FILE_SHA="$(jq -r '.content.sha // empty' <<< "$UPDATE_RESULT")"
+          if [[ -z "$UPDATED_FILE_SHA" ]]; then
+            echo "Beta updater metadata 更新未返回文件 SHA。" >&2
+            exit 1
+          fi
+
+          REMOTE_FILE="$(gh api --header "$API_VERSION_HEADER" \
+            "repos/$GITHUB_REPOSITORY/contents/$BETA_FEED_PATH?ref=$BETA_FEED_BRANCH")"
+          if [[ "$(jq -r '.sha // empty' <<< "$REMOTE_FILE")" != "$UPDATED_FILE_SHA" ]]; then
+            echo "Beta updater metadata 回读 SHA 与写入结果不一致。" >&2
+            exit 1
+          fi
+          jq -r '.content' <<< "$REMOTE_FILE" \
+            | tr -d '\n' \
+            | base64 --decode \
+            > "$REMOTE_LATEST_PATH"
+          if ! cmp -s "$LATEST_PATH" "$REMOTE_LATEST_PATH"; then
+            echo "Beta updater metadata 回读内容与已验证 Release metadata 不一致。" >&2
+            exit 1
+          fi


### PR DESCRIPTION
## 目标

缩短 Beta 发布周期，同时保留签名、公证、staple、更新器签名、版本与 tag/main 对齐、服务端资产摘要、immutable release 和最终 updater metadata 验证。

## 改动

- PR Check 记录实际测试的 merge tree；普通二父合并仅在 base/head/tree 和完整 Compare 证据全部一致时复用结果，避免 main 重复四平台构建。
- 修改 `.github/workflows/check.yml` 的 PR 永远强制 main 完整运行；分页、300 文件边界、API 或 artifact 异常也完整运行。
- Beta 跳过稳定版人工 environment 门槛；稳定版继续要求批准。
- 发布阶段不再重新下载并重复深验全部 9 个资产，改为校验 build-time manifest、GitHub 服务端 digest、DMG 首位、tag target、immutable 状态及 updater metadata 回读。
- 保持三平台构建、macOS 签名/公证、DMG 与 updater 验证不变。

## 验证

- 两份 YAML 解析通过。
- 45/45 个 `run` 脚本块通过 `bash -n`。
- Compare 门槛定向验证：正常 299 文件可复用；工作流直接修改/改名、300 文件、101 commits、错误 head 均完整运行。
- `git diff --check` 通过。
- ChatGPT Pro 实现对话：https://chatgpt.com/c/6a981a97-1590-83e8-9c0c-ee4c3e80f917

预计普通合并后的 main Check 从约 9m43s 降到 15–40s；Beta 总时长从约 23m03s 降到约 12m40s–13m10s。