### PR TITLE
fix: align task checkboxes and compact attachment cards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ Use this workflow when the user asks to process Taskboard work.
 - Keep external contributor PR maintenance in its own lane. Preserve contributor history and do not let unrelated internal work rewrite its branch.
 - Group small changes that share a feature chain into one conversation, worktree, and PR. Amortize branch setup, CI, review, UI confirmation, merge, and cleanup instead of paying that fixed cost per issue.
 - Queue work that shares a runtime or conflict domain. A visible queue is better than parallel work that later requires repeated restarts, conflict resolution, or CI reruns.
-- A waiting issue does not stop the rest of the batch. Continue every other eligible lane while one item waits for CI, Pro, user input, or an external dependency.
+- A waiting issue does not stop the rest of the batch. Continue every other eligible lane while one item waits for CI, GPT-6 Pro, user input, or an external dependency.
 - Requirement-collection and record-only issues are not active implementation. Leave them unassigned in `backlog` or another non-active tracking state; do not keep them in `in_progress` merely to preserve notes.
 
 ## 3. Follow E3
@@ -105,50 +105,52 @@ Make the smallest root-cause change. Do not add unrelated refactors, abstraction
 
 ## 6. Review by risk
 
+- In the ChatGPT web app, select **最新 → 推理强度 Pro** to use **GPT-6 Pro**.
+
 - Each dispatched execution conversation decides the review complexity for its own implementation after direct-path verification. The coordinating conversation does not make this complexity decision or perform the code review.
-- For lower-complexity work, the dispatched execution Agent performs the code review. It checks implementation correctness, the requested path, scope, and real bugs without sending the PR to ChatGPT web Pro.
-- For complex or risky work, the corresponding dispatched execution conversation opens ChatGPT web Pro itself and submits the PR URL and exact head SHA for review. It asks Pro to review only implementation correctness and real bugs.
-- The user grants standing authorization to submit the public PR URL, exact head SHA, and established review instructions to ChatGPT web Pro; execution conversations send them directly without requesting confirmation each time.
+- For lower-complexity work, the dispatched execution Agent performs the code review. It checks implementation correctness, the requested path, scope, and real bugs without sending the PR to GPT-6 Pro in the ChatGPT web app.
+- For complex or risky work, the corresponding dispatched execution conversation opens GPT-6 Pro in the ChatGPT web app itself and submits the PR URL and exact head SHA for review. It asks GPT-6 Pro to review only implementation correctness and real bugs.
+- The user grants standing authorization to submit the public PR URL, exact head SHA, and established review instructions to GPT-6 Pro in the ChatGPT web app; execution conversations send them directly without requesting confirmation each time.
 - Development and review must avoid over-design and over-defensive recommendations. Do not request or add hypothetical guardrails, unrelated refactors, compatibility layers, style preferences, or scope expansion.
-- Before any change is submitted to ChatGPT web Pro, complete the requested function, verify its direct real path, and provide the user with a working demo that uses the relevant real data or runtime. Start Pro review only after the user confirms that the function works. This gate applies to UI and non-UI work. Do not use Pro to discover whether an unfinished function basically works.
-- Independent dispatched conversations run their required reviews in parallel. Do not serialize independent Agent or Pro reviews through the coordinating conversation.
-- For Pro review, wait for the complete answer. Do not use an instant-answer result. Check at approximately five-minute intervals when necessary; a complete review can take more than 30 minutes.
-- Fix actionable blockers in the same PR. The dispatched execution conversation decides whether the changed complexity warrants another Pro review; trivial targeted follow-up edits can use its normal Agent review.
+- Before any change is submitted to GPT-6 Pro in the ChatGPT web app, complete the requested function, verify its direct real path, and provide the user with a working demo that uses the relevant real data or runtime. Start GPT-6 Pro review only after the user confirms that the function works. This gate applies to UI and non-UI work. Do not use GPT-6 Pro to discover whether an unfinished function basically works.
+- Independent dispatched conversations run their required reviews in parallel. Do not serialize independent Agent or GPT-6 Pro reviews through the coordinating conversation.
+- For GPT-6 Pro review, wait for the complete answer. Do not use an instant-answer result. Check at approximately five-minute intervals when necessary; a complete review can take more than 30 minutes.
+- Fix actionable blockers in the same PR. The dispatched execution conversation decides whether the changed complexity warrants another GPT-6 Pro review; trivial targeted follow-up edits can use its normal Agent review.
 - Before accepting a handoff, the coordinating conversation checks that the execution evidence, scope, CI state, complexity decision, and required review result are present. It does not repeat the code review.
 - Decide the UI confirmation gate from the actual visual impact and risk. Do not trigger it mechanically because code is in a UI component or changes a UI file.
 - Logic-only changes on a UI surface do not need separate user UI confirmation when they do not cause a meaningful visual change. This includes interaction logic, data behavior, toggle behavior, popover close conditions, and copy-and-paste behavior.
 - Small, low-risk, and visually unambiguous changes can skip user UI confirmation after the coordinator checks the real path and visual evidence. Examples include a local font-size, spacing, alignment, or color adjustment.
 - Require user UI confirmation before merge when the change adds UI, meaningfully changes layout, information hierarchy, or the presentation of a core interaction, has multiple reasonable visual choices, or the user explicitly asks to confirm the style.
-- User confirmation is a functional acceptance gate before Pro review. Ask only after the full function is complete and direct verification passes. Never ask the user to confirm a partially implemented UI. After confirmation, independent required Pro reviews may run in parallel.
-- After Pro approval, visual-only adjustments made from the user's final UI feedback do not require another Pro review. The coordinator checks that the delta is limited to the requested visual change, reruns the real path, and can then proceed to merge. If the adjustment changes functional logic or introduces new complex risk, reassess whether code review or Pro review is required.
+- User confirmation is a functional acceptance gate before GPT-6 Pro review. Ask only after the full function is complete and direct verification passes. Never ask the user to confirm a partially implemented UI. After confirmation, independent required GPT-6 Pro reviews may run in parallel.
+- After GPT-6 Pro approval, visual-only adjustments made from the user's final UI feedback do not require another GPT-6 Pro review. The coordinator checks that the delta is limited to the requested visual change, reruns the real path, and can then proceed to merge. If the adjustment changes functional logic or introduces new complex risk, reassess whether code review or GPT-6 Pro review is required.
 - The dispatched execution conversation closes its temporary review browser tabs after review finishes.
 
 Use this review classification:
 
 - **Agent review**: documentation, README, copy, CSS, a local font/spacing/color change, a small direct UI behavior change, or a narrow logic fix with no process, persistence, migration, concurrency, security, or cross-project effect.
-- **Pro review**: Launcher lifecycle, native host or Codex injection, process management, updater or release behavior, persistent-data migration, destructive file handling, complex concurrency, cross-project state, external boundary changes, or a broad external contributor PR.
+- **GPT-6 Pro review**: Launcher lifecycle, native host or Codex injection, process management, updater or release behavior, persistent-data migration, destructive file handling, complex concurrency, cross-project state, external boundary changes, or a broad external contributor PR.
 - File count and UI file location do not determine review level. Use blast radius and failure cost.
-- Skipping Pro for a low-risk change is the expected path, not an exception that needs extra justification.
-- Before starting Pro, obtain the user's confirmation from the working demo, then use a stable PR head based on the current merge wave. Submit only the public PR URL, exact head SHA, and the instruction to review implementation correctness and real bugs without over-design or over-defense.
-- If main advances after Pro, repeat Pro only when the integration changes reviewed functional logic or creates a real overlapping risk. A conflict-free merge commit or trivial targeted fix uses Agent review and direct-path verification.
+- Skipping GPT-6 Pro for a low-risk change is the expected path, not an exception that needs extra justification.
+- Before starting GPT-6 Pro, obtain the user's confirmation from the working demo, then use a stable PR head based on the current merge wave. Submit only the public PR URL, exact head SHA, and the instruction to review implementation correctness and real bugs without over-design or over-defense.
+- If main advances after GPT-6 Pro, repeat GPT-6 Pro only when the integration changes reviewed functional logic or creates a real overlapping risk. A conflict-free merge commit or trivial targeted fix uses Agent review and direct-path verification.
 
 ## 7. CI and integration waves
 
 - Use one PR for a coherent group of small issues. Do not create one PR per issue when the changes share a feature chain and can be reviewed and accepted together.
-- Establish a merge wave before review starts. Keep its base stable while independent PRs run CI and Pro in parallel, then merge them in a planned conflict order.
+- Establish a merge wave before review starts. Keep its base stable while independent PRs run CI and GPT-6 Pro in parallel, then merge them in a planned conflict order.
 - Do not merge an early low-priority PR when doing so will force several active related PRs to update their base, rerun packaging, and invalidate exact-head review. Urgent blockers are the exception.
 - After main advances, update only PRs that are actually conflicting, not mergeable, or affected by overlapping behavior. Do not mechanically merge main into every open branch.
 - Local validation should be focused. Let PR CI provide the broad repository check. Do not duplicate a successful full CI run with the same full local packaging unless the direct task path requires the local artifact.
 - Avoid duplicate branch `push` and `pull_request` CI for the same SHA. Workflow owners should use branch filters and concurrency cancellation so superseded or duplicate runs do not consume both macOS and Windows builders.
 - Use path-aware CI when available: Web-only, documentation, CSS, and copy changes use the fast lane; platform packaging runs only for Launcher, bundle, platform, updater, release, or final integration changes.
-- CI may run as soon as each PR reaches a stable exact head. After the working demo is confirmed by the user, run independent required Pro reviews in parallel. Do not serialize them through the coordinating conversation.
+- CI may run as soon as each PR reaches a stable exact head. After the working demo is confirmed by the user, run independent required GPT-6 Pro reviews in parallel. Do not serialize them through the coordinating conversation.
 - Present each task's working demo as soon as that task completes implementation and direct verification. Do not hold completed demos until the whole batch is ready. Other tasks continue in parallel while the user checks it. Related changes may share one preview only when they become ready together or must be integrated to work; this must not delay an already usable demo.
 
 ## 8. Acceptance and issue status
 
 - Reviewer approval means ready for user inspection, not user acceptance.
-- When work meets the user confirmation gate, put the complete directly verified function into the Taskboard-launched Codex App and ask the user to confirm that the function and final visual style work before starting any required Pro review.
-- Do not merge work that meets the UI confirmation gate until the user confirms its style. After visual-only feedback is applied and directly verified, the change can proceed without repeating Pro review.
+- When work meets the user confirmation gate, put the complete directly verified function into the Taskboard-launched Codex App and ask the user to confirm that the function and final visual style work before starting any required GPT-6 Pro review.
+- Do not merge work that meets the UI confirmation gate until the user confirms its style. After visual-only feedback is applied and directly verified, the change can proceed without repeating GPT-6 Pro review.
 - UI-surface work that does not meet the confirmation gate can proceed after the coordinator verifies the real path, visual impact, scope, and required review without a separate user UI pause.
 - After implementation and required review pass, move the issue to `in_review`.
 - Never move an issue to `done` unless the user explicitly accepts it or asks for completion.

--- a/web/src/components/InlineMediaComposer.css
+++ b/web/src/components/InlineMediaComposer.css
@@ -218,15 +218,10 @@
 .inline-media-composer.ProseMirror li.task-list-item > input[type="checkbox"] {
   width: 14px;
   height: 14px;
-  margin: 4px 0 0;
+  margin: calc((1lh - 14px) / 2) 0 0;
   padding: 0;
   accent-color: var(--accent);
   cursor: pointer;
-}
-
-.issue-description-composer .inline-media-composer.ProseMirror li.task-list-item > input[type="checkbox"],
-.inline-media-description.ProseMirror li.task-list-item > input[type="checkbox"] {
-  margin-top: 6.5px;
 }
 
 .inline-media-composer.ProseMirror .inline-media-task-content {

--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -1615,11 +1615,11 @@ function segmentsFromEditorDocument(
   return selfContainedClipboardSegments(normalizeSegments(restored.map((segment, index) => {
     if (segment.type !== "text") return segment;
     let value = segment.text;
-    if (isMediaAtomSegment(restored[index - 1]) && value.startsWith("\n\n")) {
-      value = value.slice(2);
+    if (isTaskboardAttachmentMedia(restored[index - 1]) && value.startsWith("\n")) {
+      value = value.slice(1);
     }
-    if (isMediaAtomSegment(restored[index + 1]) && value.endsWith("\n\n")) {
-      value = value.slice(0, -2);
+    if (isTaskboardAttachmentMedia(restored[index + 1]) && value.endsWith("\n")) {
+      value = value.slice(0, -1);
     }
     return value === segment.text ? segment : { ...segment, text: value };
   })));

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2378,7 +2378,7 @@ kbd {
 .issue-description-document input[type="checkbox"] {
   width: 14px;
   height: 14px;
-  margin: 4px 0 0;
+  margin: calc((1lh - 14px) / 2) 0 0;
   accent-color: var(--accent);
   pointer-events: none;
 }
@@ -3052,6 +3052,7 @@ kbd {
   flex-direction: column;
   min-width: 0;
   gap: 2px;
+  line-height: 1.4;
 }
 
 .attachment-copy strong {


### PR DESCRIPTION
Task checkboxes in issue descriptions and comments were above the first text line in preview, while attachment names and sizes inherited the body line height and made cards too tall. Use the current line height for checkbox alignment and give attachment text its own line height. Cards now measure 44px in both edit and preview.

Direct browser verification also found that saving a checkbox change removed the blank line before an attachment, placing the card inside the last list item. Preserve that Markdown block boundary during editor serialization.

Update project rules to name GPT-6 Pro and its web selection path, 最新 → 推理强度 Pro.

Validation: typecheck, Web build, and actual description/comment edit → toggle → save → reload paths passed in an isolated Taskboard Web runtime. Checkbox center offsets are 0px; saved attachment cards remain outside lists and measure 44px. Scope and implementation review found no remaining defect in these paths. No new tests or compatibility layers. Tracks LOCAL-319 and LOCAL-389.