### PR TITLE
fix: align detail description checklist checkboxes

### DIFF
--- a/web/src/components/InlineMediaComposer.css
+++ b/web/src/components/InlineMediaComposer.css
@@ -224,6 +224,7 @@
   cursor: pointer;
 }
 
+.issue-description-composer .inline-media-composer.ProseMirror li.task-list-item > input[type="checkbox"],
 .inline-media-description.ProseMirror li.task-list-item > input[type="checkbox"] {
   margin-top: 6.5px;
 }


### PR DESCRIPTION
## Summary

- apply the existing description-editor checkbox offset to the issue detail description editor
- keep the create-issue editor behavior unchanged

## Direct verification

- reproduced the user path in the real issue detail editor
- verified checked and unchecked tasks at normal width
- verified a two-line task at 520 px width
- saved the description and reopened edit mode; alignment and task state remained correct
- `npm run build:web` passed

Taskboard: LOCAL-319