### PR TITLE
fix: hide Windows injector console

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -40,7 +40,10 @@ use std::{
     time::{Duration, Instant},
 };
 #[cfg(target_os = "windows")]
-use std::{os::windows::fs::OpenOptionsExt, process::ChildStdin};
+use std::{
+    os::windows::{fs::OpenOptionsExt, process::CommandExt},
+    process::ChildStdin,
+};
 #[cfg(target_os = "macos")]
 use tauri::ActivationPolicy;
 use tauri::{
@@ -63,7 +66,7 @@ use windows::{
                 RM_UNIQUE_PROCESS,
             },
             Threading::{
-                GetProcessTimes, OpenProcess, WaitForSingleObject,
+                GetProcessTimes, OpenProcess, WaitForSingleObject, CREATE_NO_WINDOW,
                 PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE,
             },
         },
@@ -1687,6 +1690,8 @@ fn start_launcher_locked(
         .unwrap_or_else(|| home_directory.join(".config"))
         .join("Codex");
     let mut command = StdCommand::new(&node_path);
+    #[cfg(target_os = "windows")]
+    command.creation_flags(CREATE_NO_WINDOW.0);
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     command.arg(&injector_path);
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Summary

- apply Windows `CREATE_NO_WINDOW` to the bundled Node injector command before spawn
- keep stdin/stdout/stderr pipes, resident injector/server behavior, Codex injection, PID tracking, and normal process-tree shutdown unchanged
- keep macOS and Linux launch behavior unchanged

## Root cause and E3 path

Windows Taskboard Launcher cold start -> `src-tauri/src/main.rs::start_launcher_locked` -> Rust `StdCommand` starts bundled `node.exe` -> `scripts\codex-injector.mjs --launch --watch --open --cdp-pipe` remains resident -> Taskboard/server and Codex injection become visible.

The Launcher executable already uses the Windows GUI subsystem, but the external console-subsystem `node.exe` command did not set a no-console creation flag. Piped output made the allocated terminal blank; it did not prevent Windows from creating it.

## Focused verification

- `node --test test/launcher-release.test.mjs test/injector.test.mjs`: 17/17 passed
- one-off source assertion: the Node command receives `CREATE_NO_WINDOW` exactly once before `spawn()`; injector arguments and all three pipes remain
- `git diff --check`: passed
- diff scope: only `src-tauri/src/main.rs`; no AUMID, AppsFolder, injector arguments, environment, or shutdown changes
- exact-head CI run https://github.com/chuspeeism/dashi-taskboard/actions/runs/33860556842: check, macOS, Ubuntu 24.04 x64, and Windows x64 launcher jobs passed
- ChatGPT Pro implementation conversation: https://chatgpt.com/c/6a9a91f8-717c-83e8-8561-a29d4824b86e

The isolated Windows packaged cold-start check remains. It must confirm no visible Terminal/conhost, working Taskboard/injector/server/Codex injection, and a clean task process-tree exit. No Windows host is currently available, so LOCAL-387 remains in progress.

Tracks #367. The issue stays open until a Beta containing this change is published and verified.