### PR TITLE
fix: launch Microsoft Store Codex via Windows activation

### DIFF
--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -31,6 +31,13 @@ import {
   CdpPipeBrowser,
   validatedLoopbackCdpWebSocketUrl,
 } from "./codex-cdp-pipe.mjs";
+import {
+  activateWindowsCodex,
+  stopWindowsCodex,
+  windowsCodexProcesses,
+  windowsCodexProfileArgument,
+  windowsRootProcesses,
+} from "./windows-codex.mjs";
 
 const injectorPath = fileURLToPath(import.meta.url);
 const projectRoot = path.resolve(path.dirname(injectorPath), "..");
@@ -376,6 +383,12 @@ function codexAppBundleBuild(appPath) {
 }
 
 function codexAppProcesses(appPath) {
+  if (process.platform === "win32") {
+    return windowsCodexProcesses(
+      appPath,
+      withoutTaskboardLauncherEnvironment(process.env),
+    );
+  }
   const processes = spawnSync("/bin/ps", ["-ww", "-axo", "pid=,command="], {
     encoding: "utf8",
     env: withoutTaskboardLauncherEnvironment(process.env),
@@ -416,10 +429,14 @@ function codexUpdateReplacementProcess(appPath, exitedPid, previousBuild) {
 }
 
 function managedCodexProcesses(appPath) {
-  const profileArgument = `--user-data-dir=${independentCodexProfilePath}`;
-  return codexAppProcesses(appPath).filter((record) => (
-    record.command.includes(` ${profileArgument} `)
+  const processes = codexAppProcesses(appPath);
+  const managed = processes.filter((record) => (
+    process.platform === "win32"
+      ? windowsCodexProfileArgument(record.command, independentCodexProfilePath)
+      : record.command.includes(` --user-data-dir=${independentCodexProfilePath} `)
   ));
+  if (process.platform !== "win32") return managed;
+  return windowsRootProcesses(managed);
 }
 
 function managedCodexProcess(appPath) {
@@ -440,6 +457,10 @@ function managedCodexUsesPort(record, port) {
 }
 
 function isManagedCodexRunning(record) {
+  if (process.platform === "win32") {
+    return codexAppProcesses(record.executable)
+      .some((candidate) => candidate.pid === record.pid && candidate.command === record.command);
+  }
   const result = spawnSync(
     "/bin/ps",
     ["-ww", "-p", String(record.pid), "-o", "command="],
@@ -461,42 +482,58 @@ async function launchCodexWithLaunchServices(appPath, port, shouldStop = () => f
   }
   if (shouldStop()) throw new Error("Managed Codex launch stopped");
 
-  const launcher = spawn(
-    "/usr/bin/open",
-    [
-      "-a",
+  if (process.platform === "win32") {
+    activateWindowsCodex(
       appPath,
-      "--args",
-      `--user-data-dir=${independentCodexProfilePath}`,
-      "--remote-debugging-address=127.0.0.1",
-      `--remote-debugging-port=${port}`,
-      `--remote-allow-origins=http://127.0.0.1:${port}`,
-    ],
-    {
-      env: withoutTaskboardLauncherEnvironment(process.env),
-      stdio: "ignore",
-    },
-  );
-  await new Promise((resolve, reject) => {
-    launcher.once("error", reject);
-    launcher.once("exit", (code, signal) => {
-      if (code === 0) resolve();
-      else reject(new Error(`LaunchServices failed to start Codex (${signal || code})`));
+      independentCodexProfilePath,
+      port,
+      withoutTaskboardLauncherEnvironment(process.env),
+    );
+  } else {
+    const launcher = spawn(
+      "/usr/bin/open",
+      [
+        "-a",
+        appPath,
+        "--args",
+        `--user-data-dir=${independentCodexProfilePath}`,
+        "--remote-debugging-address=127.0.0.1",
+        `--remote-debugging-port=${port}`,
+        `--remote-allow-origins=http://127.0.0.1:${port}`,
+      ],
+      {
+        env: withoutTaskboardLauncherEnvironment(process.env),
+        stdio: "ignore",
+      },
+    );
+    await new Promise((resolve, reject) => {
+      launcher.once("error", reject);
+      launcher.once("exit", (code, signal) => {
+        if (code === 0) resolve();
+        else reject(new Error(`LaunchServices failed to start Codex (${signal || code})`));
+      });
     });
-  });
+  }
 
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
     const launched = managedCodexProcess(appPath);
     if (launched && managedCodexUsesPort(launched, port)) return launched;
-    if (launched) throw new Error("LaunchServices started Codex on an unexpected CDP port");
+    if (launched) throw new Error("The platform launcher started Codex on an unexpected CDP port");
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
-  throw new Error("LaunchServices did not start the managed Codex process");
+  throw new Error("The platform launcher did not start the managed Codex process");
 }
 
 async function stopManagedCodex(record) {
   if (!isManagedCodexRunning(record)) return;
+  if (process.platform === "win32") {
+    stopWindowsCodex(
+      record.pid,
+      withoutTaskboardLauncherEnvironment(process.env),
+    );
+    return;
+  }
   try {
     process.kill(record.pid, "SIGTERM");
   } catch (error) {
@@ -2858,17 +2895,7 @@ async function main() {
       if (nativeCodexBrowser) {
         const deepLink = new URL("codex://threads/new");
         deepLink.searchParams.set("browserUrl", taskboardPageUrl);
-        await new Promise((resolve, reject) => {
-          const child = spawn("/usr/bin/open", [deepLink.toString()], {
-            env: withoutTaskboardLauncherEnvironment(process.env),
-            stdio: "ignore",
-          });
-          child.once("error", reject);
-          child.once("close", (code) => {
-            if (code === 0) resolve();
-            else reject(new Error(`LaunchServices could not open Taskboard (${code})`));
-          });
-        });
+        await openWithDefaultApplication(deepLink.toString());
         openedRequestGeneration = Math.max(openedRequestGeneration, generation);
         console.log(JSON.stringify({ openedTaskboardInExistingCodex: true }));
         return true;

--- a/scripts/prepare-tauri-app.mjs
+++ b/scripts/prepare-tauri-app.mjs
@@ -253,6 +253,7 @@ async function copyApplicationResources() {
     "codex-injector-runtime.mjs",
     "codex-rate-limits.mjs",
     "taskboard-supervisor.mjs",
+    "windows-codex.mjs",
   ]) {
     await copyFile(
       path.join(projectRoot, "scripts", fileName),

--- a/scripts/windows-codex.mjs
+++ b/scripts/windows-codex.mjs
@@ -147,7 +147,7 @@ export function stopWindowsCodex(pid, environment, run = spawnSync) {
 export function windowsCodexProfileArgument(command, profilePath) {
   const normalizedCommand = command.toLocaleLowerCase("en-US");
   return normalizedCommand.includes("--user-data-dir")
-    && normalizedCommand.includes(path.resolve(profilePath).toLocaleLowerCase("en-US"));
+    && normalizedCommand.includes(path.win32.resolve(profilePath).toLocaleLowerCase("en-US"));
 }
 
 export function windowsRootProcesses(processes) {

--- a/scripts/windows-codex.mjs
+++ b/scripts/windows-codex.mjs
@@ -1,0 +1,156 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+const inspectProcessesScript = String.raw`
+$ErrorActionPreference = 'Stop'
+$app = $env:CODEX_TASKBOARD_CODEX_APP_PATH
+$name = [IO.Path]::GetFileName($app)
+$processes = @(Get-CimInstance Win32_Process -Filter "Name = '$name'" |
+  Where-Object { $_.ExecutablePath -eq $app } |
+  Select-Object ProcessId, ParentProcessId, ExecutablePath, CommandLine)
+[Console]::Out.Write(($processes | ConvertTo-Json -Compress))
+`;
+
+const activatePackagedAppScript = String.raw`
+$ErrorActionPreference = 'Stop'
+$source = @'
+using System;
+using System.Runtime.InteropServices;
+
+[ComImport]
+[Guid("2E941141-7F97-4756-BA1D-9DECDE894A3D")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+interface IApplicationActivationManager
+{
+    [PreserveSig]
+    int ActivateApplication(
+        [MarshalAs(UnmanagedType.LPWStr)] string appUserModelId,
+        [MarshalAs(UnmanagedType.LPWStr)] string arguments,
+        uint options,
+        out uint processId);
+}
+
+[ComImport]
+[Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C")]
+class ApplicationActivationManager {}
+
+public static class PackagedAppActivator
+{
+    public static uint Activate(string appUserModelId, string arguments)
+    {
+        var manager = (IApplicationActivationManager)new ApplicationActivationManager();
+        try
+        {
+            uint processId;
+            var result = manager.ActivateApplication(appUserModelId, arguments, 0, out processId);
+            if (result < 0) Marshal.ThrowExceptionForHR(result);
+            return processId;
+        }
+        finally
+        {
+            Marshal.FinalReleaseComObject(manager);
+        }
+    }
+}
+'@
+Add-Type -TypeDefinition $source
+
+$app = $env:CODEX_TASKBOARD_CODEX_APP_PATH
+$profile = $env:CODEX_TASKBOARD_CODEX_PROFILE
+$port = $env:CODEX_TASKBOARD_CODEX_PORT
+$package = Get-AppxPackage | Where-Object {
+  $app.StartsWith(($_.InstallLocation + [IO.Path]::DirectorySeparatorChar), [StringComparison]::OrdinalIgnoreCase)
+} | Select-Object -First 1
+if ($null -eq $package) { throw "Unable to find the Codex package for $app" }
+
+$relativeExecutable = $app.Substring($package.InstallLocation.Length).TrimStart('\', '/').Replace('\', '/')
+$manifest = $package | Get-AppxPackageManifest
+$application = @($manifest.Package.Applications.Application) | Where-Object {
+  ([string]$_.Executable).Replace('\', '/') -eq $relativeExecutable
+} | Select-Object -First 1
+if ($null -eq $application) { throw "Unable to find the Codex application manifest entry" }
+
+$appUserModelId = $package.PackageFamilyName + '!' + $application.Id
+$escapedProfile = $profile.Replace('"', '\"')
+$arguments = '--user-data-dir="' + $escapedProfile + '"' +
+  ' --remote-debugging-address=127.0.0.1' +
+  ' --remote-debugging-port=' + $port +
+  ' --remote-allow-origins=http://127.0.0.1:' + $port
+$processId = [PackagedAppActivator]::Activate($appUserModelId, $arguments)
+[Console]::Out.Write($processId)
+`;
+
+function runWindowsPowerShell(script, environment, run = spawnSync) {
+  const result = run(
+    "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-Command", script],
+    {
+      encoding: "utf8",
+      env: environment,
+      maxBuffer: 4 * 1024 * 1024,
+      windowsHide: true,
+    },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(result.stderr?.trim() || "Windows PowerShell command failed");
+  }
+  return result.stdout.trim();
+}
+
+export function windowsCodexProcesses(appPath, environment, run = spawnSync) {
+  const output = runWindowsPowerShell(
+    inspectProcessesScript,
+    { ...environment, CODEX_TASKBOARD_CODEX_APP_PATH: appPath },
+    run,
+  );
+  if (!output) return [];
+  const parsed = JSON.parse(output);
+  return (Array.isArray(parsed) ? parsed : [parsed]).map((record) => ({
+    pid: Number(record.ProcessId),
+    parentPid: Number(record.ParentProcessId),
+    executable: record.ExecutablePath || appPath,
+    command: record.CommandLine || record.ExecutablePath || appPath,
+  }));
+}
+
+export function activateWindowsCodex(appPath, profilePath, port, environment, run = spawnSync) {
+  const output = runWindowsPowerShell(
+    activatePackagedAppScript,
+    {
+      ...environment,
+      CODEX_TASKBOARD_CODEX_APP_PATH: appPath,
+      CODEX_TASKBOARD_CODEX_PROFILE: profilePath,
+      CODEX_TASKBOARD_CODEX_PORT: String(port),
+    },
+    run,
+  );
+  const pid = Number(output);
+  if (!Number.isInteger(pid) || pid <= 0) {
+    throw new Error(`Packaged Codex activation returned an invalid process ID: ${output}`);
+  }
+  return pid;
+}
+
+export function stopWindowsCodex(pid, environment, run = spawnSync) {
+  const result = run("taskkill.exe", ["/PID", String(pid), "/T", "/F"], {
+    encoding: "utf8",
+    env: environment,
+    windowsHide: true,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0 && !/not found|not running/i.test(result.stderr || "")) {
+    throw new Error(result.stderr?.trim() || `Unable to stop Codex process ${pid}`);
+  }
+}
+
+export function windowsCodexProfileArgument(command, profilePath) {
+  const normalizedCommand = command.toLocaleLowerCase("en-US");
+  return normalizedCommand.includes("--user-data-dir")
+    && normalizedCommand.includes(path.resolve(profilePath).toLocaleLowerCase("en-US"));
+}
+
+export function windowsRootProcesses(processes) {
+  const processIds = new Set(processes.map((record) => record.pid));
+  return processes.filter((record) => !processIds.has(record.parentPid));
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -147,7 +147,7 @@ struct LauncherState {
     lifecycle: Mutex<()>,
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     taskboard_listener: Mutex<Option<TcpListener>>,
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     codex_port: Mutex<Option<u16>>,
     #[cfg(target_os = "windows")]
     child_control: Mutex<Option<ChildStdin>>,
@@ -395,7 +395,7 @@ impl LauncherState {
             lifecycle: Mutex::new(()),
             #[cfg(any(target_os = "macos", target_os = "linux"))]
             taskboard_listener: Mutex::new(None),
-            #[cfg(target_os = "macos")]
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
             codex_port: Mutex::new(None),
             #[cfg(target_os = "windows")]
             child_control: Mutex::new(None),
@@ -859,7 +859,7 @@ fn taskboard_listener(_state: &LauncherState) -> Result<(Option<i32>, u16), Stri
     Ok((None, port))
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn codex_port(state: &LauncherState) -> Result<u16, String> {
     let mut port = state.codex_port.lock().unwrap();
     if let Some(port) = *port {
@@ -1123,7 +1123,7 @@ fn ordinary_codex_process(app_path: &Path, codex_profile: &Path) -> Result<Optio
             "-NoProfile",
             "-NonInteractive",
             "-Command",
-            "$ErrorActionPreference = 'Stop'; $app = $env:CODEX_TASKBOARD_CODEX_APP_PATH; $profile = $env:CODEX_TASKBOARD_CODEX_PROFILE; $name = [IO.Path]::GetFileName($app); $all = @(Get-CimInstance Win32_Process -Filter \"Name = '$name'\" | Where-Object { $_.ExecutablePath -eq $app }); $pids = @{}; foreach ($item in $all) { $pids[[uint32]$item.ProcessId] = $true }; $process = $all | Where-Object { $command = [string]$_.CommandLine; $isRoot = -not $pids.ContainsKey([uint32]$_.ParentProcessId); $isManaged = $command.IndexOf('--remote-debugging-pipe', [StringComparison]::OrdinalIgnoreCase) -ge 0 -and $command.IndexOf(('--user-data-dir=' + $profile), [StringComparison]::OrdinalIgnoreCase) -ge 0; $isRoot -and -not $isManaged } | Select-Object -First 1; if ($null -ne $process) { [Console]::Out.Write($process.ProcessId) }",
+            "$ErrorActionPreference = 'Stop'; $app = $env:CODEX_TASKBOARD_CODEX_APP_PATH; $profile = $env:CODEX_TASKBOARD_CODEX_PROFILE; $name = [IO.Path]::GetFileName($app); $all = @(Get-CimInstance Win32_Process -Filter \"Name = '$name'\" | Where-Object { $_.ExecutablePath -eq $app }); $pids = @{}; foreach ($item in $all) { $pids[[uint32]$item.ProcessId] = $true }; $process = $all | Where-Object { $command = [string]$_.CommandLine; $isRoot = -not $pids.ContainsKey([uint32]$_.ParentProcessId); $usesManagedProfile = $command.IndexOf('--user-data-dir', [StringComparison]::OrdinalIgnoreCase) -ge 0 -and $command.IndexOf($profile, [StringComparison]::OrdinalIgnoreCase) -ge 0; $usesPrivateCdp = $command.IndexOf('--remote-debugging-pipe', [StringComparison]::OrdinalIgnoreCase) -ge 0 -or $command.IndexOf('--remote-debugging-port', [StringComparison]::OrdinalIgnoreCase) -ge 0; $isManaged = $usesManagedProfile -and $usesPrivateCdp; $isRoot -and -not $isManaged } | Select-Object -First 1; if ($null -ne $process) { [Console]::Out.Write($process.ProcessId) }",
         ])
         .env("CODEX_TASKBOARD_CODEX_APP_PATH", app_path)
         .env("CODEX_TASKBOARD_CODEX_PROFILE", codex_profile)
@@ -1666,7 +1666,7 @@ fn start_launcher_locked(
         .map_err(|error| error.to_string())?
     };
     let (_taskboard_listener_fd, taskboard_port) = taskboard_listener(state)?;
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     let codex_port = codex_port(state)?.to_string();
     let instance_token = Uuid::new_v4().to_string();
     let instance_secret = Uuid::new_v4().to_string();
@@ -1691,9 +1691,9 @@ fn start_launcher_locked(
     command.arg(&injector_path);
     #[cfg(target_os = "windows")]
     command.arg(r"scripts\codex-injector.mjs");
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     command.args(["--launch", "--watch", "--open", "--port", &codex_port]);
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(target_os = "linux")]
     command.args(["--launch", "--watch", "--open", "--cdp-pipe"]);
     command
         .args(["--startup-token", &instance_token, "--app-path"])
@@ -1760,14 +1760,14 @@ fn start_launcher_locked(
     let snapshot = update_snapshot(app, state, |snapshot| {
         snapshot.child_pid = Some(pid);
     });
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
     append_log(
         state,
         &format!(
             "Started launcher child {pid} on Taskboard {taskboard_port} with Codex CDP {codex_port}"
         ),
     );
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(target_os = "linux")]
     append_log(
         state,
         &format!(

--- a/test/injector.test.mjs
+++ b/test/injector.test.mjs
@@ -320,6 +320,13 @@ test("the package injection command remains resident for tab-triggered recovery"
   assert.match(source, /__codexTaskboardHostStartupTokenV1/);
 });
 
+test("the existing-Codex fallback opens its deep link with the platform default application", () => {
+  assert.match(
+    source,
+    /deepLink\.searchParams\.set\("browserUrl", taskboardPageUrl\);\s*await openWithDefaultApplication\(deepLink\.toString\(\)\);/,
+  );
+});
+
 test("attach reconciles the renderer against a hashed current injection source", () => {
   assert.match(source, /createHash\("sha256"\)/);
   assert.match(source, /__CODEX_TASKBOARD_SOURCE_HASH__/);

--- a/test/launcher-release.test.mjs
+++ b/test/launcher-release.test.mjs
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { test } from "node:test";
 
 const launcherSource = await readFile(new URL("../src-tauri/src/main.rs", import.meta.url), "utf8");
+const prepareSource = await readFile(new URL("../scripts/prepare-tauri-app.mjs", import.meta.url), "utf8");
 const tauriConfig = JSON.parse(await readFile(new URL("../src-tauri/tauri.conf.json", import.meta.url), "utf8"));
 const releaseWorkflow = await readFile(new URL("../.github/workflows/release-macos.yml", import.meta.url), "utf8");
 const checkWorkflow = await readFile(new URL("../.github/workflows/check.yml", import.meta.url), "utf8");
@@ -40,6 +41,10 @@ test("the launcher keeps CDP random and prefers the Taskboard port with a fallba
     /#\[cfg\(target_os = "linux"\)\]\s+command\.args\(\["--launch", "--watch", "--open", "--cdp-pipe"\]\);/,
   );
   assert.doesNotMatch(launcherSource, /const LAUNCHER_PORT/);
+});
+
+test("the packaged injector includes its Windows Store activation module", () => {
+  assert.match(prepareSource, /"windows-codex\.mjs"/);
 });
 
 test("release signing is tag-only and PR CI builds the real unsigned app bundle", () => {

--- a/test/launcher-release.test.mjs
+++ b/test/launcher-release.test.mjs
@@ -33,7 +33,11 @@ test("the launcher keeps CDP random and prefers the Taskboard port with a fallba
   );
   assert.match(
     launcherSource,
-    /#\[cfg\(target_os = "macos"\)\]\s+command\.args\(\["--launch", "--watch", "--open", "--port", &codex_port\]\);/,
+    /#\[cfg\(any\(target_os = "macos", target_os = "windows"\)\)\]\s+command\.args\(\["--launch", "--watch", "--open", "--port", &codex_port\]\);/,
+  );
+  assert.match(
+    launcherSource,
+    /#\[cfg\(target_os = "linux"\)\]\s+command\.args\(\["--launch", "--watch", "--open", "--cdp-pipe"\]\);/,
   );
   assert.doesNotMatch(launcherSource, /const LAUNCHER_PORT/);
 });

--- a/test/windows-codex.test.mjs
+++ b/test/windows-codex.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  activateWindowsCodex,
+  stopWindowsCodex,
+  windowsCodexProcesses,
+  windowsCodexProfileArgument,
+  windowsRootProcesses,
+} from "../scripts/windows-codex.mjs";
+
+const appPath = String.raw`C:\Program Files\WindowsApps\OpenAI.Codex_1.0.0.0_x64__example\app\ChatGPT.exe`;
+const profilePath = String.raw`C:\Users\alice\AppData\Local\Codex Taskboard\codex-profile`;
+
+test("Windows Codex process inspection uses the protected executable path", () => {
+  const calls = [];
+  const processes = windowsCodexProcesses(appPath, { SAFE: "1" }, (command, args, options) => {
+    calls.push({ command, args, options });
+    return {
+      status: 0,
+      stdout: JSON.stringify({
+        ProcessId: 123,
+        ParentProcessId: 1,
+        ExecutablePath: appPath,
+        CommandLine: `"${appPath}" "--user-data-dir=${profilePath}" --remote-debugging-port=9229`,
+      }),
+      stderr: "",
+    };
+  });
+
+  assert.equal(calls[0].command, "powershell.exe");
+  assert.equal(calls[0].options.env.CODEX_TASKBOARD_CODEX_APP_PATH, appPath);
+  assert.deepEqual(processes, [{
+    pid: 123,
+    parentPid: 1,
+    executable: appPath,
+    command: `"${appPath}" "--user-data-dir=${profilePath}" --remote-debugging-port=9229`,
+  }]);
+  assert.equal(windowsCodexProfileArgument(processes[0].command, profilePath), true);
+  assert.equal(processes[0].parentPid, 1);
+});
+
+test("Windows Store activation passes the app, isolated profile, and CDP port through environment", () => {
+  const calls = [];
+  const pid = activateWindowsCodex(
+    appPath,
+    profilePath,
+    43123,
+    { SAFE: "1" },
+    (command, args, options) => {
+      calls.push({ command, args, options });
+      return { status: 0, stdout: "456\n", stderr: "" };
+    },
+  );
+
+  assert.equal(pid, 456);
+  assert.equal(calls[0].command, "powershell.exe");
+  assert.equal(calls[0].options.env.CODEX_TASKBOARD_CODEX_APP_PATH, appPath);
+  assert.equal(calls[0].options.env.CODEX_TASKBOARD_CODEX_PROFILE, profilePath);
+  assert.equal(calls[0].options.env.CODEX_TASKBOARD_CODEX_PORT, "43123");
+  assert.match(calls[0].args.at(-1), /IApplicationActivationManager/);
+  assert.match(calls[0].args.at(-1), /--remote-debugging-port=/);
+});
+
+test("Windows Codex cleanup terminates the activated process tree", () => {
+  const calls = [];
+  stopWindowsCodex(456, { SAFE: "1" }, (command, args, options) => {
+    calls.push({ command, args, options });
+    return { status: 0, stdout: "", stderr: "" };
+  });
+  assert.deepEqual(calls[0].args, ["/PID", "456", "/T", "/F"]);
+});
+
+test("Windows managed process discovery keeps only the Electron root", () => {
+  const processes = [
+    { pid: 100, parentPid: 1 },
+    { pid: 101, parentPid: 100 },
+    { pid: 102, parentPid: 100 },
+    { pid: 103, parentPid: 101 },
+  ];
+  assert.deepEqual(windowsRootProcesses(processes), [processes[0]]);
+});


### PR DESCRIPTION
## Summary

- launch the packaged Microsoft Store Codex app through `IApplicationActivationManager` instead of directly spawning the protected `ChatGPT.exe`
- use a random loopback CDP port on Windows while preserving the isolated Taskboard browser profile
- identify only the Electron root as the managed Codex process so shutdown cleans up the complete process tree
- use the platform default application for the existing-Codex deep-link fallback

## Root cause

The Windows launcher passed the Store package executable to Node's `spawn()` with `--remote-debugging-pipe`. Windows rejects direct execution of that protected `WindowsApps` path with `EPERM`, so v1.1.21 stopped the restart loop but still could not start Codex.

This change resolves the package AUMID from the installed manifest and activates it through the Windows Store app activation API, whose launch contract accepts the app-specific CDP arguments: https://learn.microsoft.com/windows/win32/api/shobjidl_core/nf-shobjidl_core-iapplicationactivationmanager-activateapplication

Follow-up to #352.

## Validation

- `node --test test/windows-codex.test.mjs test/injector.test.mjs test/launcher-release.test.mjs` — 23 passed locally and on Windows Server 2025
- `npm run typecheck` — passed
- `npm run build:web` — passed
- `npm run test:components` — 9 passed
- packaged-resource regression verifies `windows-codex.mjs` is copied beside the injector
- Windows Rust/Tauri/NSIS build — passed in [fork run 33856944411](https://github.com/zzx547651745/dashi-taskboard/actions/runs/33856944411)
- generated `Codex Taskboard_1.1.22_x64-setup.exe` from packaging commit `692fa361dc217c6cfe43d2dcb7f583279af39144` (PR head `3d58f8d13682da95f26619b4373ac5f5efe9cc4`)
- manual Windows Store integration test with Codex `26.901.1978.0`:
  - packaged activation returned a new PID and exposed CDP on an isolated random loopback port
  - Taskboard service started on a separate isolated port
  - injection reported `entryMounted`, `pageMounted`, `pageVisible`, `frameReady`, and `frameLoaded` as `true`
  - shutdown left 0 managed Codex processes and 0 test listeners

The full Node suite reached 372 passes and 2 skips; two pre-existing `ai-chat-runner` cases failed only while deleting Windows temp workspaces with `EBUSY`. The focused launcher/injector tests pass consistently.