### PR TITLE
Place the caret after uploaded media

### DIFF
--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -2143,6 +2143,12 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
         transaction = transaction.setSelection(TextSelection.near(transaction.doc.resolve(position)));
       }
       transaction = transaction.replaceSelection(new Slice(Fragment.fromArray(nodes), 0, 0));
+      if (transaction.selection instanceof NodeSelection) {
+        const paragraphPosition = transaction.selection.to;
+        transaction = transaction
+          .insert(paragraphPosition, composerSchema.nodes.paragraph.create())
+          .setSelection(TextSelection.create(transaction.doc, paragraphPosition + 1));
+      }
       onErrorRef.current(null);
       view.dispatch(transaction.scrollIntoView());
       view.focus();


### PR DESCRIPTION
## 产品变化

- 上传图片、视频或普通附件后，编辑器把输入光标放到该元素后方。
- 用户可以直接继续输入正文，不会先选中媒体元素。

## 范围

- 只修改共享描述/评论编辑器的文件插入路径。
- 不改变上传、保存或附件渲染逻辑。

## 验证

- 真实隔离页面上传图片与普通附件后，活动选择均为媒体后的空段落文本光标。
- 随后输入的文字出现在图片后方。
- `npm run typecheck`、`npm run build:web`、`git diff --check` 通过。

关联：LOCAL-375