### PR TITLE
Stop Windows Codex launch failure loops

### DIFF
--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -2,6 +2,7 @@
 
 import { spawn, spawnSync } from "node:child_process";
 import { createHash, createHmac, randomBytes, randomUUID } from "node:crypto";
+import { once } from "node:events";
 import { createReadStream, createWriteStream } from "node:fs";
 import { chmod, mkdir, readFile, rename, stat, unlink, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
@@ -537,18 +538,43 @@ function activateCodexApp(pid) {
   if (activation.status !== 0) throw new Error("Unable to activate the Codex app");
 }
 
+function managedCodexSpawnFailure(executable, args, error) {
+  const diagnosticArguments = args.map((argument) => (
+    argument.startsWith("--user-data-dir=")
+      ? "--user-data-dir=<taskboard-profile>"
+      : argument
+  ));
+  const details = [
+    typeof error?.code === "string" ? `code=${error.code}` : null,
+    error?.errno !== undefined ? `errno=${error.errno}` : null,
+    typeof error?.syscall === "string" ? `syscall=${JSON.stringify(error.syscall)}` : null,
+    `message=${JSON.stringify(error instanceof Error ? error.message : String(error))}`,
+  ].filter(Boolean);
+  const failure = new Error(
+    `Managed Codex spawn failed: executable=${JSON.stringify(executable)}; `
+      + `arguments=${JSON.stringify(diagnosticArguments)}; ${details.join("; ")}`,
+    { cause: error },
+  );
+  failure.managedCodexSpawnFailure = true;
+  return failure;
+}
+
 async function launchCodexWithPipe(appPath) {
-  const child = spawn(
-    codexExecutablePath(appPath),
-    [
-      `--user-data-dir=${independentCodexProfilePath}`,
-      "--remote-debugging-pipe",
-    ],
-    {
+  const executable = codexExecutablePath(appPath);
+  const args = [
+    `--user-data-dir=${independentCodexProfilePath}`,
+    "--remote-debugging-pipe",
+  ];
+  let child;
+  try {
+    child = spawn(executable, args, {
       env: withoutTaskboardLauncherEnvironment(process.env),
       stdio: ["ignore", "ignore", "ignore", "pipe", "pipe"],
-    },
-  );
+    });
+    if (!Number.isInteger(child.pid)) await once(child, "spawn");
+  } catch (error) {
+    throw managedCodexSpawnFailure(executable, args, error);
+  }
   const browser = new CdpPipeBrowser(child);
   try {
     await browser.open();
@@ -3183,7 +3209,18 @@ async function main() {
     if (stopping) return;
 
     if (options.cdpPipe || !cdpReachable) {
-      idleAfterNormalExit = !(await startManagedCodex()) && !nativeCodexBrowser;
+      const launchRequestGeneration = openRequestGeneration;
+      try {
+        idleAfterNormalExit = !(await startManagedCodex()) && !nativeCodexBrowser;
+      } catch (error) {
+        if (!options.watch || error?.managedCodexSpawnFailure !== true) throw error;
+        openedRequestGeneration = Math.max(
+          openedRequestGeneration,
+          launchRequestGeneration,
+        );
+        idleAfterNormalExit = true;
+        console.error(`Waiting for Codex launch: ${error.message}`);
+      }
     } else {
       if (options.launch) {
         const runningCodex = codexAppProcesses(options.appPath)
@@ -3287,6 +3324,7 @@ async function main() {
           if (idleAfterNormalExit) continue;
         } else {
           if (!hasOpenPending()) continue;
+          const launchRequestGeneration = openRequestGeneration;
           try {
             if (!(await startManagedCodex())) {
               if (nativeCodexBrowser) await requestTaskboardOpen();
@@ -3295,6 +3333,12 @@ async function main() {
             exitedManagedCodex = null;
             idleAfterNormalExit = false;
           } catch (restartError) {
+            if (restartError?.managedCodexSpawnFailure === true) {
+              openedRequestGeneration = Math.max(
+                openedRequestGeneration,
+                launchRequestGeneration,
+              );
+            }
             console.error(`Waiting to restart Codex: ${restartError.message}`);
             continue;
           }
@@ -3388,10 +3432,18 @@ async function main() {
               continue;
             }
             console.error("Codex exited unexpectedly; restarting it for the taskboard launcher.");
+            const launchRequestGeneration = openRequestGeneration;
             try {
               await startManagedCodex();
               if (options.open) openRequestGeneration += 1;
             } catch (restartError) {
+              if (restartError?.managedCodexSpawnFailure === true) {
+                openedRequestGeneration = Math.max(
+                  openedRequestGeneration,
+                  launchRequestGeneration,
+                );
+                idleAfterNormalExit = true;
+              }
               console.error(`Waiting to restart Codex: ${restartError.message}`);
             }
             continue;

--- a/test/inject-fullheight-regression.test.mjs
+++ b/test/inject-fullheight-regression.test.mjs
@@ -271,7 +271,7 @@ test("Taskboard fills the workspace, opens HTTPS links and revokes hostile ifram
   }));
 
   const profile = await mkdtemp(path.join(os.tmpdir(), "taskboard-fullheight-chrome-"));
-  t.after(() => rm(profile, { recursive: true, force: true }));
+  t.after(() => rm(profile, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 }));
   const url = `http://127.0.0.1:${server.address().port}/fixture`;
   const child = spawn(chrome, [
     "--headless=new",

--- a/test/injector.test.mjs
+++ b/test/injector.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { EventEmitter, once } from "node:events";
 import { readFile } from "node:fs/promises";
 import { test } from "node:test";
 import vm from "node:vm";
@@ -201,6 +202,112 @@ test("automation list rebuilds a stored policy on the incoming project identity"
   assert.equal(result.policy, appliedRequest);
   assert.match(source, /reconcileStoredAutomationPolicy\(\s*request,\s*rpc/);
   assert.match(source, /policy: storedAutomationPolicy\(current\.request\)/);
+});
+
+test("managed private-CDP spawn failures are bounded without changing the launch path", async () => {
+  const launchStart = source.indexOf("function managedCodexSpawnFailure");
+  const launchEnd = source.indexOf("\n\nclass CdpConnection", launchStart);
+  assert.notEqual(launchStart, -1);
+  assert.notEqual(launchEnd, -1);
+
+  const executable = String.raw`C:\Users\alice\AppData\Roaming\Codex Taskboard\codex-runtime\codex.exe`;
+  const profile = String.raw`C:\Users\alice\AppData\Roaming\Codex Taskboard\codex-profile`;
+  const launches = [];
+  let spawnMode = "failure";
+  let browserOpenCount = 0;
+  class TestPipeBrowser {
+    constructor(child) {
+      this.child = child;
+    }
+
+    async open() {
+      browserOpenCount += 1;
+    }
+  }
+  const { launchCodexWithPipe } = vm.runInNewContext(
+    `(() => {
+      ${source.slice(launchStart, launchEnd)}
+      return { launchCodexWithPipe };
+    })()`,
+    {
+      CdpPipeBrowser: TestPipeBrowser,
+      Error,
+      once,
+      codexExecutablePath: (appPath) => appPath,
+      independentCodexProfilePath: profile,
+      process: { env: { SAFE_VALUE: "kept", CODEX_TASKBOARD_SECRET: "removed" } },
+      spawn: (command, args, options) => {
+        launches.push({ command, args, options });
+        const child = new EventEmitter();
+        child.exitCode = null;
+        child.signalCode = null;
+        child.kill = () => true;
+        if (spawnMode === "success") {
+          child.pid = 376;
+        } else {
+          queueMicrotask(() => child.emit("error", Object.assign(
+            new Error(`spawn ${command} EPERM`),
+            {
+              code: "EPERM",
+              errno: -4048,
+              syscall: `spawn ${command}`,
+            },
+          )));
+        }
+        return child;
+      },
+      withoutTaskboardLauncherEnvironment: (environment) => ({
+        SAFE_VALUE: environment.SAFE_VALUE,
+      }),
+    },
+  );
+
+  await assert.rejects(launchCodexWithPipe(executable), (failure) => {
+    assert.equal(failure.managedCodexSpawnFailure, true);
+    assert.match(failure.message, /Managed Codex spawn failed/);
+    assert.match(
+      failure.message,
+      /arguments=\["--user-data-dir=<taskboard-profile>","--remote-debugging-pipe"\]/,
+    );
+    assert.match(failure.message, /code=EPERM/);
+    assert.match(failure.message, /errno=-4048/);
+    assert.ok(failure.message.includes(`syscall=${JSON.stringify(`spawn ${executable}`)}`));
+    assert.doesNotMatch(failure.message, /codex-profile/);
+    return true;
+  });
+  assert.equal(browserOpenCount, 0);
+
+  spawnMode = "success";
+  const launched = await launchCodexWithPipe(executable);
+  assert.equal(launched.child.pid, 376);
+  assert.equal(browserOpenCount, 1);
+  assert.equal(launches.at(-1).command, executable);
+  assert.deepEqual(Array.from(launches.at(-1).args), [
+    `--user-data-dir=${profile}`,
+    "--remote-debugging-pipe",
+  ]);
+  assert.deepEqual(
+    Array.from(launches.at(-1).options.stdio),
+    ["ignore", "ignore", "ignore", "pipe", "pipe"],
+  );
+  assert.deepEqual(
+    Object.fromEntries(Object.entries(launches.at(-1).options.env)),
+    { SAFE_VALUE: "kept" },
+  );
+
+  assert.match(source, /if \(!options\.watch \|\| error\?\.managedCodexSpawnFailure !== true\) throw error/);
+  assert.equal(
+    source.match(/const launchRequestGeneration = openRequestGeneration;/g)?.length,
+    3,
+  );
+  assert.equal(
+    source.match(
+      /openedRequestGeneration = Math\.max\(\s*openedRequestGeneration,\s*launchRequestGeneration,\s*\);/g,
+    )?.length,
+    3,
+  );
+  assert.match(source, /if \(!hasOpenPending\(\)\) continue;/);
+  assert.match(source, /idleAfterNormalExit = true;\s*console\.error\(`Waiting for Codex launch:/);
 });
 
 test("the package injection command remains resident for tab-triggered recovery", () => {

--- a/test/injector.test.mjs
+++ b/test/injector.test.mjs
@@ -206,7 +206,7 @@ test("automation list rebuilds a stored policy on the incoming project identity"
 
 test("managed private-CDP spawn failures are bounded without changing the launch path", async () => {
   const launchStart = source.indexOf("function managedCodexSpawnFailure");
-  const launchEnd = source.indexOf("\n\nclass CdpConnection", launchStart);
+  const launchEnd = source.indexOf("class CdpConnection", launchStart);
   assert.notEqual(launchStart, -1);
   assert.notEqual(launchEnd, -1);
 


### PR DESCRIPTION
## Summary
- keep the resident injector and Taskboard service alive when managed Codex launch fails
- consume only the launch request that failed, so there is no automatic two-second retry loop
- allow one new launch attempt for each later explicit Open Taskboard action
- log the failing executable and redacted launch diagnostics

## Verification
- node --check scripts/codex-injector.mjs
- node --test test/injector.test.mjs (12/12)
- process-level launch-permission failure: service remained available, no autonomous retry, and one explicit open signal produced exactly one retry
- git diff --check

Related to #352. Keep the issue open until a Beta containing this change is published and verified.