### PR TITLE
fix: 让 check 使用纯 Web 构建入口

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "cloud:deploy:dry-run": "npm run build:web && wrangler deploy --dry-run",
     "cloud:deploy": "npm run build:web && wrangler deploy",
     "cloud:data": "node scripts/migrate-to-cloud.mjs",
-    "check": "npm run typecheck && npm run build && npm test"
+    "check": "npm run typecheck && npm run build:web && npm test"
   },
   "dependencies": {
     "dhtmlx-gantt": "^10.0.0",


### PR DESCRIPTION
运行 `npm run check` 曾通过 `build` 刷新正在运行的 Codex Taskboard 注入。将该步骤改为现有 `build:web`，使检查只执行类型检查、Web 构建和原有测试；显式 `build` 的刷新行为保留。

验证：改后的 `npm run check` 退出码为 0，Node 测试 286 通过、1 跳过，组件测试 9 通过。生命周期追踪为 `check → typecheck → build:web → test → test:components`，没有调用 injector。`git diff --check` 通过。

Taskboard：LOCAL-397。
