### PR TITLE
feat: add Atlas Workbench document library

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -264,15 +264,15 @@ jobs:
           --bundles app
           --no-sign
           --config '{"bundle":{"createUpdaterArtifacts":false}}'
-      - run: test -d "src-tauri/target/universal-apple-darwin/release/bundle/macos/Codex Taskboard.app"
+      - run: test -d "src-tauri/target/universal-apple-darwin/release/bundle/macos/Atlas Workbench.app"
       - name: Verify packaged taskctl and inherited listener
         run: >-
           npm run app:verify-packaged-taskctl --
-          "src-tauri/target/universal-apple-darwin/release/bundle/macos/Codex Taskboard.app"
+          "src-tauri/target/universal-apple-darwin/release/bundle/macos/Atlas Workbench.app"
       - name: Verify secretless App, updater, and DMG preflight
         run: >-
           npm run app:preflight --
-          "src-tauri/target/universal-apple-darwin/release/bundle/macos/Codex Taskboard.app"
+          "src-tauri/target/universal-apple-darwin/release/bundle/macos/Atlas Workbench.app"
 
   windows-launcher:
     name: Windows x64 launcher

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -263,16 +263,16 @@ jobs:
           mkdir -p "$LINUX_RELEASE"
           cp \
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb \
-            "$LINUX_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb"
+            "$LINUX_RELEASE/Atlas.Workbench_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb"
           cp \
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb.sig \
-            "$LINUX_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb.sig"
+            "$LINUX_RELEASE/Atlas.Workbench_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb.sig"
           cp \
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage \
-            "$LINUX_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage"
+            "$LINUX_RELEASE/Atlas.Workbench_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage"
           cp \
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage.sig \
-            "$LINUX_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage.sig"
+            "$LINUX_RELEASE/Atlas.Workbench_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage.sig"
 
       - name: Preserve Ubuntu 24.04 x64 release assets
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -328,7 +328,7 @@ jobs:
       CODEX_TASKBOARD_RELEASE_VERSION: ${{ needs['release-preflight'].outputs.release_version }}
       RELEASE_TAG: ${{ needs['release-preflight'].outputs.release_tag }}
       PACKAGE_VERSION: ${{ needs['release-preflight'].outputs.package_version }}
-      APP_NAME: ${{ needs['release-preflight'].outputs.prerelease == 'true' && 'Codex Taskboard Beta.app' || 'Codex Taskboard.app' }}
+      APP_NAME: ${{ needs['release-preflight'].outputs.prerelease == 'true' && 'Atlas Workbench Beta.app' || 'Atlas Workbench.app' }}
 
     steps:
       - name: Checkout
@@ -429,7 +429,7 @@ jobs:
         run: |
           BUNDLE_ROOT="src-tauri/target/universal-apple-darwin/release/bundle"
           RAW_DMG_NAME="${APP_NAME%.app}_${PACKAGE_VERSION}_universal.dmg"
-          RELEASE_DMG_NAME="Codex.Taskboard_${PACKAGE_VERSION}_universal.dmg"
+          RELEASE_DMG_NAME="Atlas.Workbench_${PACKAGE_VERSION}_universal.dmg"
           rm -f "$BUNDLE_ROOT/dmg/$RAW_DMG_NAME" "$BUNDLE_ROOT/macos/$RAW_DMG_NAME"
           (
             cd "$BUNDLE_ROOT/macos"
@@ -472,7 +472,7 @@ jobs:
           set -euo pipefail
           BUNDLE_ROOT="src-tauri/target/universal-apple-darwin/release/bundle"
           APP_PATH="$BUNDLE_ROOT/macos/$APP_NAME"
-          DMG_PATH="$BUNDLE_ROOT/dmg/Codex.Taskboard_${PACKAGE_VERSION}_universal.dmg"
+          DMG_PATH="$BUNDLE_ROOT/dmg/Atlas.Workbench_${PACKAGE_VERSION}_universal.dmg"
           RELEASE_ROOT="$BUNDLE_ROOT/release"
           npm run app:verify-release -- "$APP_PATH" "$DMG_PATH" "$RELEASE_ROOT" "$RELEASE_TAG"
 
@@ -482,10 +482,10 @@ jobs:
           MACOS_RELEASE="$RUNNER_TEMP/macos-release"
           mkdir -p "$MACOS_RELEASE"
           cp \
-            "$BUNDLE_ROOT/dmg/Codex.Taskboard_${PACKAGE_VERSION}_universal.dmg" \
-            "$MACOS_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg"
-          cp "$BUNDLE_ROOT/release/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" "$MACOS_RELEASE/"
-          cp "$BUNDLE_ROOT/release/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" "$MACOS_RELEASE/"
+            "$BUNDLE_ROOT/dmg/Atlas.Workbench_${PACKAGE_VERSION}_universal.dmg" \
+            "$MACOS_RELEASE/Atlas.Workbench_${PACKAGE_VERSION}_macOS-universal.dmg"
+          cp "$BUNDLE_ROOT/release/Atlas.Workbench_${PACKAGE_VERSION}_universal.app.tar.gz" "$MACOS_RELEASE/"
+          cp "$BUNDLE_ROOT/release/Atlas.Workbench_${PACKAGE_VERSION}_universal.app.tar.gz.sig" "$MACOS_RELEASE/"
           cp "$BUNDLE_ROOT/release/latest.json" "$MACOS_RELEASE/"
 
       - name: Preserve final public macOS release assets
@@ -548,8 +548,8 @@ jobs:
       - name: Add and verify the Linux x64 updater
         run: |
           LATEST_PATH="$RUNNER_TEMP/macos-release/latest.json"
-          LINUX_DEB_NAME="Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb"
-          LINUX_APPIMAGE_NAME="Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage"
+          LINUX_DEB_NAME="Atlas.Workbench_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb"
+          LINUX_APPIMAGE_NAME="Atlas.Workbench_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage"
           LINUX_DEB="$RUNNER_TEMP/linux-release/$LINUX_DEB_NAME"
           LINUX_APPIMAGE="$RUNNER_TEMP/linux-release/$LINUX_APPIMAGE_NAME"
           jq \
@@ -574,36 +574,36 @@ jobs:
           RELEASE_ASSETS="$RUNNER_TEMP/release-assets"
           MANIFEST_ROOT="$RUNNER_TEMP/release-manifest"
           mkdir -p "$RELEASE_ASSETS" "$MANIFEST_ROOT"
-          cp "$MACOS_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg" "$RELEASE_ASSETS/"
-          cp "$MACOS_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" "$RELEASE_ASSETS/"
-          cp "$MACOS_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" "$RELEASE_ASSETS/"
+          cp "$MACOS_RELEASE/Atlas.Workbench_${PACKAGE_VERSION}_macOS-universal.dmg" "$RELEASE_ASSETS/"
+          cp "$MACOS_RELEASE/Atlas.Workbench_${PACKAGE_VERSION}_universal.app.tar.gz" "$RELEASE_ASSETS/"
+          cp "$MACOS_RELEASE/Atlas.Workbench_${PACKAGE_VERSION}_universal.app.tar.gz.sig" "$RELEASE_ASSETS/"
           cp "$MACOS_RELEASE/latest.json" "$RELEASE_ASSETS/"
           cp \
             "$RUNNER_TEMP/windows-preview/"*-setup.exe \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_NSIS-x64-unsigned.exe"
+            "$RELEASE_ASSETS/Atlas.Workbench_${PACKAGE_VERSION}_NSIS-x64-unsigned.exe"
           cp \
-            "$RUNNER_TEMP/linux-release/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb" \
+            "$RUNNER_TEMP/linux-release/Atlas.Workbench_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb" \
             "$RELEASE_ASSETS/"
           cp \
-            "$RUNNER_TEMP/linux-release/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb.sig" \
+            "$RUNNER_TEMP/linux-release/Atlas.Workbench_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb.sig" \
             "$RELEASE_ASSETS/"
           cp \
-            "$RUNNER_TEMP/linux-release/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage" \
+            "$RUNNER_TEMP/linux-release/Atlas.Workbench_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage" \
             "$RELEASE_ASSETS/"
           cp \
-            "$RUNNER_TEMP/linux-release/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage.sig" \
+            "$RUNNER_TEMP/linux-release/Atlas.Workbench_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage.sig" \
             "$RELEASE_ASSETS/"
           (
             cd "$RELEASE_ASSETS"
             shasum -a 256 \
-              "Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg" \
-              "Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb" \
-              "Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb.sig" \
-              "Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage" \
-              "Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage.sig" \
-              "Codex.Taskboard_${PACKAGE_VERSION}_NSIS-x64-unsigned.exe" \
-              "Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" \
-              "Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" \
+              "Atlas.Workbench_${PACKAGE_VERSION}_macOS-universal.dmg" \
+              "Atlas.Workbench_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb" \
+              "Atlas.Workbench_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb.sig" \
+              "Atlas.Workbench_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage" \
+              "Atlas.Workbench_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage.sig" \
+              "Atlas.Workbench_${PACKAGE_VERSION}_NSIS-x64-unsigned.exe" \
+              "Atlas.Workbench_${PACKAGE_VERSION}_universal.app.tar.gz" \
+              "Atlas.Workbench_${PACKAGE_VERSION}_universal.app.tar.gz.sig" \
               "latest.json" > "$MANIFEST_ROOT/release-assets.sha256"
           )
 
@@ -635,16 +635,16 @@ jobs:
             "${RELEASE_FLAGS[@]}" \
             --title "Codex Taskboard $RELEASE_TAG" \
             --generate-notes \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg"
+            "$RELEASE_ASSETS/Atlas.Workbench_${PACKAGE_VERSION}_macOS-universal.dmg"
           gh release upload "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb.sig" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage.sig" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_NSIS-x64-unsigned.exe" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" \
+            "$RELEASE_ASSETS/Atlas.Workbench_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb" \
+            "$RELEASE_ASSETS/Atlas.Workbench_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb.sig" \
+            "$RELEASE_ASSETS/Atlas.Workbench_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage" \
+            "$RELEASE_ASSETS/Atlas.Workbench_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage.sig" \
+            "$RELEASE_ASSETS/Atlas.Workbench_${PACKAGE_VERSION}_NSIS-x64-unsigned.exe" \
+            "$RELEASE_ASSETS/Atlas.Workbench_${PACKAGE_VERSION}_universal.app.tar.gz" \
+            "$RELEASE_ASSETS/Atlas.Workbench_${PACKAGE_VERSION}_universal.app.tar.gz.sig" \
             "$RELEASE_ASSETS/latest.json"
 
   promote-release:
@@ -749,7 +749,7 @@ jobs:
           API_VERSION_HEADER="X-GitHub-Api-Version: 2026-03-10"
           MANIFEST_PATH="$RUNNER_TEMP/trusted-release-manifest/release-assets.sha256"
           LATEST_PATH="$RUNNER_TEMP/release-latest.json"
-          FIRST_ASSET_NAME="Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg"
+          FIRST_ASSET_NAME="Atlas.Workbench_${PACKAGE_VERSION}_macOS-universal.dmg"
           RELEASES="$(gh api --header "$API_VERSION_HEADER" \
             "repos/$GITHUB_REPOSITORY/releases?per_page=100")"
           DRAFT_RELEASE="$(jq -c \
@@ -836,7 +836,7 @@ jobs:
           set -euo pipefail
           API_VERSION_HEADER="X-GitHub-Api-Version: 2026-03-10"
           MANIFEST_PATH="$RUNNER_TEMP/trusted-release-manifest/release-assets.sha256"
-          FIRST_ASSET_NAME="Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg"
+          FIRST_ASSET_NAME="Atlas.Workbench_${PACKAGE_VERSION}_macOS-universal.dmg"
           FINAL_RELEASE="$(gh api --header "$API_VERSION_HEADER" \
             "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG")"
           LATEST_RELEASE="$(gh api --header "$API_VERSION_HEADER" \

--- a/cli/taskctl.mjs
+++ b/cli/taskctl.mjs
@@ -34,6 +34,16 @@ const COMMAND_OPTIONS = new Map([
   ["project create", new Set(["id", "name", "workspace-path", "json"])],
   ["project map", new Set(["workspace-path", "json"])],
   ["project readme", new Set(["content", "file", "if-version", "json"])],
+  ["folder list", new Set(["project", "json"])],
+  ["folder create", new Set(["project", "name", "parent", "json"])],
+  ["folder update", new Set(["name", "parent", "json"])],
+  ["document list", new Set(["project", "folder", "type", "json"])],
+  ["document get", new Set(["json"])],
+  ["document create", new Set(["project", "folder", "title", "type", "status", "task", "content", "file", "json"])],
+  ["document update", new Set(["folder", "title", "type", "status", "content", "file", "if-version", "json"])],
+  ["document history", new Set(["json"])],
+  ["document search", new Set(["project", "query", "type", "json"])],
+  ["document export", new Set(["output", "json"])],
   ["cloud login", new Set(["url", "actor-name", "json"])],
   ["cloud status", new Set(["json"])],
   ["cloud logout", new Set(["json"])],
@@ -129,6 +139,16 @@ Commands:
   project map PROJECT_ID --workspace-path PATH
   project readme get [PROJECT_ID]
   project readme set [PROJECT_ID] (--content TEXT | --file FILE) [--if-version N]
+  folder list --project PROJECT_ID
+  folder create --project PROJECT_ID --name NAME [--parent FOLDER_ID]
+  folder update FOLDER_ID [--name NAME] [--parent FOLDER_ID]
+  document list --project PROJECT_ID [--folder FOLDER_ID] [--type TYPE]
+  document get DOCUMENT_ID
+  document create --project PROJECT_ID --title TITLE [--content TEXT | --file FILE]
+  document update DOCUMENT_ID [--content TEXT | --file FILE] --if-version N
+  document history DOCUMENT_ID
+  document search --project PROJECT_ID --query TEXT [--type TYPE]
+  document export DOCUMENT_ID --output PATH
   cloud login --url URL --actor-name NAME
   cloud status|logout
   issue list|get|create|update|move|archive|restore|tree|relation
@@ -310,7 +330,7 @@ async function execute(parsed, overrides) {
   const allowedOptions = COMMAND_OPTIONS.get(command);
   if (!allowedOptions) {
     throw usageError(
-      "Expected one of: project list/create/map/readme, cloud login/status/logout, issue list/get/create/update/move/archive/restore/tree/relation, comment list/add/update/delete, attachment list/download/upload, context current",
+      "Expected one of: project list/create/map/readme, folder list/create/update, document list/get/create/update/history/search/export, cloud login/status/logout, issue list/get/create/update/move/archive/restore/tree/relation, comment list/add/update/delete, attachment list/download/upload, context current",
     );
   }
   validateOptions(parsed.options, allowedOptions);
@@ -354,6 +374,100 @@ async function execute(parsed, overrides) {
       );
     case "project readme":
       return executeProjectReadme(api, parsed, overrides);
+    case "folder list":
+      expectOperandCount(parsed, 0);
+      return api.request(
+        "GET",
+        `/api/projects/${encodeURIComponent(requiredOption(parsed.options, "project"))}/document-folders`,
+      );
+    case "folder create":
+      expectOperandCount(parsed, 0);
+      return api.request(
+        "POST",
+        `/api/projects/${encodeURIComponent(requiredOption(parsed.options, "project"))}/document-folders`,
+        {
+          name: requiredOption(parsed.options, "name"),
+          parentId: parsed.options.parent ?? null,
+        },
+      );
+    case "folder update": {
+      expectOperandCount(parsed, 1);
+      if (parsed.options.name === undefined && parsed.options.parent === undefined) {
+        throw usageError("folder update requires --name or --parent");
+      }
+      return api.request(
+        "PATCH",
+        `/api/document-folders/${encodeURIComponent(parsed.operands[0])}`,
+        {
+          ...optionalField("name", parsed.options.name),
+          ...optionalField("parentId", parsed.options.parent),
+        },
+      );
+    }
+    case "document list": {
+      expectOperandCount(parsed, 0);
+      const search = new URLSearchParams();
+      if (parsed.options.folder !== undefined) search.set("folderId", parsed.options.folder);
+      if (parsed.options.type !== undefined) search.set("type", parsed.options.type);
+      const query = search.size > 0 ? `?${search}` : "";
+      return api.request(
+        "GET",
+        `/api/projects/${encodeURIComponent(requiredOption(parsed.options, "project"))}/documents${query}`,
+      );
+    }
+    case "document get":
+      expectOperandCount(parsed, 1);
+      return api.request("GET", `/api/documents/${encodeURIComponent(parsed.operands[0])}`);
+    case "document create": {
+      expectOperandCount(parsed, 0);
+      const content = await resolveDocumentContent(parsed.options, overrides, { optional: true });
+      return api.request(
+        "POST",
+        `/api/projects/${encodeURIComponent(requiredOption(parsed.options, "project"))}/documents`,
+        {
+          title: requiredOption(parsed.options, "title"),
+          type: parsed.options.type ?? "general",
+          status: parsed.options.status ?? "draft",
+          folderId: parsed.options.folder ?? null,
+          content,
+          ...optionalField("taskId", parsed.options.task),
+        },
+      );
+    }
+    case "document update": {
+      expectOperandCount(parsed, 1);
+      const hasContent = parsed.options.content !== undefined || parsed.options.file !== undefined;
+      if (!hasContent && ["folder", "title", "type", "status"].every((name) => parsed.options[name] === undefined)) {
+        throw usageError("document update requires a document field");
+      }
+      return api.request(
+        "PUT",
+        `/api/documents/${encodeURIComponent(parsed.operands[0])}`,
+        {
+          ...optionalField("folderId", parsed.options.folder),
+          ...optionalField("title", parsed.options.title),
+          ...optionalField("type", parsed.options.type),
+          ...optionalField("status", parsed.options.status),
+          ...(hasContent ? { content: await resolveDocumentContent(parsed.options, overrides) } : {}),
+          version: explicitVersion(parsed.options["if-version"]),
+        },
+      );
+    }
+    case "document history":
+      expectOperandCount(parsed, 1);
+      return api.request("GET", `/api/documents/${encodeURIComponent(parsed.operands[0])}/revisions`);
+    case "document search": {
+      expectOperandCount(parsed, 0);
+      const search = new URLSearchParams({ q: requiredOption(parsed.options, "query") });
+      if (parsed.options.type !== undefined) search.set("type", parsed.options.type);
+      return api.request(
+        "GET",
+        `/api/projects/${encodeURIComponent(requiredOption(parsed.options, "project"))}/documents?${search}`,
+      );
+    }
+    case "document export":
+      expectOperandCount(parsed, 1);
+      return exportDocument(api, parsed.operands[0], parsed.options, overrides);
     case "cloud login":
       expectOperandCount(parsed, 0);
       return cloudLogin(
@@ -1189,6 +1303,49 @@ function taskPath(taskId) {
 function commentPath(commentId) {
   if (!commentId) throw usageError("Missing comment id");
   return `/api/comments/${encodeURIComponent(commentId)}`;
+}
+
+async function resolveDocumentContent(options, overrides, { optional = false } = {}) {
+  if (options.content !== undefined && options.file !== undefined) {
+    throw usageError("Use either --content or --file, not both");
+  }
+  if (options.content !== undefined) return options.content;
+  if (options.file === undefined) {
+    if (optional) return "";
+    throw usageError("Document content requires --content or --file");
+  }
+  const read = overrides.readFile ?? readFile;
+  const filename = resolveInputPath(options.file, overrides);
+  try {
+    return await read(filename, "utf8");
+  } catch (error) {
+    throw new TaskctlError(`Cannot read document file: ${filename}`, {
+      code: "FILE_READ_FAILED",
+      exitCode: 2,
+      details: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function exportDocument(api, documentId, options, overrides) {
+  const output = resolveInputPath(requiredOption(options, "output"), overrides);
+  const downloaded = await api.download(`/api/documents/${encodeURIComponent(documentId)}/export`);
+  const write = overrides.writeFile ?? writeFile;
+  try {
+    await write(output, downloaded.bytes);
+  } catch (error) {
+    throw new TaskctlError(`Cannot write document export: ${output}`, {
+      code: "FILE_WRITE_FAILED",
+      exitCode: 2,
+      details: error instanceof Error ? error.message : String(error),
+    });
+  }
+  return {
+    documentId,
+    output,
+    contentType: downloaded.contentType,
+    size: downloaded.size,
+  };
 }
 
 function attachmentContentPath(attachmentId) {

--- a/inject/codex-taskboard.user.js
+++ b/inject/codex-taskboard.user.js
@@ -319,10 +319,10 @@
 
   function syncEntryText(button = entry) {
     if (!button) return;
-    button.setAttribute("aria-label", hostText("打开任务面板", "Open Taskboard"));
-    button.setAttribute("title", hostText("任务面板", "Taskboard"));
-    if (entryLabel) entryLabel.textContent = hostText("任务面板", "Taskboard");
-    else button.textContent = hostText("任务面板", "Taskboard");
+    button.setAttribute("aria-label", hostText("打开阿特拉斯工作台", "Open Atlas Workbench"));
+    button.setAttribute("title", hostText("阿特拉斯工作台", "Atlas Workbench"));
+    if (entryLabel) entryLabel.textContent = hostText("阿特拉斯工作台", "Atlas Workbench");
+    else button.textContent = hostText("阿特拉斯工作台", "Atlas Workbench");
   }
 
   function syncEntryState() {
@@ -1224,7 +1224,7 @@
         payload: {
           requestId,
           ok: false,
-          error: hostText("仅本地任务面板可用", "Available only in the local Taskboard"),
+          error: hostText("仅本地阿特拉斯工作台可用", "Available only in local Atlas Workbench"),
         },
       });
       return;
@@ -1421,7 +1421,7 @@
     section.hidden = true;
     section.setAttribute(OWNED_ATTRIBUTE, "true");
     section.setAttribute("role", "region");
-    section.setAttribute("aria-label", hostText("任务面板", "Taskboard"));
+    section.setAttribute("aria-label", hostText("阿特拉斯工作台", "Atlas Workbench"));
 
     status = document.createElement("div");
     status.id = STATUS_ID;
@@ -1460,7 +1460,7 @@
 
   function renderLoading() {
     if (!status) return;
-    status.replaceChildren(document.createTextNode(hostText("正在启动任务面板…", "Starting Taskboard…")));
+    status.replaceChildren(document.createTextNode(hostText("正在启动阿特拉斯工作台…", "Starting Atlas Workbench…")));
     status.hidden = false;
     if (frame) frame.hidden = true;
   }
@@ -1501,8 +1501,8 @@
     if (hostUiLanguage === language) return;
     hostUiLanguage = language;
     syncEntryText();
-    if (page) page.setAttribute("aria-label", hostText("任务面板", "Taskboard"));
-    if (frame) frame.title = hostText("任务面板", "Taskboard");
+    if (page) page.setAttribute("aria-label", hostText("阿特拉斯工作台", "Atlas Workbench"));
+    if (frame) frame.title = hostText("阿特拉斯工作台", "Atlas Workbench");
     if (statusView === "loading") renderLoading();
     else if (statusView === "error") renderLoadError();
   }
@@ -1523,7 +1523,7 @@
         reject,
         timer: window.setTimeout(() => {
           frameReadyWaiters.delete(waiter);
-          reject(hostError("任务面板页面加载超时", "Taskboard page load timed out"));
+          reject(hostError("阿特拉斯工作台页面加载超时", "Atlas Workbench page load timed out"));
         }, FRAME_READY_TIMEOUT_MS),
       };
       frameReadyWaiters.add(waiter);
@@ -1531,7 +1531,7 @@
   }
 
   function loadTaskboardFrame(cacheBust = false) {
-    cancelFrameReadyWaiters(hostError("任务面板正在重新加载", "Taskboard is reloading"));
+    cancelFrameReadyWaiters(hostError("阿特拉斯工作台正在重新加载", "Atlas Workbench is reloading"));
     frame?.remove();
     frame = null;
     frameTaskboardUrl = "";
@@ -1557,7 +1557,7 @@
     nextFrame.hidden = true;
     nextFrame.setAttribute("sandbox", "allow-scripts allow-forms allow-modals allow-downloads");
     nextFrame.src = "about:blank";
-    nextFrame.title = hostText("任务面板", "Taskboard");
+    nextFrame.title = hostText("阿特拉斯工作台", "Atlas Workbench");
     nextFrame.referrerPolicy = "no-referrer";
     nextFrame.setAttribute("allow", "clipboard-read; clipboard-write");
     nextFrame.addEventListener("load", challengeFrameDocument);
@@ -1606,8 +1606,8 @@
   function requestHost(action, payload = {}, timeoutMs = HOST_REQUEST_TIMEOUT_MS) {
     if (!hasLiveHostBinding()) {
       return Promise.reject(hostError(
-        "Taskboard 启动器未运行，无法操作 Codex 对话输入框",
-        "The Taskboard launcher is not running, so the Codex composer is unavailable",
+        "阿特拉斯工作台启动器未运行，无法操作 Codex 对话输入框",
+        "The Atlas Workbench launcher is not running, so the Codex composer is unavailable",
       ));
     }
 
@@ -1617,7 +1617,7 @@
         ? null
         : window.setTimeout(() => {
           hostRequests.delete(id);
-          const error = hostError("任务面板启动器没有响应", "The Taskboard launcher did not respond");
+          const error = hostError("阿特拉斯工作台启动器没有响应", "The Atlas Workbench launcher did not respond");
           if (action === "start-task-conversation") error.uncertain = true;
           reject(error);
         }, timeoutMs);
@@ -1670,7 +1670,7 @@
     else {
       const error = response.error
         ? new Error(response.error)
-        : hostError("任务面板服务启动失败", "The Taskboard service failed to start");
+        : hostError("阿特拉斯工作台服务启动失败", "The Atlas Workbench service failed to start");
       if (typeof response.threadId === "string") error.threadId = response.threadId;
       if (response.uncertain === true) error.uncertain = true;
       pending.reject(error);
@@ -1727,8 +1727,8 @@
       showLoadError(bindingAvailable
         ? error
         : hostError(
-          "任务面板服务未就绪。请保持 Taskboard 启动器运行后重试。",
-          "The Taskboard service is not ready. Keep the Taskboard launcher running and try again.",
+          "阿特拉斯工作台服务未就绪。请保持启动器运行后重试。",
+          "Atlas Workbench is not ready. Keep its launcher running and try again.",
         ));
     }
   }
@@ -1909,10 +1909,10 @@
     hostContextTimer = null;
     observer?.disconnect();
     observer = null;
-    cancelFrameReadyWaiters(hostError("任务面板已关闭", "Taskboard was closed"));
+    cancelFrameReadyWaiters(hostError("阿特拉斯工作台已关闭", "Atlas Workbench was closed"));
     hostRequests.forEach(({ reject, timeout }) => {
       if (timeout !== null) window.clearTimeout(timeout);
-      reject(hostError("任务面板已关闭", "Taskboard was closed"));
+      reject(hostError("阿特拉斯工作台已关闭", "Atlas Workbench was closed"));
     });
     hostRequests.clear();
     pendingThreadCreation = null;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": ">=22.5"
   },
   "bin": {
+    "atlasctl": "./cli/taskctl.mjs",
     "taskctl": "./cli/taskctl.mjs"
   },
   "scripts": {

--- a/scripts/create-macos-updater.mjs
+++ b/scripts/create-macos-updater.mjs
@@ -34,7 +34,7 @@ function run(command, args, options = {}) {
 }
 
 await mkdir(outputDirectory, { recursive: true });
-const artifactName = `Codex.Taskboard_${packageJson.version}_universal.app.tar.gz`;
+const artifactName = `Atlas.Workbench_${packageJson.version}_universal.app.tar.gz`;
 const artifactPath = path.join(outputDirectory, artifactName);
 run("/usr/bin/tar", ["-czf", artifactPath, path.basename(appPath)], {
   cwd: path.dirname(appPath),
@@ -46,7 +46,7 @@ const downloadUrl = `https://github.com/chuspeeism/dashi-taskboard/releases/down
 const platform = { signature, url: downloadUrl };
 const latest = {
   version: releaseVersion,
-  notes: `Codex Taskboard ${releaseVersion}`,
+  notes: `Atlas Workbench ${releaseVersion}`,
   pub_date: new Date().toISOString(),
   platforms: {
     "darwin-aarch64": platform,

--- a/scripts/preflight-macos-app.mjs
+++ b/scripts/preflight-macos-app.mjs
@@ -105,7 +105,7 @@ verifyNode(appPath);
 const temporaryRoot = await mkdtemp(path.join(os.tmpdir(), "codex-taskboard-preflight."));
 let mountedDmg = null;
 try {
-  const archivePath = path.join(temporaryRoot, "Codex.Taskboard.preflight.app.tar.gz");
+  const archivePath = path.join(temporaryRoot, "Atlas.Workbench.preflight.app.tar.gz");
   run("/usr/bin/tar", ["-czf", archivePath, path.basename(appPath)], {
     cwd: path.dirname(appPath),
   });
@@ -129,7 +129,7 @@ try {
   run("/usr/bin/codesign", ["--verify", "--deep", "--strict", "--verbose=2", extractedApp]);
   verifyNode(extractedApp);
 
-  const dmgPath = path.join(temporaryRoot, "Codex.Taskboard.preflight.dmg");
+  const dmgPath = path.join(temporaryRoot, "Atlas.Workbench.preflight.dmg");
   const dmgSource = path.join(temporaryRoot, "dmg-source");
   run("/bin/mkdir", ["-p", dmgSource]);
   run("/usr/bin/ditto", [appPath, path.join(dmgSource, path.basename(appPath))]);

--- a/scripts/tauri-build.mjs
+++ b/scripts/tauri-build.mjs
@@ -6,8 +6,8 @@ import path from "node:path";
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const productName = process.env.CODEX_TASKBOARD_RELEASE_VERSION?.includes("-beta.")
-  ? "Codex Taskboard Beta"
-  : "Codex Taskboard";
+  ? "Atlas Workbench Beta"
+  : "Atlas Workbench";
 const tauriCli = path.join(projectRoot, "node_modules", "@tauri-apps", "cli", "tauri.js");
 const result = spawnSync(
   process.execPath,

--- a/scripts/verify-linux-packages.mjs
+++ b/scripts/verify-linux-packages.mjs
@@ -14,8 +14,8 @@ if (process.platform !== "linux") {
   throw new Error("Linux packages must be verified on Linux");
 }
 const productName = process.env.CODEX_TASKBOARD_RELEASE_VERSION?.includes("-beta.")
-  ? "Codex Taskboard Beta"
-  : "Codex Taskboard";
+  ? "Atlas Workbench Beta"
+  : "Atlas Workbench";
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {

--- a/scripts/verify-macos-release.mjs
+++ b/scripts/verify-macos-release.mjs
@@ -45,7 +45,7 @@ if (releaseTag !== stableTag && !/^[1-9]\d*$/.test(betaNumber)) {
   throw new Error("Release tag does not match package.json version");
 }
 const releaseVersion = releaseTag.slice(1);
-const productName = betaNumber ? "Codex Taskboard Beta" : tauriConfig.productName;
+const productName = betaNumber ? "Atlas Workbench Beta" : tauriConfig.productName;
 const appName = `${productName}.app`;
 
 function run(command, args, options = {}) {
@@ -147,7 +147,7 @@ async function manifest(root, relative = "") {
   return entries;
 }
 
-const artifactName = `Codex.Taskboard_${packageJson.version}_universal.app.tar.gz`;
+const artifactName = `Atlas.Workbench_${packageJson.version}_universal.app.tar.gz`;
 const artifactPath = path.join(releaseDirectory, artifactName);
 const signaturePath = `${artifactPath}.sig`;
 const signature = await readFile(signaturePath, "utf8");

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -38,6 +38,9 @@ const execFileAsync = promisify(execFile);
 const JSON_BODY_LIMIT = 1024 * 1024;
 const PROJECT_README_BODY_LIMIT = 3 * 1024 * 1024;
 const ATTACHMENT_BODY_LIMIT = 25 * 1024 * 1024;
+const DOCUMENT_BODY_LIMIT = 3 * 1024 * 1024;
+const DOCUMENT_TYPES = new Set(["general", "spec", "plan", "tasks", "run-report", "test-report"]);
+const DOCUMENT_STATUSES = new Set(["draft", "awaiting_confirmation", "approved", "frozen", "superseded"]);
 const AI_CHAT_TURN_BODY_LIMIT = 25 * 1024 * 1024;
 const AI_CHAT_ATTACHMENT_LIMIT = 10;
 const AI_CHAT_SKILL_MARKER = "\uFFFC";
@@ -517,6 +520,93 @@ function parseProjectReadmeSave(body) {
     throw new ApiError(400, "INVALID_FIELD", "'version' must be a non-negative integer");
   }
   return { content, version };
+}
+
+function parseDocumentFolderCreate(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["name", "parentId"]));
+  return {
+    name: stringField(body.name, "name", { required: true, maxLength: 120 }),
+    parentId: stringField(body.parentId ?? null, "parentId", { nullable: true, maxLength: 128 }),
+  };
+}
+
+function parseDocumentFolderUpdate(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["name", "parentId"]));
+  if (body.name === undefined && body.parentId === undefined) {
+    throw new ApiError(400, "INVALID_BODY", "PATCH requires name or parentId");
+  }
+  return {
+    ...(body.name === undefined
+      ? {}
+      : { name: stringField(body.name, "name", { required: true, maxLength: 120 }) }),
+    ...(body.parentId === undefined
+      ? {}
+      : { parentId: stringField(body.parentId, "parentId", { nullable: true, maxLength: 128 }) }),
+  };
+}
+
+function parseDocumentType(value, fallback = "general") {
+  const type = value ?? fallback;
+  if (!DOCUMENT_TYPES.has(type)) {
+    throw new ApiError(400, "INVALID_FIELD", "'type' is not a supported document type");
+  }
+  return type;
+}
+
+function parseDocumentStatus(value, fallback = "draft") {
+  const status = value ?? fallback;
+  if (!DOCUMENT_STATUSES.has(status)) {
+    throw new ApiError(400, "INVALID_FIELD", "'status' is not a supported document status");
+  }
+  return status;
+}
+
+function parseDocumentContent(value) {
+  const content = value ?? "";
+  if (typeof content !== "string") {
+    throw new ApiError(400, "INVALID_FIELD", "'content' must be a string");
+  }
+  if (content.length > 500_000) {
+    throw new ApiError(400, "INVALID_FIELD", "'content' cannot exceed 500000 characters");
+  }
+  return content;
+}
+
+function parseDocumentCreate(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["folderId", "title", "type", "status", "content", "taskId"]));
+  return {
+    folderId: stringField(body.folderId ?? null, "folderId", { nullable: true, maxLength: 128 }),
+    title: stringField(body.title, "title", { required: true, maxLength: 240 }),
+    type: parseDocumentType(body.type),
+    status: parseDocumentStatus(body.status),
+    content: parseDocumentContent(body.content),
+    taskId: stringField(body.taskId ?? null, "taskId", { nullable: true, maxLength: 128 }),
+  };
+}
+
+function parseDocumentUpdate(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["folderId", "title", "type", "status", "content", "version"]));
+  if (!Number.isSafeInteger(body.version) || body.version < 1) {
+    throw new ApiError(400, "INVALID_FIELD", "'version' must be a positive integer");
+  }
+  const changes = {};
+  if (body.folderId !== undefined) {
+    changes.folderId = stringField(body.folderId, "folderId", { nullable: true, maxLength: 128 });
+  }
+  if (body.title !== undefined) {
+    changes.title = stringField(body.title, "title", { required: true, maxLength: 240 });
+  }
+  if (body.type !== undefined) changes.type = parseDocumentType(body.type);
+  if (body.status !== undefined) changes.status = parseDocumentStatus(body.status);
+  if (body.content !== undefined) changes.content = parseDocumentContent(body.content);
+  if (Object.keys(changes).length === 0) {
+    throw new ApiError(400, "INVALID_BODY", "PUT requires at least one document field");
+  }
+  return { changes, version: body.version };
 }
 
 function parseThreadId(value) {
@@ -2697,6 +2787,246 @@ export function createTaskboardServer(options = {}) {
         return sendJson(response, 200, { project });
       }
 
+      const documentFoldersRoute = pathname.match(/^\/api\/projects\/([^/]+)\/document-folders$/);
+      if (documentFoldersRoute) {
+        let projectId;
+        try {
+          projectId = decodeURIComponent(documentFoldersRoute[1]);
+        } catch {
+          throw new ApiError(400, "INVALID_PATH", "Project id contains invalid encoding");
+        }
+        validateProjectId(projectId);
+        if ([...url.searchParams.keys()].length > 0) {
+          throw new ApiError(400, "UNKNOWN_QUERY_PARAMETER", "Document folder routes do not accept query parameters");
+        }
+        if (request.method === "GET") {
+          return sendJson(response, 200, { folders: database.listDocumentFolders(projectId) });
+        }
+        if (request.method === "POST") {
+          const folder = database.createDocumentFolder(
+            projectId,
+            parseDocumentFolderCreate(await readJson(request)),
+          );
+          events.emit("document.folder.created", { projectId, folder });
+          return sendJson(response, 201, { folder });
+        }
+        return methodNotAllowed(response, ["GET", "POST"]);
+      }
+
+      const documentFolderRoute = pathname.match(/^\/api\/document-folders\/([^/]+)$/);
+      if (documentFolderRoute) {
+        let folderId;
+        try {
+          folderId = decodeURIComponent(documentFolderRoute[1]);
+        } catch {
+          throw new ApiError(400, "INVALID_PATH", "Document folder id contains invalid encoding");
+        }
+        if (!folderId || folderId.length > 128) {
+          throw new ApiError(400, "INVALID_PATH", "Document folder id is invalid");
+        }
+        if ([...url.searchParams.keys()].length > 0) {
+          throw new ApiError(400, "UNKNOWN_QUERY_PARAMETER", "Document folder routes do not accept query parameters");
+        }
+        if (request.method !== "PATCH") return methodNotAllowed(response, ["PATCH"]);
+        const folder = database.updateDocumentFolder(
+          folderId,
+          parseDocumentFolderUpdate(await readJson(request)),
+        );
+        events.emit("document.folder.updated", { projectId: folder.projectId, folder });
+        return sendJson(response, 200, { folder });
+      }
+
+      const projectDocumentsRoute = pathname.match(/^\/api\/projects\/([^/]+)\/documents$/);
+      if (projectDocumentsRoute) {
+        let projectId;
+        try {
+          projectId = decodeURIComponent(projectDocumentsRoute[1]);
+        } catch {
+          throw new ApiError(400, "INVALID_PATH", "Project id contains invalid encoding");
+        }
+        validateProjectId(projectId);
+        if (request.method === "GET") {
+          const allowed = new Set(["folderId", "q", "type"]);
+          const unknown = [...url.searchParams.keys()].find((key) => !allowed.has(key));
+          if (unknown) throw new ApiError(400, "UNKNOWN_QUERY_PARAMETER", `Unknown query parameter: ${unknown}`);
+          const options = {};
+          if (url.searchParams.has("folderId")) {
+            options.folderId = url.searchParams.get("folderId") || null;
+          }
+          const query = url.searchParams.get("q")?.trim();
+          if (query) options.query = query.slice(0, 240);
+          if (url.searchParams.has("type")) options.type = parseDocumentType(url.searchParams.get("type"));
+          return sendJson(response, 200, { documents: database.listDocuments(projectId, options) });
+        }
+        if ([...url.searchParams.keys()].length > 0) {
+          throw new ApiError(400, "UNKNOWN_QUERY_PARAMETER", "POST document routes do not accept query parameters");
+        }
+        if (request.method === "POST") {
+          const document = database.createDocument(
+            projectId,
+            parseDocumentCreate(await readJson(
+              request,
+              DOCUMENT_BODY_LIMIT,
+              "Document request cannot exceed 3 MiB",
+            )),
+            actorFromRequest(request),
+          );
+          events.emit("document.created", { projectId, document });
+          return sendJson(response, 201, { document });
+        }
+        return methodNotAllowed(response, ["GET", "POST"]);
+      }
+
+      const documentRevisionsRoute = pathname.match(/^\/api\/documents\/([^/]+)\/revisions$/);
+      if (documentRevisionsRoute) {
+        let documentId;
+        try {
+          documentId = decodeURIComponent(documentRevisionsRoute[1]);
+        } catch {
+          throw new ApiError(400, "INVALID_PATH", "Document id contains invalid encoding");
+        }
+        if ([...url.searchParams.keys()].length > 0) {
+          throw new ApiError(400, "UNKNOWN_QUERY_PARAMETER", "Document revision routes do not accept query parameters");
+        }
+        if (request.method !== "GET") return methodNotAllowed(response, ["GET"]);
+        return sendJson(response, 200, { revisions: database.listDocumentRevisions(documentId) });
+      }
+
+      const documentExportRoute = pathname.match(/^\/api\/documents\/([^/]+)\/export$/);
+      if (documentExportRoute) {
+        let documentId;
+        try {
+          documentId = decodeURIComponent(documentExportRoute[1]);
+        } catch {
+          throw new ApiError(400, "INVALID_PATH", "Document id contains invalid encoding");
+        }
+        if ([...url.searchParams.keys()].length > 0) {
+          throw new ApiError(400, "UNKNOWN_QUERY_PARAMETER", "Document export routes do not accept query parameters");
+        }
+        if (request.method !== "GET" && request.method !== "HEAD") {
+          return methodNotAllowed(response, ["GET", "HEAD"]);
+        }
+        const document = database.getDocument(documentId);
+        if (!document) throw new ApiError(404, "DOCUMENT_NOT_FOUND", `Document '${documentId}' does not exist`);
+        const filename = `${document.title.replace(/[\\/:*?"<>|]/g, "-") || "document"}.md`;
+        const encodedFilename = encodeURIComponent(filename).replace(/['()*]/g, (character) => (
+          `%${character.charCodeAt(0).toString(16).toUpperCase()}`
+        ));
+        const body = Buffer.from(document.content, "utf8");
+        response.writeHead(200, {
+          "cache-control": "private, no-store",
+          "content-disposition": `attachment; filename*=UTF-8''${encodedFilename}`,
+          "content-length": body.length,
+          "content-type": "text/markdown; charset=utf-8",
+        });
+        response.end(request.method === "HEAD" ? undefined : body);
+        return;
+      }
+
+      const documentAttachmentsRoute = pathname.match(/^\/api\/documents\/([^/]+)\/attachments$/);
+      if (documentAttachmentsRoute) {
+        let documentId;
+        try {
+          documentId = decodeURIComponent(documentAttachmentsRoute[1]);
+        } catch {
+          throw new ApiError(400, "INVALID_PATH", "Document id contains invalid encoding");
+        }
+        if ([...url.searchParams.keys()].length > 0) {
+          throw new ApiError(400, "UNKNOWN_QUERY_PARAMETER", "Document attachment routes do not accept query parameters");
+        }
+        if (request.method === "GET") {
+          return sendJson(response, 200, { attachments: database.listDocumentAttachments(documentId) });
+        }
+        if (request.method !== "POST") return methodNotAllowed(response, ["GET", "POST"]);
+        const metadata = parseAttachmentHeaders(request);
+        const body = await readBody(request, ATTACHMENT_BODY_LIMIT, "Attachment cannot exceed 25 MiB");
+        const id = randomUUID();
+        await mkdir(resolved.attachmentsDirectory, { recursive: true });
+        const storagePath = path.join(resolved.attachmentsDirectory, id);
+        await writeFile(storagePath, body, { flag: "wx" });
+        let attachment;
+        try {
+          attachment = database.createDocumentAttachment(documentId, {
+            id,
+            ...metadata,
+            size: body.length,
+          });
+        } catch (error) {
+          await unlink(storagePath);
+          throw error;
+        }
+        events.emit("document.attachment.created", {
+          projectId: database.getDocument(documentId)?.projectId,
+          documentId,
+          attachment,
+        });
+        return sendJson(response, 201, { attachment });
+      }
+
+      const documentAttachmentContentRoute = pathname.match(/^\/api\/document-attachments\/([^/]+)\/content$/);
+      if (documentAttachmentContentRoute) {
+        let attachmentId;
+        try {
+          attachmentId = decodeURIComponent(documentAttachmentContentRoute[1]);
+        } catch {
+          throw new ApiError(400, "INVALID_PATH", "Document attachment id contains invalid encoding");
+        }
+        if ([...url.searchParams.keys()].length > 0) {
+          throw new ApiError(400, "UNKNOWN_QUERY_PARAMETER", "Document attachment routes do not accept query parameters");
+        }
+        if (request.method !== "GET" && request.method !== "HEAD") {
+          return methodNotAllowed(response, ["GET", "HEAD"]);
+        }
+        const attachment = database.getDocumentAttachment(attachmentId);
+        if (!attachment) throw new ApiError(404, "ATTACHMENT_NOT_FOUND", `Attachment '${attachmentId}' does not exist`);
+        const body = await readFile(path.join(resolved.attachmentsDirectory, attachment.id));
+        const encodedFilename = encodeURIComponent(attachment.filename).replace(/['()*]/g, (character) => (
+          `%${character.charCodeAt(0).toString(16).toUpperCase()}`
+        ));
+        response.writeHead(200, {
+          "cache-control": "private, no-store",
+          "content-disposition": `attachment; filename*=UTF-8''${encodedFilename}`,
+          "content-length": body.length,
+          "content-type": "application/octet-stream",
+        });
+        response.end(request.method === "HEAD" ? undefined : body);
+        return;
+      }
+
+      const documentRoute = pathname.match(/^\/api\/documents\/([^/]+)$/);
+      if (documentRoute) {
+        let documentId;
+        try {
+          documentId = decodeURIComponent(documentRoute[1]);
+        } catch {
+          throw new ApiError(400, "INVALID_PATH", "Document id contains invalid encoding");
+        }
+        if ([...url.searchParams.keys()].length > 0) {
+          throw new ApiError(400, "UNKNOWN_QUERY_PARAMETER", "Document routes do not accept query parameters");
+        }
+        if (request.method === "GET") {
+          const document = database.getDocument(documentId);
+          if (!document) throw new ApiError(404, "DOCUMENT_NOT_FOUND", `Document '${documentId}' does not exist`);
+          return sendJson(response, 200, { document });
+        }
+        if (request.method === "PUT") {
+          const input = parseDocumentUpdate(await readJson(
+            request,
+            DOCUMENT_BODY_LIMIT,
+            "Document request cannot exceed 3 MiB",
+          ));
+          const document = database.updateDocument(
+            documentId,
+            input.changes,
+            input.version,
+            actorFromRequest(request),
+          );
+          events.emit("document.updated", { projectId: document.projectId, document });
+          return sendJson(response, 200, { document });
+        }
+        return methodNotAllowed(response, ["GET", "PUT"]);
+      }
+
       const projectReadmeAttachmentsRoute = pathname.match(
         /^\/api\/projects\/([^/]+)\/readme\/attachments$/,
       );
@@ -2756,7 +3086,12 @@ export function createTaskboardServer(options = {}) {
             PROJECT_README_BODY_LIMIT,
             "Project README request cannot exceed 3 MiB",
           ));
-          const readme = database.saveProjectReadme(projectId, input.content, input.version);
+          const readme = database.saveProjectReadme(
+            projectId,
+            input.content,
+            input.version,
+            actorFromRequest(request),
+          );
           events.emit("project.readme.updated", {
             projectId,
             readmeVersion: readme.version,

--- a/server/codex-app-server.mjs
+++ b/server/codex-app-server.mjs
@@ -126,7 +126,7 @@ export class CodexAppServer {
         this.#sendRequest("initialize", {
           clientInfo: {
             name: "codex-taskboard",
-            title: "Codex Taskboard",
+            title: "Atlas Workbench",
             version: "1.0.1",
           },
           capabilities: {

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -387,6 +387,76 @@ function projectReadmeAttachmentFromRow(row) {
   };
 }
 
+function documentFolderFromRow(row) {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    parentId: row.parent_id,
+    name: row.name,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function documentActorFromRow(row, prefix) {
+  return {
+    type: row[`${prefix}_by_type`],
+    id: row[`${prefix}_by_id`],
+    name: row[`${prefix}_by_name`],
+    avatarUrl: row[`${prefix}_by_avatar_url`],
+  };
+}
+
+function documentFromRow(row) {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    folderId: row.folder_id,
+    title: row.title,
+    type: row.type,
+    status: row.status,
+    content: row.content,
+    size: Buffer.byteLength(row.content, "utf8"),
+    version: row.version,
+    isProjectOverview: row.is_project_overview === 1,
+    createdBy: documentActorFromRow(row, "created"),
+    updatedBy: documentActorFromRow(row, "updated"),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function documentRevisionFromRow(row) {
+  return {
+    id: row.id,
+    documentId: row.document_id,
+    version: row.version,
+    title: row.title,
+    type: row.type,
+    status: row.status,
+    content: row.content,
+    updatedBy: {
+      type: row.updated_by_type,
+      id: row.updated_by_id,
+      name: row.updated_by_name,
+      avatarUrl: row.updated_by_avatar_url,
+    },
+    createdAt: row.created_at,
+  };
+}
+
+function documentAttachmentFromRow(row) {
+  return {
+    id: row.id,
+    documentId: row.document_id,
+    kind: row.kind,
+    filename: row.filename,
+    contentType: row.content_type,
+    size: row.size,
+    createdAt: row.created_at,
+  };
+}
+
 function aiChatRunFromRow(row) {
   return {
     id: row.id,
@@ -587,6 +657,89 @@ export class TaskboardDatabase {
         created_at TEXT NOT NULL
       );
 
+      CREATE TABLE IF NOT EXISTS document_folders (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        parent_id TEXT REFERENCES document_folders(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS document_folders_project_parent
+        ON document_folders(project_id, parent_id, name, id);
+
+      CREATE TABLE IF NOT EXISTS documents (
+        id TEXT PRIMARY KEY,
+        project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        folder_id TEXT REFERENCES document_folders(id) ON DELETE SET NULL,
+        title TEXT NOT NULL,
+        type TEXT NOT NULL CHECK (type IN (
+          'general', 'spec', 'plan', 'tasks', 'run-report', 'test-report'
+        )),
+        status TEXT NOT NULL CHECK (status IN (
+          'draft', 'awaiting_confirmation', 'approved', 'frozen', 'superseded'
+        )),
+        content TEXT NOT NULL DEFAULT '',
+        version INTEGER NOT NULL DEFAULT 1 CHECK (version > 0),
+        is_project_overview INTEGER NOT NULL DEFAULT 0 CHECK (is_project_overview IN (0, 1)),
+        created_by_type TEXT NOT NULL,
+        created_by_id TEXT NOT NULL,
+        created_by_name TEXT NOT NULL,
+        created_by_avatar_url TEXT,
+        updated_by_type TEXT NOT NULL,
+        updated_by_id TEXT NOT NULL,
+        updated_by_name TEXT NOT NULL,
+        updated_by_avatar_url TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS documents_project_folder_updated
+        ON documents(project_id, folder_id, updated_at DESC, id);
+
+      CREATE UNIQUE INDEX IF NOT EXISTS documents_one_project_overview
+        ON documents(project_id) WHERE is_project_overview = 1;
+
+      CREATE TABLE IF NOT EXISTS document_revisions (
+        id TEXT PRIMARY KEY,
+        document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+        version INTEGER NOT NULL CHECK (version > 0),
+        title TEXT NOT NULL,
+        type TEXT NOT NULL,
+        status TEXT NOT NULL,
+        content TEXT NOT NULL,
+        updated_by_type TEXT NOT NULL,
+        updated_by_id TEXT NOT NULL,
+        updated_by_name TEXT NOT NULL,
+        updated_by_avatar_url TEXT,
+        created_at TEXT NOT NULL,
+        UNIQUE(document_id, version)
+      );
+
+      CREATE INDEX IF NOT EXISTS document_revisions_document_version
+        ON document_revisions(document_id, version DESC);
+
+      CREATE TABLE IF NOT EXISTS task_documents (
+        task_id TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+        document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY(task_id, document_id)
+      );
+
+      CREATE TABLE IF NOT EXISTS document_attachments (
+        id TEXT PRIMARY KEY,
+        document_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+        kind TEXT NOT NULL CHECK (kind IN ('inline', 'attachment')),
+        filename TEXT NOT NULL,
+        content_type TEXT NOT NULL,
+        size INTEGER NOT NULL CHECK (size >= 0),
+        created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS document_attachments_document_created
+        ON document_attachments(document_id, created_at, id);
+
       CREATE TABLE IF NOT EXISTS project_summaries (
         project_id TEXT PRIMARY KEY REFERENCES projects(id) ON DELETE CASCADE,
         summary TEXT,
@@ -653,6 +806,34 @@ export class TaskboardDatabase {
       CREATE INDEX IF NOT EXISTS ai_chat_events_thread_created
         ON ai_chat_events(thread_id, created_at, id);
 
+    `);
+
+    this.database.exec(`
+      INSERT OR IGNORE INTO documents (
+        id, project_id, folder_id, title, type, status, content, version,
+        is_project_overview,
+        created_by_type, created_by_id, created_by_name, created_by_avatar_url,
+        updated_by_type, updated_by_id, updated_by_name, updated_by_avatar_url,
+        created_at, updated_at
+      )
+      SELECT
+        'project-overview:' || project_id, project_id, NULL, '项目说明', 'general', 'draft',
+        content, version, 1,
+        'agent', 'migration-agent', '系统迁移', NULL,
+        'agent', 'migration-agent', '系统迁移', NULL,
+        created_at, updated_at
+      FROM project_readmes;
+
+      INSERT OR IGNORE INTO document_revisions (
+        id, document_id, version, title, type, status, content,
+        updated_by_type, updated_by_id, updated_by_name, updated_by_avatar_url, created_at
+      )
+      SELECT
+        'project-overview:' || project_id || ':v' || version,
+        'project-overview:' || project_id,
+        version, '项目说明', 'general', 'draft', content,
+        'agent', 'migration-agent', '系统迁移', NULL, updated_at
+      FROM project_readmes;
     `);
 
     const projectColumns = this.database.prepare("PRAGMA table_info(projects)").all();
@@ -1497,59 +1678,288 @@ export class TaskboardDatabase {
     return this.getProjectSummary(projectId);
   }
 
+  listDocumentFolders(projectId) {
+    if (!this.database.prepare("SELECT 1 FROM projects WHERE id = ?").get(projectId)) {
+      throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${projectId}' does not exist`);
+    }
+    return this.database.prepare(`
+      SELECT * FROM document_folders
+      WHERE project_id = ?
+      ORDER BY name COLLATE NOCASE, id
+    `).all(projectId).map(documentFolderFromRow);
+  }
+
+  createDocumentFolder(projectId, input) {
+    if (!this.database.prepare("SELECT 1 FROM projects WHERE id = ?").get(projectId)) {
+      throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${projectId}' does not exist`);
+    }
+    if (input.parentId !== null && input.parentId !== undefined) {
+      const parent = this.database.prepare(`
+        SELECT project_id FROM document_folders WHERE id = ?
+      `).get(input.parentId);
+      if (!parent || parent.project_id !== projectId) {
+        throw new ApiError(400, "INVALID_FOLDER", "Parent folder does not belong to this project");
+      }
+    }
+    const timestamp = now();
+    const id = input.id ?? randomUUID();
+    this.database.prepare(`
+      INSERT INTO document_folders (id, project_id, parent_id, name, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(id, projectId, input.parentId ?? null, input.name, timestamp, timestamp);
+    return documentFolderFromRow(this.database.prepare(`
+      SELECT * FROM document_folders WHERE id = ?
+    `).get(id));
+  }
+
+  updateDocumentFolder(id, changes) {
+    const current = this.database.prepare("SELECT * FROM document_folders WHERE id = ?").get(id);
+    if (!current) throw new ApiError(404, "DOCUMENT_FOLDER_NOT_FOUND", `Document folder '${id}' does not exist`);
+    const parentId = changes.parentId === undefined ? current.parent_id : changes.parentId;
+    if (parentId === id) throw new ApiError(400, "INVALID_FOLDER", "A folder cannot contain itself");
+    if (parentId !== null) {
+      const parent = this.database.prepare("SELECT project_id FROM document_folders WHERE id = ?").get(parentId);
+      if (!parent || parent.project_id !== current.project_id) {
+        throw new ApiError(400, "INVALID_FOLDER", "Parent folder does not belong to this project");
+      }
+    }
+    this.database.prepare(`
+      UPDATE document_folders
+      SET name = ?, parent_id = ?, updated_at = ?
+      WHERE id = ?
+    `).run(changes.name ?? current.name, parentId, now(), id);
+    return documentFolderFromRow(this.database.prepare("SELECT * FROM document_folders WHERE id = ?").get(id));
+  }
+
+  #documentWithTaskIds(row) {
+    if (!row) return null;
+    const document = documentFromRow(row);
+    document.taskIds = this.database.prepare(`
+      SELECT task_id FROM task_documents WHERE document_id = ? ORDER BY created_at, task_id
+    `).all(document.id).map((relation) => relation.task_id);
+    return document;
+  }
+
+  listDocuments(projectId, options = {}) {
+    if (!this.database.prepare("SELECT 1 FROM projects WHERE id = ?").get(projectId)) {
+      throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${projectId}' does not exist`);
+    }
+    const where = ["project_id = ?"];
+    const params = [projectId];
+    if (Object.hasOwn(options, "folderId")) {
+      where.push(options.folderId === null ? "folder_id IS NULL" : "folder_id = ?");
+      if (options.folderId !== null) params.push(options.folderId);
+    }
+    if (options.type) {
+      where.push("type = ?");
+      params.push(options.type);
+    }
+    if (options.query) {
+      where.push("(title LIKE ? ESCAPE '\\' OR content LIKE ? ESCAPE '\\')");
+      const escaped = options.query.replace(/[\\%_]/g, "\\$&");
+      params.push(`%${escaped}%`, `%${escaped}%`);
+    }
+    return this.database.prepare(`
+      SELECT * FROM documents
+      WHERE ${where.join(" AND ")}
+      ORDER BY is_project_overview DESC, updated_at DESC, title COLLATE NOCASE, id
+    `).all(...params).map((row) => this.#documentWithTaskIds(row));
+  }
+
+  getDocument(id) {
+    return this.#documentWithTaskIds(this.database.prepare("SELECT * FROM documents WHERE id = ?").get(id));
+  }
+
+  createDocument(projectId, input, actor) {
+    if (!this.database.prepare("SELECT 1 FROM projects WHERE id = ?").get(projectId)) {
+      throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${projectId}' does not exist`);
+    }
+    if (input.folderId !== null && input.folderId !== undefined) {
+      const folder = this.database.prepare("SELECT project_id FROM document_folders WHERE id = ?").get(input.folderId);
+      if (!folder || folder.project_id !== projectId) {
+        throw new ApiError(400, "INVALID_FOLDER", "Document folder does not belong to this project");
+      }
+    }
+    if (input.taskId) {
+      const task = this.database.prepare("SELECT project_id FROM tasks WHERE id = ? OR identifier = ?").get(input.taskId, input.taskId);
+      if (!task || task.project_id !== projectId) {
+        throw new ApiError(400, "INVALID_TASK", "Document task does not belong to this project");
+      }
+    }
+    const id = input.id ?? randomUUID();
+    const timestamp = input.timestamp ?? now();
+    const version = input.version ?? 1;
+    const principal = actor ?? { type: "user", id: "local-user", name: "本地用户", avatarUrl: null };
+    this.database.exec("BEGIN IMMEDIATE");
+    try {
+      this.database.prepare(`
+        INSERT INTO documents (
+          id, project_id, folder_id, title, type, status, content, version, is_project_overview,
+          created_by_type, created_by_id, created_by_name, created_by_avatar_url,
+          updated_by_type, updated_by_id, updated_by_name, updated_by_avatar_url,
+          created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        id, projectId, input.folderId ?? null, input.title, input.type ?? "general",
+        input.status ?? "draft", input.content ?? "", version, input.isProjectOverview ? 1 : 0,
+        principal.type, principal.id, principal.name, principal.avatarUrl ?? null,
+        principal.type, principal.id, principal.name, principal.avatarUrl ?? null,
+        timestamp, timestamp,
+      );
+      this.database.prepare(`
+        INSERT INTO document_revisions (
+          id, document_id, version, title, type, status, content,
+          updated_by_type, updated_by_id, updated_by_name, updated_by_avatar_url, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        `${id}:v${version}`, id, version, input.title, input.type ?? "general",
+        input.status ?? "draft", input.content ?? "",
+        principal.type, principal.id, principal.name, principal.avatarUrl ?? null, timestamp,
+      );
+      if (input.taskId) {
+        const task = this.database.prepare("SELECT id FROM tasks WHERE id = ? OR identifier = ?").get(input.taskId, input.taskId);
+        this.database.prepare(`
+          INSERT INTO task_documents (task_id, document_id, created_at) VALUES (?, ?, ?)
+        `).run(task.id, id, timestamp);
+      }
+      this.database.exec("COMMIT");
+    } catch (error) {
+      this.database.exec("ROLLBACK");
+      throw error;
+    }
+    return this.getDocument(id);
+  }
+
+  updateDocument(id, changes, expectedVersion, actor) {
+    const principal = actor ?? { type: "user", id: "local-user", name: "本地用户", avatarUrl: null };
+    this.database.exec("BEGIN IMMEDIATE");
+    try {
+      const current = this.database.prepare("SELECT * FROM documents WHERE id = ?").get(id);
+      if (!current) throw new ApiError(404, "DOCUMENT_NOT_FOUND", `Document '${id}' does not exist`);
+      if (current.version !== expectedVersion) {
+        throw new ApiError(409, "VERSION_CONFLICT", "Document changed since it was last read", {
+          expectedVersion,
+          actualVersion: current.version,
+        });
+      }
+      if (current.status === "frozen" && changes.content !== undefined) {
+        throw new ApiError(409, "DOCUMENT_FROZEN", "Frozen documents cannot be overwritten");
+      }
+      const folderId = changes.folderId === undefined ? current.folder_id : changes.folderId;
+      if (folderId !== null) {
+        const folder = this.database.prepare("SELECT project_id FROM document_folders WHERE id = ?").get(folderId);
+        if (!folder || folder.project_id !== current.project_id) {
+          throw new ApiError(400, "INVALID_FOLDER", "Document folder does not belong to this project");
+        }
+      }
+      const timestamp = now();
+      const version = current.version + 1;
+      const title = changes.title ?? current.title;
+      const type = changes.type ?? current.type;
+      const status = changes.status ?? current.status;
+      const content = changes.content ?? current.content;
+      this.database.prepare(`
+        UPDATE documents
+        SET folder_id = ?, title = ?, type = ?, status = ?, content = ?, version = ?,
+            updated_by_type = ?, updated_by_id = ?, updated_by_name = ?, updated_by_avatar_url = ?,
+            updated_at = ?
+        WHERE id = ? AND version = ?
+      `).run(
+        folderId, title, type, status, content, version,
+        principal.type, principal.id, principal.name, principal.avatarUrl ?? null,
+        timestamp, id, expectedVersion,
+      );
+      this.database.prepare(`
+        INSERT INTO document_revisions (
+          id, document_id, version, title, type, status, content,
+          updated_by_type, updated_by_id, updated_by_name, updated_by_avatar_url, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        `${id}:v${version}`, id, version, title, type, status, content,
+        principal.type, principal.id, principal.name, principal.avatarUrl ?? null, timestamp,
+      );
+      this.database.exec("COMMIT");
+    } catch (error) {
+      this.database.exec("ROLLBACK");
+      throw error;
+    }
+    return this.getDocument(id);
+  }
+
+  listDocumentRevisions(documentId) {
+    if (!this.getDocument(documentId)) {
+      throw new ApiError(404, "DOCUMENT_NOT_FOUND", `Document '${documentId}' does not exist`);
+    }
+    return this.database.prepare(`
+      SELECT * FROM document_revisions
+      WHERE document_id = ?
+      ORDER BY version DESC
+    `).all(documentId).map(documentRevisionFromRow);
+  }
+
+  createDocumentAttachment(documentId, input) {
+    if (!this.getDocument(documentId)) {
+      throw new ApiError(404, "DOCUMENT_NOT_FOUND", `Document '${documentId}' does not exist`);
+    }
+    this.database.prepare(`
+      INSERT INTO document_attachments (
+        id, document_id, kind, filename, content_type, size, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      input.id, documentId, input.kind, input.filename, input.contentType, input.size, now(),
+    );
+    return this.getDocumentAttachment(input.id);
+  }
+
+  getDocumentAttachment(id) {
+    const row = this.database.prepare("SELECT * FROM document_attachments WHERE id = ?").get(id);
+    return row ? documentAttachmentFromRow(row) : null;
+  }
+
+  listDocumentAttachments(documentId) {
+    if (!this.getDocument(documentId)) {
+      throw new ApiError(404, "DOCUMENT_NOT_FOUND", `Document '${documentId}' does not exist`);
+    }
+    return this.database.prepare(`
+      SELECT * FROM document_attachments WHERE document_id = ? ORDER BY created_at, id
+    `).all(documentId).map(documentAttachmentFromRow);
+  }
+
   getProjectReadme(projectId) {
     if (!this.database.prepare("SELECT 1 FROM projects WHERE id = ?").get(projectId)) {
       throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${projectId}' does not exist`);
     }
     const row = this.database.prepare(`
       SELECT project_id, content, version, created_at, updated_at
-      FROM project_readmes
-      WHERE project_id = ?
+      FROM documents
+      WHERE project_id = ? AND is_project_overview = 1
     `).get(projectId);
     return row
       ? projectReadmeFromRow(row, projectId)
       : { projectId, content: "", version: 0, createdAt: null, updatedAt: null };
   }
 
-  saveProjectReadme(projectId, content, expectedVersion) {
-    const timestamp = now();
-    this.database.exec("BEGIN IMMEDIATE");
-    try {
-      if (!this.database.prepare("SELECT 1 FROM projects WHERE id = ?").get(projectId)) {
-        throw new ApiError(404, "PROJECT_NOT_FOUND", `Project '${projectId}' does not exist`);
+  saveProjectReadme(projectId, content, expectedVersion, actor) {
+    const current = this.database.prepare(`
+      SELECT id, version FROM documents WHERE project_id = ? AND is_project_overview = 1
+    `).get(projectId);
+    if (!current) {
+      if (expectedVersion !== undefined && expectedVersion !== 0) {
+        throw new ApiError(409, "VERSION_CONFLICT", "Project README changed since it was last read", {
+          expectedVersion,
+          actualVersion: 0,
+        });
       }
-      const current = this.database.prepare(`
-        SELECT version FROM project_readmes WHERE project_id = ?
-      `).get(projectId);
-      if (expectedVersion !== undefined) {
-        const actualVersion = current?.version ?? 0;
-        if (actualVersion !== expectedVersion) {
-          throw new ApiError(409, "VERSION_CONFLICT", "Project README changed since it was last read", {
-            expectedVersion,
-            actualVersion,
-          });
-        }
-      }
-      if (current) {
-        const versionCondition = expectedVersion !== undefined ? " AND version = ?" : "";
-        const params = expectedVersion !== undefined
-          ? [content, timestamp, projectId, expectedVersion]
-          : [content, timestamp, projectId];
-        this.database.prepare(`
-          UPDATE project_readmes
-          SET content = ?, version = version + 1, updated_at = ?
-          WHERE project_id = ?${versionCondition}
-        `).run(...params);
-      } else {
-        this.database.prepare(`
-          INSERT INTO project_readmes (project_id, content, version, created_at, updated_at)
-          VALUES (?, ?, 1, ?, ?)
-        `).run(projectId, content, timestamp, timestamp);
-      }
-      this.database.exec("COMMIT");
-    } catch (error) {
-      this.database.exec("ROLLBACK");
-      throw error;
+      this.createDocument(projectId, {
+        id: `project-overview:${projectId}`,
+        title: "项目说明",
+        type: "general",
+        status: "draft",
+        content,
+        isProjectOverview: true,
+      }, actor);
+    } else {
+      this.updateDocument(current.id, { content }, expectedVersion ?? current.version, actor);
     }
     return this.getProjectReadme(projectId);
   }

--- a/skills/manage-taskboard/SKILL.md
+++ b/skills/manage-taskboard/SKILL.md
@@ -12,7 +12,7 @@ Open only the relevant section of [references/cli.md](references/cli.md) when co
 ## Select the CLI and active service
 
 - Use the exact `taskctl` binary and Taskboard URL supplied by the task or injected runtime. Do not replace them with a global CLI, the default port, or another board.
-- On macOS, when no binary is injected and the desktop app is installed, use `'/Applications/Codex Taskboard.app/Contents/Resources/bin/taskctl' issue get ID --json`. Keep the single quotes because the path contains a space. The packaged wrapper reads the active launcher runtime; do not search the filesystem for another CLI or reconstruct the tokenized URL.
+- On macOS, when no binary is injected and the desktop app is installed, use `'/Applications/Atlas Workbench.app/Contents/Resources/bin/taskctl' issue get ID --json`. During compatibility upgrades only, fall back to the legacy `'/Applications/Codex Taskboard.app/Contents/Resources/bin/taskctl'` path. Keep the single quotes because the paths contain spaces. The packaged wrapper reads the active launcher runtime; do not search the filesystem for another CLI or reconstruct the tokenized URL.
 - On Linux, when no binary is injected and Codex was started by the desktop app, use `taskctl issue get ID --json`. The desktop app adds its packaged wrapper to the managed Codex `PATH`; do not search the filesystem for another CLI or reconstruct the tokenized URL.
 - If that exact command reaches a sandbox restriction on the loopback service, retry the same command with the required permission. Do not switch binaries or endpoints.
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -220,7 +220,7 @@ struct UpdateDialog {
 impl UpdateDialog {
     fn prompt(_app: &AppHandle, version: &str) -> Option<Self> {
         let message = format!(
-            "Codex Taskboard {version} 已下载并通过签名验证。是否现在安装并重启？"
+            "Atlas Workbench {version} 已下载并通过签名验证。是否现在安装并重启？"
         );
         let (response, result) = std::sync::mpsc::channel();
         let dialog = run_on_main(move |mtm| {
@@ -233,7 +233,7 @@ impl UpdateDialog {
             progress_indicator.setFrameSize(NSSize::new(280.0, 20.0));
             progress_indicator.sizeToFit();
             progress_indicator.setDisplayedWhenStopped(true);
-            alert.setMessageText(&NSString::from_str("Codex Taskboard 更新"));
+            alert.setMessageText(&NSString::from_str("Atlas Workbench 更新"));
             alert.setInformativeText(&NSString::from_str(&message));
             let install_button = alert.addButtonWithTitle(&NSString::from_str("立即更新"));
             let defer_button = alert.addButtonWithTitle(&NSString::from_str("稍后"));
@@ -331,9 +331,9 @@ impl UpdateDialog {
     fn prompt(app: &AppHandle, version: &str) -> Option<Self> {
         app.dialog()
             .message(format!(
-                "Codex Taskboard {version} 已下载并通过签名验证。是否现在安装并重启？"
+                "Atlas Workbench {version} 已下载并通过签名验证。是否现在安装并重启？"
             ))
-            .title("Codex Taskboard 更新")
+            .title("Atlas Workbench 更新")
             .kind(MessageDialogKind::Info)
             .buttons(MessageDialogButtons::OkCancelCustom(
                 "立即更新".into(),
@@ -378,7 +378,7 @@ impl LauncherState {
             child: Mutex::new(None),
             snapshot: Mutex::new(LauncherSnapshot {
                 phase: "starting".into(),
-                message: "正在启动任务面板…".into(),
+                message: "正在启动阿特拉斯工作台…".into(),
                 update_message: "启动后将自动检查更新。".into(),
                 update_available: false,
                 version,
@@ -560,7 +560,7 @@ fn take_macos_bundle_migration_marker() -> Result<Option<MacosBundleMigration>, 
         .map_err(|error| format!("无法解析当前可执行文件路径：{error}"))?;
     let current_app = macos_app_path_from_executable(&current_executable)
         .ok_or_else(|| "当前可执行文件不在 macOS App bundle 内".to_string())?;
-    if current_app.file_name() != Some(std::ffi::OsStr::new("Codex Taskboard Beta.app")) {
+    if current_app.file_name() != Some(std::ffi::OsStr::new("Atlas Workbench Beta.app")) {
         return Err(format!(
             "macOS App bundle migration marker 只能由改名后的 Beta App 恢复：{}",
             current_app.display()
@@ -572,7 +572,7 @@ fn take_macos_bundle_migration_marker() -> Result<Option<MacosBundleMigration>, 
     let expected_source_executable = current_app
         .parent()
         .ok_or_else(|| format!("无法定位 App 上级目录：{}", current_app.display()))?
-        .join("Codex Taskboard.app")
+        .join("Atlas Workbench.app")
         .join(relative_executable);
     if source_executable != expected_source_executable {
         return Err(format!(
@@ -604,10 +604,10 @@ fn migrate_macos_beta_app_bundle_name() -> Result<Option<MacosBundleMigration>, 
     let Some(current_app) = macos_app_path_from_executable(&current_executable) else {
         return Ok(None);
     };
-    if current_app.file_name() == Some(std::ffi::OsStr::new("Codex Taskboard Beta.app")) {
+    if current_app.file_name() == Some(std::ffi::OsStr::new("Atlas Workbench Beta.app")) {
         return Ok(None);
     }
-    if current_app.file_name() != Some(std::ffi::OsStr::new("Codex Taskboard.app")) {
+    if current_app.file_name() != Some(std::ffi::OsStr::new("Atlas Workbench.app")) {
         return Err(format!(
             "Beta App 当前路径名称不受支持：{}",
             current_app.display()
@@ -616,7 +616,7 @@ fn migrate_macos_beta_app_bundle_name() -> Result<Option<MacosBundleMigration>, 
     let destination_app = current_app
         .parent()
         .ok_or_else(|| format!("无法定位 App 上级目录：{}", current_app.display()))?
-        .join("Codex Taskboard Beta.app");
+        .join("Atlas Workbench Beta.app");
     let executable_name = current_executable
         .file_name()
         .ok_or_else(|| format!("无法定位 App 可执行文件名：{}", current_executable.display()))?
@@ -808,7 +808,7 @@ fn resolve_legacy_skill_conflict(
             "检测到旧位置中的 manage-taskboard Skill 与当前 App 内置版本不同，可能包含你的修改。\n\n为避免 Codex 同时发现两个版本，Taskboard 会把旧副本完整保留到：\n\n{}\n\n选择退出不会改动旧副本，也不会启动 Codex。",
             backup_path.display()
         ))
-        .title("Codex Taskboard Skill 冲突")
+        .title("Atlas Workbench Skill 冲突")
         .kind(MessageDialogKind::Warning)
         .buttons(MessageDialogButtons::OkCancelCustom(
             "保留备份并继续".into(),
@@ -1090,7 +1090,7 @@ fn quit_codex_normally(pid: u32) -> Result<(), String> {
         thread::sleep(Duration::from_millis(100));
     }
     if process_is_running(pid) {
-        return Err("Codex 尚未退出，任务面板没有启动".to_string());
+        return Err("Codex 尚未退出，阿特拉斯工作台没有启动".to_string());
     }
     Ok(())
 }
@@ -1204,7 +1204,7 @@ fn quit_codex_normally(pid: u32) -> Result<(), String> {
     if exited {
         Ok(())
     } else {
-        Err("Codex 尚未退出，任务面板没有启动".to_string())
+        Err("Codex 尚未退出，阿特拉斯工作台没有启动".to_string())
     }
 }
 
@@ -1271,7 +1271,7 @@ fn quit_codex_normally(pid: u32) -> Result<(), String> {
         thread::sleep(Duration::from_millis(100));
     }
     if process_is_running(pid) {
-        return Err("Codex 尚未退出，任务面板没有启动".to_string());
+        return Err("Codex 尚未退出，阿特拉斯工作台没有启动".to_string());
     }
     Ok(())
 }
@@ -1496,7 +1496,7 @@ fn stop_managed_child_locked(app: &AppHandle, state: &Arc<LauncherState>) {
     }
     update_snapshot(app, state, |snapshot| {
         snapshot.phase = "stopped".into();
-        snapshot.message = "任务面板已停止。".into();
+        snapshot.message = "阿特拉斯工作台已停止。".into();
         snapshot.child_pid = None;
         snapshot.open_signal_pid = None;
     });
@@ -1533,7 +1533,7 @@ fn watch_launcher_output<R: std::io::Read + Send + 'static>(
                         && snapshot.child_pid == Some(pid)
                     {
                         snapshot.phase = "starting".into();
-                        snapshot.message = "任务面板服务已启动，正在注入 Codex…".into();
+                        snapshot.message = "阿特拉斯工作台服务已启动，正在注入 Codex…".into();
                     }
                 });
             } else if !is_stderr && line.contains("\"openTaskboardSignalReady\":true") {
@@ -1563,7 +1563,7 @@ fn watch_launcher_output<R: std::io::Read + Send + 'static>(
                         && snapshot.child_pid == Some(pid)
                     {
                         snapshot.phase = "running".into();
-                        snapshot.message = "任务面板已在现有 Codex 的浏览面板中打开。".into();
+                        snapshot.message = "阿特拉斯工作台已在现有 Codex 的浏览面板中打开。".into();
                     }
                 });
             } else if !is_stderr && line.contains("\"injected\"") {
@@ -1572,7 +1572,7 @@ fn watch_launcher_output<R: std::io::Read + Send + 'static>(
                         && snapshot.child_pid == Some(pid)
                     {
                         snapshot.phase = "running".into();
-                        snapshot.message = "任务面板已在 Codex 客户端中打开。".into();
+                        snapshot.message = "阿特拉斯工作台已在 Codex 客户端中打开。".into();
                     }
                 });
             }
@@ -1618,8 +1618,8 @@ fn start_launcher_locked(
     if let Some(codex_pid) = ordinary_codex_pid {
         let restart = app
             .dialog()
-            .message("需要重新启动 Codex 才能显示任务面板")
-            .title("Codex Taskboard")
+            .message("需要重新启动 Codex 才能显示阿特拉斯工作台")
+            .title("Atlas Workbench")
             .kind(MessageDialogKind::Info)
             .buttons(MessageDialogButtons::OkCancelCustom(
                 "重新启动 Codex".into(),
@@ -1630,7 +1630,7 @@ fn start_launcher_locked(
             append_log(state, "Codex restart canceled by user");
             return Ok(update_snapshot(app, state, |snapshot| {
                 snapshot.phase = "stopped".into();
-                snapshot.message = "已取消重新启动 Codex，任务面板未注入。".into();
+                snapshot.message = "已取消重新启动 Codex，阿特拉斯工作台未注入。".into();
                 snapshot.app_path = Some(codex_app.display().to_string());
                 snapshot.open_signal_pid = None;
                 snapshot.open_request_pending = false;
@@ -1646,7 +1646,7 @@ fn start_launcher_locked(
     state.intentional_stop.store(false, Ordering::SeqCst);
     update_snapshot(app, state, |snapshot| {
         snapshot.phase = "starting".into();
-        snapshot.message = "正在启动任务面板服务…".into();
+        snapshot.message = "正在启动阿特拉斯工作台服务…".into();
         snapshot.app_path = Some(codex_app.display().to_string());
         snapshot.open_signal_pid = None;
     });
@@ -1829,7 +1829,7 @@ fn start_launcher_locked(
                 snapshot.open_signal_pid = None;
                 if !intentional {
                     snapshot.phase = "error".into();
-                    snapshot.message = "任务面板进程已退出，正在恢复…".into();
+                    snapshot.message = "阿特拉斯工作台进程已退出，正在恢复…".into();
                 }
             }
         });
@@ -1868,8 +1868,8 @@ fn start_launcher_locked(
             });
             show_error_dialog(
                 &event_app,
-                "Codex Taskboard 恢复失败",
-                &format!("任务面板进程无法恢复：{error}\n\n请重新打开 App。"),
+                "Atlas Workbench 恢复失败",
+                &format!("阿特拉斯工作台进程无法恢复：{error}\n\n请重新打开 App。"),
             );
         }
     });
@@ -1912,7 +1912,7 @@ fn restart_launcher(
                 && snapshot.child_pid.is_none()
             {
                 snapshot.phase = "error".into();
-                snapshot.message = format!("任务面板启动失败：{error}");
+                snapshot.message = format!("阿特拉斯工作台启动失败：{error}");
                 snapshot.open_signal_pid = None;
             }
         });
@@ -1949,7 +1949,7 @@ fn open_taskboard_in_browser(state: &LauncherState) -> Result<(), String> {
     status
         .success()
         .then_some(())
-        .ok_or_else(|| "系统默认浏览器没有打开任务面板".to_string())
+        .ok_or_else(|| "系统默认浏览器没有打开阿特拉斯工作台".to_string())
 }
 
 async fn check_for_startup_update(
@@ -2213,7 +2213,7 @@ fn install_update(
             snapshot.update_available = true;
             if let Some(restart_error) = &restart_error {
                 snapshot.phase = "error".into();
-                snapshot.message = format!("任务面板恢复失败：{restart_error}");
+                snapshot.message = format!("阿特拉斯工作台恢复失败：{restart_error}");
             }
         });
         return Err(error.to_string());
@@ -2279,7 +2279,7 @@ async fn offer_update(
             if show_current_version {
                 show_error_dialog(
                     app,
-                    "Codex Taskboard 更新检查失败",
+                    "Atlas Workbench 更新检查失败",
                     &format!("无法检查更新。请稍后重试。\n\n{error}"),
                 );
             }
@@ -2292,7 +2292,7 @@ async fn offer_update(
             let current_version = state.snapshot.lock().unwrap().version.clone();
             app.dialog()
                 .message(format!("当前版本 {current_version} 已是最新版本。"))
-                .title("Codex Taskboard 更新")
+                .title("Atlas Workbench 更新")
                 .buttons(MessageDialogButtons::Ok)
                 .blocking_show();
         }
@@ -2315,7 +2315,7 @@ async fn offer_update(
             if show_current_version {
                 show_error_dialog(
                     app,
-                    "Codex Taskboard 更新准备失败",
+                    "Atlas Workbench 更新准备失败",
                     &format!("无法下载或验证更新。请稍后重试。\n\n{error}"),
                 );
             }
@@ -2349,14 +2349,14 @@ async fn offer_update(
             append_log(state, &format!("Update installation failed: {error}"));
             let service_recovered = state.snapshot.lock().unwrap().child_pid.is_some();
             let service_message = if service_recovered {
-                "任务面板服务已恢复。"
+                "阿特拉斯工作台服务已恢复。"
             } else {
-                "任务面板服务未能恢复，请重新打开 App。"
+                "阿特拉斯工作台服务未能恢复，请重新打开 App。"
             };
             update_dialog.close();
             show_error_dialog(
                 app,
-                "Codex Taskboard 更新失败",
+                "Atlas Workbench 更新失败",
                 &format!(
                     "更新未完成。{service_message}\n\n请稍后重试。详情见启动日志。\n\n{error}"
                 ),
@@ -2468,11 +2468,11 @@ fn main() {
             )?;
             *state.status_menu.lock().unwrap() = Some(launcher_status.clone());
             let open_taskboard_item =
-                MenuItem::with_id(app, "open-taskboard", "打开任务面板", true, None::<&str>)?;
+                MenuItem::with_id(app, "open-taskboard", "打开阿特拉斯工作台", true, None::<&str>)?;
             let open_taskboard_web = MenuItem::with_id(
                 app,
                 "open-taskboard-web",
-                "在网页打开任务面板",
+                "在网页打开阿特拉斯工作台",
                 true,
                 None::<&str>,
             )?;
@@ -2525,7 +2525,7 @@ fn main() {
             TrayIconBuilder::new()
                 .icon(tauri::include_image!("icons/tray-codex.png"))
                 .icon_as_template(true)
-                .tooltip("Codex Taskboard")
+                .tooltip("Atlas Workbench")
                 .menu(&tray_menu)
                 .on_menu_event(move |app, event| match event.id().as_ref() {
                     "check-update" => {
@@ -2551,7 +2551,7 @@ fn main() {
                                 append_log(&state, &format!("Launcher menu open failed: {error}"));
                                 show_error_dialog(
                                     &app,
-                                    "Codex Taskboard 打开失败",
+                                    "Atlas Workbench 打开失败",
                                     &format!("{error}\n\n请确认 Codex 正在运行。"),
                                 );
                             }
@@ -2569,7 +2569,7 @@ fn main() {
                                     &state,
                                     &format!("Launcher menu browser open failed: {error}"),
                                 );
-                                show_error_dialog(&app, "Codex Taskboard 网页打开失败", &error);
+                                show_error_dialog(&app, "Atlas Workbench 网页打开失败", &error);
                             }
                         });
                     }
@@ -2587,7 +2587,7 @@ fn main() {
                                 );
                                 show_error_dialog(
                                     &app,
-                                    "Codex Taskboard 启动失败",
+                                    "Atlas Workbench 启动失败",
                                     &format!("{error}\n\n请确认官方 Codex/ChatGPT App 已安装。"),
                                 );
                             }
@@ -2623,7 +2623,7 @@ fn main() {
                             }
                         };
                         if let Some(error) = operation_error.or(sync_error) {
-                            show_error_dialog(app, "Codex Taskboard 自启动设置失败", &error);
+                            show_error_dialog(app, "Atlas Workbench 自启动设置失败", &error);
                         }
                     }
                     "quit" => {
@@ -2671,7 +2671,7 @@ fn main() {
                         Err(error) => {
                             show_error_dialog(
                                 &app_handle,
-                                "Codex Taskboard Skill 更新失败",
+                                "Atlas Workbench Skill 更新失败",
                                 &format!("无法保留旧 Skill：{error}"),
                             );
                             app_handle.exit(1);
@@ -2687,7 +2687,7 @@ fn main() {
                     });
                     show_error_dialog(
                         &app_handle,
-                        "Codex Taskboard 启动失败",
+                        "Atlas Workbench 启动失败",
                         &format!(
                             "{error}\n\n请确认官方 Codex/ChatGPT App 已安装。详情见启动日志。"
                         ),
@@ -2705,7 +2705,7 @@ fn main() {
             Ok(())
         })
         .build(tauri::generate_context!())
-        .expect("failed to build Codex Taskboard");
+        .expect("failed to build Atlas Workbench");
 
     app.run(|app_handle, event| match event {
         #[cfg(target_os = "macos")]
@@ -2718,7 +2718,7 @@ fn main() {
                 append_log(&state, &format!("Launcher panel reopen failed: {error}"));
                 show_error_dialog(
                     app_handle,
-                    "Codex Taskboard 打开失败",
+                    "Atlas Workbench 打开失败",
                     &format!("{error}\n\n请确认官方 Codex/ChatGPT App 已安装。"),
                 );
             }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "Codex Taskboard",
+  "productName": "Atlas Workbench",
   "version": "1.1.22",
   "identifier": "com.chuspeeism.codex-taskboard",
   "app": {
@@ -10,7 +10,7 @@
     "active": true,
     "targets": ["app", "dmg"],
     "category": "Productivity",
-    "shortDescription": "在 Codex 客户端中打开本地任务面板",
+    "shortDescription": "在 Codex 客户端中打开阿特拉斯工作台",
     "createUpdaterArtifacts": true,
     "externalBin": ["binaries/node"],
     "resources": {

--- a/test/atlas-brand.test.mjs
+++ b/test/atlas-brand.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const read = (relativePath) => readFile(new URL(relativePath, import.meta.url), "utf8");
+
+test("Atlas Workbench is the visible product while existing Taskboard data remains compatible", async () => {
+  const [html, styles, tauriSource, injectionSource, packageSource, tauriConfigSource, buildSource, updaterSource, releaseWorkflow] =
+    await Promise.all([
+      read("../web/index.html"),
+      read("../web/src/styles.css"),
+      read("../src-tauri/src/main.rs"),
+      read("../inject/codex-taskboard.user.js"),
+      read("../package.json"),
+      read("../src-tauri/tauri.conf.json"),
+      read("../scripts/tauri-build.mjs"),
+      read("../scripts/create-macos-updater.mjs"),
+      read("../.github/workflows/release-macos.yml"),
+    ]);
+
+  const packageJson = JSON.parse(packageSource);
+  const tauriConfig = JSON.parse(tauriConfigSource);
+
+  assert.match(html, /<html lang="zh-CN">/);
+  assert.match(html, /<title>Atlas Workbench<\/title>/);
+  assert.match(html, /阿特拉斯工作台/);
+  assert.match(styles, /--accent:\s*#6a1b9a;/i);
+  assert.equal(tauriConfig.productName, "Atlas Workbench");
+  assert.equal(tauriConfig.identifier, "com.chuspeeism.codex-taskboard");
+  assert.equal(packageJson.bin.atlasctl, "./cli/taskctl.mjs");
+  assert.equal(packageJson.bin.taskctl, "./cli/taskctl.mjs");
+  assert.match(buildSource, /"Atlas Workbench"/);
+  assert.match(updaterSource, /Atlas\.Workbench_/);
+  assert.doesNotMatch(releaseWorkflow, /Codex\.Taskboard_/);
+  assert.match(releaseWorkflow, /Atlas\.Workbench_/);
+  assert.match(injectionSource, /阿特拉斯工作台/);
+  assert.match(injectionSource, /Atlas Workbench/);
+
+  // Compatibility boundary: do not move existing local data during the rename.
+  assert.match(tauriSource, /Library\/Application Support\/Codex Taskboard/);
+});

--- a/test/document-library.test.mjs
+++ b/test/document-library.test.mjs
@@ -1,0 +1,238 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, test } from "node:test";
+
+import { main } from "../cli/taskctl.mjs";
+import { TaskboardDatabase } from "../server/database.mjs";
+import { createTaskboardServer } from "../server/index.mjs";
+
+const runningApps = [];
+
+afterEach(async () => {
+  while (runningApps.length > 0) {
+    const { app, directory } = runningApps.pop();
+    await app.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+async function startServer() {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "atlas-library-test-"));
+  const app = createTaskboardServer({ dataDirectory: directory });
+  const address = await app.listen({ port: 0 });
+  runningApps.push({ app, directory });
+  return { baseUrl: `http://127.0.0.1:${address.port}`, directory };
+}
+
+async function jsonRequest(baseUrl, pathname, options = {}) {
+  const headers = new Headers(options.headers);
+  if (options.body !== undefined && !headers.has("content-type")) {
+    headers.set("content-type", "application/json");
+  }
+  const response = await fetch(`${baseUrl}${pathname}`, {
+    ...options,
+    headers,
+    body: options.body === undefined || typeof options.body === "string"
+      ? options.body
+      : JSON.stringify(options.body),
+  });
+  const text = await response.text();
+  return { response, body: text ? JSON.parse(text) : undefined };
+}
+
+function capture() {
+  let value = "";
+  return {
+    stream: { write(chunk) { value += chunk; } },
+    json() { return JSON.parse(value); },
+  };
+}
+
+async function runCli(argv, baseUrl, overrides = {}) {
+  const stdout = capture();
+  const stderr = capture();
+  const exitCode = await main(argv, {
+    stdout: stdout.stream,
+    stderr: stderr.stream,
+    env: {
+      CODEX_TASKBOARD_URL: baseUrl,
+      CODEX_THREAD_ID: "atlas-library-test-thread",
+    },
+    ...overrides,
+  });
+  return {
+    exitCode,
+    stdout: exitCode === 0 ? stdout.json() : null,
+    stderr: exitCode === 0 ? null : stderr.json(),
+  };
+}
+
+test("database migrates Project Docs into one project overview document", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "atlas-library-db-"));
+  const filename = path.join(directory, "taskboard.sqlite");
+  let database;
+  try {
+    database = new TaskboardDatabase(filename);
+    database.createProject({ id: "legacy", name: "Legacy", workspacePath: null });
+    database.database.prepare(`
+      INSERT INTO project_readmes (project_id, content, version, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?)
+    `).run("legacy", "# 旧项目\n\n原始内容", 3, "2026-09-01T00:00:00.000Z", "2026-09-02T00:00:00.000Z");
+    database.database.close();
+
+    database = new TaskboardDatabase(filename);
+    const documents = database.listDocuments("legacy");
+    assert.equal(documents.length, 1);
+    assert.equal(documents[0].title, "项目说明");
+    assert.equal(documents[0].content, "# 旧项目\n\n原始内容");
+    assert.equal(documents[0].version, 3);
+    assert.deepEqual(database.listDocumentRevisions(documents[0].id).map((revision) => revision.version), [3]);
+
+    const readme = database.getProjectReadme("legacy");
+    assert.equal(readme.content, documents[0].content);
+    assert.equal(readme.version, documents[0].version);
+  } finally {
+    database?.database.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("local API provides Chinese folders, Markdown history, search, export, and conflicts", async () => {
+  const { baseUrl } = await startServer();
+  await jsonRequest(baseUrl, "/api/projects", {
+    method: "POST",
+    body: { id: "atlas-demo", name: "Atlas Demo" },
+  });
+
+  const folderResult = await jsonRequest(baseUrl, "/api/projects/atlas-demo/document-folders", {
+    method: "POST",
+    body: { name: "项目资料", parentId: null },
+  });
+  assert.equal(folderResult.response.status, 201);
+  assert.equal(folderResult.body.folder.name, "项目资料");
+
+  const createResult = await jsonRequest(baseUrl, "/api/projects/atlas-demo/documents", {
+    method: "POST",
+    headers: {
+      "x-taskboard-user-id": "owner",
+      "x-taskboard-user-name": encodeURIComponent("老板"),
+    },
+    body: {
+      folderId: folderResult.body.folder.id,
+      title: "服务器连接信息",
+      type: "general",
+      content: "# 服务器\n\nhost: 10.0.0.8",
+    },
+  });
+  assert.equal(createResult.response.status, 201);
+  assert.equal(createResult.body.document.version, 1);
+  assert.equal(createResult.body.document.updatedBy.name, "老板");
+  const documentId = createResult.body.document.id;
+
+  const updateResult = await jsonRequest(baseUrl, `/api/documents/${documentId}`, {
+    method: "PUT",
+    body: { content: "# 服务器\n\nhost: 10.0.0.9", version: 1 },
+  });
+  assert.equal(updateResult.response.status, 200);
+  assert.equal(updateResult.body.document.version, 2);
+
+  const conflict = await jsonRequest(baseUrl, `/api/documents/${documentId}`, {
+    method: "PUT",
+    body: { content: "# 被覆盖", version: 1 },
+  });
+  assert.equal(conflict.response.status, 409);
+  assert.equal(conflict.body.error.code, "VERSION_CONFLICT");
+  assert.equal(conflict.body.error.details.actualVersion, 2);
+
+  const search = await jsonRequest(baseUrl, "/api/projects/atlas-demo/documents?q=10.0.0.9");
+  assert.equal(search.response.status, 200);
+  assert.deepEqual(search.body.documents.map((document) => document.id), [documentId]);
+
+  const revisions = await jsonRequest(baseUrl, `/api/documents/${documentId}/revisions`);
+  assert.deepEqual(revisions.body.revisions.map((revision) => revision.version), [2, 1]);
+
+  const exported = await fetch(`${baseUrl}/api/documents/${documentId}/export`);
+  assert.equal(exported.status, 200);
+  assert.equal(await exported.text(), "# 服务器\n\nhost: 10.0.0.9");
+  assert.match(exported.headers.get("content-disposition"), /filename\*=UTF-8''/);
+});
+
+test("document attachment uploads and downloads from the library", async () => {
+  const { baseUrl } = await startServer();
+  await jsonRequest(baseUrl, "/api/projects", {
+    method: "POST",
+    body: { id: "files", name: "Files" },
+  });
+  const created = await jsonRequest(baseUrl, "/api/projects/files/documents", {
+    method: "POST",
+    body: { title: "交付资料", type: "general", content: "" },
+  });
+  const documentId = created.body.document.id;
+  const upload = await fetch(`${baseUrl}/api/documents/${documentId}/attachments`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/pdf",
+      "x-taskboard-filename": encodeURIComponent("验收资料.pdf"),
+      "x-taskboard-attachment-kind": "attachment",
+    },
+    body: Buffer.from("pdf-test"),
+  });
+  assert.equal(upload.status, 201);
+  const { attachment } = await upload.json();
+  assert.equal(attachment.documentId, documentId);
+  assert.equal(attachment.filename, "验收资料.pdf");
+
+  const download = await fetch(`${baseUrl}/api/document-attachments/${attachment.id}/content`);
+  assert.equal(download.status, 200);
+  assert.equal(await download.text(), "pdf-test");
+});
+
+test("atlasctl document commands complete the AI Markdown round trip", async () => {
+  const { baseUrl, directory } = await startServer();
+  await jsonRequest(baseUrl, "/api/projects", {
+    method: "POST",
+    body: { id: "cli-docs", name: "CLI Docs" },
+  });
+
+  const created = await runCli([
+    "document", "create",
+    "--project", "cli-docs",
+    "--title", "登录改造 SPEC",
+    "--type", "spec",
+    "--content", "# 登录改造\n\n验收标准",
+  ], baseUrl);
+  assert.equal(created.exitCode, 0);
+  assert.equal(created.stdout.document.version, 1);
+  const documentId = created.stdout.document.id;
+
+  const updated = await runCli([
+    "document", "update", documentId,
+    "--content", "# 登录改造\n\n已确认",
+    "--if-version", "1",
+  ], baseUrl);
+  assert.equal(updated.exitCode, 0);
+  assert.equal(updated.stdout.document.version, 2);
+
+  const searched = await runCli([
+    "document", "search", "--project", "cli-docs", "--query", "已确认",
+  ], baseUrl);
+  assert.deepEqual(searched.stdout.documents.map((document) => document.id), [documentId]);
+
+  const output = path.join(directory, "登录改造 SPEC.md");
+  const exported = await runCli([
+    "document", "export", documentId, "--output", output,
+  ], baseUrl);
+  assert.equal(exported.exitCode, 0);
+  assert.equal(exported.stdout.output, output);
+  assert.equal(await readFile(output, "utf8"), "# 登录改造\n\n已确认");
+
+  const stale = await runCli([
+    "document", "update", documentId,
+    "--content", "# 旧内容",
+    "--if-version", "1",
+  ], baseUrl);
+  assert.equal(stale.exitCode, 5);
+  assert.equal(stale.stderr.error.code, "VERSION_CONFLICT");
+});

--- a/test/project-automation-settings.test.mjs
+++ b/test/project-automation-settings.test.mjs
@@ -118,7 +118,7 @@ test("the project navigation automation menu owns the icon, fields, and accessib
   assert.match(appSource, /<ProjectAutomationMenu/);
   assert.match(appSource, /<ProjectAutomationMenu[\s\S]*?<button[\s\S]*?header-create-button/);
   assert.doesNotMatch(appSource, /toolbar-connection/);
-  assert.match(appSource, /仅本地任务面板可用/);
+  assert.match(appSource, /仅本地阿特拉斯工作台可用/);
 });
 
 test("automation status uses the exported Taskboard play and pause icon assets", () => {

--- a/test/project-home.test.mjs
+++ b/test/project-home.test.mjs
@@ -99,7 +99,7 @@ test("the project header exposes project, automation, and create controls", () =
 });
 
 test("the project header keeps detail navigation separate from the project switcher", () => {
-  assert.match(appSource, /const headerProjectName = isAllProjects\s*\? text\("所有项目", "All projects"\)\s*: selectedProject\?\.id === GLOBAL_PROJECT_ID\s*\? text\("临时任务", "Temporary tasks"\)\s*: selectedProject\?\.name \?\? text\("任务面板", "Taskboard"\)/);
+  assert.match(appSource, /const headerProjectName = isAllProjects\s*\? text\("所有项目", "All projects"\)\s*: selectedProject\?\.id === GLOBAL_PROJECT_ID\s*\? text\("临时任务", "Temporary tasks"\)\s*: selectedProject\?\.name \?\? text\("阿特拉斯工作台", "Atlas Workbench"\)/);
   assert.match(appSource, /detailTask && \([\s\S]*?aria-label=\{text\("返回议题看板", "Back to issue board"\)\}[\s\S]*?<\/button>/);
   assert.match(appSource, /className="header-project-switcher"[\s\S]*?<span className="project-name">\{headerProjectName\}<\/span>/);
   assert.doesNotMatch(appSource, /className="issue-root-button"/);

--- a/web/index.html
+++ b/web/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -7,9 +7,9 @@
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <meta
       name="description"
-      content="A focused issue board for turning plans into finished work with Codex."
+      content="阿特拉斯工作台：面向 AI 协作开发的项目、任务与资料库。"
     />
-    <title>Taskboard</title>
+    <title>Atlas Workbench</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -59,7 +59,7 @@ import {
   type BoardDisplaySettings,
 } from "./components/BoardCardDisplayMenu";
 import { DashboardView } from "./components/DashboardView";
-import { ProjectReadmeView } from "./components/ProjectReadmeView";
+import { ProjectLibrary } from "./components/ProjectLibrary";
 import { IssueListView } from "./components/IssueListView";
 import { JiraConnectionDialog } from "./components/JiraConnectionDialog";
 import { ArchivedTasksColumn, OtherTasksPanel } from "./components/OtherTasksPanel";
@@ -325,7 +325,7 @@ function issueReadStorageKey(mode: string, task: Pick<Task, "id" | "projectId">)
 
 function readProjectBoardView(projectId: string): BoardView {
   const view = taskboardStorage.getItem(`${PROJECT_VIEW_KEY_PREFIX}${projectId}`);
-  return view === "readme" || view === "dashboard" || view === "list" || view === "gantt" || view === "issues"
+  return view === "readme" || view === "dashboard" || view === "list" || view === "issues"
     ? view
     : "issues";
 }
@@ -374,6 +374,11 @@ const EVENT_NAMES = [
   "project.created",
   "project.labels.updated",
   "project.readme.updated",
+  "document.created",
+  "document.updated",
+  "document.folder.created",
+  "document.folder.updated",
+  "document.attachment.created",
   "client-storage.updated",
 ] as const;
 
@@ -651,7 +656,7 @@ function LocalRealtimeSync({
         return;
       }
       if (!affectsSelectedProject) return;
-      if (event.type === "project.readme.updated") {
+      if (event.type === "project.readme.updated" || event.type.startsWith("document.")) {
         setReadmeRevision((current) => current + 1);
         return;
       }
@@ -1010,7 +1015,7 @@ export function App() {
       return { unavailableReason: text("仅可在 Codex App 中使用", "Available only in the Codex app") };
     }
     if (!isLocalTaskboardOrigin(new URL(document.baseURI).origin)) {
-      return { unavailableReason: text("仅本地任务面板可用", "Available only on the local taskboard") };
+      return { unavailableReason: text("仅本地阿特拉斯工作台可用", "Available only in local Atlas Workbench") };
     }
     if (!selectedProject) {
       return { unavailableReason: text("请先选择项目", "Select a project first") };
@@ -1033,8 +1038,8 @@ export function App() {
       }
       if (!manageTaskboardSkillPath) {
         return { unavailableReason: text(
-          "任务面板还没有读取到 Skill 路径",
-          "Taskboard has not received the Skill path",
+          "阿特拉斯工作台还没有读取到 Skill 路径",
+          "Atlas Workbench has not received the Skill path",
         ) };
       }
       return { ...savedIdentity, unavailableReason: null };
@@ -1073,8 +1078,8 @@ export function App() {
     }
     if (!manageTaskboardSkillPath) {
       return { unavailableReason: text(
-        "任务面板还没有读取到 Skill 路径",
-        "Taskboard has not received the Skill path",
+        "阿特拉斯工作台还没有读取到 Skill 路径",
+        "Atlas Workbench has not received the Skill path",
       ) };
     }
     const codexProject = hostContext?.projects?.find((project) => project.id === codexProjectId);
@@ -1813,8 +1818,8 @@ export function App() {
       for (const pending of pendingAutomationRequestsRef.current.values()) {
         window.clearTimeout(pending.timeoutId);
         pending.reject(new Error(textRef.current(
-          "Taskboard 消息桥已关闭",
-          "The Taskboard host bridge was closed",
+          "阿特拉斯工作台消息桥已关闭",
+          "The Atlas Workbench host bridge was closed",
         )));
       }
       pendingAutomationRequestsRef.current.clear();
@@ -3324,7 +3329,7 @@ export function App() {
     ? text("所有项目", "All projects")
     : selectedProject?.id === GLOBAL_PROJECT_ID
       ? text("临时任务", "Temporary tasks")
-      : selectedProject?.name ?? text("任务面板", "Taskboard");
+      : selectedProject?.name ?? text("阿特拉斯工作台", "Atlas Workbench");
   const appShellStyle = embedded
     ? { "--codex-titlebar-left-inset": `${hostContext?.titlebarLeftInset ?? 0}px` } as CSSProperties
     : undefined;
@@ -3546,7 +3551,7 @@ export function App() {
               aria-pressed={boardView === "dashboard"}
               onClick={() => selectBoardView("dashboard")}
             >
-              {text("仪表盘", "Dashboard")}
+              {text("动态", "Activity")}
             </button>
             <button
               className={`view-tab${boardView === "issues" ? " active" : ""}`}
@@ -3554,7 +3559,7 @@ export function App() {
               aria-pressed={boardView === "issues"}
               onClick={() => selectBoardView("issues")}
             >
-              {text("议题看板", "Issue board")}
+              {text("计划", "Plan")}
             </button>
             <button
               className={`view-tab${boardView === "list" ? " active" : ""}`}
@@ -3562,15 +3567,7 @@ export function App() {
               aria-pressed={boardView === "list"}
               onClick={() => selectBoardView("list")}
             >
-              {text("列表视图", "List")}
-            </button>
-            <button
-              className={`view-tab${boardView === "gantt" ? " active" : ""}`}
-              type="button"
-              aria-pressed={boardView === "gantt"}
-              onClick={() => selectBoardView("gantt")}
-            >
-              {text("甘特图", "Gantt")}
+              {text("任务", "Tasks")}
             </button>
             {!isAllProjects && (
               <button
@@ -3579,7 +3576,7 @@ export function App() {
                 aria-pressed={boardView === "readme"}
                 onClick={() => selectBoardView("readme")}
               >
-                {text("项目文档", "Project Docs")}
+                {text("资料库", "Library")}
               </button>
             )}
           </div>
@@ -3671,7 +3668,7 @@ export function App() {
         {(loadError || actionErrorText) && (
           <div className="error-banner" role="alert">
             <span className="error-mark" aria-hidden="true"><LinearIcon name="alert" /></span>
-            <div><strong>{text("任务面板需要处理", "Taskboard needs attention")}</strong><p>{actionErrorText ?? loadError?.message}</p></div>
+            <div><strong>{text("阿特拉斯工作台需要处理", "Atlas Workbench needs attention")}</strong><p>{actionErrorText ?? loadError?.message}</p></div>
             <button
               type="button"
               onClick={() => {
@@ -3738,8 +3735,8 @@ export function App() {
                     projectId: selectedProject.id,
                     issueId: null,
                     composerText: text(
-                      "只检查当前项目目录对应的 Codex 对话。请将其中已完成、处理中和待执行的任务整理并导入当前项目的 Taskboard。",
-                      "Only inspect Codex conversations associated with this project directory. Organize completed, in-progress, and pending tasks, then import them into this project's Taskboard.",
+                      "只检查当前项目目录对应的 Codex 对话。请将其中已完成、处理中和待执行的任务整理并导入当前项目的阿特拉斯工作台。",
+                      "Only inspect Codex conversations associated with this project directory. Organize completed, in-progress, and pending tasks, then import them into this project's Atlas Workbench.",
                     ),
                     requestId: aiOpenThreadRequestSequenceRef.current,
                   });
@@ -3757,13 +3754,10 @@ export function App() {
             </div>
           </div>
         ) : boardView === "readme" && selectedProject ? (
-          <ProjectReadmeView
+          <ProjectLibrary
             key={selectedProjectId}
             project={selectedProject}
-            tasks={tasks.filter((task) => task.projectId === selectedProject.id)}
-            referenceTasks={referenceTasks.filter((task) => task.projectId === selectedProject.id)}
             revision={readmeRevision}
-            onOpenTask={openTaskDetail}
             onError={setActionError}
           />
         ) : boardView === "dashboard" && (selectedProject || isAllProjects) ? (

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -23,6 +23,12 @@ import type {
   Project,
   ProjectReadme,
   ProjectReadmeAttachment,
+  DocumentAttachment,
+  DocumentFolder,
+  DocumentRevision,
+  ProjectDocument,
+  ProjectDocumentStatus,
+  ProjectDocumentType,
   ProjectSummary,
   Task,
   TaskChangeActivity,
@@ -498,6 +504,107 @@ export async function uploadProjectReadmeAttachment(
         "Content-Type": file.type || "application/octet-stream",
         "X-Taskboard-Filename": encodeURIComponent(file.name),
         "X-Taskboard-Attachment-Kind": "inline",
+      },
+      body: file,
+    },
+  );
+  return data.attachment;
+}
+
+export async function listDocumentFolders(projectId: string): Promise<DocumentFolder[]> {
+  const data = await request<{ folders: DocumentFolder[] }>(
+    `/api/projects/${encodeURIComponent(projectId)}/document-folders`,
+  );
+  return data.folders;
+}
+
+export async function createDocumentFolder(
+  projectId: string,
+  name: string,
+  parentId: string | null,
+): Promise<DocumentFolder> {
+  const data = await request<{ folder: DocumentFolder }>(
+    `/api/projects/${encodeURIComponent(projectId)}/document-folders`,
+    { method: "POST", body: JSON.stringify({ name, parentId }) },
+  );
+  return data.folder;
+}
+
+export async function listProjectDocuments(
+  projectId: string,
+  options: { folderId?: string | null; query?: string; type?: ProjectDocumentType | "" } = {},
+): Promise<ProjectDocument[]> {
+  const search = new URLSearchParams();
+  if (Object.hasOwn(options, "folderId")) search.set("folderId", options.folderId ?? "");
+  if (options.query) search.set("q", options.query);
+  if (options.type) search.set("type", options.type);
+  const suffix = search.size > 0 ? `?${search}` : "";
+  const data = await request<{ documents: ProjectDocument[] }>(
+    `/api/projects/${encodeURIComponent(projectId)}/documents${suffix}`,
+  );
+  return data.documents;
+}
+
+export async function createProjectDocument(
+  projectId: string,
+  input: {
+    folderId: string | null;
+    title: string;
+    type: ProjectDocumentType;
+    content?: string;
+  },
+): Promise<ProjectDocument> {
+  const data = await request<{ document: ProjectDocument }>(
+    `/api/projects/${encodeURIComponent(projectId)}/documents`,
+    { method: "POST", body: JSON.stringify(input) },
+  );
+  return data.document;
+}
+
+export async function updateProjectDocument(
+  documentId: string,
+  input: {
+    version: number;
+    title?: string;
+    folderId?: string | null;
+    type?: ProjectDocumentType;
+    status?: ProjectDocumentStatus;
+    content?: string;
+  },
+): Promise<ProjectDocument> {
+  const data = await request<{ document: ProjectDocument }>(
+    `/api/documents/${encodeURIComponent(documentId)}`,
+    { method: "PUT", body: JSON.stringify(input) },
+  );
+  return data.document;
+}
+
+export async function listDocumentRevisions(documentId: string): Promise<DocumentRevision[]> {
+  const data = await request<{ revisions: DocumentRevision[] }>(
+    `/api/documents/${encodeURIComponent(documentId)}/revisions`,
+  );
+  return data.revisions;
+}
+
+export async function listDocumentAttachments(documentId: string): Promise<DocumentAttachment[]> {
+  const data = await request<{ attachments: DocumentAttachment[] }>(
+    `/api/documents/${encodeURIComponent(documentId)}/attachments`,
+  );
+  return data.attachments;
+}
+
+export async function uploadDocumentAttachment(
+  documentId: string,
+  file: File,
+): Promise<DocumentAttachment> {
+  const data = await request<{ attachment: DocumentAttachment }>(
+    `/api/documents/${encodeURIComponent(documentId)}/attachments`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": file.type || "application/octet-stream",
+        "X-Taskboard-Filename": encodeURIComponent(file.name),
+        "X-Taskboard-Attachment-Kind": file.type.startsWith("image/") ? "inline" : "attachment",
       },
       body: file,
     },

--- a/web/src/components/ProjectLibrary.css
+++ b/web/src/components/ProjectLibrary.css
@@ -1,0 +1,318 @@
+.project-library {
+  --atlas-purple: #6a1b9a;
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+  background: var(--color-bg-primary, #fff);
+}
+
+.library-toolbar,
+.library-create {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--color-border, #e7e7e7);
+}
+
+.library-actions,
+.library-filters,
+.library-create,
+.library-detail-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.library-toolbar .button.primary,
+.library-create .button.primary,
+.library-detail .button.primary {
+  border-color: var(--atlas-purple);
+  background: var(--atlas-purple);
+  color: white;
+}
+
+.library-filters select,
+.library-create select,
+.library-create input,
+.library-search {
+  min-height: 36px;
+  border: 1px solid var(--color-border, #dedede);
+  border-radius: 9px;
+  background: var(--color-bg-primary, #fff);
+}
+
+.library-filters select,
+.library-create select,
+.library-create input {
+  padding: 0 10px;
+  color: inherit;
+}
+
+.library-search {
+  display: flex;
+  width: min(320px, 30vw);
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+}
+
+.library-search input {
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: inherit;
+}
+
+.library-create {
+  justify-content: flex-start;
+  background: color-mix(in srgb, var(--atlas-purple) 4%, transparent);
+}
+
+.library-alert {
+  margin: 12px 24px 0;
+}
+
+.library-layout {
+  display: grid;
+  min-height: 0;
+  flex: 1;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.library-layout.has-detail {
+  grid-template-columns: minmax(540px, 1fr) minmax(360px, 42%);
+}
+
+.library-browser,
+.library-detail {
+  min-width: 0;
+  overflow: auto;
+}
+
+.library-breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 52px;
+  padding: 0 24px;
+  color: var(--color-text-secondary, #737373);
+}
+
+.library-breadcrumbs span {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.library-breadcrumbs button {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.library-breadcrumbs button:hover {
+  color: var(--atlas-purple);
+}
+
+.library-table {
+  padding: 0 16px 28px;
+}
+
+.library-row {
+  display: grid;
+  width: 100%;
+  min-height: 52px;
+  grid-template-columns: minmax(240px, 1.8fr) minmax(110px, .7fr) minmax(100px, .7fr) minmax(150px, 1fr) 72px;
+  align-items: center;
+  gap: 16px;
+  padding: 0 14px;
+  border: 0;
+  border-bottom: 1px solid var(--color-border, #eeeeee);
+  background: transparent;
+  color: inherit;
+  text-align: left;
+}
+
+button.library-row {
+  cursor: pointer;
+}
+
+button.library-row:hover,
+button.library-row.selected {
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--atlas-purple) 7%, transparent);
+}
+
+.library-head {
+  min-height: 42px;
+  color: var(--color-text-secondary, #777);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.library-name {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 10px;
+  overflow: hidden;
+  font-weight: 540;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.library-icon {
+  display: inline-grid;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 auto;
+  place-items: center;
+  border-radius: 6px;
+  font-size: 11px;
+}
+
+.library-icon.folder {
+  color: #2389df;
+  font-size: 19px;
+}
+
+.library-icon.markdown {
+  background: color-mix(in srgb, var(--atlas-purple) 13%, transparent);
+  color: var(--atlas-purple);
+  font-weight: 750;
+}
+
+.library-empty {
+  padding: 56px 24px;
+  color: var(--color-text-secondary, #888);
+  text-align: center;
+}
+
+.library-detail {
+  border-left: 1px solid var(--color-border, #e7e7e7);
+  background: var(--color-bg-primary, #fff);
+}
+
+.library-detail > header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 22px 24px 12px;
+}
+
+.library-detail h2,
+.library-detail p {
+  margin: 0;
+}
+
+.library-detail h2 {
+  font-size: 18px;
+}
+
+.library-detail header p {
+  margin-top: 6px;
+  color: var(--color-text-secondary, #777);
+  font-size: 12px;
+}
+
+.library-detail-actions {
+  padding: 0 24px 16px;
+}
+
+.library-detail-actions a {
+  text-decoration: none;
+}
+
+.library-document-body {
+  min-height: 260px;
+  padding: 20px 24px;
+  border-block: 1px solid var(--color-border, #ececec);
+}
+
+.library-document-body textarea {
+  width: 100%;
+  min-height: 360px;
+  resize: vertical;
+  border: 1px solid var(--color-border, #d8d8d8);
+  border-radius: 10px;
+  outline: 0;
+  padding: 14px;
+  background: var(--color-bg-primary, #fff);
+  color: inherit;
+  font: 13px/1.65 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.library-document-body textarea:focus {
+  border-color: var(--atlas-purple);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--atlas-purple) 12%, transparent);
+}
+
+.library-empty-copy {
+  color: var(--color-text-secondary, #888);
+}
+
+.library-meta-section {
+  padding: 18px 24px;
+  border-bottom: 1px solid var(--color-border, #ececec);
+}
+
+.library-meta-section h3 {
+  margin: 0 0 10px;
+  font-size: 13px;
+}
+
+.library-meta-section > a,
+.library-revision {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  padding: 8px 0;
+  color: inherit;
+  text-decoration: none;
+  font-size: 12px;
+}
+
+.library-meta-section > a small,
+.library-revision time {
+  color: var(--color-text-secondary, #888);
+}
+
+.library-revision {
+  grid-template-columns: 44px 1fr auto;
+}
+
+@media (max-width: 980px) {
+  .library-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .library-search {
+    flex: 1;
+    width: auto;
+  }
+
+  .library-layout.has-detail {
+    grid-template-columns: 1fr;
+  }
+
+  .library-detail {
+    border-top: 1px solid var(--color-border, #e7e7e7);
+    border-left: 0;
+  }
+
+  .library-row {
+    grid-template-columns: minmax(220px, 1fr) 110px 120px;
+  }
+
+  .library-row > :nth-child(3),
+  .library-row > :nth-child(5) {
+    display: none;
+  }
+}

--- a/web/src/components/ProjectLibrary.test.tsx
+++ b/web/src/components/ProjectLibrary.test.tsx
@@ -1,0 +1,116 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TaskboardLanguageProvider } from "../i18n";
+import type { Project, ProjectDocument } from "../types";
+import { ProjectLibrary } from "./ProjectLibrary";
+
+const api = vi.hoisted(() => ({
+  createDocumentFolder: vi.fn(),
+  createProjectDocument: vi.fn(),
+  listDocumentAttachments: vi.fn(),
+  listDocumentFolders: vi.fn(),
+  listDocumentRevisions: vi.fn(),
+  listProjectDocuments: vi.fn(),
+  updateProjectDocument: vi.fn(),
+  uploadDocumentAttachment: vi.fn(),
+}));
+
+vi.mock("../api", () => ({
+  ...api,
+  ApiError: class ApiError extends Error { code: string; constructor(code: string) { super(code); this.code = code; } },
+  resolvePersistedAttachmentUrl: (url: string) => url,
+  resolveTaskboardUrl: (url: string) => url,
+}));
+
+const project: Project = {
+  id: "atlas",
+  name: "Atlas Workbench",
+  workspacePath: null,
+  source: "local",
+  labels: [],
+  issueCount: 0,
+  createdAt: "2026-09-03T00:00:00.000Z",
+  updatedAt: "2026-09-03T00:00:00.000Z",
+};
+
+const document: ProjectDocument = {
+  id: "doc-1",
+  projectId: "atlas",
+  folderId: null,
+  title: "服务器连接信息",
+  type: "general",
+  status: "draft",
+  content: "# 服务器\n\nhost: 10.0.0.8",
+  size: 31,
+  version: 1,
+  isProjectOverview: false,
+  taskIds: [],
+  createdBy: { type: "user", id: "owner", name: "老板", avatarUrl: null },
+  updatedBy: { type: "user", id: "owner", name: "老板", avatarUrl: null },
+  createdAt: "2026-09-03T00:00:00.000Z",
+  updatedAt: "2026-09-03T00:00:00.000Z",
+};
+
+describe("ProjectLibrary", () => {
+  beforeEach(() => {
+    api.listDocumentFolders.mockResolvedValue([]);
+    api.listProjectDocuments.mockResolvedValue([document]);
+    api.listDocumentRevisions.mockResolvedValue([{ ...document, documentId: document.id, id: "doc-1:v1" }]);
+    api.listDocumentAttachments.mockResolvedValue([]);
+    api.updateProjectDocument.mockResolvedValue({
+      ...document,
+      content: "# 服务器\n\nhost: 10.0.0.9",
+      version: 2,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("lists Chinese Markdown documents and saves with the current version", async () => {
+    render(
+      <TaskboardLanguageProvider language="zh">
+        <ProjectLibrary project={project} revision={0} />
+      </TaskboardLanguageProvider>,
+    );
+
+    const row = await screen.findByRole("row", { name: /服务器连接信息/ });
+    fireEvent.click(row);
+    expect(await screen.findByText("项目资料 · v1 · 老板")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "编辑 Markdown" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Markdown 正文" }), {
+      target: { value: "# 服务器\n\nhost: 10.0.0.9" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() => expect(api.updateProjectDocument).toHaveBeenCalledWith("doc-1", {
+      content: "# 服务器\n\nhost: 10.0.0.9",
+      version: 1,
+    }));
+  });
+
+  it("creates a Chinese folder in the current library path", async () => {
+    api.createDocumentFolder.mockResolvedValue({
+      id: "folder-1",
+      projectId: "atlas",
+      parentId: null,
+      name: "项目资料",
+      createdAt: "2026-09-03T00:00:00.000Z",
+      updatedAt: "2026-09-03T00:00:00.000Z",
+    });
+    render(
+      <TaskboardLanguageProvider language="zh">
+        <ProjectLibrary project={project} revision={0} />
+      </TaskboardLanguageProvider>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /新建文件夹/ }));
+    fireEvent.change(screen.getByPlaceholderText("文件夹名称"), { target: { value: "项目资料" } });
+    fireEvent.click(screen.getByRole("button", { name: "创建" }));
+
+    await waitFor(() => expect(api.createDocumentFolder).toHaveBeenCalledWith("atlas", "项目资料", null));
+  });
+});

--- a/web/src/components/ProjectLibrary.tsx
+++ b/web/src/components/ProjectLibrary.tsx
@@ -1,0 +1,390 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ApiError,
+  createDocumentFolder,
+  createProjectDocument,
+  listDocumentAttachments,
+  listDocumentFolders,
+  listDocumentRevisions,
+  listProjectDocuments,
+  resolveTaskboardUrl,
+  updateProjectDocument,
+  uploadDocumentAttachment,
+} from "../api";
+import { useTaskboardI18n } from "../i18n";
+import type {
+  DocumentAttachment,
+  DocumentFolder,
+  DocumentRevision,
+  Project,
+  ProjectDocument,
+  ProjectDocumentType,
+} from "../types";
+import { MarkdownDocument } from "./MarkdownDocument";
+import { LinearIcon } from "./LinearIcon";
+import { PlusIcon } from "./SemanticIcons";
+import "./ProjectLibrary.css";
+
+type LibraryError = string | readonly [string, string];
+
+interface ProjectLibraryProps {
+  project: Project;
+  revision: number;
+  onError?: (error: LibraryError | null) => void;
+}
+
+const DOCUMENT_TYPES: Array<{ value: ProjectDocumentType; zh: string; en: string }> = [
+  { value: "general", zh: "项目资料", en: "Project docs" },
+  { value: "spec", zh: "SPEC", en: "SPEC" },
+  { value: "plan", zh: "Plan", en: "Plan" },
+  { value: "tasks", zh: "Tasks", en: "Tasks" },
+  { value: "run-report", zh: "执行报告", en: "Run report" },
+  { value: "test-report", zh: "测试报告", en: "Test report" },
+];
+
+function fileSize(value: number): string {
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(value < 10 * 1024 ? 1 : 0)} KB`;
+  return `${(value / (1024 * 1024)).toFixed(value < 10 * 1024 * 1024 ? 1 : 0)} MB`;
+}
+
+function shortDate(value: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function documentTypeLabel(type: ProjectDocumentType, language: "zh" | "en") {
+  const option = DOCUMENT_TYPES.find((candidate) => candidate.value === type);
+  return language === "zh" ? option?.zh ?? type : option?.en ?? type;
+}
+
+export function ProjectLibrary({ project, revision, onError }: ProjectLibraryProps) {
+  const { language, text } = useTaskboardI18n();
+  const [folders, setFolders] = useState<DocumentFolder[]>([]);
+  const [documents, setDocuments] = useState<ProjectDocument[]>([]);
+  const [currentFolderId, setCurrentFolderId] = useState<string | null>(null);
+  const [selected, setSelected] = useState<ProjectDocument | null>(null);
+  const [revisions, setRevisions] = useState<DocumentRevision[]>([]);
+  const [attachments, setAttachments] = useState<DocumentAttachment[]>([]);
+  const [query, setQuery] = useState("");
+  const [typeFilter, setTypeFilter] = useState<ProjectDocumentType | "">("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [createMode, setCreateMode] = useState<"folder" | "document" | null>(null);
+  const [createName, setCreateName] = useState("");
+  const [createType, setCreateType] = useState<ProjectDocumentType>("general");
+  const [creating, setCreating] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const loadLibrary = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [nextFolders, nextDocuments] = await Promise.all([
+        listDocumentFolders(project.id),
+        listProjectDocuments(project.id, {
+          ...(query.trim() ? {} : { folderId: currentFolderId }),
+          query: query.trim() || undefined,
+          type: typeFilter,
+        }),
+      ]);
+      setFolders(nextFolders);
+      setDocuments(nextDocuments);
+      setSelected((current) => (
+        current ? nextDocuments.find((document) => document.id === current.id) ?? current : null
+      ));
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : String(caught);
+      setError(message);
+      onError?.(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [currentFolderId, onError, project.id, query, typeFilter]);
+
+  useEffect(() => {
+    void loadLibrary();
+  }, [loadLibrary, revision]);
+
+  useEffect(() => {
+    if (!selected) {
+      setRevisions([]);
+      setAttachments([]);
+      return;
+    }
+    setDraft(selected.content);
+    Promise.all([
+      listDocumentRevisions(selected.id),
+      listDocumentAttachments(selected.id),
+    ]).then(([nextRevisions, nextAttachments]) => {
+      setRevisions(nextRevisions);
+      setAttachments(nextAttachments);
+    }).catch((caught) => {
+      const message = caught instanceof Error ? caught.message : String(caught);
+      setError(message);
+    });
+  }, [selected?.id, selected?.version]);
+
+  const childFolders = useMemo(
+    () => folders.filter((folder) => folder.parentId === currentFolderId),
+    [currentFolderId, folders],
+  );
+
+  const breadcrumbs = useMemo(() => {
+    const result: DocumentFolder[] = [];
+    let id = currentFolderId;
+    const visited = new Set<string>();
+    while (id && !visited.has(id)) {
+      visited.add(id);
+      const folder = folders.find((candidate) => candidate.id === id);
+      if (!folder) break;
+      result.unshift(folder);
+      id = folder.parentId;
+    }
+    return result;
+  }, [currentFolderId, folders]);
+
+  async function submitCreate() {
+    const name = createName.trim();
+    if (!name || !createMode || creating) return;
+    setCreating(true);
+    setError(null);
+    try {
+      if (createMode === "folder") {
+        await createDocumentFolder(project.id, name, currentFolderId);
+      } else {
+        const document = await createProjectDocument(project.id, {
+          folderId: currentFolderId,
+          title: name,
+          type: createType,
+          content: "",
+        });
+        setSelected(document);
+        setEditing(true);
+      }
+      setCreateMode(null);
+      setCreateName("");
+      await loadLibrary();
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : String(caught);
+      setError(message);
+      onError?.(message);
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function saveDocument() {
+    if (!selected || saving || draft === selected.content) {
+      setEditing(false);
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await updateProjectDocument(selected.id, {
+        content: draft,
+        version: selected.version,
+      });
+      setSelected(updated);
+      setEditing(false);
+      await loadLibrary();
+    } catch (caught) {
+      if (caught instanceof ApiError && caught.code === "VERSION_CONFLICT") {
+        setError(text(
+          "文档已被其他成员或 Agent 更新。你的草稿已保留，请复制后刷新再合并。",
+          "This document changed elsewhere. Your draft is preserved; refresh and merge it.",
+        ));
+      } else {
+        const message = caught instanceof Error ? caught.message : String(caught);
+        setError(message);
+        onError?.(message);
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function uploadFile(file: File) {
+    if (!selected) return;
+    setError(null);
+    try {
+      const attachment = await uploadDocumentAttachment(selected.id, file);
+      setAttachments((current) => [...current, attachment]);
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : String(caught);
+      setError(message);
+      onError?.(message);
+    }
+  }
+
+  return (
+    <div className="project-library">
+      <div className="library-toolbar">
+        <div className="library-actions">
+          <button type="button" className="button secondary" onClick={() => setCreateMode("folder")}>
+            <PlusIcon size={14} /> {text("新建文件夹", "New folder")}
+          </button>
+          <button type="button" className="button primary" onClick={() => setCreateMode("document")}>
+            <PlusIcon size={14} /> {text("新建文档", "New document")}
+          </button>
+          <button
+            type="button"
+            className="button secondary"
+            disabled={!selected}
+            title={selected ? undefined : text("先选择一份文档", "Select a document first")}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            {text("上传文件", "Upload file")}
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            hidden
+            onChange={(event) => {
+              const file = event.target.files?.[0];
+              if (file) void uploadFile(file);
+              event.target.value = "";
+            }}
+          />
+        </div>
+        <div className="library-filters">
+          <select value={typeFilter} onChange={(event) => setTypeFilter(event.target.value as ProjectDocumentType | "")}>
+            <option value="">{text("全部类型", "All types")}</option>
+            {DOCUMENT_TYPES.map((option) => (
+              <option key={option.value} value={option.value}>{language === "zh" ? option.zh : option.en}</option>
+            ))}
+          </select>
+          <label className="library-search">
+            <LinearIcon name="search" />
+            <input
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={text("搜索文件或正文…", "Search files or content…")}
+            />
+          </label>
+        </div>
+      </div>
+
+      {createMode && (
+        <form className="library-create" onSubmit={(event) => { event.preventDefault(); void submitCreate(); }}>
+          <input
+            autoFocus
+            value={createName}
+            onChange={(event) => setCreateName(event.target.value)}
+            placeholder={createMode === "folder" ? text("文件夹名称", "Folder name") : text("文档标题", "Document title")}
+          />
+          {createMode === "document" && (
+            <select value={createType} onChange={(event) => setCreateType(event.target.value as ProjectDocumentType)}>
+              {DOCUMENT_TYPES.map((option) => (
+                <option key={option.value} value={option.value}>{language === "zh" ? option.zh : option.en}</option>
+              ))}
+            </select>
+          )}
+          <button type="submit" className="button primary" disabled={!createName.trim() || creating}>
+            {creating ? text("创建中…", "Creating…") : text("创建", "Create")}
+          </button>
+          <button type="button" className="button ghost" onClick={() => setCreateMode(null)}>
+            {text("取消", "Cancel")}
+          </button>
+        </form>
+      )}
+
+      {error && <div className="project-readme-alert error library-alert" role="alert"><LinearIcon name="alert" />{error}</div>}
+
+      <div className={`library-layout${selected ? " has-detail" : ""}`}>
+        <section className="library-browser" aria-label={text("项目资料库", "Project library")}>
+          <nav className="library-breadcrumbs" aria-label={text("资料库路径", "Library path")}>
+            <button type="button" onClick={() => setCurrentFolderId(null)}>{text("资料库", "Library")}</button>
+            {breadcrumbs.map((folder) => (
+              <span key={folder.id}><i>/</i><button type="button" onClick={() => setCurrentFolderId(folder.id)}>{folder.name}</button></span>
+            ))}
+          </nav>
+          <div className="library-table" role="table">
+            <div className="library-row library-head" role="row">
+              <span>{text("名称", "Name")}</span>
+              <span>{text("类型", "Type")}</span>
+              <span>{text("更新人", "Updated by")}</span>
+              <span>{text("更新时间", "Updated")}</span>
+              <span>{text("大小", "Size")}</span>
+            </div>
+            {loading ? (
+              <div className="library-empty">{text("正在加载资料库…", "Loading library…")}</div>
+            ) : (
+              <>
+                {!query && childFolders.map((folder) => (
+                  <button className="library-row" role="row" type="button" key={folder.id} onClick={() => setCurrentFolderId(folder.id)}>
+                    <span className="library-name"><b className="library-icon folder">▰</b>{folder.name}</span>
+                    <span>{text("文件夹", "Folder")}</span><span>—</span><span>{shortDate(folder.updatedAt)}</span><span>—</span>
+                  </button>
+                ))}
+                {documents.map((document) => (
+                  <button
+                    className={`library-row${selected?.id === document.id ? " selected" : ""}`}
+                    role="row"
+                    type="button"
+                    key={document.id}
+                    onClick={() => { setSelected(document); setEditing(false); }}
+                  >
+                    <span className="library-name"><b className="library-icon markdown">M</b>{document.title}</span>
+                    <span>{documentTypeLabel(document.type, language)}</span>
+                    <span>{document.updatedBy.name}</span>
+                    <span>{shortDate(document.updatedAt)}</span>
+                    <span>{fileSize(document.size)}</span>
+                  </button>
+                ))}
+                {childFolders.length === 0 && documents.length === 0 && (
+                  <div className="library-empty">{text("这里还没有资料", "No files here yet")}</div>
+                )}
+              </>
+            )}
+          </div>
+        </section>
+
+        {selected && (
+          <aside className="library-detail" aria-label={text("文档详情", "Document details")}>
+            <header>
+              <div><h2>{selected.title}</h2><p>{documentTypeLabel(selected.type, language)} · v{selected.version} · {selected.updatedBy.name}</p></div>
+              <button type="button" className="icon-button" aria-label={text("关闭详情", "Close details")} onClick={() => setSelected(null)}>×</button>
+            </header>
+            <div className="library-detail-actions">
+              {editing ? (
+                <>
+                  <button type="button" className="button primary" disabled={saving} onClick={() => void saveDocument()}>{saving ? text("保存中…", "Saving…") : text("保存", "Save")}</button>
+                  <button type="button" className="button secondary" onClick={() => { setDraft(selected.content); setEditing(false); }}>{text("取消", "Cancel")}</button>
+                </>
+              ) : (
+                <button type="button" className="button primary" onClick={() => setEditing(true)}>{text("编辑 Markdown", "Edit Markdown")}</button>
+              )}
+              <a className="button secondary" href={resolveTaskboardUrl(`/api/documents/${encodeURIComponent(selected.id)}/export`)} download>{text("导出 .md", "Export .md")}</a>
+            </div>
+            <div className="library-document-body">
+              {editing
+                ? <textarea aria-label={text("Markdown 正文", "Markdown content")} value={draft} onChange={(event) => setDraft(event.target.value)} />
+                : selected.content
+                  ? <MarkdownDocument value={selected.content} />
+                  : <p className="library-empty-copy">{text("点击编辑开始编写 Markdown。", "Choose edit to start writing Markdown.")}</p>}
+            </div>
+            {attachments.length > 0 && (
+              <section className="library-meta-section"><h3>{text("附件", "Attachments")}</h3>{attachments.map((attachment) => (
+                <a key={attachment.id} href={resolveTaskboardUrl(`/api/document-attachments/${encodeURIComponent(attachment.id)}/content`)} download>{attachment.filename}<small>{fileSize(attachment.size)}</small></a>
+              ))}</section>
+            )}
+            <section className="library-meta-section"><h3>{text("版本历史", "Version history")}</h3>{revisions.map((item) => (
+              <div className="library-revision" key={item.id}><span>v{item.version}</span><span>{item.updatedBy.name}</span><time>{shortDate(item.createdAt)}</time></div>
+            ))}</section>
+          </aside>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -20,9 +20,9 @@
   --border: #e1e1e1;
   --border-strong: #d5d5d5;
   --border-hairline: 0.5px;
-  --accent: #317cff;
-  --accent-hover: #3b84ff;
-  --accent-soft: rgba(49, 124, 255, 0.11);
+  --accent: #6a1b9a;
+  --accent-hover: #7b2aad;
+  --accent-soft: rgba(106, 27, 154, 0.11);
   --danger: #f34e52;
   --danger-soft: #fff0f0;
   --warning: #f0bf00;
@@ -62,9 +62,9 @@
   --text-quaternary: #65656b;
   --border: rgba(255, 255, 255, 0.075);
   --border-strong: rgba(255, 255, 255, 0.13);
-  --accent: #317cff;
-  --accent-hover: #3f8aff;
-  --accent-soft: rgba(49, 124, 255, 0.16);
+  --accent: #9a55c3;
+  --accent-hover: #ad6ad0;
+  --accent-soft: rgba(154, 85, 195, 0.16);
   --danger: #ef686d;
   --danger-soft: rgba(229, 72, 77, 0.12);
   --warning: #e5b729;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -373,6 +373,77 @@ export interface ProjectReadmeAttachment {
   createdAt: string;
 }
 
+export type ProjectDocumentType =
+  | "general"
+  | "spec"
+  | "plan"
+  | "tasks"
+  | "run-report"
+  | "test-report";
+
+export type ProjectDocumentStatus =
+  | "draft"
+  | "awaiting_confirmation"
+  | "approved"
+  | "frozen"
+  | "superseded";
+
+export interface DocumentActor {
+  type: "user" | "agent";
+  id: string;
+  name: string;
+  avatarUrl: string | null;
+}
+
+export interface DocumentFolder {
+  id: string;
+  projectId: string;
+  parentId: string | null;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProjectDocument {
+  id: string;
+  projectId: string;
+  folderId: string | null;
+  title: string;
+  type: ProjectDocumentType;
+  status: ProjectDocumentStatus;
+  content: string;
+  size: number;
+  version: number;
+  isProjectOverview: boolean;
+  taskIds: string[];
+  createdBy: DocumentActor;
+  updatedBy: DocumentActor;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface DocumentRevision {
+  id: string;
+  documentId: string;
+  version: number;
+  title: string;
+  type: ProjectDocumentType;
+  status: ProjectDocumentStatus;
+  content: string;
+  updatedBy: DocumentActor;
+  createdAt: string;
+}
+
+export interface DocumentAttachment {
+  id: string;
+  documentId: string;
+  kind: "inline" | "attachment";
+  filename: string;
+  contentType: string;
+  size: number;
+  createdAt: string;
+}
+
 export interface TaskRelationSummary {
   id: string;
   identifier: string;


### PR DESCRIPTION
## Summary

- rename the visible product to Atlas Workbench while preserving existing identifiers and data locations
- add the local Markdown document library, immutable revisions, folders, attachments, search, export, and optimistic conflicts
- add `atlasctl` document commands while keeping `taskctl` compatible
- replace Project Docs with the new library UI and expose 动态 / 计划 / 任务 / 资料库 navigation

## Direct verification

- created a Chinese folder and Markdown document in an isolated local runtime
- saved v2, rendered the Markdown, and verified v1/v2 history
- searched the same content through `atlasctl` and exported identical `.md` content

## Tests

- `npm test` — 377 passed, 1 skipped, 0 failed; component suite 9 passed
- `npx vitest run web/src/components/ProjectLibrary.test.tsx --environment jsdom` — 2 passed
- `npm run typecheck`
- `npm run build:web`
- `git diff --check`

## Limitation

`cargo check` reaches the existing Tauri build script but cannot continue until `src-tauri/binaries/node-aarch64-apple-darwin` is prepared by the repository's packaging step.

Taskboard: ATL-1
