### PR TITLE
perf: 批量读取任务关系并共享 API 输入规则

### DIFF
--- a/cloud/src/index.mjs
+++ b/cloud/src/index.mjs
@@ -1,7 +1,12 @@
 import {
-  parseThreadBinding, parseMove, parseVersionMutation, parseRelationMutation,
+  parseMove, parseVersionMutation, parseRelationMutation,
   parseCommentCreate, parseCommentPatch, parseTaskCreate,
+  parseCloudTaskPatch as parseTaskPatch,
+  parseCloudTaskFilters as parseTaskFilters,
+  parseCloudTaskTreeQuery as parseTaskTreeQuery,
+  parseCloudProjectReadmeSave as parseProjectReadmeSave,
 } from "../../shared/task-input.mjs";
+import { taskRelationsQuery, taskRelationsFromRows } from "../../shared/task-relations.mjs";
 import {
   commentConversationTitle,
   threadBindingFromRow,
@@ -16,20 +21,12 @@ import {
 } from "../../shared/task-records.mjs";
 import {
   ApiError,
-  parseVersion,
   validateProjectId,
   assertPlainObject,
   assertAllowedKeys,
   stringField,
-  parseDueDate,
-  parseRecurrence,
-  parseLabels,
-  parseStatus,
-  parsePriority,
   slugify,
   parseProjectLabel,
-  parseThreadId,
-  parseAssigneeTarget,
 } from "../../shared/api-fields.mjs";
 import { DurableObject } from "cloudflare:workers";
 
@@ -656,98 +653,91 @@ async function hydrateComment(env, row) {
   return commentFromRow(row, await attachmentsForComment(env, row.id));
 }
 
-async function hydrateTask(env, row, activityComments = null, activityChanges = null) {
-  const task = taskFromRow(row);
-  const [parent, subIssues, blockedBy, blocks, related, previewImageRow] = await Promise.all([
-    env.DB.prepare(`
-      SELECT tasks.*
-      FROM task_relations
-      JOIN tasks ON tasks.id = task_relations.source_task_id
-      WHERE task_relations.relation_type = 'parent'
-        AND task_relations.target_task_id = ?
-    `).bind(task.id).first(),
-    all(env.DB.prepare(`
-      SELECT tasks.*
-      FROM task_relations
-      JOIN tasks ON tasks.id = task_relations.target_task_id
-      WHERE task_relations.relation_type = 'parent'
-        AND task_relations.source_task_id = ?
-      ORDER BY tasks.sort_order, tasks.created_at, tasks.id
-    `).bind(task.id)),
-    all(env.DB.prepare(`
-      SELECT tasks.*
-      FROM task_relations
-      JOIN tasks ON tasks.id = task_relations.source_task_id
-      WHERE task_relations.relation_type = 'blocks'
-        AND task_relations.target_task_id = ?
-      ORDER BY tasks.sort_order, tasks.created_at, tasks.id
-    `).bind(task.id)),
-    all(env.DB.prepare(`
-      SELECT tasks.*
-      FROM task_relations
-      JOIN tasks ON tasks.id = task_relations.target_task_id
-      WHERE task_relations.relation_type = 'blocks'
-        AND task_relations.source_task_id = ?
-      ORDER BY tasks.sort_order, tasks.created_at, tasks.id
-    `).bind(task.id)),
-    all(env.DB.prepare(`
-      SELECT tasks.*
-      FROM task_relations
-      JOIN tasks ON tasks.id = CASE
-        WHEN task_relations.source_task_id = ? THEN task_relations.target_task_id
-        ELSE task_relations.source_task_id
-      END
-      WHERE task_relations.relation_type = 'related'
-        AND (
-          task_relations.source_task_id = ?
-          OR task_relations.target_task_id = ?
-        )
-      ORDER BY tasks.sort_order, tasks.created_at, tasks.id
-    `).bind(task.id, task.id, task.id)),
-    env.DB.prepare(`
+async function hydrateComments(env, rows) {
+  const attachmentsByComment = new Map(rows.map((row) => [row.id, []]));
+  const commentIds = rows.map((row) => row.id);
+  const batches = [];
+  for (let offset = 0; offset < commentIds.length; offset += 80) {
+    const chunk = commentIds.slice(offset, offset + 80);
+    const placeholders = chunk.map(() => "?").join(", ");
+    batches.push(all(env.DB.prepare(`
+      SELECT * FROM attachments
+      WHERE comment_id IN (${placeholders})
+      ORDER BY comment_id, created_at, id
+    `).bind(...chunk)));
+  }
+  for (const attachments of await Promise.all(batches)) {
+    for (const attachment of attachments) {
+      attachmentsByComment.get(attachment.comment_id).push(attachmentFromRow(attachment));
+    }
+  }
+  return rows.map((row) => commentFromRow(row, attachmentsByComment.get(row.id)));
+}
+
+async function taskRelationsForTasks(env, taskIds) {
+  const relationsByTask = new Map();
+  const batches = [];
+  for (let offset = 0; offset < taskIds.length; offset += 80) {
+    const chunk = taskIds.slice(offset, offset + 80);
+    const placeholders = chunk.map(() => "?").join(", ");
+    batches.push(all(env.DB.prepare(taskRelationsQuery(placeholders)).bind(...chunk)).then(
+      (rows) => taskRelationsFromRows(chunk, rows, taskRelationSummaryFromRow),
+    ));
+  }
+  for (const batch of await Promise.all(batches)) {
+    for (const [taskId, relations] of batch) relationsByTask.set(taskId, relations);
+  }
+  return relationsByTask;
+}
+
+async function taskPreviewImages(env, taskIds) {
+  const imagesByTask = new Map();
+  const batches = [];
+  for (let offset = 0; offset < taskIds.length; offset += 80) {
+    const chunk = taskIds.slice(offset, offset + 80);
+    const placeholders = chunk.map(() => "?").join(", ");
+    batches.push(all(env.DB.prepare(`
       SELECT attachments.*
       FROM attachments
       JOIN tasks ON tasks.id = attachments.task_id
-      WHERE attachments.task_id = ?
+      WHERE attachments.task_id IN (${placeholders})
         AND attachments.comment_id IS NULL
         AND attachments.content_type LIKE 'image/%'
         AND instr(tasks.description, 'api/attachments/' || attachments.id || '/content') > 0
-      ORDER BY attachments.created_at, attachments.id
-      LIMIT 1
-    `).bind(task.id).first(),
+      ORDER BY attachments.task_id, attachments.created_at, attachments.id
+    `).bind(...chunk)));
+  }
+  for (const rows of await Promise.all(batches)) {
+    for (const row of rows) {
+      if (!imagesByTask.has(row.task_id)) imagesByTask.set(row.task_id, attachmentFromRow(row));
+    }
+  }
+  return imagesByTask;
+}
+
+async function hydrateTasks(env, rows) {
+  const taskIds = rows.map((row) => row.id);
+  const [relationsByTask, commentsByTask, activitiesByTask, previewImagesByTask] = await Promise.all([
+    taskRelationsForTasks(env, taskIds),
+    taskActivityComments(env, taskIds),
+    taskActivitiesForTasks(env, taskIds),
+    taskPreviewImages(env, taskIds),
   ]);
-  task.relations = {
-    parent: parent ? taskRelationSummaryFromRow(parent) : null,
-    subIssues: subIssues.map(taskRelationSummaryFromRow),
-    blockedBy: blockedBy.map(taskRelationSummaryFromRow),
-    blocks: blocks.map(taskRelationSummaryFromRow),
-    related: related.map(taskRelationSummaryFromRow),
-  };
-  const comments = activityComments ?? await all(env.DB.prepare(`
-    SELECT
-      id, task_id,
-      CASE WHEN thread_id IS NULL THEN NULL ELSE substr(body, 1, 512) END AS body,
-      thread_id, thread_codex_project_id, thread_codex_project_kind,
-      thread_codex_host_id, thread_workspace_path,
-      author_type, author_id, author_name,
-      author_avatar_url, version, updated_at
-    FROM comments
-    WHERE task_id = ?
-    ORDER BY id
-  `).bind(task.id));
-  const activities = activityChanges ?? await all(env.DB.prepare(`
-    SELECT
-      id, task_id, actor_type, actor_id, actor_name, actor_avatar_url, created_at
-    FROM task_activities
-    WHERE task_id = ?
-    ORDER BY created_at, id
-  `).bind(task.id));
-  return attachTaskActivity(
-    task,
-    comments,
-    activities,
-    previewImageRow ? attachmentFromRow(previewImageRow) : null,
-  );
+  return rows.map((row) => {
+    const task = taskFromRow(row);
+    task.relations = relationsByTask.get(row.id);
+    return attachTaskActivity(
+      task,
+      commentsByTask.get(row.id) ?? [],
+      activitiesByTask.get(row.id) ?? [],
+      previewImagesByTask.get(row.id) ?? null,
+    );
+  });
+}
+
+async function hydrateTask(env, row) {
+  const [task] = await hydrateTasks(env, [row]);
+  return task;
 }
 
 async function getTask(env, id) {
@@ -903,101 +893,6 @@ function parseClientStorageUpdate(body) {
     key,
     value: stringField(body.value, "value", { nullable: true, maxLength: 100_000 }),
   };
-}
-
-function parseTaskPatch(body) {
-  assertPlainObject(body);
-  assertAllowedKeys(body, new Set([
-    "version",
-    "projectId",
-    "title",
-    "description",
-    "status",
-    "priority",
-    "labels",
-    "threadId",
-    "threadBinding",
-    "assigneeTarget",
-    "developmentContext",
-    "startDate",
-    "dueDate",
-    "recurrence",
-  ]));
-  const changes = {};
-  if (body.projectId !== undefined) changes.projectId = validateProjectId(body.projectId);
-  if (body.title !== undefined) {
-    changes.title = stringField(body.title, "title", { required: true, maxLength: 240 });
-  }
-  if (body.description !== undefined) {
-    changes.description = stringField(body.description, "description", { maxLength: 100_000 });
-  }
-  if (body.status !== undefined) changes.status = parseStatus(body.status);
-  if (body.priority !== undefined) changes.priority = parsePriority(body.priority);
-  if (body.labels !== undefined) changes.labels = parseLabels(body.labels);
-  if (body.developmentContext !== undefined) {
-    changes.developmentContext = parseDevelopmentContext(body.developmentContext);
-  }
-  if (body.startDate !== undefined) changes.startDate = parseDueDate(body.startDate, "startDate");
-  if (body.dueDate !== undefined) changes.dueDate = parseDueDate(body.dueDate);
-  if (body.recurrence !== undefined) changes.recurrence = parseRecurrence(body.recurrence);
-  const assigneeTarget = parseAssigneeTarget(body.assigneeTarget);
-  if (Object.keys(changes).length === 0 && assigneeTarget === undefined) {
-    throw new ApiError(400, "INVALID_BODY", "PATCH requires at least one task field");
-  }
-  return {
-    version: parseVersion(body.version),
-    changes,
-    threadId: parseThreadId(body.threadId),
-    threadBinding: parseThreadBinding(body.threadBinding),
-    assigneeTarget,
-  };
-}
-
-function parseTaskFilters(searchParams) {
-  const allowed = new Set(["projectId", "status", "archived"]);
-  for (const key of searchParams.keys()) {
-    if (!allowed.has(key)) {
-      throw new ApiError(400, "UNKNOWN_QUERY_PARAMETER", `Unknown query parameter: ${key}`);
-    }
-    if (searchParams.getAll(key).length > 1) {
-      throw new ApiError(400, "INVALID_QUERY_PARAMETER", `'${key}' cannot be repeated`);
-    }
-  }
-  const projectId = searchParams.get("projectId");
-  const status = searchParams.get("status");
-  const archived = searchParams.get("archived") ?? "false";
-  if (projectId !== null) validateProjectId(projectId);
-  if (status !== null) parseStatus(status);
-  if (!["false", "true", "all"].includes(archived)) {
-    throw new ApiError(
-      400,
-      "INVALID_QUERY_PARAMETER",
-      "'archived' must be false, true, or all",
-    );
-  }
-  return { projectId, status, archived };
-}
-
-function parseTaskTreeQuery(searchParams) {
-  const allowed = new Set(["direction", "depth"]);
-  for (const key of searchParams.keys()) {
-    if (!allowed.has(key)) {
-      throw new ApiError(400, "UNKNOWN_QUERY_PARAMETER", `Unknown query parameter: ${key}`);
-    }
-    if (searchParams.getAll(key).length !== 1) {
-      throw new ApiError(400, "INVALID_TREE_QUERY", `'${key}' cannot be repeated`);
-    }
-  }
-  const direction = searchParams.get("direction");
-  if (direction !== "descendants" && direction !== "ancestors") {
-    throw new ApiError(400, "INVALID_TREE_QUERY", "'direction' must be descendants or ancestors");
-  }
-  const rawDepth = searchParams.get("depth");
-  const depth = Number(rawDepth);
-  if (!/^\d+$/.test(rawDepth ?? "") || !Number.isSafeInteger(depth) || depth < 1 || depth > 25) {
-    throw new ApiError(400, "INVALID_TREE_QUERY", "'depth' must be an integer from 1 to 25");
-  }
-  return { direction, depth };
 }
 
 function parseAfterCursor(searchParams) {
@@ -1204,17 +1099,7 @@ async function listTasks(env, filters) {
         id
     `).bind(...values),
   );
-  const taskIds = rows.map((row) => row.id);
-  const [commentsByTask, activitiesByTask] = await Promise.all([
-    taskActivityComments(env, taskIds),
-    taskActivitiesForTasks(env, taskIds),
-  ]);
-  return Promise.all(rows.map((row) => hydrateTask(
-    env,
-    row,
-    commentsByTask.get(row.id) ?? [],
-    activitiesByTask.get(row.id) ?? [],
-  )));
+  return hydrateTasks(env, rows);
 }
 
 async function createTask(env, input, actor) {
@@ -2199,7 +2084,7 @@ async function listComments(env, taskId) {
     ORDER BY created_at, id
   `).bind(task.id));
   return {
-    comments: await Promise.all(rows.map((row) => hydrateComment(env, row))),
+    comments: await hydrateComments(env, rows),
     nextCursor: nextCursor(rows, null),
   };
 }
@@ -2213,7 +2098,7 @@ async function listCommentsAfter(env, taskId, after) {
     ORDER BY change_revision
   `).bind(task.id, after.revision));
   return {
-    comments: await Promise.all(rows.map((row) => hydrateComment(env, row))),
+    comments: await hydrateComments(env, rows),
     nextCursor: nextCursor(rows, after),
   };
 }
@@ -2700,23 +2585,11 @@ async function routeApi(request, env, actor, url) {
       return json(200, { readme: await getProjectReadme(env, projectId) });
     }
     if (request.method === "PUT") {
-      const body = await readJson(
+      const { content, version } = parseProjectReadmeSave(await readJson(
         request,
         PROJECT_README_BODY_LIMIT,
         "Project README request cannot exceed 3 MiB",
-      );
-      assertPlainObject(body);
-      assertAllowedKeys(body, new Set(["version", "content"]));
-      const version = body.version === undefined
-        ? undefined
-        : parseVersion(body.version, { allowZero: true });
-      const content = body.content ?? "";
-      if (typeof content !== "string") {
-        throw new ApiError(400, "INVALID_FIELD", "'content' must be a string");
-      }
-      if (content.length > 500_000) {
-        throw new ApiError(400, "INVALID_FIELD", "'content' cannot exceed 500000 characters");
-      }
+      ));
       return json(200, {
         readme: await saveProjectReadme(env, projectId, content, version),
       });
@@ -2899,7 +2772,7 @@ async function routeApi(request, env, actor, url) {
         task: await updateTask(
           env,
           taskId,
-          parseTaskPatch(await readJson(request)),
+          parseTaskPatch(await readJson(request), parseDevelopmentContext),
           actor,
         ),
       });

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -1,23 +1,17 @@
 import {
-  parseThreadBinding, parseMove, parseVersionMutation, parseRelationMutation,
+  parseMove, parseVersionMutation, parseRelationMutation,
   parseCommentCreate, parseCommentPatch, parseTaskCreate,
+  parseTaskPatch, parseTaskFilters, parseTaskTreeQuery, parseProjectReadmeSave,
 } from "../shared/task-input.mjs";
 import {
   ApiError,
-  parseVersion,
   validateProjectId,
   assertPlainObject,
   assertAllowedKeys,
   stringField,
-  parseDueDate,
-  parseRecurrence,
-  parseLabels,
-  parseStatus,
-  parsePriority,
   slugify,
   parseProjectLabel,
   parseThreadId,
-  parseAssigneeTarget,
 } from "../shared/api-fields.mjs";
 import { createHmac, randomUUID } from "node:crypto";
 import { execFile } from "node:child_process";
@@ -35,7 +29,6 @@ import {
   DEFAULT_PROJECT_ID,
   JIRA_PROJECT_ID,
   TASK_STATUSES,
-  isTaskStatus,
 } from "../shared/domain.mjs";
 import { resolveCodexExecutable } from "../shared/codex-executable.mjs";
 import { withoutTaskboardLauncherEnvironment } from "../shared/codex-environment.mjs";
@@ -396,23 +389,6 @@ function parseProjectCreate(body) {
   return { id, name, workspacePath };
 }
 
-function parseProjectReadmeSave(body) {
-  assertPlainObject(body);
-  assertAllowedKeys(body, new Set(["content", "version"]));
-  const content = body.content ?? "";
-  if (typeof content !== "string") {
-    throw new ApiError(400, "INVALID_FIELD", "'content' must be a string");
-  }
-  if (content.length > 500_000) {
-    throw new ApiError(400, "INVALID_FIELD", "'content' cannot exceed 500000 characters");
-  }
-  const version = body.version;
-  if (version !== undefined && (!Number.isSafeInteger(version) || version < 0)) {
-    throw new ApiError(400, "INVALID_FIELD", "'version' must be a non-negative integer");
-  }
-  return { content, version };
-}
-
 function requestHeader(request, name) {
   const value = request.headers[name];
   return Array.isArray(value) ? value[0] : value;
@@ -469,36 +445,6 @@ function resolveAssignee(target, actor) {
     throw new ApiError(400, "INVALID_FIELD", "'current-user' requires a user request identity");
   }
   return actor;
-}
-
-function parseTaskPatch(body) {
-  assertPlainObject(body);
-  assertAllowedKeys(body, new Set([
-    "version", "projectId", "title", "description", "status", "priority", "labels", "threadId", "threadBinding",
-    "assigneeTarget", "developmentContext", "startDate", "dueDate", "recurrence",
-  ]));
-  const version = parseVersion(body.version);
-  const threadId = parseThreadId(body.threadId);
-  const threadBinding = parseThreadBinding(body.threadBinding);
-  const assigneeTarget = parseAssigneeTarget(body.assigneeTarget);
-  const changes = {};
-  if (body.projectId !== undefined) changes.projectId = validateProjectId(body.projectId);
-  if (body.title !== undefined) changes.title = stringField(body.title, "title", { required: true, maxLength: 240 });
-  if (body.description !== undefined) changes.description = stringField(body.description, "description", { maxLength: 100_000 });
-  if (body.status !== undefined) changes.status = parseStatus(body.status);
-  if (body.priority !== undefined) changes.priority = parsePriority(body.priority);
-  if (body.labels !== undefined) changes.labels = parseLabels(body.labels);
-  if (body.developmentContext !== undefined) changes.developmentContext = parseDevelopmentContext(body.developmentContext);
-  if (body.startDate !== undefined) changes.startDate = parseDueDate(body.startDate, "startDate");
-  if (body.dueDate !== undefined) changes.dueDate = parseDueDate(body.dueDate);
-  if (body.recurrence !== undefined) changes.recurrence = parseRecurrence(body.recurrence);
-  if (changes.recurrence && body.dueDate === null) {
-    throw new ApiError(400, "INVALID_FIELD", "A recurring issue requires 'dueDate'");
-  }
-  if (Object.keys(changes).length === 0 && assigneeTarget === undefined) {
-    throw new ApiError(400, "INVALID_BODY", "PATCH requires at least one task field");
-  }
-  return { version, changes, threadId, threadBinding, assigneeTarget };
 }
 
 function parseIssueRelationType(value) {
@@ -595,52 +541,6 @@ async function assertEmptyRequestBody(request, routeLabel) {
   if (body.length > 0) {
     throw new ApiError(400, "INVALID_BODY", `${routeLabel} does not accept a request body`);
   }
-}
-
-function parseTaskFilters(searchParams) {
-  const allowed = new Set(["projectId", "status", "archived"]);
-  for (const key of searchParams.keys()) {
-    if (!allowed.has(key)) {
-      throw new ApiError(400, "UNKNOWN_QUERY_PARAMETER", `Unknown query parameter '${key}'`);
-    }
-    if (searchParams.getAll(key).length !== 1) {
-      throw new ApiError(400, "INVALID_QUERY_PARAMETER", `Query parameter '${key}' cannot be repeated`);
-    }
-  }
-
-  const projectIdValue = searchParams.get("projectId");
-  const statusValue = searchParams.get("status");
-  const archived = searchParams.get("archived") ?? "false";
-  if (statusValue !== null && !isTaskStatus(statusValue)) {
-    throw new ApiError(400, "INVALID_QUERY_PARAMETER", "Invalid task status");
-  }
-  if (!new Set(["true", "false", "all"]).has(archived)) {
-    throw new ApiError(400, "INVALID_QUERY_PARAMETER", "'archived' must be true, false, or all");
-  }
-  const projectId = projectIdValue === null ? undefined : validateProjectId(projectIdValue);
-  return { projectId, status: statusValue ?? undefined, archived };
-}
-
-function parseTaskTreeQuery(searchParams) {
-  const allowed = new Set(["direction", "depth"]);
-  for (const key of searchParams.keys()) {
-    if (!allowed.has(key)) {
-      throw new ApiError(400, "UNKNOWN_QUERY_PARAMETER", `Unknown query parameter '${key}'`);
-    }
-    if (searchParams.getAll(key).length !== 1) {
-      throw new ApiError(400, "INVALID_TREE_QUERY", `Query parameter '${key}' cannot be repeated`);
-    }
-  }
-  const direction = searchParams.get("direction");
-  if (direction !== "descendants" && direction !== "ancestors") {
-    throw new ApiError(400, "INVALID_TREE_QUERY", "'direction' must be descendants or ancestors");
-  }
-  const rawDepth = searchParams.get("depth");
-  const depth = Number(rawDepth);
-  if (!/^\d+$/.test(rawDepth ?? "") || !Number.isSafeInteger(depth) || depth < 1 || depth > 25) {
-    throw new ApiError(400, "INVALID_TREE_QUERY", "'depth' must be an integer from 1 to 25");
-  }
-  return { direction, depth };
 }
 
 function parseAiSandbox(value) {
@@ -1549,12 +1449,16 @@ export function createTaskboardServer(options = {}) {
     configStore: cloudConfig,
     fetch: options.remoteFetch ?? globalThis.fetch,
     resolveThreadBinding: currentHostThreadBinding,
-    resolveDevelopmentContext: async (projectId, context) => {
+    resolveDevelopmentContext: async (projectId, context, scans) => {
       if (!context.branch) return null;
       const config = await cloudConfig.read();
       const workspacePath = config.projectMappings[projectId];
       if (!workspacePath) return null;
-      const result = await scanDevelopmentContexts(workspacePath, codexProcessEnvironment);
+      const key = `${projectId}\0${workspacePath}`;
+      if (!scans.has(key)) {
+        scans.set(key, scanDevelopmentContexts(workspacePath, codexProcessEnvironment));
+      }
+      const result = await scans.get(key);
       return result.contexts.find((candidate) => (
         candidate.type === "worktree" && candidate.branch === context.branch
       )) ?? null;
@@ -2958,18 +2862,19 @@ export function createTaskboardServer(options = {}) {
             threadId,
             threadBinding,
             assigneeTarget,
-          } = resolveInputThreadBinding(parseTaskPatch(await readJson(request)));
-          const current = database.getTask(id);
-          if (!current) throw new ApiError(404, "TASK_NOT_FOUND", `Task '${id}' does not exist`);
+          } = resolveInputThreadBinding(parseTaskPatch(await readJson(request), parseDevelopmentContext));
+          const source = database.getTaskSource(id);
+          if (!source) throw new ApiError(404, "TASK_NOT_FOUND", `Task '${id}' does not exist`);
           let jiraChanged = false;
-          if (current.source !== "jira" && changes.projectId === JIRA_PROJECT_ID) {
+          if (source !== "jira" && changes.projectId === JIRA_PROJECT_ID) {
             throw new ApiError(
               409,
               "JIRA_PROJECT_MOVE_UNAVAILABLE",
               "本地任务不能移入 Jira 同步项目",
             );
           }
-          if (current.source === "jira") {
+          if (source === "jira") {
+            const current = database.getTask(id);
             if (current.version !== version) {
               throw new ApiError(409, "VERSION_CONFLICT", "Task changed since it was last read", {
                 expectedVersion: version,

--- a/server/cloud-proxy.mjs
+++ b/server/cloud-proxy.mjs
@@ -162,20 +162,21 @@ async function localizeResponse(
         : config.projectMappings[payload.project.id] ?? null,
     };
   }
+  const contexts = new Map();
+  const scans = new Map();
+  const resolveOnce = resolveDevelopmentContext
+    ? (projectId, context) => {
+      const key = `${projectId ?? ""}\0${context.branch ?? ""}`;
+      if (!contexts.has(key)) {
+        contexts.set(key, resolveDevelopmentContext(projectId, context, scans));
+      }
+      return contexts.get(key);
+    }
+    : null;
   if (payload.task) {
-    payload.task = await localizeTask(payload.task, resolveDevelopmentContext);
+    payload.task = await localizeTask(payload.task, resolveOnce);
   }
   if (Array.isArray(payload.tasks)) {
-    const contexts = new Map();
-    const resolveOnce = resolveDevelopmentContext
-      ? (projectId, context) => {
-        const key = `${projectId ?? ""}\0${context.branch ?? ""}`;
-        if (!contexts.has(key)) {
-          contexts.set(key, resolveDevelopmentContext(projectId, context));
-        }
-        return contexts.get(key);
-      }
-      : null;
     payload.tasks = await Promise.all(
       payload.tasks.map((task) => localizeTask(task, resolveOnce)),
     );

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -1,4 +1,5 @@
 import { ApiError } from "../shared/api-fields.mjs";
+import { taskRelationsQuery, taskRelationsFromRows } from "../shared/task-relations.mjs";
 import {
   commentConversationTitle,
   threadBindingFromRow,
@@ -1697,15 +1698,23 @@ export class TaskboardDatabase {
         id
     `;
     const rows = this.database.prepare(sql).all(...values);
+    const relationsByTask = this.#taskRelationsForTasks(rows.map((row) => row.id));
     const commentsByTask = this.#commentsForTaskActivity(rows.map((row) => row.id));
     const activitiesByTask = this.#activitiesForTasks(rows.map((row) => row.id));
     const previewImagesByTask = this.#taskPreviewImages(rows.map((row) => row.id));
     return rows.map((row) => attachTaskActivity(
-      this.#taskWithRelations(row),
+      this.#taskWithRelations(row, relationsByTask.get(row.id)),
       commentsByTask.get(row.id) ?? [],
       activitiesByTask.get(row.id) ?? [],
       previewImagesByTask.get(row.id) ?? null,
     ));
+  }
+
+  getTaskSource(id) {
+    const row = this.database.prepare(
+      "SELECT external_source FROM tasks WHERE id = ? OR identifier = ?",
+    ).get(id, id);
+    return row ? (row.external_source === "jira" ? "jira" : "local") : null;
   }
 
   getTask(id) {
@@ -1882,7 +1891,7 @@ export class TaskboardDatabase {
   }
 
   updateTask(id, version, changes, threadId, threadBinding, actor) {
-    const current = this.#requireTask(id);
+    const current = this.#requireTaskRecord(id);
     this.#requireVersion(current, version);
     const activityChanges = taskFieldChanges(current, changes);
     const targetProject = Object.hasOwn(changes, "projectId")
@@ -2336,23 +2345,24 @@ export class TaskboardDatabase {
   }
 
   listComments(taskId) {
-    const task = this.#requireTask(taskId);
-    return this.database.prepare(`
+    const task = this.#requireTaskRecord(taskId);
+    const rows = this.database.prepare(`
       SELECT * FROM comments
       WHERE task_id = ?
       ORDER BY created_at, id
-    `).all(task.id).map((row) => this.#commentWithAttachments(row));
+    `).all(task.id);
+    return this.#commentsWithAttachments(rows);
   }
 
   listCommentsAfter(taskId, after) {
-    const task = this.#requireTask(taskId);
-    return this.database.prepare(`
+    const task = this.#requireTaskRecord(taskId);
+    const rows = this.database.prepare(`
       SELECT * FROM comments
       WHERE task_id = ?
         AND change_revision > ?
       ORDER BY change_revision
-    `).all(task.id, after.revision)
-      .map((row) => this.#commentWithAttachments(row));
+    `).all(task.id, after.revision);
+    return this.#commentsWithAttachments(rows);
   }
 
   createComment(taskId, input) {
@@ -2529,10 +2539,28 @@ export class TaskboardDatabase {
     return attachment;
   }
 
-  #commentWithAttachments(row) {
+  #commentWithAttachments(row, attachments = this.#attachmentsForComment(row.id)) {
     const comment = commentFromRow(row);
-    comment.attachments = this.#attachmentsForComment(comment.id);
+    comment.attachments = attachments;
     return comment;
+  }
+
+  #commentsWithAttachments(rows) {
+    const attachmentsByComment = new Map(rows.map((row) => [row.id, []]));
+    const commentIds = rows.map((row) => row.id);
+    for (let offset = 0; offset < commentIds.length; offset += 400) {
+      const chunk = commentIds.slice(offset, offset + 400);
+      const placeholders = chunk.map(() => "?").join(", ");
+      const attachments = this.database.prepare(`
+        SELECT * FROM attachments
+        WHERE comment_id IN (${placeholders})
+        ORDER BY comment_id, created_at, id
+      `).all(...chunk);
+      for (const attachment of attachments) {
+        attachmentsByComment.get(attachment.comment_id).push(attachmentFromRow(attachment));
+      }
+    }
+    return rows.map((row) => this.#commentWithAttachments(row, attachmentsByComment.get(row.id)));
   }
 
   #aiChatThreadWithCurrentRun(row) {
@@ -2646,60 +2674,22 @@ export class TaskboardDatabase {
     `).get().value;
   }
 
-  #taskWithRelations(row) {
+  #taskRelationsForTasks(taskIds) {
+    const relationsByTask = new Map();
+    for (let offset = 0; offset < taskIds.length; offset += 400) {
+      const chunk = taskIds.slice(offset, offset + 400);
+      const placeholders = chunk.map(() => "?").join(", ");
+      const rows = this.database.prepare(taskRelationsQuery(placeholders)).all(...chunk);
+      for (const [taskId, relations] of taskRelationsFromRows(chunk, rows, taskRelationSummaryFromRow)) {
+        relationsByTask.set(taskId, relations);
+      }
+    }
+    return relationsByTask;
+  }
+
+  #taskWithRelations(row, relations = this.#taskRelationsForTasks([row.id]).get(row.id)) {
     const task = taskFromRow(row);
-    const parent = this.database.prepare(`
-      SELECT tasks.*
-      FROM task_relations
-      JOIN tasks ON tasks.id = task_relations.source_task_id
-      WHERE task_relations.relation_type = 'parent'
-        AND task_relations.target_task_id = ?
-    `).get(task.id);
-    const subIssues = this.database.prepare(`
-      SELECT tasks.*
-      FROM task_relations
-      JOIN tasks ON tasks.id = task_relations.target_task_id
-      WHERE task_relations.relation_type = 'parent'
-        AND task_relations.source_task_id = ?
-      ORDER BY tasks.sort_order, tasks.created_at, tasks.id
-    `).all(task.id);
-    const blockedBy = this.database.prepare(`
-      SELECT tasks.*
-      FROM task_relations
-      JOIN tasks ON tasks.id = task_relations.source_task_id
-      WHERE task_relations.relation_type = 'blocks'
-        AND task_relations.target_task_id = ?
-      ORDER BY tasks.sort_order, tasks.created_at, tasks.id
-    `).all(task.id);
-    const blocks = this.database.prepare(`
-      SELECT tasks.*
-      FROM task_relations
-      JOIN tasks ON tasks.id = task_relations.target_task_id
-      WHERE task_relations.relation_type = 'blocks'
-        AND task_relations.source_task_id = ?
-      ORDER BY tasks.sort_order, tasks.created_at, tasks.id
-    `).all(task.id);
-    const related = this.database.prepare(`
-      SELECT tasks.*
-      FROM task_relations
-      JOIN tasks ON tasks.id = CASE
-        WHEN task_relations.source_task_id = ? THEN task_relations.target_task_id
-        ELSE task_relations.source_task_id
-      END
-      WHERE task_relations.relation_type = 'related'
-        AND (
-          task_relations.source_task_id = ?
-          OR task_relations.target_task_id = ?
-        )
-      ORDER BY tasks.sort_order, tasks.created_at, tasks.id
-    `).all(task.id, task.id, task.id);
-    task.relations = {
-      parent: parent ? taskRelationSummaryFromRow(parent) : null,
-      subIssues: subIssues.map(taskRelationSummaryFromRow),
-      blockedBy: blockedBy.map(taskRelationSummaryFromRow),
-      blocks: blocks.map(taskRelationSummaryFromRow),
-      related: related.map(taskRelationSummaryFromRow),
-    };
+    task.relations = relations;
     return task;
   }
 
@@ -2792,6 +2782,14 @@ export class TaskboardDatabase {
     }
   }
 
+  #requireTaskRecord(id) {
+    const row = this.database.prepare("SELECT * FROM tasks WHERE id = ? OR identifier = ?").get(id, id);
+    if (!row) {
+      throw new ApiError(404, "TASK_NOT_FOUND", `Task '${id}' does not exist`);
+    }
+    return taskFromRow(row);
+  }
+
   #requireTask(id) {
     const task = this.getTask(id);
     if (!task) {
@@ -2827,10 +2825,7 @@ export class TaskboardDatabase {
   }
 
   #throwMissingOrConflict(id, expectedVersion) {
-    const task = this.getTask(id);
-    if (!task) {
-      throw new ApiError(404, "TASK_NOT_FOUND", `Task '${id}' does not exist`);
-    }
+    const task = this.#requireTaskRecord(id);
     throw new ApiError(409, "VERSION_CONFLICT", "Task was changed by another client", {
       expectedVersion,
       actualVersion: task.version,

--- a/shared/task-input.mjs
+++ b/shared/task-input.mjs
@@ -1,4 +1,4 @@
-import { DEFAULT_PROJECT_ID } from "./domain.mjs";
+import { DEFAULT_PROJECT_ID, isTaskStatus } from "./domain.mjs";
 import {
   ApiError, assertPlainObject, assertAllowedKeys, stringField,
   parseVersion, validateProjectId, parseThreadId, parseAssigneeTarget,
@@ -140,4 +140,169 @@ export function parseTaskCreate(body, parseDevelopmentContext) {
     throw new ApiError(400, "INVALID_FIELD", "A recurring issue requires 'dueDate'");
   }
   return task;
+}
+
+// Local and cloud entry points retain their existing validation order and errors.
+function assertTaskPatchBody(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set([
+    "version", "projectId", "title", "description", "status", "priority", "labels", "threadId", "threadBinding",
+    "assigneeTarget", "developmentContext", "startDate", "dueDate", "recurrence",
+  ]));
+}
+
+function parseTaskPatchChanges(body, parseDevelopmentContext) {
+  const changes = {};
+  if (body.projectId !== undefined) changes.projectId = validateProjectId(body.projectId);
+  if (body.title !== undefined) changes.title = stringField(body.title, "title", { required: true, maxLength: 240 });
+  if (body.description !== undefined) changes.description = stringField(body.description, "description", { maxLength: 100_000 });
+  if (body.status !== undefined) changes.status = parseStatus(body.status);
+  if (body.priority !== undefined) changes.priority = parsePriority(body.priority);
+  if (body.labels !== undefined) changes.labels = parseLabels(body.labels);
+  if (body.developmentContext !== undefined) changes.developmentContext = parseDevelopmentContext(body.developmentContext);
+  if (body.startDate !== undefined) changes.startDate = parseDueDate(body.startDate, "startDate");
+  if (body.dueDate !== undefined) changes.dueDate = parseDueDate(body.dueDate);
+  if (body.recurrence !== undefined) changes.recurrence = parseRecurrence(body.recurrence);
+  return changes;
+}
+
+function assertTaskPatchFields(changes, assigneeTarget) {
+  if (Object.keys(changes).length === 0 && assigneeTarget === undefined) {
+    throw new ApiError(400, "INVALID_BODY", "PATCH requires at least one task field");
+  }
+}
+
+export function parseTaskPatch(body, parseDevelopmentContext) {
+  assertTaskPatchBody(body);
+  const version = parseVersion(body.version);
+  const threadId = parseThreadId(body.threadId);
+  const threadBinding = parseThreadBinding(body.threadBinding);
+  const assigneeTarget = parseAssigneeTarget(body.assigneeTarget);
+  const changes = parseTaskPatchChanges(body, parseDevelopmentContext);
+  if (changes.recurrence && body.dueDate === null) {
+    throw new ApiError(400, "INVALID_FIELD", "A recurring issue requires 'dueDate'");
+  }
+  assertTaskPatchFields(changes, assigneeTarget);
+  return { version, changes, threadId, threadBinding, assigneeTarget };
+}
+
+export function parseCloudTaskPatch(body, parseDevelopmentContext) {
+  assertTaskPatchBody(body);
+  const changes = parseTaskPatchChanges(body, parseDevelopmentContext);
+  const assigneeTarget = parseAssigneeTarget(body.assigneeTarget);
+  assertTaskPatchFields(changes, assigneeTarget);
+  return {
+    version: parseVersion(body.version),
+    changes,
+    threadId: parseThreadId(body.threadId),
+    threadBinding: parseThreadBinding(body.threadBinding),
+    assigneeTarget,
+  };
+}
+
+function assertTaskQueryParameters(searchParams, allowed, repeatedCode, cloud = false) {
+  for (const key of searchParams.keys()) {
+    if (!allowed.has(key)) {
+      throw new ApiError(400, "UNKNOWN_QUERY_PARAMETER", cloud
+        ? `Unknown query parameter: ${key}`
+        : `Unknown query parameter '${key}'`);
+    }
+    const count = searchParams.getAll(key).length;
+    if (cloud ? count > 1 : count !== 1) {
+      throw new ApiError(400, repeatedCode, cloud
+        ? `'${key}' cannot be repeated`
+        : `Query parameter '${key}' cannot be repeated`);
+    }
+  }
+}
+
+function taskFilterValues(searchParams) {
+  return {
+    projectId: searchParams.get("projectId"),
+    status: searchParams.get("status"),
+    archived: searchParams.get("archived") ?? "false",
+  };
+}
+
+export function parseTaskFilters(searchParams) {
+  assertTaskQueryParameters(
+    searchParams, new Set(["projectId", "status", "archived"]), "INVALID_QUERY_PARAMETER",
+  );
+
+  const { projectId: projectIdValue, status: statusValue, archived } = taskFilterValues(searchParams);
+  if (statusValue !== null && !isTaskStatus(statusValue)) {
+    throw new ApiError(400, "INVALID_QUERY_PARAMETER", "Invalid task status");
+  }
+  if (!new Set(["true", "false", "all"]).has(archived)) {
+    throw new ApiError(400, "INVALID_QUERY_PARAMETER", "'archived' must be true, false, or all");
+  }
+  const projectId = projectIdValue === null ? undefined : validateProjectId(projectIdValue);
+  return { projectId, status: statusValue ?? undefined, archived };
+}
+
+export function parseCloudTaskFilters(searchParams) {
+  assertTaskQueryParameters(
+    searchParams, new Set(["projectId", "status", "archived"]), "INVALID_QUERY_PARAMETER", true,
+  );
+  const { projectId, status, archived } = taskFilterValues(searchParams);
+  if (projectId !== null) validateProjectId(projectId);
+  if (status !== null) parseStatus(status);
+  if (!["false", "true", "all"].includes(archived)) {
+    throw new ApiError(
+      400,
+      "INVALID_QUERY_PARAMETER",
+      "'archived' must be false, true, or all",
+    );
+  }
+  return { projectId, status, archived };
+}
+
+function taskTreeQueryValues(searchParams) {
+  const direction = searchParams.get("direction");
+  if (direction !== "descendants" && direction !== "ancestors") {
+    throw new ApiError(400, "INVALID_TREE_QUERY", "'direction' must be descendants or ancestors");
+  }
+  const rawDepth = searchParams.get("depth");
+  const depth = Number(rawDepth);
+  if (!/^\d+$/.test(rawDepth ?? "") || !Number.isSafeInteger(depth) || depth < 1 || depth > 25) {
+    throw new ApiError(400, "INVALID_TREE_QUERY", "'depth' must be an integer from 1 to 25");
+  }
+  return { direction, depth };
+}
+
+export function parseTaskTreeQuery(searchParams) {
+  assertTaskQueryParameters(searchParams, new Set(["direction", "depth"]), "INVALID_TREE_QUERY");
+  return taskTreeQueryValues(searchParams);
+}
+
+export function parseCloudTaskTreeQuery(searchParams) {
+  assertTaskQueryParameters(searchParams, new Set(["direction", "depth"]), "INVALID_TREE_QUERY", true);
+  return taskTreeQueryValues(searchParams);
+}
+
+function projectReadmeContent(value) {
+  const content = value ?? "";
+  if (typeof content !== "string") {
+    throw new ApiError(400, "INVALID_FIELD", "'content' must be a string");
+  }
+  if (content.length > 500_000) {
+    throw new ApiError(400, "INVALID_FIELD", "'content' cannot exceed 500000 characters");
+  }
+  return content;
+}
+
+export function parseProjectReadmeSave(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["content", "version"]));
+  const content = projectReadmeContent(body.content);
+  const version = body.version === undefined ? undefined : parseVersion(body.version, { allowZero: true });
+  return { content, version };
+}
+
+export function parseCloudProjectReadmeSave(body) {
+  assertPlainObject(body);
+  assertAllowedKeys(body, new Set(["version", "content"]));
+  const version = body.version === undefined ? undefined : parseVersion(body.version, { allowZero: true });
+  const content = projectReadmeContent(body.content);
+  return { content, version };
 }

--- a/shared/task-relations.mjs
+++ b/shared/task-relations.mjs
@@ -1,0 +1,55 @@
+// Select both endpoints once per ID batch; the outer order also interleaves
+// incoming and outgoing "related" edges in the original task order.
+export function taskRelationsQuery(placeholders) {
+  return `
+    WITH selected_tasks AS (
+      SELECT id FROM tasks WHERE id IN (${placeholders})
+    ), relation_targets AS (
+      SELECT
+        selected_tasks.id AS task_id,
+        task_relations.target_task_id AS related_task_id,
+        CASE task_relations.relation_type
+          WHEN 'parent' THEN 'subIssues'
+          WHEN 'blocks' THEN 'blocks'
+          WHEN 'related' THEN 'related'
+        END AS relation_field
+      FROM selected_tasks
+      JOIN task_relations ON task_relations.source_task_id = selected_tasks.id
+      UNION ALL
+      SELECT
+        selected_tasks.id AS task_id,
+        task_relations.source_task_id AS related_task_id,
+        CASE task_relations.relation_type
+          WHEN 'parent' THEN 'parent'
+          WHEN 'blocks' THEN 'blockedBy'
+          WHEN 'related' THEN 'related'
+        END AS relation_field
+      FROM selected_tasks
+      JOIN task_relations ON task_relations.target_task_id = selected_tasks.id
+    )
+    SELECT tasks.*, relation_targets.task_id AS relation_task_id, relation_targets.relation_field
+    FROM relation_targets
+    JOIN tasks ON tasks.id = relation_targets.related_task_id
+    ORDER BY tasks.sort_order, tasks.created_at, tasks.id
+  `;
+}
+
+export function taskRelationsFromRows(taskIds, rows, summarizeTask) {
+  const relationsByTask = new Map(taskIds.map((taskId) => [taskId, {
+    parent: null,
+    subIssues: [],
+    blockedBy: [],
+    blocks: [],
+    related: [],
+  }]));
+  for (const row of rows) {
+    const relations = relationsByTask.get(row.relation_task_id);
+    const summary = summarizeTask(row);
+    if (row.relation_field === "parent") {
+      relations.parent = summary;
+    } else {
+      relations[row.relation_field].push(summary);
+    }
+  }
+  return relationsByTask;
+}


### PR DESCRIPTION
任务列表原来逐条查询五类关系，云端还逐条查询预览；评论列表逐条读取附件。此变更按现有 ID 批次装配关系、预览及评论附件，并让普通标题更新只在响应阶段完整装配一次任务。

同一次云列表响应按项目和工作区复用 Git 扫描，再解析各分支路径。PATCH、列表筛选、树查询及 README 保存沿用 `shared/task-input.mjs` 共用规则，保留两端返回字段、排序、版本冲突和输入差异。公开 `getTask()` 仍返回完整任务，Jira 同步逻辑不变。

关联 Taskboard：LOCAL-399、LOCAL-404、LOCAL-406。

验证：
- 在完整本地 HTTP 服务与隔离 Miniflare/workerd D1 中，对照同一份 100 条主任务、3 条归档任务、父子/阻塞/关联关系和 10 条带附件评论。主列表、归档、详情、增量评论、树、筛选、标题更新、版本冲突及 README 的响应与基线一致。
- 100 条主任务的 SQL 次数：本地 504 → 5，D1 605 → 9；普通标题 PATCH：本地 31 → 11，D1 14 → 10。SQL 计数含实际 HTTP 路由读写，不含触发器内部语句。
- 临时 Git 项目中的多分支和缺失分支返回相同，单响应 Git 进程从 9 → 3。
- 路径解析与 README 校验先后顺序的定向请求对照一致。六个源码文件 `node --check` 和 `git diff --check` 通过。

验证使用独立临时数据；未访问已安装 App 数据。耗时记录仅代表该次本地运行，不作为生产云网络延迟结论。未新增测试或改变 schema。
