### PR TITLE
fix(editor): allow selecting inline videos while editing

### DIFF
--- a/web/src/components/InlineMediaComposer.tsx
+++ b/web/src/components/InlineMediaComposer.tsx
@@ -1958,7 +1958,7 @@ export const InlineMediaComposer = forwardRef<InlineMediaComposerHandle, InlineM
         },
         stopEvent(event) {
           const target = event.target;
-          return target instanceof Element && Boolean(target.closest("button, video, a"));
+          return target instanceof Element && Boolean(target.closest("button, a"));
         },
         ignoreMutation() {
           return true;


### PR DESCRIPTION
编辑议题描述时，视频点击被媒体节点的事件处理拦截，无法像图片一样选中。移除对 video 元素的拦截，让点击进入现有编辑器选中流程；原生播放控制仍可使用。

验证：在正式数据的独立副本中复现原问题，并用实际视频确认选中边框、两次 Backspace 删除、撤销恢复、失焦保存和重新打开后的结果。图片选中及周边文字保留正常。类型检查、Web 构建和 diff 检查通过；Agent 自查未发现当前改动引入的缺陷。

对应内部议题 LOCAL-390。仅修改一行事件条件。