### PR TITLE
feat: group board tasks by priority

### DIFF
--- a/test/board-interactions.test.mjs
+++ b/test/board-interactions.test.mjs
@@ -122,7 +122,8 @@ test("common issue mutations enter a Linear-style undo queue", () => {
   assert.match(appSource, /function pushUndo/);
   assert.match(appSource, /function performUndo[\s\S]*?await operation\.undo\(\)/);
   assert.match(appSource, /void performUndo\(\)/);
-  assert.match(appSource, /moveTask\(task, destination, beforeTaskId, true\)/);
+  assert.match(appSource, /moveTask\(task, destination, beforeTaskId, true, targetPriority\)/);
+  assert.match(appSource, /priorityChanged[\s\S]*?updateTaskRequest\(movedTask/);
   assert.match(appSource, /className="toast undo-toast"/);
   assert.match(appSource, />\s*\{text\("撤回", "Undo"\)\} <kbd>\{undoShortcut\}<\/kbd>/);
   assert.match(appSource, /restoreTaskRequest\(archived\)/);

--- a/test/other-tasks-panel.test.mjs
+++ b/test/other-tasks-panel.test.mjs
@@ -92,7 +92,7 @@ test("panel cards reuse TaskCard and the existing ranked board drop path", () =>
   assert.match(panelSource, /onDrop\(activeTab, taskId, findDropBefore/);
   assert.match(panelSource, /busy=\{restoringTaskId !== null \|\| deletingTaskId !== null\}/);
   assert.match(appSource, /onDrop=\{finishTaskDrop\}/);
-  assert.match(appSource, /moveTask\(task, destination, beforeTaskId, true\)/);
+  assert.match(appSource, /moveTask\(task, destination, beforeTaskId, true, targetPriority\)/);
 });
 
 test("global creation defaults to todo while per-column creation keeps the chosen status", () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2552,6 +2552,7 @@ export function App() {
     status: TaskStatus,
     beforeTaskId: string | null = null,
     useDropPosition = false,
+    targetPriority?: TaskPriority,
   ) {
     if (movingTaskId) {
       setDropTarget(null);
@@ -2597,21 +2598,37 @@ export function App() {
           ? nextTask.sortOrder - 1024
           : 1024;
     const previous = task;
+    const nextPriority = targetPriority ?? task.priority;
+    const priorityChanged = task.priority !== nextPriority;
     setActionError(null);
     setMovingTaskId(task.id);
     setTasks((current) => sortTasks(current.map((candidate) =>
-      candidate.id === task.id ? { ...candidate, status, sortOrder } : candidate,
+      candidate.id === task.id
+        ? { ...candidate, status, sortOrder, ...(priorityChanged ? { priority: nextPriority } : {}) }
+        : candidate,
     )));
 
     try {
-      const moved = await moveTaskRequest(task, status, sortOrder);
+      const movedTask = await moveTaskRequest(task, status, sortOrder);
+      const moved = priorityChanged
+        ? await updateTaskRequest(movedTask, {
+          ...taskToDraft(movedTask),
+          priority: nextPriority,
+        })
+        : movedTask;
       setTasks((current) => sortTasks(current.map((candidate) =>
         candidate.id === moved.id ? moved : candidate,
       )));
       pushUndo(null, async () => {
         const candidate = tasksRef.current.find((current) => current.id === moved.id);
         const current = candidate && candidate.version >= moved.version ? candidate : moved;
-        const restored = await moveTaskRequest(current, previous.status, previous.sortOrder);
+        const restoredPosition = await moveTaskRequest(current, previous.status, previous.sortOrder);
+        const restored = priorityChanged
+          ? await updateTaskRequest(restoredPosition, {
+            ...taskToDraft(restoredPosition),
+            priority: previous.priority,
+          })
+          : restoredPosition;
         setTasks((tasks) => sortTasks(tasks.map((item) => item.id === restored.id ? restored : item)));
       });
     } catch (error) {
@@ -2664,7 +2681,7 @@ export function App() {
       void updateTaskProperties(task, { priority: targetPriority });
       return;
     }
-    void moveTask(task, destination, beforeTaskId, true);
+    void moveTask(task, destination, beforeTaskId, true, targetPriority);
   }
 
   async function updateTaskProperties(task: Task, changes: Partial<TaskDraft>): Promise<Task> {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -139,6 +139,7 @@ import {
   type Task,
   type TaskboardMetadata,
   type TaskDraft,
+  type TaskPriority,
   type TaskStatus,
 } from "./types";
 // The poller stays in ESM JavaScript so its lifecycle can be tested directly with node:test.
@@ -2644,7 +2645,12 @@ export function App() {
     setDropTarget(null);
   }
 
-  function finishTaskDrop(destination: TaskStatus, taskId: string, beforeTaskId: string | null = null) {
+  function finishTaskDrop(
+    destination: TaskStatus,
+    taskId: string,
+    beforeTaskId: string | null = null,
+    targetPriority?: TaskPriority,
+  ) {
     const task = tasks.find((candidate) => candidate.id === taskId);
     setDraggedTaskId(null);
     setDraggedTaskHeight(0);
@@ -2654,6 +2660,10 @@ export function App() {
     window.setTimeout(() => {
       setSettlingTaskId((current) => current === task.id ? null : current);
     }, 220);
+    if (task.status === destination && targetPriority !== undefined && task.priority !== targetPriority) {
+      void updateTaskProperties(task, { priority: targetPriority });
+      return;
+    }
     void moveTask(task, destination, beforeTaskId, true);
   }
 

--- a/web/src/components/BoardColumn.tsx
+++ b/web/src/components/BoardColumn.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
 import type { DragEvent } from "react";
-import type { ActorIdentity, Task, TaskDraft, TaskStatus } from "../types";
-import { taskStatusLabel, useTaskboardI18n } from "../i18n";
+import type { ActorIdentity, Task, TaskDraft, TaskPriority, TaskStatus } from "../types";
+import { taskPriorityLabel, taskStatusLabel, useTaskboardI18n } from "../i18n";
 import type { TaskCardPresentation, TaskConversationItem } from "../taskConversations";
 import { TaskCard } from "./TaskCard";
-import { PlusIcon, StatusIcon } from "./SemanticIcons";
+import { PlusIcon, PriorityIcon, StatusIcon } from "./SemanticIcons";
+
+const PRIORITY_GROUPS: TaskPriority[] = ["urgent", "high", "medium", "low", "none"];
 
 export const STATUS_DETAILS: Record<
   TaskStatus,
@@ -86,6 +88,7 @@ export function BoardColumn({
   const details = STATUS_DETAILS[status];
   const label = taskStatusLabel(language, status);
   const [dropBeforeTaskId, setDropBeforeTaskId] = useState<string | null | undefined>();
+  const [collapsedPriorities, setCollapsedPriorities] = useState<Partial<Record<TaskPriority, boolean>>>({});
   const taskIndexes = new Map(tasks.map((task, index) => [task.id, index]));
   const remainingTasks = tasks.filter((task) => task.id !== draggedTaskId);
   const remainingIndexes = new Map(remainingTasks.map((task, index) => [task.id, index]));
@@ -170,33 +173,57 @@ export function BoardColumn({
       </header>
 
       <div className="column-list" ref={scrollRef}>
-        {tasks.map((task) => {
-          const dragShift = getTaskDragShift(task);
+        {PRIORITY_GROUPS.map((priority) => {
+          const priorityTasks = tasks.filter((task) => task.priority === priority);
+          const isCollapsed = collapsedPriorities[priority] ?? false;
           return (
-            <TaskCard
-              key={task.id}
-              task={task}
-              presentation={presentations[task.id]}
-              now={now}
-              isDragging={draggedTaskId === task.id}
-              dragShift={dragShift}
-              isMoving={movingTaskId === task.id}
-              isSettling={settlingTaskId === task.id}
-              isContextMenuOpen={contextMenuTaskId === task.id}
-              availableLabels={availableLabels}
-              projectName={projectNames?.[task.projectId]}
-              currentUser={currentUser}
-              showCover={showCover}
-              showBody={showBody}
-              onCreateLabel={(label) => onCreateLabel(label, task.projectId)}
-              onEdit={onEdit}
-              onUpdate={onUpdate}
-              onComplete={onComplete}
-              onContextMenu={onContextMenu}
-              onDragStart={onDragStart}
-              onDragEnd={onDragEnd}
-              onOpenConversation={onOpenConversation}
-            />
+            <section className={`priority-group priority-group-${priority}`} key={priority}>
+              <button
+                type="button"
+                className="priority-group-header"
+                aria-expanded={!isCollapsed}
+                onClick={() => setCollapsedPriorities((current) => ({ ...current, [priority]: !isCollapsed }))}
+              >
+                <span className="priority-group-title">
+                  <PriorityIcon priority={priority} size={14} />
+                  <span>{taskPriorityLabel(language, priority)}</span>
+                </span>
+                <span className="priority-group-count">{priorityTasks.length}</span>
+              </button>
+              {!isCollapsed && (
+                <div className="priority-group-list">
+                  {priorityTasks.map((task) => {
+                    const dragShift = getTaskDragShift(task);
+                    return (
+                      <TaskCard
+                        key={task.id}
+                        task={task}
+                        presentation={presentations[task.id]}
+                        now={now}
+                        isDragging={draggedTaskId === task.id}
+                        dragShift={dragShift}
+                        isMoving={movingTaskId === task.id}
+                        isSettling={settlingTaskId === task.id}
+                        isContextMenuOpen={contextMenuTaskId === task.id}
+                        availableLabels={availableLabels}
+                        projectName={projectNames?.[task.projectId]}
+                        currentUser={currentUser}
+                        showCover={showCover}
+                        showBody={showBody}
+                        onCreateLabel={(label) => onCreateLabel(label, task.projectId)}
+                        onEdit={onEdit}
+                        onUpdate={onUpdate}
+                        onComplete={onComplete}
+                        onContextMenu={onContextMenu}
+                        onDragStart={onDragStart}
+                        onDragEnd={onDragEnd}
+                        onOpenConversation={onOpenConversation}
+                      />
+                    );
+                  })}
+                </div>
+              )}
+            </section>
           );
         })}
         {tasks.length === 0 && <div className="column-empty">{emptyMessage}</div>}

--- a/web/src/components/BoardColumn.tsx
+++ b/web/src/components/BoardColumn.tsx
@@ -207,7 +207,6 @@ export function BoardColumn({
           const priorityTasks = tasks.filter((task) => task.priority === priority);
           const isCollapsed = collapsedPriorities[priority] ?? false;
           return (
-<<<<<<< HEAD
             <section
               className={`priority-group priority-group-${priority}${priorityTasks.length === 0 ? " priority-group-empty" : ""}${dropPriority === priority ? " is-drop-target" : ""}`}
               data-priority-group={priority}
@@ -240,7 +239,7 @@ export function BoardColumn({
                 onClick={() => setCollapsedPriorities((current) => ({ ...current, [priority]: !isCollapsed }))}
               >
                 <span className="priority-group-title">
-                  <PriorityIcon priority={priority} size={14} />
+                  <PriorityIcon priority={priority} color="currentColor" size={14} />
                   <span>{taskPriorityLabel(language, priority)}</span>
                 </span>
                 <span className="priority-group-count">{priorityTasks.length}</span>

--- a/web/src/components/BoardColumn.tsx
+++ b/web/src/components/BoardColumn.tsx
@@ -49,7 +49,12 @@ interface BoardColumnProps {
   onDragStart: (task: Task, height: number) => void;
   onDragEnd: () => void;
   onDragEnter: (status: TaskStatus) => void;
-  onDrop: (status: TaskStatus, taskId: string, beforeTaskId: string | null) => void;
+  onDrop: (
+    status: TaskStatus,
+    taskId: string,
+    beforeTaskId: string | null,
+    priority?: TaskPriority,
+  ) => void;
   onOpenConversation: (conversation: TaskConversationItem) => void;
 }
 
@@ -88,6 +93,7 @@ export function BoardColumn({
   const details = STATUS_DETAILS[status];
   const label = taskStatusLabel(language, status);
   const [dropBeforeTaskId, setDropBeforeTaskId] = useState<string | null | undefined>();
+  const [dropPriority, setDropPriority] = useState<TaskPriority | null>(null);
   const [collapsedPriorities, setCollapsedPriorities] = useState<Partial<Record<TaskPriority, boolean>>>({});
   const taskIndexes = new Map(tasks.map((task, index) => [task.id, index]));
   const remainingTasks = tasks.filter((task) => task.id !== draggedTaskId);
@@ -100,7 +106,10 @@ export function BoardColumn({
   const dragDistance = draggedTaskHeight + 8;
 
   useEffect(() => {
-    if (!isDropTarget || !draggedTaskId) setDropBeforeTaskId(undefined);
+    if (!isDropTarget || !draggedTaskId) {
+      setDropBeforeTaskId(undefined);
+      setDropPriority(null);
+    }
   }, [draggedTaskId, isDropTarget]);
 
   function findDropBefore(container: HTMLElement, clientY: number): string | null {
@@ -117,6 +126,20 @@ export function BoardColumn({
       event.dataTransfer.getData("text/plain");
     if (taskId) onDrop(status, taskId, findDropBefore(event.currentTarget, event.clientY));
     setDropBeforeTaskId(undefined);
+    setDropPriority(null);
+  }
+
+  function handlePriorityDrop(event: DragEvent<HTMLElement>, priority: TaskPriority) {
+    event.preventDefault();
+    event.stopPropagation();
+    const taskId =
+      event.dataTransfer.getData("application/x-taskboard-task") ||
+      event.dataTransfer.getData("text/plain");
+    if (taskId) {
+      onDrop(status, taskId, findDropBefore(event.currentTarget, event.clientY), priority);
+    }
+    setDropBeforeTaskId(undefined);
+    setDropPriority(null);
   }
 
   function getTaskDragShift(task: Task): number {
@@ -177,7 +200,32 @@ export function BoardColumn({
           const priorityTasks = tasks.filter((task) => task.priority === priority);
           const isCollapsed = collapsedPriorities[priority] ?? false;
           return (
-            <section className={`priority-group priority-group-${priority}`} key={priority}>
+<<<<<<< HEAD
+            <section
+              className={`priority-group priority-group-${priority}${priorityTasks.length === 0 ? " priority-group-empty" : ""}${dropPriority === priority ? " is-drop-target" : ""}`}
+              data-priority-group={priority}
+              data-status={status}
+              key={priority}
+              onDragEnter={(event) => {
+                event.stopPropagation();
+                onDragEnter(status);
+                setDropPriority(priority);
+              }}
+              onDragOver={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                event.dataTransfer.dropEffect = "move";
+                onDragEnter(status);
+                setDropPriority(priority);
+                setDropBeforeTaskId(findDropBefore(event.currentTarget, event.clientY));
+              }}
+              onDragLeave={(event) => {
+                if (!(event.relatedTarget instanceof Node) || !event.currentTarget.contains(event.relatedTarget)) {
+                  setDropPriority((current) => current === priority ? null : current);
+                }
+              }}
+              onDrop={(event) => handlePriorityDrop(event, priority)}
+            >
               <button
                 type="button"
                 className="priority-group-header"

--- a/web/src/components/BoardColumn.tsx
+++ b/web/src/components/BoardColumn.tsx
@@ -98,6 +98,9 @@ export function BoardColumn({
   const taskIndexes = new Map(tasks.map((task, index) => [task.id, index]));
   const remainingTasks = tasks.filter((task) => task.id !== draggedTaskId);
   const remainingIndexes = new Map(remainingTasks.map((task, index) => [task.id, index]));
+  const draggedTask = draggedTaskId
+    ? tasks.find((task) => task.id === draggedTaskId)
+    : undefined;
   const draggedTaskIndex = draggedTaskId ? taskIndexes.get(draggedTaskId) ?? -1 : -1;
   const beforeIndex = dropBeforeTaskId
     ? remainingIndexes.get(dropBeforeTaskId) ?? remainingTasks.length
@@ -144,6 +147,10 @@ export function BoardColumn({
 
   function getTaskDragShift(task: Task): number {
     if (!draggedTaskId || task.id === draggedTaskId) return 0;
+    if (dropPriority !== null) {
+      if (task.priority !== dropPriority) return 0;
+      if (draggedTask?.priority !== dropPriority) return 0;
+    }
     let shift = 0;
     const taskIndex = taskIndexes.get(task.id) ?? -1;
     const remainingIndex = remainingIndexes.get(task.id) ?? -1;

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type DragEvent,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import remarkGfm from "remark-gfm";
 import remarkParse from "remark-parse";
 import { unified } from "unified";
@@ -414,6 +422,13 @@ export function TaskCard({
 }: TaskCardProps) {
   const { language, locale, text } = useTaskboardI18n();
   const displayIdentifier = task.externalKey ?? task.identifier;
+  const pointerDragRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    dragged: boolean;
+  } | null>(null);
+  const suppressOpenRef = useRef(false);
   const [propertyMenu, setPropertyMenu] = useState<"labels" | "assignee" | "priority" | null>(null);
   const [savingProperty, setSavingProperty] = useState<"labels" | "dueDate" | "assignee" | "priority" | null>(null);
   const creator: ActorIdentity = {
@@ -448,6 +463,69 @@ export function TaskCard({
       .finally(() => setSavingProperty((current) => current === property ? null : current));
   }
 
+  function startDrag(event: DragEvent<HTMLElement>) {
+    event.stopPropagation();
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData("text/plain", task.id);
+    event.dataTransfer.setData("application/x-taskboard-task", task.id);
+    const card = event.currentTarget.closest<HTMLElement>(".task-card") ?? event.currentTarget;
+    onDragStart(task, card.offsetHeight);
+  }
+
+  function startPointerDrag(event: ReactPointerEvent<HTMLButtonElement>) {
+    if (event.button !== 0) return;
+    pointerDragRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      dragged: false,
+    };
+    window.addEventListener("pointermove", trackPointerDrag);
+    window.addEventListener("pointerup", finishPointerDrag);
+    window.addEventListener("pointercancel", cancelPointerDrag);
+  }
+
+  function trackPointerDrag(event: PointerEvent) {
+    const pointer = pointerDragRef.current;
+    if (!pointer || pointer.pointerId !== event.pointerId || pointer.dragged) return;
+    pointer.dragged = Math.hypot(
+      event.clientX - pointer.startX,
+      event.clientY - pointer.startY,
+    ) >= 6;
+  }
+
+  function cancelPointerDrag() {
+    pointerDragRef.current = null;
+    window.removeEventListener("pointermove", trackPointerDrag);
+    window.removeEventListener("pointerup", finishPointerDrag);
+    window.removeEventListener("pointercancel", cancelPointerDrag);
+  }
+
+  function finishPointerDrag(event: PointerEvent) {
+    const pointer = pointerDragRef.current;
+    if (!pointer || pointer.pointerId !== event.pointerId) return;
+    cancelPointerDrag();
+    if (!pointer.dragged) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    suppressOpenRef.current = true;
+    window.setTimeout(() => { suppressOpenRef.current = false; }, 0);
+
+    const group = document.elementFromPoint(event.clientX, event.clientY)
+      ?.closest<HTMLElement>("[data-priority-group]");
+    const priority = group?.dataset.priorityGroup as TaskPriority | undefined;
+    if (
+      group?.dataset.status !== task.status
+      || !priority
+      || !TASK_PRIORITIES.includes(priority)
+      || priority === task.priority
+    ) return;
+
+    onDragEnd();
+    updateProperty({ priority }, "priority");
+  }
+
   return (
     <article
       className={`task-card task-card-${variant} status-${task.status} priority-${task.priority}${processingCard ? " is-processing-card" : ""}${processingCard && presentation.processing.running ? " is-running-card" : ""}${image ? " has-media" : ""}${presentation.unread ? " is-unread" : ""}${isDragging ? " is-dragging" : ""}${dragShift ? " is-drag-shifted" : ""}${isMoving ? " is-moving" : ""}${isSettling ? " is-settling" : ""}${isContextMenuOpen ? " is-context-open" : ""}${propertyMenu ? " is-property-menu-open" : ""}`}
@@ -464,19 +542,20 @@ export function TaskCard({
         event.stopPropagation();
         onContextMenu(task, { x: event.clientX, y: event.clientY });
       }}
-      onDragStart={(event) => {
-        event.dataTransfer.effectAllowed = "move";
-        event.dataTransfer.setData("text/plain", task.id);
-        event.dataTransfer.setData("application/x-taskboard-task", task.id);
-        onDragStart(task, event.currentTarget.offsetHeight);
-      }}
+      onDragStart={startDrag}
       onDragEnd={onDragEnd}
     >
       <button
         className="task-card-open"
         type="button"
+        draggable={!isMoving}
         aria-label={text(`打开 ${displayIdentifier}: ${task.title}`, `Open ${displayIdentifier}: ${task.title}`)}
-        onClick={() => onEdit(task)}
+        onClick={() => {
+          if (!suppressOpenRef.current) onEdit(task);
+        }}
+        onDragStart={startDrag}
+        onDragEnd={onDragEnd}
+        onPointerDown={startPointerDrag}
       />
 
       <PriorityControl

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -4,12 +4,10 @@ import remarkParse from "remark-parse";
 import { unified } from "unified";
 import { resolvePersistedAttachmentUrl } from "../api";
 import {
-  TASK_PRIORITIES,
   type ActorIdentity,
   type AssigneeTarget,
   type Task,
   type TaskDraft,
-  type TaskPriority,
 } from "../types";
 import { labelPresentation } from "../labels";
 import { taskPriorityLabel, useTaskboardI18n } from "../i18n";
@@ -20,7 +18,7 @@ import type {
 } from "../taskConversations";
 import { ActorAvatar } from "./ActorAvatar";
 import { LinearIcon } from "./LinearIcon";
-import { DueDateIcon, PriorityIcon, ProjectIcon } from "./SemanticIcons";
+import { DueDateIcon, ProjectIcon } from "./SemanticIcons";
 import { LabelPicker } from "./LabelPicker";
 import { TaskPropertyPicker } from "./TaskPropertyPicker";
 import { TaskConversationMenu } from "./TaskConversationMenu";
@@ -270,45 +268,6 @@ function TaskLabels({ task }: { task: Task }) {
   );
 }
 
-function PriorityControl({
-  task,
-  disabled,
-  open,
-  onOpenChange,
-  onChange,
-}: {
-  task: Task;
-  disabled: boolean;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  onChange: (priority: TaskPriority) => void;
-}) {
-  const { language, text } = useTaskboardI18n();
-  const displayIdentifier = task.externalKey ?? task.identifier;
-  return (
-    <TaskPropertyPicker
-      value={task.priority}
-      options={TASK_PRIORITIES.map((priority) => ({
-        value: priority,
-        label: taskPriorityLabel(language, priority),
-        icon: <PriorityIcon priority={priority} size={14} />,
-        className: `priority-${priority}`,
-      }))}
-      open={open}
-      disabled={disabled}
-      className="card-property-control"
-      triggerClassName={`priority-chip priority-chip-${task.priority}`}
-      ariaLabel={text(`${displayIdentifier} 优先级`, `${displayIdentifier} priority`)}
-      title={text(
-        `优先级：${taskPriorityLabel(language, task.priority)}`,
-        `Priority: ${taskPriorityLabel(language, task.priority)}`,
-      )}
-      onOpenChange={onOpenChange}
-      onChange={onChange}
-    />
-  );
-}
-
 function DueDateControl({
   task,
   disabled,
@@ -412,10 +371,10 @@ export function TaskCard({
   onDragEnd,
   onOpenConversation,
 }: TaskCardProps) {
-  const { locale, text } = useTaskboardI18n();
+  const { language, locale, text } = useTaskboardI18n();
   const displayIdentifier = task.externalKey ?? task.identifier;
-  const [propertyMenu, setPropertyMenu] = useState<"priority" | "labels" | "assignee" | null>(null);
-  const [savingProperty, setSavingProperty] = useState<"priority" | "labels" | "dueDate" | "assignee" | null>(null);
+  const [propertyMenu, setPropertyMenu] = useState<"labels" | "assignee" | null>(null);
+  const [savingProperty, setSavingProperty] = useState<"labels" | "dueDate" | "assignee" | null>(null);
   const creator: ActorIdentity = {
     type: task.creatorType,
     id: task.creatorId,
@@ -436,7 +395,7 @@ export function TaskCard({
     () => showBody ? taskBodyText(task.description) : "",
     [showBody, task.description],
   );
-  const hasProperties = task.priority !== "none" || task.labels.length > 0 || task.dueDate;
+  const hasProperties = task.labels.length > 0 || task.dueDate;
   const showsProperties = Boolean(projectName)
     || (!processingCard && (hasProperties || showsInlineParticipants || showsConversation));
   const propertyDisabled = savingProperty !== null;
@@ -450,7 +409,7 @@ export function TaskCard({
 
   return (
     <article
-      className={`task-card task-card-${variant} status-${task.status}${processingCard ? " is-processing-card" : ""}${processingCard && presentation.processing.running ? " is-running-card" : ""}${image ? " has-media" : ""}${presentation.unread ? " is-unread" : ""}${isDragging ? " is-dragging" : ""}${dragShift ? " is-drag-shifted" : ""}${isMoving ? " is-moving" : ""}${isSettling ? " is-settling" : ""}${isContextMenuOpen ? " is-context-open" : ""}${propertyMenu ? " is-property-menu-open" : ""}`}
+      className={`task-card task-card-${variant} status-${task.status} priority-${task.priority}${processingCard ? " is-processing-card" : ""}${processingCard && presentation.processing.running ? " is-running-card" : ""}${image ? " has-media" : ""}${presentation.unread ? " is-unread" : ""}${isDragging ? " is-dragging" : ""}${dragShift ? " is-drag-shifted" : ""}${isMoving ? " is-moving" : ""}${isSettling ? " is-settling" : ""}${isContextMenuOpen ? " is-context-open" : ""}${propertyMenu ? " is-property-menu-open" : ""}`}
       style={{
         viewTransitionName: task.status === "in_review" ? `review-task-${task.id}` : "none",
         ...(dragShift ? { transform: `translate3d(0, ${dragShift}px, 0)` } : {}),
@@ -477,6 +436,12 @@ export function TaskCard({
         type="button"
         aria-label={text(`打开 ${displayIdentifier}: ${task.title}`, `Open ${displayIdentifier}: ${task.title}`)}
         onClick={() => onEdit(task)}
+      />
+
+      <span
+        className="task-card-priority-indicator"
+        aria-label={text(`优先级：${taskPriorityLabel(language, task.priority)}`, `Priority: ${taskPriorityLabel(language, task.priority)}`)}
+        title={text(`优先级：${taskPriorityLabel(language, task.priority)}`, `Priority: ${taskPriorityLabel(language, task.priority)}`)}
       />
 
       <div className="card-topline">
@@ -536,15 +501,6 @@ export function TaskCard({
               <ProjectIcon color="currentColor" />
               <span>{projectName}</span>
             </span>
-          )}
-          {!processingCard && task.priority !== "none" && (
-            <PriorityControl
-              task={task}
-              disabled={propertyDisabled}
-              open={propertyMenu === "priority"}
-              onOpenChange={(open) => setPropertyMenu(open ? "priority" : null)}
-              onChange={(priority) => updateProperty({ priority }, "priority")}
-            />
           )}
           {!processingCard && task.labels.length > 0 && (
             <LabelPicker

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -4,10 +4,12 @@ import remarkParse from "remark-parse";
 import { unified } from "unified";
 import { resolvePersistedAttachmentUrl } from "../api";
 import {
+  TASK_PRIORITIES,
   type ActorIdentity,
   type AssigneeTarget,
   type Task,
   type TaskDraft,
+  type TaskPriority,
 } from "../types";
 import { labelPresentation } from "../labels";
 import { taskPriorityLabel, useTaskboardI18n } from "../i18n";
@@ -18,7 +20,7 @@ import type {
 } from "../taskConversations";
 import { ActorAvatar } from "./ActorAvatar";
 import { LinearIcon } from "./LinearIcon";
-import { DueDateIcon, ProjectIcon } from "./SemanticIcons";
+import { DueDateIcon, PriorityIcon, ProjectIcon } from "./SemanticIcons";
 import { LabelPicker } from "./LabelPicker";
 import { TaskPropertyPicker } from "./TaskPropertyPicker";
 import { TaskConversationMenu } from "./TaskConversationMenu";
@@ -347,6 +349,45 @@ function AssigneeControl({
   );
 }
 
+function PriorityControl({
+  task,
+  language,
+  disabled,
+  open,
+  onOpenChange,
+  onChange,
+}: {
+  task: Task;
+  language: Parameters<typeof taskPriorityLabel>[0];
+  disabled: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onChange: (priority: TaskPriority) => void;
+}) {
+  const { text } = useTaskboardI18n();
+  const displayIdentifier = task.externalKey ?? task.identifier;
+  return (
+    <TaskPropertyPicker
+      value={task.priority}
+      options={TASK_PRIORITIES.map((priority) => ({
+        value: priority,
+        label: taskPriorityLabel(language, priority),
+        icon: <PriorityIcon priority={priority} size={14} />,
+        className: `priority-${priority}`,
+      }))}
+      open={open}
+      disabled={disabled}
+      className="task-card-priority-picker"
+      triggerClassName="task-card-priority-indicator"
+      triggerContent={<span aria-hidden="true" />}
+      ariaLabel={text(`${displayIdentifier} 优先级`, `${displayIdentifier} priority`)}
+      title={text(`优先级：${taskPriorityLabel(language, task.priority)}`, `Priority: ${taskPriorityLabel(language, task.priority)}`)}
+      onOpenChange={onOpenChange}
+      onChange={onChange}
+    />
+  );
+}
+
 export function TaskCard({
   task,
   variant = "main",
@@ -373,8 +414,8 @@ export function TaskCard({
 }: TaskCardProps) {
   const { language, locale, text } = useTaskboardI18n();
   const displayIdentifier = task.externalKey ?? task.identifier;
-  const [propertyMenu, setPropertyMenu] = useState<"labels" | "assignee" | null>(null);
-  const [savingProperty, setSavingProperty] = useState<"labels" | "dueDate" | "assignee" | null>(null);
+  const [propertyMenu, setPropertyMenu] = useState<"labels" | "assignee" | "priority" | null>(null);
+  const [savingProperty, setSavingProperty] = useState<"labels" | "dueDate" | "assignee" | "priority" | null>(null);
   const creator: ActorIdentity = {
     type: task.creatorType,
     id: task.creatorId,
@@ -438,10 +479,13 @@ export function TaskCard({
         onClick={() => onEdit(task)}
       />
 
-      <span
-        className="task-card-priority-indicator"
-        aria-label={text(`优先级：${taskPriorityLabel(language, task.priority)}`, `Priority: ${taskPriorityLabel(language, task.priority)}`)}
-        title={text(`优先级：${taskPriorityLabel(language, task.priority)}`, `Priority: ${taskPriorityLabel(language, task.priority)}`)}
+      <PriorityControl
+        task={task}
+        language={language}
+        disabled={propertyDisabled}
+        open={propertyMenu === "priority"}
+        onOpenChange={(open) => setPropertyMenu(open ? "priority" : null)}
+        onChange={(priority) => updateProperty({ priority }, "priority")}
       />
 
       <div className="card-topline">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -27,10 +27,10 @@
   --danger-soft: #fff0f0;
   --warning: #f0bf00;
   --success: #43bc58;
-  --priority-urgent: #ff7236;
+  --priority-urgent: #f34e52;
   --priority-high: #ff7236;
-  --priority-medium: var(--text-tertiary);
-  --priority-low: var(--text-tertiary);
+  --priority-medium: #317cff;
+  --priority-low: #43bc58;
   --priority-none: var(--text-tertiary);
   --status-backlog: #9e9ea1;
   --status-todo: #9e9ea1;
@@ -2345,8 +2345,8 @@ kbd {
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  min-height: 24px;
-  padding: 2px 4px;
+  min-height: 18px;
+  padding: 0 4px;
   border: 0;
   border-radius: 4px;
   background: transparent;
@@ -2369,7 +2369,7 @@ kbd {
   overflow: hidden;
   font-size: 11px;
   font-weight: 550;
-  line-height: 16px;
+  line-height: 14px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -9157,6 +9157,24 @@ kbd {
 
 .task-card > :not(.task-card-open) {
   z-index: 2;
+}
+
+.task-card {
+  --task-card-priority-color: var(--priority-none);
+}
+
+.task-card.priority-urgent { --task-card-priority-color: var(--priority-urgent); }
+.task-card.priority-high { --task-card-priority-color: var(--priority-high); }
+.task-card.priority-medium { --task-card-priority-color: var(--priority-medium); }
+.task-card.priority-low { --task-card-priority-color: var(--priority-low); }
+
+.task-card > .task-card-priority-indicator {
+  position: absolute;
+  z-index: 3;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--task-card-priority-color);
+  pointer-events: none;
 }
 
 .card-topline {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2361,6 +2361,11 @@ kbd {
   color: var(--text-secondary);
 }
 
+.priority-group.is-drop-target > .priority-group-header {
+  background: color-mix(in srgb, var(--task-card-priority-color, var(--accent)) 14%, var(--surface-muted));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, currentColor 32%, transparent);
+}
+
 .priority-group-title {
   display: flex;
   align-items: center;
@@ -2526,6 +2531,8 @@ kbd {
   border-radius: inherit;
   background: transparent;
   cursor: pointer;
+  -webkit-user-drag: element;
+  user-select: none;
 }
 
 .task-card-open:focus-visible {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2333,6 +2333,78 @@ kbd {
   padding: 8px 8px 8px;
 }
 
+.priority-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.priority-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-height: 24px;
+  padding: 2px 4px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.priority-group-header:hover {
+  background: var(--surface-muted);
+  color: var(--text-secondary);
+}
+
+.priority-group-title {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 6px;
+  overflow: hidden;
+  font-size: 11px;
+  font-weight: 550;
+  line-height: 16px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.priority-group-title > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.priority-group-title > span:first-child {
+  flex: 0 0 auto;
+}
+
+.priority-group-count {
+  flex: 0 0 auto;
+  min-width: 16px;
+  color: var(--text-quaternary);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.priority-group-urgent .priority-group-title { color: var(--priority-urgent); }
+.priority-group-high .priority-group-title { color: var(--priority-high); }
+.priority-group-medium .priority-group-title { color: var(--priority-medium); }
+.priority-group-low .priority-group-title { color: var(--priority-low); }
+.priority-group-none .priority-group-title { color: var(--priority-none); }
+
+.priority-group-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
 .column-empty {
   display: grid;
   flex: 1;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -9168,13 +9168,36 @@ kbd {
 .task-card.priority-medium { --task-card-priority-color: var(--priority-medium); }
 .task-card.priority-low { --task-card-priority-color: var(--priority-low); }
 
-.task-card > .task-card-priority-indicator {
+.task-card > .task-card-priority-picker {
   position: absolute;
   z-index: 3;
   inset: 0 auto 0 0;
   width: 3px;
+  pointer-events: auto;
+}
+
+.task-card .task-card-priority-indicator {
+  display: block;
+  width: 3px;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  outline: 0;
   background: var(--task-card-priority-color);
-  pointer-events: none;
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.task-card .task-card-priority-indicator:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.task-card .task-card-priority-indicator:disabled {
+  cursor: wait;
+  opacity: .7;
 }
 
 .card-topline {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2402,6 +2402,7 @@ kbd {
 .priority-group-medium .priority-group-title { color: var(--priority-medium); }
 .priority-group-low .priority-group-title { color: var(--priority-low); }
 .priority-group-none .priority-group-title { color: var(--priority-none); }
+.priority-group-empty .priority-group-title { color: var(--text-tertiary); }
 
 .priority-group-list {
   display: flex;


### PR DESCRIPTION
## Summary

Add priority swimlanes to the issue board so tasks can be scanned and reorganized by priority within each status column.

## Changes

- Group tasks into `urgent`, `high`, `medium`, `low`, and `none` sections.
- Allow each priority section to be collapsed or expanded.
- Show counts and priority-aware visual indicators for each section.
- Allow changing a task's priority from its card indicator.
- Allow dragging cards between priority groups, including empty groups.
- Preserve task ordering and status-column drag behavior.

## Verification

- `node --test test/board-interactions.test.mjs`
- `npm run typecheck`
- `npm run build:web`
- `git diff --check`

All checks passed. The local browser preview was started, but the isolated worktree had no companion backend data service, so real-data rendering was not available in that preview.
