### PR TITLE
Keep macOS Rust caches independent of preinstalled stable

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -277,6 +277,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@2eae45db285e407f22119950686d47e1101e071b # 1.88.0
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
+      - name: Remove unused preinstalled Rust toolchain
+        run: rustup toolchain uninstall stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: src-tauri -> target

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -362,6 +362,9 @@ jobs:
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
+      - name: Remove unused preinstalled Rust toolchain
+        run: rustup toolchain uninstall stable
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:


### PR DESCRIPTION
The macOS Rust cache failed to restore when GitHub's unused preinstalled stable compiler changed from 1.98.0 to 1.97.1. rust-cache hashes every installed compiler, although this project builds with the pinned 1.88.0 toolchain.

After installing and selecting 1.88.0, remove the unused stable toolchain on the ephemeral macOS Check and Release runners. Five added lines across two workflows keep the existing compiler, dependency and environment hashes while excluding the unrelated compiler.

Validation: both YAML files parse and all six existing launcher/release checks pass. PR run 33971449155 at 5986b269af0ddd0f38fa5166a066d99280ffa670 and main run 33972008282 at merge 08f0419cc3cb1b14f09578806f6bcac53b067414 passed all five jobs. Native logs confirm successful removal and only Rust 1.88.0 in the identical cache key; main saved the corrected dependency cache. The first warm restore is still to be measured in the following build/release.

Follow-up to LOCAL-388 / #376.