### PR TITLE
Fix protected release promotion environment

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -647,31 +647,15 @@ jobs:
             "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" \
             "$RELEASE_ASSETS/latest.json"
 
-  approve-stable-release:
-    name: Approve stable release
-    needs:
-      - release-preflight
-      - draft-release
-    if: ${{ needs['release-preflight'].outputs.prerelease == 'false' }}
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    environment: macos-release
-
-    steps:
-      - name: Confirm protected stable promotion
-        env:
-          RELEASE_TAG: ${{ needs['release-preflight'].outputs.release_tag }}
-        run: echo "Approved stable promotion for $RELEASE_TAG"
-
   promote-release:
     name: Verify and publish immutable release
     needs:
       - release-preflight
       - draft-release
-      - approve-stable-release
-    if: ${{ !cancelled() && needs['release-preflight'].result == 'success' && needs['draft-release'].result == 'success' && (needs['release-preflight'].outputs.prerelease == 'true' || needs['approve-stable-release'].result == 'success') }}
+    if: ${{ !cancelled() && needs['release-preflight'].result == 'success' && needs['draft-release'].result == 'success' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    environment: macos-release
     env:
       RELEASE_TAG: ${{ needs['release-preflight'].outputs.release_tag }}
       PACKAGE_VERSION: ${{ needs['release-preflight'].outputs.package_version }}


### PR DESCRIPTION
## 产品结果

修复 Beta 发布在 Draft 资产全部生成后无法自动完成发布的问题。

## 根因

`RELEASE_RULESET_TOKEN` 存在于受保护的 `macos-release` environment，但 Beta 的 `promote-release` 作业不再绑定该 environment，因此 beta.7 在最终发布前读不到密钥。

## 最小修改

- 删除单独的 stable 审批作业。
- 让 `promote-release` 成为唯一绑定 `macos-release` 的作业。
- Beta 与 stable 都只经过这一个受保护审批点。
- 保留 tag ruleset、immutable release、资产摘要、DMG 首位、tag target 和 Beta updater metadata 的全部校验。

## 验证

- YAML 与作业依赖结构通过。
- 27 个保留的 shell 脚本逐字节未变，且全部通过 `bash -n`。
- `node --test test/launcher-release.test.mjs`：5/5 通过。
- `git diff --check` 通过。

Taskboard: LOCAL-377
Pro implementation: https://chatgpt.com/c/6a981a97-1590-83e8-9c0c-ee4c3e80f917