### PR TITLE
fix(skill): scope taskctl workflow to Codex Taskboard

### DIFF
--- a/skills/manage-taskboard/SKILL.md
+++ b/skills/manage-taskboard/SKILL.md
@@ -1,11 +1,15 @@
 ---
 name: manage-taskboard
-description: Manage Codex Taskboard / e-taskboard work with taskctl. Use for taskboard issue IDs, status sync, comments, or taskctl cloud setup—not for unrelated product docs.
+description: Manage Codex Taskboard issues and taskctl setup when the request names Codex Taskboard, e-taskboard, or taskctl, or the conversation already establishes that board as the target. Not for GitHub, Phabricator, other external trackers, or unrelated product docs.
 ---
 
 # Manage Taskboard
 
-Use `taskctl` for every project, issue, relation, and comment operation. Consume its JSON output. Use the exact issue identifier returned by the taskboard or supplied in the prompt. Never assume, derive, or rewrite an identifier prefix.
+This skill serves the local-first Codex Taskboard product, including its configured LAN and cloud services.
+
+Apply the workflow below only to work explicitly targeting Codex Taskboard or already established as belonging to it in the conversation. An issue identifier, repository, or generic request to manage tasks, sync status, or add comments does not establish that scope. For GitHub, Phabricator, or another external tracker, use that system's tools and workflow; do not query, claim, or mirror its issues in Taskboard unless the user asks for that board operation. When the target is unclear, clarify it before running `taskctl`.
+
+Within that scope, use `taskctl` for every project, issue, relation, and comment operation. Consume its JSON output. Use the exact issue identifier returned by the taskboard or supplied in the prompt. Never assume, derive, or rewrite an identifier prefix.
 
 Open only the relevant section of [references/cli.md](references/cli.md) when command syntax is needed.
 


### PR DESCRIPTION
The bundled `manage-taskboard` skill still describes generic status/comment work and instructs agents to use `taskctl` for every issue operation. With the skill installed globally, an external-tracker request can be routed to the Taskboard API. A Taskboard connection failure can then unnecessarily block unrelated work.

Scope both discovery and the opening instructions to the Codex Taskboard product. Require an explicit Taskboard request or established conversation context; an issue ID or repository alone is insufficient. Direct GitHub, Phabricator, and other external-tracker work to the corresponding workflow, allowing Taskboard operations when the user actually requests them.

The existing `e-taskboard` composer entry point, ongoing board conversations, and taskctl setup (including LAN/cloud use) remain in scope. Claiming, status transitions, and CLI behavior are unchanged.

Validation: skill frontmatter validator and `git diff --check` passed. Manually traced the generated `e-taskboard` instruction through the skill to the CLI Taskboard API, and reviewed the routing boundary against generic examples: “comment on a GitHub issue”, “update a Phabricator task”, and “sync this issue” without board context. These should not initiate taskctl operations; an established Taskboard conversation should continue to do so. This is an instruction-level check, not an end-to-end model-selection evaluation.

Only the skill instructions change; no application code or tests are added.
