### PR TITLE
Reduce board refresh work and simplify shared editing rules

### DIFF
--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -1,4 +1,8 @@
 import {
+  parseThreadBinding, parseMove, parseVersionMutation, parseRelationMutation,
+  parseCommentCreate, parseCommentPatch, parseTaskCreate,
+} from "../../shared/task-input.mjs";
+import {
   commentConversationTitle,
   threadBindingFromRow,
   legacyLocalThreadIdFromRow,
@@ -12,12 +16,13 @@ import {
 } from "../../shared/task-records.mjs";
 import {
   ApiError,
+  parseVersion,
+  validateProjectId,
   assertPlainObject,
   assertAllowedKeys,
   stringField,
   parseDueDate,
   parseRecurrence,
-  parseSortOrder,
   parseLabels,
   parseStatus,
   parsePriority,
@@ -25,7 +30,6 @@ import {
   parseProjectLabel,
   parseThreadId,
   parseAssigneeTarget,
-  parseRelationOrigin,
 } from "../../shared/api-fields.mjs";
 import { DurableObject } from "cloudflare:workers";
 
@@ -35,7 +39,6 @@ const JSON_BODY_LIMIT = 1024 * 1024;
 const PROJECT_README_BODY_LIMIT = 3 * 1024 * 1024;
 const ATTACHMENT_BODY_LIMIT = 25 * 1024 * 1024;
 const DEFAULT_PROJECT_LABELS_JSON = JSON.stringify(DEFAULT_LABEL_NAMES);
-const PROJECT_ID_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
 const PROJECT_BOARD_DISPLAY_SETTINGS_KEY_PREFIX = "taskboard.project-board-display-settings.v3.";
 const INLINE_ATTACHMENT_TYPES = new Set([
   "application/pdf",
@@ -135,17 +138,6 @@ function methodNotAllowed(allowed) {
   });
 }
 
-function parseVersion(value, { allowZero = false } = {}) {
-  if (!Number.isSafeInteger(value) || value < (allowZero ? 0 : 1)) {
-    throw new ApiError(
-      400,
-      "INVALID_FIELD",
-      `'version' must be a ${allowZero ? "non-negative" : "positive"} integer`,
-    );
-  }
-  return value;
-}
-
 function parseDevelopmentContext(value) {
   if (value === null) return null;
   assertPlainObject(value);
@@ -185,66 +177,6 @@ function parseDevelopmentContext(value) {
     "INVALID_FIELD",
     "'developmentContext.type' must be branch or worktree",
   );
-}
-
-function parseThreadBinding(value) {
-  if (value === undefined || value === null) return value;
-  assertPlainObject(value);
-  assertAllowedKeys(value, new Set([
-    "threadId",
-    "codexProjectId",
-    "codexProjectKind",
-    "codexHostId",
-    "workspacePath",
-  ]));
-  const threadId = stringField(value.threadId, "threadBinding.threadId", {
-    required: true,
-    maxLength: 256,
-  });
-  const identityFields = [
-    value.codexProjectId,
-    value.codexProjectKind,
-    value.codexHostId,
-    value.workspacePath,
-  ];
-  if (identityFields.every((field) => field === undefined)) return { threadId };
-  if (identityFields.some((field) => field === undefined)) {
-    throw new ApiError(400, "INVALID_FIELD", "Thread identity must include project, kind, host, and workspace");
-  }
-  const codexProjectId = stringField(value.codexProjectId, "threadBinding.codexProjectId", {
-    required: true,
-    maxLength: 256,
-  });
-  const codexProjectKind = value.codexProjectKind;
-  const codexHostId = stringField(value.codexHostId, "threadBinding.codexHostId", {
-    required: true,
-    maxLength: 256,
-  });
-  const workspacePath = stringField(value.workspacePath, "threadBinding.workspacePath", {
-    required: true,
-    maxLength: 4096,
-  });
-  if (
-    (codexProjectKind !== "local" && codexProjectKind !== "remote")
-    || (codexProjectKind === "local" && codexHostId !== "local")
-    || (codexProjectKind === "remote" && codexHostId === "local")
-    || workspacePath.includes("\0")
-  ) {
-    throw new ApiError(400, "INVALID_FIELD", "Thread project identity is invalid");
-  }
-  return { threadId, codexProjectId, codexProjectKind, codexHostId, workspacePath };
-}
-
-function validateProjectId(value) {
-  const id = stringField(value, "id", { required: true, maxLength: 64 });
-  if (!PROJECT_ID_PATTERN.test(id)) {
-    throw new ApiError(
-      400,
-      "INVALID_FIELD",
-      "'id' must be a lowercase slug containing letters, numbers, or hyphens",
-    );
-  }
-  return id;
 }
 
 function now() {
@@ -973,46 +905,6 @@ function parseClientStorageUpdate(body) {
   };
 }
 
-function parseTaskCreate(body) {
-  assertPlainObject(body);
-  assertAllowedKeys(body, new Set([
-    "projectId",
-    "title",
-    "description",
-    "status",
-    "priority",
-    "labels",
-    "sortOrder",
-    "threadId",
-    "threadBinding",
-    "assigneeTarget",
-    "developmentContext",
-    "startDate",
-    "dueDate",
-    "recurrence",
-  ]));
-  const input = {
-    projectId: validateProjectId(body.projectId ?? "local"),
-    title: stringField(body.title, "title", { required: true, maxLength: 240 }),
-    description: stringField(body.description ?? "", "description", { maxLength: 100_000 }),
-    status: parseStatus(body.status, "backlog"),
-    priority: parsePriority(body.priority, "none"),
-    labels: body.labels === undefined ? [] : parseLabels(body.labels),
-    sortOrder: body.sortOrder === undefined ? undefined : parseSortOrder(body.sortOrder),
-    threadId: parseThreadId(body.threadId),
-    threadBinding: parseThreadBinding(body.threadBinding),
-    assigneeTarget: parseAssigneeTarget(body.assigneeTarget),
-    developmentContext: parseDevelopmentContext(body.developmentContext ?? null),
-    startDate: parseDueDate(body.startDate ?? null, "startDate"),
-    dueDate: parseDueDate(body.dueDate ?? null),
-    recurrence: parseRecurrence(body.recurrence ?? null),
-  };
-  if (input.recurrence && !input.dueDate) {
-    throw new ApiError(400, "INVALID_FIELD", "A recurring issue requires 'dueDate'");
-  }
-  return input;
-}
-
 function parseTaskPatch(body) {
   assertPlainObject(body);
   assertAllowedKeys(body, new Set([
@@ -1058,63 +950,6 @@ function parseTaskPatch(body) {
     threadId: parseThreadId(body.threadId),
     threadBinding: parseThreadBinding(body.threadBinding),
     assigneeTarget,
-  };
-}
-
-function parseMove(body) {
-  assertPlainObject(body);
-  assertAllowedKeys(body, new Set(["version", "status", "sortOrder", "threadId", "threadBinding"]));
-  return {
-    version: parseVersion(body.version),
-    status: parseStatus(body.status),
-    sortOrder: body.sortOrder === undefined ? undefined : parseSortOrder(body.sortOrder),
-    threadId: parseThreadId(body.threadId),
-    threadBinding: parseThreadBinding(body.threadBinding),
-  };
-}
-
-function parseVersionMutation(body) {
-  assertPlainObject(body);
-  assertAllowedKeys(body, new Set(["version", "threadId", "threadBinding"]));
-  return {
-    version: parseVersion(body.version),
-    threadId: parseThreadId(body.threadId),
-    threadBinding: parseThreadBinding(body.threadBinding),
-  };
-}
-
-function parseRelationMutation(body) {
-  assertPlainObject(body);
-  assertAllowedKeys(body, new Set(["version", "threadId", "threadBinding", "origin"]));
-  return {
-    version: parseVersion(body.version),
-    threadId: parseThreadId(body.threadId),
-    threadBinding: parseThreadBinding(body.threadBinding),
-    origin: parseRelationOrigin(body.origin),
-  };
-}
-
-function parseCommentCreate(body) {
-  assertPlainObject(body);
-  assertAllowedKeys(body, new Set(["body", "threadId", "threadBinding"]));
-  return {
-    body: stringField(body.body ?? "", "body", { maxLength: 100_000 }),
-    threadId: parseThreadId(body.threadId),
-    threadBinding: parseThreadBinding(body.threadBinding),
-  };
-}
-
-function parseCommentPatch(body) {
-  assertPlainObject(body);
-  assertAllowedKeys(body, new Set(["version", "body", "threadId", "threadBinding"]));
-  if (body.body === undefined) {
-    throw new ApiError(400, "INVALID_FIELD", "'body' is required");
-  }
-  return {
-    version: parseVersion(body.version),
-    body: stringField(body.body, "body", { maxLength: 100_000 }),
-    threadId: parseThreadId(body.threadId),
-    threadBinding: parseThreadBinding(body.threadBinding),
   };
 }
 
@@ -2897,7 +2732,7 @@ async function routeApi(request, env, actor, url) {
     }
     if (request.method === "POST") {
       return json(201, {
-        task: await createTask(env, parseTaskCreate(await readJson(request)), actor),
+        task: await createTask(env, parseTaskCreate(await readJson(request), parseDevelopmentContext), actor),
       });
     }
     methodNotAllowed(["GET", "POST"]);

--- a/server/ai-chat-catalog.mjs
+++ b/server/ai-chat-catalog.mjs
@@ -8,7 +8,7 @@ import { parse as parseToml } from "smol-toml";
 
 import { withoutTaskboardLauncherEnvironment } from "../shared/codex-environment.mjs";
 import { executableCommand } from "../shared/executable-command.mjs";
-import { composerReferencePersistence } from "./composer-reference.mjs";
+import { composerReferencePersistence } from "../shared/composer-reference.mjs";
 import { ApiError } from "../shared/api-fields.mjs";
 
 const execFileAsync = promisify(execFile);

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -1,11 +1,16 @@
 import {
+  parseThreadBinding, parseMove, parseVersionMutation, parseRelationMutation,
+  parseCommentCreate, parseCommentPatch, parseTaskCreate,
+} from "../shared/task-input.mjs";
+import {
   ApiError,
+  parseVersion,
+  validateProjectId,
   assertPlainObject,
   assertAllowedKeys,
   stringField,
   parseDueDate,
   parseRecurrence,
-  parseSortOrder,
   parseLabels,
   parseStatus,
   parsePriority,
@@ -13,7 +18,6 @@ import {
   parseProjectLabel,
   parseThreadId,
   parseAssigneeTarget,
-  parseRelationOrigin,
 } from "../shared/api-fields.mjs";
 import { createHmac, randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
@@ -37,7 +41,7 @@ import { resolveCodexExecutable } from "../shared/codex-executable.mjs";
 import { withoutTaskboardLauncherEnvironment } from "../shared/codex-environment.mjs";
 import { AiChatService } from "./ai-chat.mjs";
 import { resolveAiWorkspace, resolveMappedAiWorkspace } from "./ai-chat-catalog.mjs";
-import { decodeComposerReferenceKey } from "./composer-reference.mjs";
+import { decodeComposerReferenceKey } from "../shared/composer-reference.mjs";
 import { createCloudConfigStore } from "./cloud-config.mjs";
 import {
   CloudProxyError,
@@ -68,7 +72,6 @@ const INLINE_ATTACHMENT_TYPES = new Set([
   "image/webp",
   "text/plain",
 ]);
-const PROJECT_ID_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
 const PROJECT_BOARD_DISPLAY_SETTINGS_KEY_PREFIX = "taskboard.project-board-display-settings.v3.";
 const TRUSTED_EMBED_ORIGINS = new Set(["app://-"]);
 const TRUSTED_ORIGINS_ENV = "CODEX_TASKBOARD_TRUSTED_ORIGINS";
@@ -375,21 +378,6 @@ function parseDevelopmentContext(value) {
   throw new ApiError(400, "INVALID_FIELD", "'developmentContext.type' must be branch or worktree");
 }
 
-function parseVersion(value) {
-  if (!Number.isSafeInteger(value) || value < 1) {
-    throw new ApiError(400, "INVALID_FIELD", "'version' must be a positive integer");
-  }
-  return value;
-}
-
-function validateProjectId(value, { required = true } = {}) {
-  const id = stringField(value, "id", { required, maxLength: 64 });
-  if (id !== undefined && !PROJECT_ID_PATTERN.test(id)) {
-    throw new ApiError(400, "INVALID_FIELD", "'id' must be a lowercase slug containing letters, numbers, or hyphens");
-  }
-  return id;
-}
-
 function parseProjectCreate(body) {
   assertPlainObject(body);
   assertAllowedKeys(body, new Set(["id", "name", "workspacePath"]));
@@ -423,56 +411,6 @@ function parseProjectReadmeSave(body) {
     throw new ApiError(400, "INVALID_FIELD", "'version' must be a non-negative integer");
   }
   return { content, version };
-}
-
-function parseThreadBinding(value) {
-  if (value === undefined || value === null) return value;
-  assertPlainObject(value);
-  assertAllowedKeys(value, new Set([
-    "threadId",
-    "codexProjectId",
-    "codexProjectKind",
-    "codexHostId",
-    "workspacePath",
-  ]));
-  const threadId = stringField(value.threadId, "threadBinding.threadId", {
-    required: true,
-    maxLength: 256,
-  });
-  const identityFields = [
-    value.codexProjectId,
-    value.codexProjectKind,
-    value.codexHostId,
-    value.workspacePath,
-  ];
-  if (identityFields.every((field) => field === undefined)) return { threadId };
-  if (identityFields.some((field) => field === undefined)) {
-    throw new ApiError(400, "INVALID_FIELD", "Thread identity must include project, kind, host, and workspace");
-  }
-  const codexProjectId = stringField(value.codexProjectId, "threadBinding.codexProjectId", {
-    required: true,
-    maxLength: 256,
-  });
-  const codexProjectKind = value.codexProjectKind;
-  const codexHostId = stringField(value.codexHostId, "threadBinding.codexHostId", {
-    required: true,
-    maxLength: 256,
-  });
-  const workspacePath = stringField(value.workspacePath, "threadBinding.workspacePath", {
-    required: true,
-    maxLength: 4096,
-  });
-  if (codexProjectKind !== "local" && codexProjectKind !== "remote") {
-    throw new ApiError(400, "INVALID_FIELD", "threadBinding.codexProjectKind must be local or remote");
-  }
-  if (
-    (codexProjectKind === "local" && codexHostId !== "local")
-    || (codexProjectKind === "remote" && codexHostId === "local")
-    || workspacePath.includes("\0")
-  ) {
-    throw new ApiError(400, "INVALID_FIELD", "Thread project identity is invalid");
-  }
-  return { threadId, codexProjectId, codexProjectKind, codexHostId, workspacePath };
 }
 
 function requestHeader(request, name) {
@@ -533,35 +471,6 @@ function resolveAssignee(target, actor) {
   return actor;
 }
 
-function parseTaskCreate(body) {
-  assertPlainObject(body);
-  assertAllowedKeys(body, new Set([
-    "projectId", "title", "description", "status", "priority", "labels", "sortOrder", "threadId", "threadBinding",
-    "assigneeTarget", "developmentContext", "startDate", "dueDate", "recurrence",
-  ]));
-  const projectId = validateProjectId(body.projectId ?? DEFAULT_PROJECT_ID);
-  const task = {
-    projectId,
-    title: stringField(body.title, "title", { required: true, maxLength: 240 }),
-    description: stringField(body.description ?? "", "description", { maxLength: 100_000 }),
-    status: parseStatus(body.status, "backlog"),
-    priority: parsePriority(body.priority, "none"),
-    labels: body.labels === undefined ? [] : parseLabels(body.labels),
-    sortOrder: body.sortOrder === undefined ? undefined : parseSortOrder(body.sortOrder),
-    threadId: parseThreadId(body.threadId),
-    threadBinding: parseThreadBinding(body.threadBinding),
-    assigneeTarget: parseAssigneeTarget(body.assigneeTarget),
-    developmentContext: parseDevelopmentContext(body.developmentContext ?? null),
-    startDate: parseDueDate(body.startDate ?? null, "startDate"),
-    dueDate: parseDueDate(body.dueDate ?? null),
-    recurrence: parseRecurrence(body.recurrence ?? null),
-  };
-  if (task.recurrence && !task.dueDate) {
-    throw new ApiError(400, "INVALID_FIELD", "A recurring issue requires 'dueDate'");
-  }
-  return task;
-}
-
 function parseTaskPatch(body) {
   assertPlainObject(body);
   assertAllowedKeys(body, new Set([
@@ -592,39 +501,6 @@ function parseTaskPatch(body) {
   return { version, changes, threadId, threadBinding, assigneeTarget };
 }
 
-function parseMove(body) {
-  assertPlainObject(body);
-  assertAllowedKeys(body, new Set(["version", "status", "sortOrder", "threadId", "threadBinding"]));
-  return {
-    version: parseVersion(body.version),
-    status: parseStatus(body.status),
-    sortOrder: body.sortOrder === undefined ? undefined : parseSortOrder(body.sortOrder),
-    threadId: parseThreadId(body.threadId),
-    threadBinding: parseThreadBinding(body.threadBinding),
-  };
-}
-
-function parseArchive(body) {
-  assertPlainObject(body);
-  assertAllowedKeys(body, new Set(["version", "threadId", "threadBinding"]));
-  return {
-    version: parseVersion(body.version),
-    threadId: parseThreadId(body.threadId),
-    threadBinding: parseThreadBinding(body.threadBinding),
-  };
-}
-
-function parseRelationMutation(body) {
-  assertPlainObject(body);
-  assertAllowedKeys(body, new Set(["version", "threadId", "threadBinding", "origin"]));
-  return {
-    version: parseVersion(body.version),
-    threadId: parseThreadId(body.threadId),
-    threadBinding: parseThreadBinding(body.threadBinding),
-    origin: parseRelationOrigin(body.origin),
-  };
-}
-
 function parseIssueRelationType(value) {
   if (!["parent", "blocks", "blocked_by", "related"].includes(value)) {
     throw new ApiError(
@@ -634,30 +510,6 @@ function parseIssueRelationType(value) {
     );
   }
   return value;
-}
-
-function parseCommentCreate(body) {
-  assertPlainObject(body);
-  assertAllowedKeys(body, new Set(["body", "threadId", "threadBinding"]));
-  return {
-    body: stringField(body.body ?? "", "body", { maxLength: 100_000 }),
-    threadId: parseThreadId(body.threadId),
-    threadBinding: parseThreadBinding(body.threadBinding),
-  };
-}
-
-function parseCommentPatch(body) {
-  assertPlainObject(body);
-  assertAllowedKeys(body, new Set(["version", "body", "threadId", "threadBinding"]));
-  if (body.body === undefined) {
-    throw new ApiError(400, "INVALID_FIELD", "'body' is required");
-  }
-  return {
-    version: parseVersion(body.version),
-    body: stringField(body.body, "body", { maxLength: 100_000 }),
-    threadId: parseThreadId(body.threadId),
-    threadBinding: parseThreadBinding(body.threadBinding),
-  };
 }
 
 function parseAttachmentHeaders(request) {
@@ -2714,7 +2566,7 @@ export function createTaskboardServer(options = {}) {
         }
         if (request.method === "POST") {
           const actor = actorFromRequest(request);
-          const { assigneeTarget, ...parsedInput } = parseTaskCreate(await readJson(request));
+          const { assigneeTarget, ...parsedInput } = parseTaskCreate(await readJson(request), parseDevelopmentContext);
           const input = resolveInputThreadBinding(parsedInput);
           if (input.projectId === JIRA_PROJECT_ID) {
             throw new ApiError(
@@ -2890,7 +2742,7 @@ export function createTaskboardServer(options = {}) {
           return sendJson(response, 200, { comment });
         }
         if (request.method === "DELETE") {
-          const { version } = parseArchive(await readJson(request));
+          const { version } = parseVersionMutation(await readJson(request));
           const comment = database.deleteComment(id, version);
           for (const attachment of comment.attachments) {
             try {
@@ -3170,7 +3022,7 @@ export function createTaskboardServer(options = {}) {
           if (current?.source === "jira") {
             throw new ApiError(409, "JIRA_DELETE_UNAVAILABLE", "Jira 任务不能从 Taskboard 永久删除");
           }
-          const { version } = parseArchive(await readJson(request));
+          const { version } = parseVersionMutation(await readJson(request));
           const deleted = database.deleteArchivedTask(id, version);
           for (const attachmentId of deleted.attachmentIds) {
             try {
@@ -3216,7 +3068,7 @@ export function createTaskboardServer(options = {}) {
             throw new ApiError(409, "JIRA_ARCHIVE_UNAVAILABLE", "Jira 任务由同步范围自动管理，不能手动归档");
           }
           const { version, threadId, threadBinding } = resolveInputThreadBinding(
-            parseArchive(await readJson(request)),
+            parseVersionMutation(await readJson(request)),
           );
           const task = database.archiveTask(
             id,
@@ -3234,7 +3086,7 @@ export function createTaskboardServer(options = {}) {
             throw new ApiError(409, "JIRA_RESTORE_UNAVAILABLE", "Jira 任务由同步范围自动管理，不能手动恢复");
           }
           const { version, threadId, threadBinding } = resolveInputThreadBinding(
-            parseArchive(await readJson(request)),
+            parseVersionMutation(await readJson(request)),
           );
           const task = database.restoreTask(
             id,

--- a/shared/api-fields.mjs
+++ b/shared/api-fields.mjs
@@ -140,3 +140,24 @@ export function parseRelationOrigin(value) {
   }
   return value;
 }
+
+const PROJECT_ID_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
+
+export function parseVersion(value, { allowZero = false } = {}) {
+  if (!Number.isSafeInteger(value) || value < (allowZero ? 0 : 1)) {
+    throw new ApiError(
+      400,
+      "INVALID_FIELD",
+      `'version' must be a ${allowZero ? "non-negative" : "positive"} integer`,
+    );
+  }
+  return value;
+}
+
+export function validateProjectId(value, { required = true } = {}) {
+  const id = stringField(value, "id", { required, maxLength: 64 });
+  if (id !== undefined && !PROJECT_ID_PATTERN.test(id)) {
+    throw new ApiError(400, "INVALID_FIELD", "'id' must be a lowercase slug containing letters, numbers, or hyphens");
+  }
+  return id;
+}

--- a/shared/composer-reference.d.mts
+++ b/shared/composer-reference.d.mts
@@ -1,0 +1,19 @@
+type ReferenceKind = "skill" | "agent";
+
+export const COMPOSER_REFERENCE_FORMAT: "taskboard.composer-reference.v1";
+export function encodeComposerReferenceKey(stableId: string): string;
+export function decodeComposerReferenceKey(referenceKey: string): string;
+export function readComposerReferenceId(referenceKey: string, kind?: string): string | null;
+export function composerReferenceUri(kind: ReferenceKind, stableId: string): string;
+export function composerReferencePersistence(kind: ReferenceKind, stableId: string, label: string): {
+  format: typeof COMPOSER_REFERENCE_FORMAT;
+  kind: ReferenceKind;
+  referenceKey: string;
+  markdown: string;
+};
+export function parseComposerReferenceUri(uri: string): {
+  format: typeof COMPOSER_REFERENCE_FORMAT;
+  kind: ReferenceKind;
+  referenceKey: string;
+  stableId: string;
+};

--- a/shared/composer-reference.mjs
+++ b/shared/composer-reference.mjs
@@ -9,8 +9,13 @@ function requiredString(value, name) {
   return value;
 }
 
-function encodeReferenceKey(stableId) {
-  return Buffer.from(requiredString(stableId, "stableId"), "utf8").toString("base64url");
+export function encodeComposerReferenceKey(stableId) {
+  let binary = "";
+  for (const byte of new TextEncoder().encode(requiredString(stableId, "stableId"))) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
 export function decodeComposerReferenceKey(referenceKey) {
@@ -18,11 +23,27 @@ export function decodeComposerReferenceKey(referenceKey) {
   if (!/^[A-Za-z0-9_-]+$/.test(key)) {
     throw new TypeError("referenceKey must be unpadded base64url");
   }
-  const decoded = Buffer.from(key, "base64url").toString("utf8");
-  if (!decoded || encodeReferenceKey(decoded) !== key) {
+  let decoded;
+  try {
+    const padded = `${key.replace(/-/g, "+").replace(/_/g, "/")}${"=".repeat((4 - key.length % 4) % 4)}`;
+    const bytes = Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
+    decoded = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(bytes);
+  } catch {
+    throw new TypeError("referenceKey is not canonical base64url UTF-8");
+  }
+  if (!decoded || encodeComposerReferenceKey(decoded) !== key) {
     throw new TypeError("referenceKey is not canonical base64url UTF-8");
   }
   return decoded;
+}
+
+export function readComposerReferenceId(referenceKey, kind) {
+  try {
+    const stableId = decodeComposerReferenceKey(referenceKey);
+    return kind === "skill" && stableId !== stableId.normalize("NFC") ? null : stableId;
+  } catch {
+    return null;
+  }
 }
 
 function assertReferenceKind(kind) {
@@ -37,14 +58,14 @@ function escapedMarkdownLabel(label) {
 }
 
 export function composerReferenceUri(kind, stableId) {
-  return `${REFERENCE_PREFIX}/${assertReferenceKind(kind)}/${encodeReferenceKey(stableId)}`;
+  return `${REFERENCE_PREFIX}/${assertReferenceKind(kind)}/${encodeComposerReferenceKey(stableId)}`;
 }
 
 export function composerReferencePersistence(kind, stableId, label) {
   const normalizedStableId = kind === "skill"
     ? requiredString(stableId, "stableId").normalize("NFC")
     : requiredString(stableId, "stableId");
-  const referenceKey = encodeReferenceKey(normalizedStableId);
+  const referenceKey = encodeComposerReferenceKey(normalizedStableId);
   const uri = `${REFERENCE_PREFIX}/${assertReferenceKind(kind)}/${referenceKey}`;
   return {
     format: REFERENCE_FORMAT,

--- a/shared/task-input.mjs
+++ b/shared/task-input.mjs
@@ -1,0 +1,143 @@
+import { DEFAULT_PROJECT_ID } from "./domain.mjs";
+import {
+  ApiError, assertPlainObject, assertAllowedKeys, stringField,
+  parseVersion, validateProjectId, parseThreadId, parseAssigneeTarget,
+  parseRelationOrigin, parseStatus, parsePriority, parseLabels,
+  parseSortOrder, parseDueDate, parseRecurrence,
+} from "./api-fields.mjs";
+
+export function parseThreadBinding(value) {
+  if (value === undefined || value === null) return value;
+  assertPlainObject(value);
+  assertAllowedKeys(value, new Set([
+    "threadId",
+    "codexProjectId",
+    "codexProjectKind",
+    "codexHostId",
+    "workspacePath",
+  ]));
+  const threadId = stringField(value.threadId, "threadBinding.threadId", {
+    required: true,
+    maxLength: 256,
+  });
+  const identityFields = [
+    value.codexProjectId,
+    value.codexProjectKind,
+    value.codexHostId,
+    value.workspacePath,
+  ];
+  if (identityFields.every((field) => field === undefined)) return { threadId };
+  if (identityFields.some((field) => field === undefined)) {
+    throw new ApiError(400, "INVALID_FIELD", "Thread identity must include project, kind, host, and workspace");
+  }
+  const codexProjectId = stringField(value.codexProjectId, "threadBinding.codexProjectId", {
+    required: true,
+    maxLength: 256,
+  });
+  const codexProjectKind = value.codexProjectKind;
+  const codexHostId = stringField(value.codexHostId, "threadBinding.codexHostId", {
+    required: true,
+    maxLength: 256,
+  });
+  const workspacePath = stringField(value.workspacePath, "threadBinding.workspacePath", {
+    required: true,
+    maxLength: 4096,
+  });
+  if (codexProjectKind !== "local" && codexProjectKind !== "remote") {
+    throw new ApiError(400, "INVALID_FIELD", "threadBinding.codexProjectKind must be local or remote");
+  }
+  if (
+    (codexProjectKind === "local" && codexHostId !== "local")
+    || (codexProjectKind === "remote" && codexHostId === "local")
+    || workspacePath.includes("\0")
+  ) {
+    throw new ApiError(400, "INVALID_FIELD", "Thread project identity is invalid");
+  }
+  return { threadId, codexProjectId, codexProjectKind, codexHostId, workspacePath };
+}
+
+export function parseMove(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["version", "status", "sortOrder", "threadId", "threadBinding"]));
+  return {
+    version: parseVersion(body.version),
+    status: parseStatus(body.status),
+    sortOrder: body.sortOrder === undefined ? undefined : parseSortOrder(body.sortOrder),
+    threadId: parseThreadId(body.threadId),
+    threadBinding: parseThreadBinding(body.threadBinding),
+  };
+}
+
+export function parseVersionMutation(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["version", "threadId", "threadBinding"]));
+  return {
+    version: parseVersion(body.version),
+    threadId: parseThreadId(body.threadId),
+    threadBinding: parseThreadBinding(body.threadBinding),
+  };
+}
+
+export function parseRelationMutation(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["version", "threadId", "threadBinding", "origin"]));
+  return {
+    version: parseVersion(body.version),
+    threadId: parseThreadId(body.threadId),
+    threadBinding: parseThreadBinding(body.threadBinding),
+    origin: parseRelationOrigin(body.origin),
+  };
+}
+
+export function parseCommentCreate(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["body", "threadId", "threadBinding"]));
+  return {
+    body: stringField(body.body ?? "", "body", { maxLength: 100_000 }),
+    threadId: parseThreadId(body.threadId),
+    threadBinding: parseThreadBinding(body.threadBinding),
+  };
+}
+
+export function parseCommentPatch(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["version", "body", "threadId", "threadBinding"]));
+  if (body.body === undefined) {
+    throw new ApiError(400, "INVALID_FIELD", "'body' is required");
+  }
+  return {
+    version: parseVersion(body.version),
+    body: stringField(body.body, "body", { maxLength: 100_000 }),
+    threadId: parseThreadId(body.threadId),
+    threadBinding: parseThreadBinding(body.threadBinding),
+  };
+}
+
+export function parseTaskCreate(body, parseDevelopmentContext) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set([
+    "projectId", "title", "description", "status", "priority", "labels", "sortOrder", "threadId", "threadBinding",
+    "assigneeTarget", "developmentContext", "startDate", "dueDate", "recurrence",
+  ]));
+  const projectId = validateProjectId(body.projectId ?? DEFAULT_PROJECT_ID);
+  const task = {
+    projectId,
+    title: stringField(body.title, "title", { required: true, maxLength: 240 }),
+    description: stringField(body.description ?? "", "description", { maxLength: 100_000 }),
+    status: parseStatus(body.status, "backlog"),
+    priority: parsePriority(body.priority, "none"),
+    labels: body.labels === undefined ? [] : parseLabels(body.labels),
+    sortOrder: body.sortOrder === undefined ? undefined : parseSortOrder(body.sortOrder),
+    threadId: parseThreadId(body.threadId),
+    threadBinding: parseThreadBinding(body.threadBinding),
+    assigneeTarget: parseAssigneeTarget(body.assigneeTarget),
+    developmentContext: parseDevelopmentContext(body.developmentContext ?? null),
+    startDate: parseDueDate(body.startDate ?? null, "startDate"),
+    dueDate: parseDueDate(body.dueDate ?? null),
+    recurrence: parseRecurrence(body.recurrence ?? null),
+  };
+  if (task.recurrence && !task.dueDate) {
+    throw new ApiError(400, "INVALID_FIELD", "A recurring issue requires 'dueDate'");
+  }
+  return task;
+}

--- a/test/ai-chat-runner.test.mjs
+++ b/test/ai-chat-runner.test.mjs
@@ -15,7 +15,7 @@ import {
   composerReferencePersistence,
   decodeComposerReferenceKey,
   parseComposerReferenceUri,
-} from "../server/composer-reference.mjs";
+} from "../shared/composer-reference.mjs";
 import { createTaskboardServer } from "../server/index.mjs";
 import { normalizeCodexEvent } from "../server/ai-chat-process.mjs";
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,3 +1,4 @@
+import { resolveInlineAttachments } from "./inlineAttachments";
 import {
   Fragment,
   lazy,
@@ -63,8 +64,6 @@ import { IssueListView } from "./components/IssueListView";
 import { JiraConnectionDialog } from "./components/JiraConnectionDialog";
 import { ArchivedTasksColumn, OtherTasksPanel } from "./components/OtherTasksPanel";
 import {
-  resolveInlineAttachmentMarkdown,
-  resolveInlineMediaMarkdown,
   type PendingInlineAttachment,
   type PendingInlineImage,
 } from "./components/InlineMediaComposer";
@@ -109,6 +108,7 @@ import {
   type OtherTaskTab,
 } from "./issueBoardStatuses";
 import {
+  indexAiThreadsByTask,
   normalizeCodexThreadId,
   taskCardPresentation,
   type TaskCardPresentation,
@@ -738,7 +738,6 @@ export function App() {
       running: boolean;
     } | null>
   >({});
-  const [processingNow, setProcessingNow] = useState(() => Date.now());
   const [recentProjectIds, setRecentProjectIds] = useState(readRecentProjectIds);
   const initialProjectId = query.get("project") ?? recentProjectIds[0] ?? ALL_PROJECTS_ID;
   const [projects, setProjects] = useState<Project[]>([]);
@@ -2290,6 +2289,7 @@ export function App() {
     setOtherTasksTab(otherTaskTabs[0]);
   }, [otherTaskTabsKey, otherTasksAvailable, otherTasksTab]);
 
+  const aiThreadsByTask = useMemo(() => indexAiThreadsByTask(aiThreads), [aiThreads]);
   const taskPresentations = useMemo(() => Object.fromEntries(tasks.map((task) => {
     const storageKey = issueReadStorageKey(issueReadMode, task);
     const readActivityKey = readActivityKeys[storageKey] ?? taskboardStorage.getItem(storageKey);
@@ -2301,14 +2301,14 @@ export function App() {
     const taskThreadId = normalizeCodexThreadId(task.threadId);
     return [task.id, taskCardPresentation(
       task,
-      aiThreads,
+      aiThreadsByTask.get(task.id) ?? [],
       unread,
       runningNativeThreadId,
       hostContext?.threadTodoProgress ?? null,
       taskThreadId ? codexThreadProgress[taskThreadId] ?? null : undefined,
     )];
   })) as Record<string, TaskCardPresentation>, [
-    aiThreads,
+    aiThreadsByTask,
     codexThreadProgress,
     hostContext?.threadId,
     hostContext?.threadRunning,
@@ -2317,18 +2317,6 @@ export function App() {
     readActivityKeys,
     tasks,
   ]);
-  const hasRunningTask = useMemo(
-    () => Object.values(taskPresentations).some((presentation) => presentation.processing.running),
-    [taskPresentations],
-  );
-
-  useEffect(() => {
-    setProcessingNow(Date.now());
-    if (!hasRunningTask) return;
-    const timer = window.setInterval(() => setProcessingNow(Date.now()), 1_000);
-    return () => window.clearInterval(timer);
-  }, [hasRunningTask]);
-
 
   function selectBoardView(view: BoardView) {
     closeContextMenu();
@@ -2412,14 +2400,10 @@ export function App() {
         postCreateWriteFailed = true;
       } else if (inlineFiles.length > 0 || inlineImages.length > 0) {
         try {
-          const description = resolveInlineAttachmentMarkdown(
-            resolveInlineMediaMarkdown(
-              draft.description,
-              inlineImages,
-              inlineAttachments,
-            ),
-            inlineFiles,
-            fileAttachments,
+          const description = resolveInlineAttachments(
+            draft.description,
+            [...inlineImages, ...inlineFiles],
+            [...inlineAttachments, ...fileAttachments],
           );
           saved = await updateTaskRequest(saved, { ...draft, description });
         } catch {
@@ -3828,7 +3812,6 @@ export function App() {
                         status={item}
                         tasks={tasksByStatus[item]}
                         presentations={taskPresentations}
-                        now={processingNow}
                         emptyMessage={hasActiveTaskFilters
                           ? text("当前筛选下无匹配议题", "No issues match the current filters")
                           : text("暂无议题", "No issues")}
@@ -3867,7 +3850,6 @@ export function App() {
                     tasksByStatus={tasksByStatus}
                     archivedTasks={filteredArchivedTasks}
                     presentations={taskPresentations}
-                    now={processingNow}
                     hasActiveFilters={hasActiveTaskFilters}
                     isDropTarget={otherTasksTab !== "archived" && dropTarget === otherTasksTab}
                     draggedTaskId={draggedTaskId}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -775,7 +775,7 @@ export function attachmentContentUrl(attachment: { id: string }): string {
   return `api/attachments/${encodeURIComponent(attachment.id)}/content`;
 }
 
-export function attachmentDownloadUrl(attachment: Attachment): string {
+export function attachmentDownloadUrl(attachment: { id: string }): string {
   return `api/attachments/${encodeURIComponent(attachment.id)}/download`;
 }
 

--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -1,3 +1,4 @@
+import { composerReferencePersistence, readComposerReferenceId } from "../../../shared/composer-reference.mjs";
 import {
   useCallback,
   useEffect,
@@ -299,49 +300,19 @@ function skillDisplayName(skill: Pick<AiChatSkill, "id" | "label">): string {
     .join(" ");
 }
 
-function stableComposerReferenceId(
-  referenceKey: string,
-  kind: "skill" | "agent" = "skill",
-): string | null {
-  try {
-    if (!/^[A-Za-z0-9_-]+$/.test(referenceKey) || referenceKey.length % 4 === 1) return null;
-    const padded = `${referenceKey.replace(/-/g, "+").replace(/_/g, "/")}${"=".repeat((4 - referenceKey.length % 4) % 4)}`;
-    const bytes = Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
-    const stableId = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-    if (!stableId || (kind === "skill" && stableId !== stableId.normalize("NFC"))) return null;
-    const encoded = btoa(String.fromCharCode(...new TextEncoder().encode(stableId)))
-      .replace(/\+/g, "-")
-      .replace(/\//g, "_")
-      .replace(/=+$/, "");
-    return encoded === referenceKey ? stableId : null;
-  } catch {
-    return null;
-  }
-}
-
-function stableComposerReferenceKey(
-  stableId: string,
-  kind: "skill" | "agent" = "skill",
-): string {
-  const normalizedStableId = kind === "skill" ? stableId.normalize("NFC") : stableId;
-  return btoa(String.fromCharCode(...new TextEncoder().encode(normalizedStableId)))
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "");
-}
-
-function escapedComposerReferenceLabel(label: string): string {
-  return label.replace(/[\\[\]]/g, "\\$&");
-}
-
 function composerStableReference(
   kind: "skill" | "agent",
   stableId: string,
   label: string,
-  referenceKey = stableComposerReferenceKey(stableId, kind),
-  markdown = `[${escapedComposerReferenceLabel(label)}](taskboard://composer-reference/v1/${kind}/${referenceKey})`,
+  referenceKey?: string,
+  markdown?: string,
 ): ComposerStableReference {
-  return { kind, stableId, referenceKey, label, markdown };
+  const persistence = composerReferencePersistence(kind, stableId, label);
+  return {
+    kind, stableId, label,
+    referenceKey: referenceKey ?? persistence.referenceKey,
+    markdown: markdown ?? persistence.markdown,
+  };
 }
 
 function eventSkillIds(event: AiChatEvent): string[] {
@@ -627,7 +598,7 @@ function composerFragmentFromHtml(
       const referenceMatch = /^taskboard:\/\/composer-reference\/v1\/(skill|agent)\/([A-Za-z0-9_-]+)$/.exec(href);
       const referenceKind = referenceMatch?.[1] === "agent" ? "agent" : "skill";
       const stableReferenceId = referenceMatch
-        ? stableComposerReferenceId(referenceMatch[2], referenceKind)
+        ? readComposerReferenceId(referenceMatch[2], referenceKind)
         : null;
       if (stableReferenceId && referenceMatch) {
         const referenceKey = referenceMatch[2];
@@ -686,7 +657,7 @@ function composerFragmentFromPlainText(
     const referenceKind = match[3] === "agent" ? "agent" : "skill";
     const referenceKey = match[4];
     const stableReferenceId = referenceKey
-      ? stableComposerReferenceId(referenceKey, referenceKind)
+      ? readComposerReferenceId(referenceKey, referenceKind)
       : null;
     const legacySkillId = !referenceKey && label.startsWith("$") ? label.slice(1) : null;
     const stableId = stableReferenceId ?? legacySkillId;
@@ -697,7 +668,7 @@ function composerFragmentFromPlainText(
       kind,
       stableId,
       stableReferenceId ? label : skill?.label ?? stableId,
-      referenceKey || stableComposerReferenceKey(stableId),
+      referenceKey || undefined,
       stableReferenceId ? match[0] : undefined,
     );
     message += text.slice(cursor, match.index).replaceAll(SKILL_MARKER, "\uFFFD");
@@ -2291,7 +2262,7 @@ export function AiChat({
     tokenElement.dataset.composerKind = candidate.kind;
     const persistence = candidate.persistence?.kind === candidate.kind ? candidate.persistence : null;
     const stableId = persistence
-      ? stableComposerReferenceId(persistence.referenceKey, candidate.kind)
+      ? readComposerReferenceId(persistence.referenceKey, candidate.kind)
       : null;
     if (stableId && persistence) {
       if (candidate.kind === "skill") tokenElement.dataset.skillId = stableId;

--- a/web/src/components/BoardCardDisplayMenu.tsx
+++ b/web/src/components/BoardCardDisplayMenu.tsx
@@ -1,3 +1,4 @@
+import { listenForOutsidePointerDown } from "../menuEvents";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { DragEvent } from "react";
 import { createPortal } from "react-dom";
@@ -67,20 +68,15 @@ export function BoardCardDisplayMenu({
 
   useEffect(() => {
     if (!menuOpen) return;
-    function closeFromOutside(event: PointerEvent) {
-      if (!menuRef.current?.contains(event.target as Node) && !triggerRef.current?.contains(event.target as Node)) {
-        setMenuOpen(false);
-      }
-    }
+    const stopOutside = listenForOutsidePointerDown([menuRef, triggerRef], () => setMenuOpen(false));
     function closeFromEscape(event: KeyboardEvent) {
       if (event.key !== "Escape") return;
       setMenuOpen(false);
       triggerRef.current?.focus();
     }
-    document.addEventListener("pointerdown", closeFromOutside);
     document.addEventListener("keydown", closeFromEscape);
     return () => {
-      document.removeEventListener("pointerdown", closeFromOutside);
+      stopOutside();
       document.removeEventListener("keydown", closeFromEscape);
     };
   }, [menuOpen]);

--- a/web/src/components/BoardColumn.tsx
+++ b/web/src/components/BoardColumn.tsx
@@ -24,7 +24,6 @@ interface BoardColumnProps {
   status: TaskStatus;
   tasks: Task[];
   presentations: Record<string, TaskCardPresentation>;
-  now: number;
   emptyMessage: string;
   isDropTarget: boolean;
   draggedTaskId: string | null;
@@ -56,7 +55,6 @@ export function BoardColumn({
   status,
   tasks,
   presentations,
-  now,
   emptyMessage,
   isDropTarget,
   draggedTaskId,
@@ -177,7 +175,6 @@ export function BoardColumn({
               key={task.id}
               task={task}
               presentation={presentations[task.id]}
-              now={now}
               isDragging={draggedTaskId === task.id}
               dragShift={dragShift}
               isMoving={movingTaskId === task.id}

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -1,3 +1,4 @@
+import { encodeComposerReferenceKey, readComposerReferenceId } from "../../../shared/composer-reference.mjs";
 import {
   forwardRef,
   useEffect,
@@ -279,39 +280,12 @@ const COMPOSER_REFERENCE_URL = /^taskboard:\/\/composer-reference\/v1\/(skill|ag
 const COMPOSER_REFERENCE_NAMESPACE_URL = /^taskboard:\/\/composer-reference\/([^/]+)\/([^/]+)\/([A-Za-z0-9_-]+)$/;
 const PENDING_IMAGE_COMPOSER_REFERENCE_URL = /^taskboard:\/\/composer-reference\/v1\/pending-image\/([A-Za-z0-9_-]+)\.([A-Za-z0-9_-]+)$/;
 
-function encodedComposerReferenceKey(value: string): string {
-  return btoa(String.fromCharCode(...new TextEncoder().encode(value)))
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "");
-}
-
-function decodedComposerReferenceKey(value: string): string | null {
-  if (!value || value.length % 4 === 1) return null;
-  try {
-    const padded = `${value.replace(/-/g, "+").replace(/_/g, "/")}${"=".repeat((4 - value.length % 4) % 4)}`;
-    const bytes = Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
-    const decoded = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-    return decoded && encodedComposerReferenceKey(decoded) === value ? decoded : null;
-  } catch {
-    return null;
-  }
-}
-
-function base64UrlReferenceKey(
-  value: string,
-  requireNfc: boolean,
-): string | null {
-  const decoded = decodedComposerReferenceKey(value);
-  return decoded && (!requireNfc || decoded === decoded.normalize("NFC")) ? value : null;
-}
-
 function pendingImageComposerReference(
   url: string,
   name: string,
 ): { file: File; dataUrl: string } | null {
   const match = PENDING_IMAGE_COMPOSER_REFERENCE_URL.exec(url);
-  const type = match ? decodedComposerReferenceKey(match[1]) : null;
+  const type = match ? readComposerReferenceId(match[1]) : null;
   if (!match || !type?.startsWith("image/")) return null;
   try {
     const base64 = `${match[2].replace(/-/g, "+").replace(/_/g, "/")}${"=".repeat((4 - match[2].length % 4) % 4)}`;
@@ -348,7 +322,7 @@ function composerReferenceFromNode(
 ) & { start: number; end: number } | null {
   if (node.type !== "link" || !node.url) return null;
   const namespaceMatch = COMPOSER_REFERENCE_NAMESPACE_URL.exec(node.url);
-  if (!namespaceMatch || !base64UrlReferenceKey(namespaceMatch[3], namespaceMatch[2] === "skill")) return null;
+  if (!namespaceMatch || !readComposerReferenceId(namespaceMatch[3], namespaceMatch[2])) return null;
   const label = markdownNodeText(node);
   const markdown = source.slice(node.position.start.offset, node.position.end.offset);
   if (
@@ -368,7 +342,7 @@ function composerReferenceFromNode(
     };
   }
   const kind = urlMatch[1] as "skill" | "agent";
-  const referenceKey = base64UrlReferenceKey(urlMatch[2], kind === "skill")!;
+  const referenceKey = urlMatch[2];
   return {
     type: `${kind}-reference`,
     start: node.position.start.offset,
@@ -660,38 +634,6 @@ export function serializeInlineMedia(segments: InlineMediaSegment[]): string {
   ));
 }
 
-export function resolveInlineMediaMarkdown(
-  value: string,
-  images: PendingInlineImage[],
-  attachments: Array<{ id: string }>,
-): string {
-  return images.reduce((markdown, image, index) => {
-    const attachment = attachments[index];
-    if (!attachment) return markdown;
-    const alt = image.file.name.replace(/[\\[\]]/g, "\\$&");
-    return markdown.replace(
-      image.token,
-      `![${alt}](${attachmentContentUrl(attachment)})`,
-    );
-  }, value);
-}
-
-export function resolveInlineAttachmentMarkdown(
-  value: string,
-  files: PendingInlineAttachment[],
-  attachments: Attachment[],
-): string {
-  return files.reduce((markdown, file, index) => {
-    const attachment = attachments[index];
-    if (!attachment) return markdown;
-    const filename = file.file.name.replace(/[\\[\]]/g, "\\$&");
-    return markdown.replace(
-      file.token,
-      `[${filename}](${attachmentDownloadUrl(attachment)})`,
-    );
-  }, value);
-}
-
 function normalizeSegments(segments: InlineMediaSegment[]): InlineMediaSegment[] {
   const normalized: InlineMediaSegment[] = [];
   for (const segment of segments) {
@@ -741,7 +683,7 @@ function inlineMediaClipboardText(segments: InlineMediaSegment[]): string {
 function pendingImageClipboardMarkdown(segment: InlineImageSegment): string | null {
   const match = segment.dataUrl?.match(/^data:([^;,]+);base64,(.+)$/);
   if (!match) return null;
-  const typeKey = encodedComposerReferenceKey(match[1]);
+  const typeKey = encodeComposerReferenceKey(match[1]);
   const dataKey = match[2].replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
   const alt = segment.file.name.replace(/[\\[\]]/g, "\\$&");
   return `![${alt}](taskboard://composer-reference/v1/pending-image/${typeKey}.${dataKey})`;

--- a/web/src/components/LabelPicker.tsx
+++ b/web/src/components/LabelPicker.tsx
@@ -1,3 +1,4 @@
+import { listenForOutsidePointerDown } from "../menuEvents";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { labelDisplayName, labelPresentation } from "../labels";
 import { useTaskboardI18n } from "../i18n";
@@ -60,9 +61,7 @@ export function LabelPicker({
       return;
     }
 
-    function closeFromOutside(event: PointerEvent) {
-      if (!rootRef.current?.contains(event.target as Node)) onOpenChange(false);
-    }
+    const stopOutside = listenForOutsidePointerDown([rootRef], () => onOpenChange(false));
 
     function closeFromEscape(event: globalThis.KeyboardEvent) {
       if (event.key === "Escape") {
@@ -71,10 +70,9 @@ export function LabelPicker({
       }
     }
 
-    document.addEventListener("pointerdown", closeFromOutside);
     window.addEventListener("keydown", closeFromEscape);
     return () => {
-      document.removeEventListener("pointerdown", closeFromOutside);
+      stopOutside();
       window.removeEventListener("keydown", closeFromEscape);
     };
   }, [onOpenChange, open]);

--- a/web/src/components/OtherTasksPanel.tsx
+++ b/web/src/components/OtherTasksPanel.tsx
@@ -136,7 +136,6 @@ interface OtherTasksPanelProps {
   tasksByStatus: Record<TaskStatus, Task[]>;
   archivedTasks: Task[];
   presentations: Record<string, TaskCardPresentation>;
-  now: number;
   hasActiveFilters: boolean;
   isDropTarget: boolean;
   draggedTaskId: string | null;
@@ -173,7 +172,6 @@ export function OtherTasksPanel({
   tasksByStatus,
   archivedTasks,
   presentations,
-  now,
   hasActiveFilters,
   isDropTarget,
   draggedTaskId,
@@ -342,7 +340,6 @@ export function OtherTasksPanel({
               task={task}
               variant="sidebar"
               presentation={presentations[task.id]}
-              now={now}
               isDragging={draggedTaskId === task.id}
               dragShift={dragShift}
               isMoving={movingTaskId === task.id}

--- a/web/src/components/ProjectReadmeView.tsx
+++ b/web/src/components/ProjectReadmeView.tsx
@@ -1,3 +1,4 @@
+import { resolveInlineAttachments } from "../inlineAttachments";
 import { useEffect, useRef, useState } from "react";
 import {
   ApiError,
@@ -12,7 +13,6 @@ import {
   createInlineMediaSegments,
   InlineMediaComposer,
   inlineMediaImages,
-  resolveInlineMediaMarkdown,
   serializeInlineMedia,
   type InlineMediaComposerHandle,
   type InlineMediaSegment,
@@ -115,7 +115,7 @@ export function ProjectReadmeView({
       const uploaded = await Promise.all(
         inlineImages.map((image) => uploadProjectReadmeAttachment(project.id, image.file)),
       );
-      const resolvedContent = resolveInlineMediaMarkdown(
+      const resolvedContent = resolveInlineAttachments(
         draftContent,
         inlineImages,
         uploaded,

--- a/web/src/components/TaskCard.tsx
+++ b/web/src/components/TaskCard.tsx
@@ -31,7 +31,6 @@ interface TaskCardProps {
   task: Task;
   variant?: "main" | "sidebar";
   presentation: TaskCardPresentation;
-  now: number;
   isDragging: boolean;
   dragShift: number;
   isMoving: boolean;
@@ -195,26 +194,38 @@ function ProcessingProgress({
   );
 }
 
+function ProcessingLabel({ processing }: { processing: TaskCardPresentation["processing"] }) {
+  const { text } = useTaskboardI18n();
+  const { running, startedAt } = processing;
+  const [now, setNow] = useState(Date.now);
+  useEffect(() => {
+    if (!running || !startedAt) return;
+    setNow(Date.now());
+    const timer = window.setInterval(() => setNow(Date.now()), 1_000);
+    return () => window.clearInterval(timer);
+  }, [running, startedAt]);
+  const elapsed = elapsedTime(startedAt, now);
+  return (
+    <span className="task-processing-label">
+      {running
+        ? (elapsed ? text(`已处理 ${elapsed}...`, `Processing for ${elapsed}...`) : text("正在处理...", "Processing..."))
+        : text("暂停处理", "Processing paused")}
+    </span>
+  );
+}
+
 function ProcessingStatusRow({
   presentation,
-  now,
   onOpenConversation,
 }: {
   presentation: TaskCardPresentation;
-  now: number;
   onOpenConversation: (conversation: TaskConversationItem) => void;
 }) {
-  const { text } = useTaskboardI18n();
-  const elapsed = elapsedTime(presentation.processing.startedAt, now);
   const running = presentation.processing.running;
   return (
     <div className={`task-processing-row${running ? " is-running" : " is-paused"}`}>
       {running && <img className="task-processing-glyph" src={processingAnimation} alt="" aria-hidden="true" />}
-      <span className="task-processing-label">
-        {running
-          ? (elapsed ? text(`已处理 ${elapsed}...`, `Processing for ${elapsed}...`) : text("正在处理...", "Processing..."))
-          : text("暂停处理", "Processing paused")}
-      </span>
+      <ProcessingLabel processing={presentation.processing} />
       <span className="task-processing-spacer" aria-hidden="true" />
       {presentation.conversations.length > 0 && (
         <TaskConversationMenu
@@ -392,7 +403,6 @@ export function TaskCard({
   task,
   variant = "main",
   presentation,
-  now,
   isDragging,
   dragShift,
   isMoving,
@@ -596,7 +606,6 @@ export function TaskCard({
           <ProcessingProgress presentation={presentation} />
           <ProcessingStatusRow
             presentation={presentation}
-            now={now}
             onOpenConversation={onOpenConversation}
           />
         </>

--- a/web/src/components/TaskContextMenu.tsx
+++ b/web/src/components/TaskContextMenu.tsx
@@ -1,3 +1,4 @@
+import { listenForOutsidePointerDown, listenForMenuViewportChange } from "../menuEvents";
 import {
   useEffect,
   useLayoutEffect,
@@ -182,24 +183,13 @@ export function TaskContextMenu({
     const previousFocus = document.activeElement as HTMLElement | null;
     requestAnimationFrame(() => menuRef.current?.querySelector<HTMLElement>(".context-menu-item:not(:disabled)")?.focus());
 
-    function closeFromOutside(event: PointerEvent) {
-      if (!menuRef.current?.contains(event.target as Node)) onClose();
-    }
-    function closeFromViewportChange(event: Event) {
-      if (event.type === "scroll" && menuRef.current?.contains(event.target as Node)) return;
-      onClose();
-    }
+    const stopOutside = listenForOutsidePointerDown([menuRef], onClose);
+    const stopViewport = listenForMenuViewportChange(menuRef, onClose);
 
-    document.addEventListener("pointerdown", closeFromOutside);
-    window.addEventListener("blur", closeFromViewportChange);
-    window.addEventListener("resize", closeFromViewportChange);
-    window.addEventListener("scroll", closeFromViewportChange, true);
     return () => {
       if (submenuTimerRef.current !== null) window.clearTimeout(submenuTimerRef.current);
-      document.removeEventListener("pointerdown", closeFromOutside);
-      window.removeEventListener("blur", closeFromViewportChange);
-      window.removeEventListener("resize", closeFromViewportChange);
-      window.removeEventListener("scroll", closeFromViewportChange, true);
+      stopOutside();
+      stopViewport();
       previousFocus?.focus?.({ preventScroll: true });
     };
   }, [onClose]);

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -1,3 +1,4 @@
+import { resolveInlineAttachments, uploadInlineAttachments } from "../inlineAttachments";
 import {
   useCallback,
   useEffect,
@@ -79,8 +80,6 @@ import {
   inlineMediaFiles,
   inlineMediaImages,
   inlineMediaText,
-  resolveInlineAttachmentMarkdown,
-  resolveInlineMediaMarkdown,
   serializeInlineMedia,
   type InlineMediaComposerHandle,
   type InlineMediaSegment,
@@ -775,20 +774,13 @@ export function TaskDetail({
     setSavingProperty("description");
     onError(null);
     try {
-      const uploadedImages = await Promise.all(
-        inlineImages.map((image) => uploadAttachment(currentTask.id, image.file, "inline")),
-      );
-      const uploadedFiles = await Promise.all(
-        inlineFiles.map((file) => uploadAttachment(currentTask.id, file.file, "attachment")),
-      );
-      const resolvedDescription = resolveInlineAttachmentMarkdown(
-        resolveInlineMediaMarkdown(
-          draftDescription,
-          inlineImages,
-          uploadedImages,
-        ),
-        inlineFiles,
-        uploadedFiles,
+      const upload = (file: File, kind: Attachment["kind"]) => uploadAttachment(currentTask.id, file, kind);
+      const uploadedImages = await uploadInlineAttachments(inlineImages, upload);
+      const uploadedFiles = await uploadInlineAttachments(inlineFiles, upload);
+      const resolvedDescription = resolveInlineAttachments(
+        draftDescription,
+        [...inlineImages, ...inlineFiles],
+        [...uploadedImages, ...uploadedFiles],
       ).trim();
       const saved = await onUpdate(currentTask, { description: resolvedDescription }).catch((error) => {
         onError(issueMessageFor(error));
@@ -829,23 +821,12 @@ export function TaskDetail({
     setCommentsError(null);
     try {
       const comment = await createComment(task.id, body);
-      const [inlineAttachments, fileAttachments] = await Promise.all([
-        Promise.all(
-          commentInlineImages.map((image) => uploadCommentAttachment(comment.id, image.file, "inline")),
-        ),
-        Promise.all(
-          commentInlineFiles.map((file) => uploadCommentAttachment(comment.id, file.file, "attachment")),
-        ),
-      ]);
-      const nextComment = commentInlineImages.length > 0 || commentInlineFiles.length > 0
-        ? await updateComment(
-            comment,
-            resolveInlineAttachmentMarkdown(
-              resolveInlineMediaMarkdown(body, commentInlineImages, inlineAttachments),
-              commentInlineFiles,
-              fileAttachments,
-            ),
-          )
+      const pending = [...commentInlineImages, ...commentInlineFiles];
+      const uploaded = await uploadInlineAttachments(
+        pending, (file, kind) => uploadCommentAttachment(comment.id, file, kind),
+      );
+      const nextComment = pending.length > 0
+        ? await updateComment(comment, resolveInlineAttachments(body, pending, uploaded))
         : comment;
       setComments((current) => [...current, nextComment]);
       setCommentSegments(createInlineMediaSegments());
@@ -908,31 +889,20 @@ export function TaskDetail({
     setSavingCommentId(comment.id);
     setCommentsError(null);
     try {
-      const uploadedImages: Attachment[] = [];
-      for (const image of editingInlineImages) {
-        let attachment = editingUploadedAttachmentsRef.current.get(image.id);
+      const pending = [...editingInlineImages, ...editingInlineFiles];
+      const uploaded: Attachment[] = [];
+      for (const item of pending) {
+        let attachment = editingUploadedAttachmentsRef.current.get(item.id);
         if (!attachment) {
-          attachment = await uploadCommentAttachment(comment.id, image.file, "inline");
-          editingUploadedAttachmentsRef.current.set(image.id, attachment);
+          attachment = await uploadCommentAttachment(
+            comment.id, item.file, item.type === "pending-image" ? "inline" : "attachment",
+          );
+          editingUploadedAttachmentsRef.current.set(item.id, attachment);
         }
-        uploadedImages.push(attachment);
-      }
-      const uploadedFiles: Attachment[] = [];
-      for (const file of editingInlineFiles) {
-        let attachment = editingUploadedAttachmentsRef.current.get(file.id);
-        if (!attachment) {
-          attachment = await uploadCommentAttachment(comment.id, file.file, "attachment");
-          editingUploadedAttachmentsRef.current.set(file.id, attachment);
-        }
-        uploadedFiles.push(attachment);
+        uploaded.push(attachment);
       }
       const updated = await updateComment(
-        comment,
-        resolveInlineAttachmentMarkdown(
-          resolveInlineMediaMarkdown(body, editingInlineImages, uploadedImages),
-          editingInlineFiles,
-          uploadedFiles,
-        ).trim(),
+        comment, resolveInlineAttachments(body, pending, uploaded).trim(),
       );
       setComments((current) => current.map((item) => item.id === updated.id ? updated : item));
       const relationAnchor = await getTask(currentTask.id);

--- a/web/src/components/TaskFilterMenu.tsx
+++ b/web/src/components/TaskFilterMenu.tsx
@@ -1,3 +1,4 @@
+import { listenForOutsidePointerDown, listenForMenuViewportChange } from "../menuEvents";
 import {
   useEffect,
   useLayoutEffect,
@@ -279,25 +280,12 @@ export function TaskFilterMenu({ tasks, search, labels, filters, onChange }: Tas
     if (!open) return;
     requestAnimationFrame(() => menuRef.current?.querySelector<HTMLInputElement>(".task-filter-search input")?.focus());
 
-    function closeFromOutside(event: PointerEvent) {
-      if (!menuRef.current?.contains(event.target as Node) && !triggerRef.current?.contains(event.target as Node)) {
-        closeMenu();
-      }
-    }
-    function closeFromViewportChange(event: Event) {
-      if (event.type === "scroll" && menuRef.current?.contains(event.target as Node)) return;
-      closeMenu();
-    }
+    const stopOutside = listenForOutsidePointerDown([menuRef, triggerRef], closeMenu);
+    const stopViewport = listenForMenuViewportChange(menuRef, closeMenu);
 
-    document.addEventListener("pointerdown", closeFromOutside);
-    window.addEventListener("blur", closeFromViewportChange);
-    window.addEventListener("resize", closeFromViewportChange);
-    window.addEventListener("scroll", closeFromViewportChange, true);
     return () => {
-      document.removeEventListener("pointerdown", closeFromOutside);
-      window.removeEventListener("blur", closeFromViewportChange);
-      window.removeEventListener("resize", closeFromViewportChange);
-      window.removeEventListener("scroll", closeFromViewportChange, true);
+      stopOutside();
+      stopViewport();
     };
   }, [open]);
 

--- a/web/src/components/TaskPropertyPicker.tsx
+++ b/web/src/components/TaskPropertyPicker.tsx
@@ -1,3 +1,4 @@
+import { listenForOutsidePointerDown } from "../menuEvents";
 import {
   useEffect,
   useLayoutEffect,
@@ -123,12 +124,7 @@ export function TaskPropertyPicker<Value extends string>({
   useEffect(() => {
     if (!open) return;
 
-    function closeFromOutside(event: PointerEvent) {
-      const target = event.target as Node;
-      if (!rootRef.current?.contains(target) && !menuRef.current?.contains(target)) {
-        onOpenChange(false);
-      }
-    }
+    const stopOutside = listenForOutsidePointerDown([rootRef, menuRef], () => onOpenChange(false));
 
     function closeFromEscape(event: globalThis.KeyboardEvent) {
       if (event.key !== "Escape") return;
@@ -143,14 +139,13 @@ export function TaskPropertyPicker<Value extends string>({
       onOpenChange(false);
     }
 
-    document.addEventListener("pointerdown", closeFromOutside);
     window.addEventListener("keydown", closeFromEscape);
     const viewportListenerFrame = requestAnimationFrame(() => {
       window.addEventListener("resize", closeFromViewportChange);
       window.addEventListener("scroll", closeFromViewportChange, true);
     });
     return () => {
-      document.removeEventListener("pointerdown", closeFromOutside);
+      stopOutside();
       window.removeEventListener("keydown", closeFromEscape);
       cancelAnimationFrame(viewportListenerFrame);
       window.removeEventListener("resize", closeFromViewportChange);

--- a/web/src/inlineAttachments.ts
+++ b/web/src/inlineAttachments.ts
@@ -1,0 +1,29 @@
+import { attachmentContentUrl, attachmentDownloadUrl } from "./api";
+import type { Attachment } from "./types";
+import type { PendingInlineAttachment, PendingInlineImage } from "./components/InlineMediaComposer";
+
+type PendingAttachment = PendingInlineImage | PendingInlineAttachment;
+
+export function uploadInlineAttachments(
+  pending: PendingAttachment[],
+  upload: (file: File, kind: Attachment["kind"]) => Promise<Attachment>,
+) {
+  return Promise.all(pending.map((item) => upload(
+    item.file, item.type === "pending-image" ? "inline" : "attachment",
+  )));
+}
+
+export function resolveInlineAttachments(
+  value: string,
+  pending: PendingAttachment[],
+  attachments: Array<{ id: string }>,
+): string {
+  return pending.reduce((markdown, item, index) => {
+    const attachment = attachments[index];
+    if (!attachment) return markdown;
+    const label = item.file.name.replace(/[\\[\]]/g, "\\$&");
+    const image = item.type === "pending-image";
+    const url = image ? attachmentContentUrl(attachment) : attachmentDownloadUrl(attachment);
+    return markdown.replace(item.token, `${image ? "!" : ""}[${label}](${url})`);
+  }, value);
+}

--- a/web/src/menuEvents.ts
+++ b/web/src/menuEvents.ts
@@ -1,0 +1,30 @@
+import type { RefObject } from "react";
+
+export function listenForOutsidePointerDown(
+  boundaries: readonly RefObject<HTMLElement | null>[],
+  onOutside: () => void,
+) {
+  function handlePointerDown(event: PointerEvent) {
+    if (!boundaries.some((ref) => ref.current?.contains(event.target as Node))) onOutside();
+  }
+  document.addEventListener("pointerdown", handlePointerDown);
+  return () => document.removeEventListener("pointerdown", handlePointerDown);
+}
+
+export function listenForMenuViewportChange(
+  menuRef: RefObject<HTMLElement | null>,
+  onChange: () => void,
+) {
+  function handleChange(event: Event) {
+    if (event.type === "scroll" && menuRef.current?.contains(event.target as Node)) return;
+    onChange();
+  }
+  window.addEventListener("blur", handleChange);
+  window.addEventListener("resize", handleChange);
+  window.addEventListener("scroll", handleChange, true);
+  return () => {
+    window.removeEventListener("blur", handleChange);
+    window.removeEventListener("resize", handleChange);
+    window.removeEventListener("scroll", handleChange, true);
+  };
+}

--- a/web/src/taskConversations.ts
+++ b/web/src/taskConversations.ts
@@ -43,6 +43,18 @@ function newerTimestamp(left: string, right: string) {
   return left > right ? left : right;
 }
 
+export function indexAiThreadsByTask(aiThreads: AiChatThread[]) {
+  const index = new Map<string, AiChatThread[]>();
+  for (const thread of aiThreads) {
+    const taskId = thread.origin.issueId;
+    if (!taskId) continue;
+    const threads = index.get(taskId);
+    if (threads) threads.push(thread);
+    else index.set(taskId, [thread]);
+  }
+  return index;
+}
+
 export function taskConversations(task: Task, aiThreads: AiChatThread[]) {
   const items = new Map<string, TaskConversationItem>();
 
@@ -131,11 +143,13 @@ export function taskCardPresentation(
   } | null | undefined = undefined,
 ): TaskCardPresentation {
   const conversations = taskConversations(task, aiThreads);
-  const runningAi = conversations
-    .filter((conversation) => conversation.currentRun?.status === "running")
-    .sort((left, right) => (
-      (right.currentRun?.startedAt ?? "").localeCompare(left.currentRun?.startedAt ?? "")
-    ))[0];
+  let runningAi: TaskConversationItem | undefined;
+  for (const conversation of conversations) {
+    if (conversation.currentRun?.status !== "running") continue;
+    if (!runningAi || (conversation.currentRun.startedAt ?? "").localeCompare(
+      runningAi.currentRun?.startedAt ?? "",
+    ) > 0) runningAi = conversation;
+  }
   const normalizedRunningNativeThreadId = normalizeCodexThreadId(runningNativeThreadId);
   const runningNative = task.status === "in_progress" && normalizedRunningNativeThreadId
     ? conversations.find((conversation) => (


### PR DESCRIPTION
Running task timers currently update App and every board card each second, and task presentations repeatedly scan all AI threads. This change keeps each elapsed label's clock local, indexes AI threads once by issue, and selects the latest running conversation without sorting.

It also shares the existing Skill/Agent reference codec, local/cloud task input parsers, menu event listeners, and attachment Markdown/upload steps. Real differences remain at callers: local/cloud development context, menu focus and Escape behavior, and each editor's upload ordering/retry cache. The cloud invalid-project-kind response now uses the more specific local message while retaining HTTP 400 and INVALID_FIELD.

Validation on head 25a3da7378191782b574389e27475b2b31910bb3:
- TypeScript and web build pass. Existing Node suite: 286 pass, 1 platform skip; Markdown component suite: 9 pass. No tests added or removed.
- Isolated real Chrome before/after: 80 cards over 4.2 seconds go from 4 App / 16 column / 320 card renders to 4 elapsed-label renders. The clock continues to advance.
- Presentation results match at 80, 500 and 1,000 tasks. At 500 tasks / 2,502 conversations, the median computation including index creation changes from 9.78 ms to 0.56 ms; this is a focused computation measurement, not overall app speed.
- Real isolated task API: description, new comment and edited comment save images/files and render after reload with matching Markdown. Creating a new issue with both attachments also passes.
- Filter/context/property/label/display menu dismissal and property focus restoration match.
- Chinese and Unicode Skill/Agent insertion, rebind and outbound payloads match in real browser flows with an isolated AI transport fixture. No live AI run was sent.
- Codec round trips and canonical/invalid inputs match the former server codec.

25 source files changed, net 201 lines removed including the added .d.mts declaration. LOCAL-385.