### PR TITLE
Raise project menu height limit

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -785,7 +785,7 @@ kbd {
   display: flex;
   flex-direction: column;
   width: min(240px, calc(100vw - 24px));
-  max-height: min(480px, calc(100vh - 56px));
+  max-height: 80vh;
   padding: 5px;
   overflow: hidden;
   border: var(--border-hairline) solid var(--border-strong);


### PR DESCRIPTION
## Summary

- raise the project switcher maximum height from 480px to 80% of the viewport
- keep overflow scrolling inside the existing project list so search and bottom actions stay visible

## Verification

- `npm run typecheck`
- `npm run build:web`
- `git diff --check`
- real browser at 1280×900: menu height 720px (80vh), list scrollable
- real browser at 1280×600: menu height 480px (80vh), list scrollable, search and actions visible

Taskboard: LOCAL-383