### PR TITLE
Fix inline media in new issues and stale AI chat reopening

### DIFF
--- a/test/project-home.test.mjs
+++ b/test/project-home.test.mjs
@@ -8,7 +8,6 @@ const styles = await readFile(new URL("../web/src/styles.css", import.meta.url),
 const editorSource = await readFile(new URL("../web/src/components/TaskEditor.tsx", import.meta.url), "utf8");
 const detailSource = await readFile(new URL("../web/src/components/TaskDetail.tsx", import.meta.url), "utf8");
 const labelPickerSource = await readFile(new URL("../web/src/components/LabelPicker.tsx", import.meta.url), "utf8");
-const pendingAttachmentsSource = await readFile(new URL("../web/src/components/PendingAttachments.tsx", import.meta.url), "utf8");
 const labelsSource = await readFile(new URL("../web/src/labels.ts", import.meta.url), "utf8");
 
 test("the project switcher merges live Codex projects with persisted Taskboard projects", () => {
@@ -60,14 +59,15 @@ test("the selected project exposes the current board surfaces", () => {
   assert.match(styles, /\.workspace-header \{[\s\S]*?border-bottom: var\(--border-hairline\) solid var\(--border\)/);
 });
 
-test("new issues stage attachments in the composer and upload them after creation", () => {
+test("new issues insert attachments into the description and upload them after creation", () => {
   assert.match(editorSource, /type="file"[\s\S]*?multiple/);
-  assert.match(editorSource, /<PendingAttachments[\s\S]*?uploadLabel=\{text\("保存后上传", "Upload after saving"\)\}/);
-  assert.match(pendingAttachmentsSource, /className="composer-attachment-list"/);
+  assert.match(editorSource, /<InlineMediaComposer[\s\S]*?allowAttachments/);
+  assert.match(editorSource, /descriptionComposerRef\.current\?\.addFiles\(event\.currentTarget\.files\)/);
+  assert.match(editorSource, /inlineMediaFiles\(descriptionSegments\)/);
   assert.match(appSource, /Promise\.allSettled/);
-  assert.match(appSource, /uploadAttachment\(saved\.id, file, "attachment"\)/);
+  assert.match(appSource, /uploadAttachment\(saved\.id, file\.file, "attachment"\)/);
   assert.match(appSource, /uploadAttachment\(saved\.id, image\.file, "inline"\)/);
-  assert.match(appSource, /zh: `\$\{failedAttachments\} 个附件`[\s\S]*?以下内容写入失败/);
+  assert.match(appSource, /resolveInlineAttachmentMarkdown\([\s\S]*?resolveInlineMediaMarkdown\(/);
 });
 
 test("the issue composer includes Linear-style labels and scheduling", () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -64,7 +64,9 @@ import { IssueListView } from "./components/IssueListView";
 import { JiraConnectionDialog } from "./components/JiraConnectionDialog";
 import { ArchivedTasksColumn, OtherTasksPanel } from "./components/OtherTasksPanel";
 import {
+  resolveInlineAttachmentMarkdown,
   resolveInlineMediaMarkdown,
+  type PendingInlineAttachment,
   type PendingInlineImage,
 } from "./components/InlineMediaComposer";
 import { LinearIcon } from "./components/LinearIcon";
@@ -723,6 +725,12 @@ export function App() {
   const [aiImportReadyProjectId, setAiImportReadyProjectId] = useState<string | null>(null);
   const [aiThreads, setAiThreads] = useState<AiChatThread[]>([]);
   const [aiOpenThreadRequest, setAiOpenThreadRequest] = useState<AiChatOpenThreadRequest | null>(null);
+  const aiOpenThreadRequestSequenceRef = useRef(0);
+  const handleAiOpenThreadRequestHandled = useCallback((requestId: number) => {
+    setAiOpenThreadRequest((current) => (
+      current?.requestId === requestId ? null : current
+    ));
+  }, []);
   const [readActivityKeys, setReadActivityKeys] = useState<Record<string, string>>({});
   const [codexThreadProgress, setCodexThreadProgress] = useState<
     Record<string, {
@@ -2373,7 +2381,7 @@ export function App() {
 
   async function saveEditor(
     draft: TaskDraft,
-    attachments: File[],
+    inlineFiles: PendingInlineAttachment[],
     inlineImages: PendingInlineImage[],
     createOptions?: NewTaskCreateOptions,
   ) {
@@ -2399,29 +2407,37 @@ export function App() {
           : project
       )));
     }
-    let failedAttachments = 0;
     let postCreateWriteFailed = false;
-    if (creating && (attachments.length > 0 || inlineImages.length > 0)) {
-      const [results, inlineResults] = await Promise.all([
+    if (creating && (inlineFiles.length > 0 || inlineImages.length > 0)) {
+      const [fileResults, inlineResults] = await Promise.all([
           Promise.allSettled(
-            attachments.map((file) => uploadAttachment(saved.id, file, "attachment")),
+            inlineFiles.map((file) => uploadAttachment(saved.id, file.file, "attachment")),
           ),
           Promise.allSettled(
             inlineImages.map((image) => uploadAttachment(saved.id, image.file, "inline")),
           ),
       ]);
-      failedAttachments = results.filter((result) => result.status === "rejected").length;
+      const fileAttachments = fileResults.flatMap((result) => (
+        result.status === "fulfilled" ? [result.value] : []
+      ));
       const inlineAttachments = inlineResults.flatMap((result) => (
         result.status === "fulfilled" ? [result.value] : []
       ));
-      if (inlineAttachments.length !== inlineImages.length) {
+      if (
+        fileAttachments.length !== inlineFiles.length
+        || inlineAttachments.length !== inlineImages.length
+      ) {
         postCreateWriteFailed = true;
-      } else if (inlineImages.length > 0) {
+      } else if (inlineFiles.length > 0 || inlineImages.length > 0) {
         try {
-          const description = resolveInlineMediaMarkdown(
-            draft.description,
-            inlineImages,
-            inlineAttachments,
+          const description = resolveInlineAttachmentMarkdown(
+            resolveInlineMediaMarkdown(
+              draft.description,
+              inlineImages,
+              inlineAttachments,
+            ),
+            inlineFiles,
+            fileAttachments,
           );
           saved = await updateTaskRequest(saved, { ...draft, description });
         } catch {
@@ -2470,11 +2486,7 @@ export function App() {
     if (creating) setNewTaskDraft(null);
     const failedWrites = [
       ...(relationWriteFailed ? [{ zh: "关系", en: "relations" }] : []),
-      ...(postCreateWriteFailed ? [{ zh: "正文或图片", en: "description or images" }] : []),
-      ...(failedAttachments > 0 ? [{
-        zh: `${failedAttachments} 个附件`,
-        en: `${failedAttachments} attachment${failedAttachments === 1 ? "" : "s"}`,
-      }] : []),
+      ...(postCreateWriteFailed ? [{ zh: "正文或媒体", en: "description or media" }] : []),
     ];
     if (!creating || !createOptions?.keepOpen || failedWrites.length > 0) setEditor(null);
     if (failedWrites.length > 0) {
@@ -2940,10 +2952,11 @@ export function App() {
 
   function openTaskConversation(conversation: TaskConversationItem) {
     if (conversation.kind === "local-ai" && conversation.aiThreadId) {
-      setAiOpenThreadRequest((current) => ({
+      aiOpenThreadRequestSequenceRef.current += 1;
+      setAiOpenThreadRequest({
         threadId: conversation.aiThreadId!,
-        requestId: (current?.requestId ?? 0) + 1,
-      }));
+        requestId: aiOpenThreadRequestSequenceRef.current,
+      });
       return;
     }
     if (conversation.threadBinding) {
@@ -3719,15 +3732,18 @@ export function App() {
               <button
                 className="button primary"
                 type="button"
-                onClick={() => setAiOpenThreadRequest((current) => ({
-                  projectId: selectedProject.id,
-                  issueId: null,
-                  composerText: text(
-                    "只检查当前项目目录对应的 Codex 对话。请将其中已完成、处理中和待执行的任务整理并导入当前项目的 Taskboard。",
-                    "Only inspect Codex conversations associated with this project directory. Organize completed, in-progress, and pending tasks, then import them into this project's Taskboard.",
-                  ),
-                  requestId: (current?.requestId ?? 0) + 1,
-                }))}
+                onClick={() => {
+                  aiOpenThreadRequestSequenceRef.current += 1;
+                  setAiOpenThreadRequest({
+                    projectId: selectedProject.id,
+                    issueId: null,
+                    composerText: text(
+                      "只检查当前项目目录对应的 Codex 对话。请将其中已完成、处理中和待执行的任务整理并导入当前项目的 Taskboard。",
+                      "Only inspect Codex conversations associated with this project directory. Organize completed, in-progress, and pending tasks, then import them into this project's Taskboard.",
+                    ),
+                    requestId: aiOpenThreadRequestSequenceRef.current,
+                  });
+                }}
               >
                 {text("导入当前项目任务状态", "Import current project task status")}
               </button>
@@ -4184,6 +4200,7 @@ export function App() {
             codexProjectIdentity={selectedCodexProjectIdentity}
             onThreadsChange={setAiThreads}
             openThreadRequest={aiOpenThreadRequest}
+            onOpenThreadRequestHandled={handleAiOpenThreadRequestHandled}
           />
         </Suspense>
       )}

--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -115,6 +115,7 @@ interface AiChatProps {
   codexProjectIdentity: CodexProjectIdentity | null;
   onThreadsChange?: (threads: AiChatThread[]) => void;
   openThreadRequest?: AiChatOpenThreadRequest | null;
+  onOpenThreadRequestHandled: (requestId: number) => void;
 }
 
 type MenuName = "model" | "model-list" | "effort-list" | "sandbox" | null;
@@ -1305,6 +1306,7 @@ export function AiChat({
   codexProjectIdentity,
   onThreadsChange,
   openThreadRequest,
+  onOpenThreadRequestHandled,
 }: AiChatProps) {
   const { locale, text } = useTaskboardI18n();
   const [panelOpen, setPanelOpen] = useState(false);
@@ -1933,6 +1935,7 @@ export function AiChat({
       setComposerRebindBlocked(composerDraft?.ready === false);
       if (composerDraft?.ready) setComposerRevision(composerDraft.revision);
       setPanelOpen(true);
+      onOpenThreadRequestHandled(openThreadRequest.requestId);
       return;
     }
     if (!threads.some((thread) => thread.id === openThreadRequest.threadId)) return;
@@ -1953,11 +1956,13 @@ export function AiChat({
     setMenu(null);
     setError(null);
     setPanelOpen(true);
+    onOpenThreadRequestHandled(openThreadRequest.requestId);
   }, [
     available,
     draftOrigin,
     loadSnapshot,
     openThreadRequest,
+    onOpenThreadRequestHandled,
     selectThread,
     snapshot?.thread.id,
     threads,

--- a/web/src/components/TaskEditor.tsx
+++ b/web/src/components/TaskEditor.tsx
@@ -40,17 +40,14 @@ import {
   StatusIcon,
 } from "./SemanticIcons";
 import {
-  fileKey,
-  MAX_ATTACHMENT_SIZE,
-  PendingAttachments,
-} from "./PendingAttachments";
-import {
   createInlineMediaSegments,
   InlineMediaComposer,
+  inlineMediaFiles,
   inlineMediaImages,
   serializeInlineMedia,
   type InlineMediaComposerHandle,
   type InlineMediaSegment,
+  type PendingInlineAttachment,
   type PendingInlineImage,
 } from "./InlineMediaComposer";
 import { TaskPropertyPicker } from "./TaskPropertyPicker";
@@ -96,7 +93,6 @@ export interface NewTaskEditorDraft {
   startDate: string;
   dueDate: string;
   recurrence: Recurrence | null;
-  attachments: File[];
   relations: NewTaskRelationDraft;
 }
 
@@ -117,7 +113,7 @@ interface TaskEditorProps {
   onCancel: (draft: NewTaskEditorDraft | null) => void;
   onSave: (
     draft: TaskDraft,
-    attachments: File[],
+    inlineFiles: PendingInlineAttachment[],
     inlineImages: PendingInlineImage[],
     createOptions?: NewTaskCreateOptions,
   ) => Promise<void>;
@@ -208,7 +204,6 @@ export function TaskEditor({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<TaskEditorError | null>(null);
   const [attachmentError, setAttachmentError] = useState<TaskEditorError | null>(null);
-  const [attachments, setAttachments] = useState<File[]>(initialDraft?.attachments ?? []);
 
   const developmentOptions = useMemo(() => {
     const options = [...developmentScan.contexts];
@@ -402,14 +397,13 @@ export function TaskEditor({
         startDate: startDate || null,
         dueDate: dueDate || null,
         recurrence,
-      }, attachments, inlineMediaImages(descriptionSegments), task ? undefined : {
+      }, inlineMediaFiles(descriptionSegments), inlineMediaImages(descriptionSegments), task ? undefined : {
         keepOpen: createMore,
         relations: { parentId, relatedIds, subIssueIds },
       });
       if (!task && createMore) {
         setTitle("");
         setDescriptionSegments(createInlineMediaSegments());
-        setAttachments([]);
         setSubIssueIds([]);
         setRelationMenu(null);
         setAttachmentError(null);
@@ -447,23 +441,6 @@ export function TaskEditor({
     if (task) event.currentTarget.requestSubmit();
   }
 
-  function addAttachments(files: FileList | File[]) {
-    const selected = Array.from(files);
-    const oversized = selected.find((file) => file.size > MAX_ATTACHMENT_SIZE);
-    if (oversized) {
-      setAttachmentError([
-        `“${oversized.name}” 超过 25 MB，无法上传。`,
-        `“${oversized.name}” is larger than 25 MB and cannot be uploaded.`,
-      ]);
-      return;
-    }
-    setAttachmentError(null);
-    setAttachments((current) => {
-      const existing = new Set(current.map(fileKey));
-      return [...current, ...selected.filter((file) => !existing.has(fileKey(file)))];
-    });
-  }
-
   function chooseDueDate(value: string) {
     setDueDate(value);
     setMenu(null);
@@ -481,7 +458,6 @@ export function TaskEditor({
       startDate,
       dueDate,
       recurrence,
-      attachments,
       relations: { parentId, relatedIds, subIssueIds },
     });
   }
@@ -564,18 +540,9 @@ export function TaskEditor({
               placeholder={text("添加描述…", "Add description…")}
               ariaLabel={text("描述", "Description")}
               disabled={saving}
+              allowAttachments
               onChange={setDescriptionSegments}
               onError={setAttachmentError}
-            />
-          )}
-
-          {!task && (
-            <PendingAttachments
-              files={attachments}
-              disabled={saving}
-              uploadLabel={text("保存后上传", "Upload after saving")}
-              ariaLabel={text("待上传附件", "Pending attachments")}
-              onRemove={(index) => setAttachments((current) => current.filter((_, itemIndex) => itemIndex !== index))}
             />
           )}
 
@@ -815,9 +782,9 @@ export function TaskEditor({
             {!task && (
               <>
                 <button className="composer-attach-icon" type="button" disabled={saving} onClick={() => attachmentInputRef.current?.click()} aria-label={text("上传附件", "Upload attachments")}>
-                  <AttachmentIcon color="currentColor" />{attachments.length > 0 && <span>{attachments.length}</span>}
+                  <AttachmentIcon color="currentColor" />
                 </button>
-                <input ref={attachmentInputRef} type="file" multiple hidden onChange={(event) => { if (event.currentTarget.files) addAttachments(event.currentTarget.files); event.currentTarget.value = ""; }} />
+                <input ref={attachmentInputRef} type="file" multiple hidden onChange={(event) => { if (event.currentTarget.files) descriptionComposerRef.current?.addFiles(event.currentTarget.files); event.currentTarget.value = ""; }} />
               </>
             )}
             {task && <span aria-hidden="true" />}


### PR DESCRIPTION
## Summary
- reuse the existing inline media composer for ordinary attachments in the new-issue description
- upload and resolve ordinary attachments, images, and videos into the saved description
- consume AI chat open requests after handling so a closed panel stays closed across remounts
- keep later explicit AI chat open requests working with monotonic request IDs

## Validation
- npm run typecheck
- npm run build:web
- git diff --check
- real isolated browser path: create an issue with text, ordinary attachment, image, and video; refresh and edit again
- real isolated browser path: close imported AI chat, switch to all projects and back, confirm it stays closed; import again and confirm it opens

Refs #354
Taskboard: LOCAL-314, LOCAL-379