### PR TITLE
修复 AI 输入草稿清理并统一引用解析

### DIFF
--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -325,12 +325,21 @@ function eventHasAttachments(event: AiChatEvent): boolean {
   return Array.isArray(event.data?.attachments) && event.data.attachments.length > 0;
 }
 
-function serializeComposer(root: HTMLElement): ComposerFragment {
-  let message = "";
-  const skillIds: string[] = [];
-  const references: Array<ComposerStableReference | null> = [];
+function readComposer(root: HTMLElement): {
+  fragment: ComposerFragment;
+  document: ComposerDraftDocument;
+} {
+  const nodes: Array<{
+    node: ComposerDraftNode;
+    skillId?: string;
+    reference?: ComposerStableReference | null;
+  }> = [];
   const appendText = (value: string) => {
-    message += value.replaceAll("\u200B", "");
+    const text = value.replaceAll("\u200B", "");
+    if (!text) return;
+    const previous = nodes.at(-1)?.node;
+    if (previous?.type === "text") previous.text += text;
+    else nodes.push({ node: { type: "text", text } });
   };
   const visit = (node: Node) => {
     if (node.nodeType === Node.TEXT_NODE) {
@@ -341,63 +350,23 @@ function serializeComposer(root: HTMLElement): ComposerFragment {
     const stableId = node.dataset.composerStableId ?? node.dataset.skillId;
     const skillId = stableId ?? node.dataset.composerCandidateRef;
     if (skillId) {
-      message += SKILL_MARKER;
-      skillIds.push(skillId);
       const referenceKey = node.dataset.composerReferenceKey;
       const kind = node.dataset.composerKind === "agent" ? "agent" : "skill";
-      references.push(stableId && referenceKey ? composerStableReference(
-        kind,
-        stableId,
-        node.dataset.composerLabel ?? stableId,
-        referenceKey,
-        node.dataset.composerMarkdown,
-      ) : null);
-      return;
-    }
-    if (node.tagName === "BR") {
-      message += "\n";
-      return;
-    }
-    const isBlock = node.tagName === "DIV" || node.tagName === "P";
-    if (isBlock && message && !message.endsWith("\n")) message += "\n";
-    for (const child of node.childNodes) visit(child);
-    if (isBlock && node.nextSibling && !message.endsWith("\n")) message += "\n";
-  };
-  for (const child of root.childNodes) visit(child);
-  return { message, skillIds, references };
-}
-
-function serializeComposerDocumentFromDom(
-  root: HTMLElement,
-): ComposerDraftDocument {
-  const nodes: ComposerDraftNode[] = [];
-  const appendText = (value: string) => {
-    const text = value.replaceAll("\u200B", "");
-    if (!text) return;
-    const previous = nodes.at(-1);
-    if (previous?.type === "text") previous.text += text;
-    else nodes.push({ type: "text", text });
-  };
-  const visit = (node: Node) => {
-    if (node.nodeType === Node.TEXT_NODE) {
-      appendText(node.textContent ?? "");
-      return;
-    }
-    if (!(node instanceof HTMLElement)) return;
-    if (node.dataset.composerReferenceKey) {
+      const label = node.dataset.composerLabel ?? "";
       nodes.push({
-        type: "persistedReference",
-        referenceKind: node.dataset.composerKind === "agent" ? "agent" : "skill",
-        referenceKey: node.dataset.composerReferenceKey,
-        label: node.dataset.composerLabel ?? "",
-      });
-      return;
-    }
-    if (node.dataset.composerCandidateRef) {
-      nodes.push({
-          type: node.dataset.composerKind === "agent" ? "agent" : "skill",
-          candidateRef: node.dataset.composerCandidateRef,
-          label: node.dataset.composerLabel ?? "",
+        node: referenceKey ? {
+          type: "persistedReference", referenceKind: kind, referenceKey, label,
+        } : {
+          type: kind, candidateRef: node.dataset.composerCandidateRef ?? skillId, label,
+        },
+        skillId,
+        reference: stableId && referenceKey ? composerStableReference(
+          kind,
+          stableId,
+          node.dataset.composerLabel ?? stableId,
+          referenceKey,
+          node.dataset.composerMarkdown,
+        ) : null,
       });
       return;
     }
@@ -406,22 +375,34 @@ function serializeComposerDocumentFromDom(
       return;
     }
     const isBlock = node.tagName === "DIV" || node.tagName === "P";
-    const previousText = nodes.at(-1);
+    const previous = nodes.at(-1)?.node;
     if (
-      isBlock
-      && nodes.length > 0
-      && !(previousText?.type === "text" && previousText.text.endsWith("\n"))
+      isBlock && previous
+      && !(previous.type === "text" && previous.text.endsWith("\n"))
     ) appendText("\n");
     for (const child of node.childNodes) visit(child);
-    const finalText = nodes.at(-1);
+    const final = nodes.at(-1)?.node;
     if (
-      isBlock
-      && node.nextSibling
-      && !(finalText?.type === "text" && finalText.text.endsWith("\n"))
+      isBlock && node.nextSibling
+      && !(final?.type === "text" && final.text.endsWith("\n"))
     ) appendText("\n");
   };
   for (const child of root.childNodes) visit(child);
-  return { version: 1, nodes };
+
+  let message = "";
+  const skillIds: string[] = [];
+  const references: Array<ComposerStableReference | null> = [];
+  const document: ComposerDraftDocument = { version: 1, nodes: [] };
+  for (const { node, skillId, reference } of nodes) {
+    document.nodes.push(node);
+    if (node.type === "text") message += node.text;
+    else if (skillId) {
+      message += SKILL_MARKER;
+      skillIds.push(skillId);
+      references.push(reference ?? null);
+    }
+  }
+  return { fragment: { message, skillIds, references }, document };
 }
 
 function selectedComposerFragment(root: HTMLElement): {
@@ -454,7 +435,7 @@ function selectedComposerFragment(root: HTMLElement): {
   if (endSkill) copyRange.setEndAfter(endSkill);
   const wrapper = root.ownerDocument.createElement("div");
   wrapper.append(copyRange.cloneContents());
-  const fragment = serializeComposer(wrapper);
+  const { fragment } = readComposer(wrapper);
   return fragment.message ? { ...fragment, range: copyRange } : null;
 }
 
@@ -1270,6 +1251,7 @@ export function AiChat({
   const [catalogLoadedProjectId, setCatalogLoadedProjectId] = useState<string | null>(null);
   const [catalogError, setCatalogError] = useState<AiChatError | null>(null);
   const [loading, setLoading] = useState(false);
+  const [sending, setSending] = useState(false);
   const [error, setError] = useState<AiChatError | null>(null);
   const [draft, setDraft] = useState("");
   const [requestedComposerText, setRequestedComposerText] = useState<string | null>(null);
@@ -1651,15 +1633,17 @@ export function AiChat({
     catalogCodexProjectIdentity?.workspacePath,
   ]);
 
+  const composerQueryTrigger = composerQueryState?.trigger;
+  const composerQueryText = composerQueryState?.query;
   const composerRequestQuery = useMemo(() => {
-    if (!composerQueryState) return "";
-    const escapedTrigger = composerQueryState.trigger === "/" ? "\\/" : "@";
+    if (!composerQueryTrigger) return "";
+    const escapedTrigger = composerQueryTrigger === "/" ? "\\/" : "@";
     const match = new RegExp(`(?:^|\\s)${escapedTrigger}([^\\s@/]*)$`).exec(draft);
-    return match?.[1] ?? composerQueryState.query;
-  }, [composerQueryState, draft]);
+    return match?.[1] ?? composerQueryText ?? "";
+  }, [composerQueryTrigger, composerQueryText, draft]);
 
   useEffect(() => {
-    if (!composerQueryState) {
+    if (!composerQueryTrigger) {
       setComposerCandidates(null);
       setComposerCandidatesLoading(false);
       setComposerCandidatesError(null);
@@ -1673,7 +1657,7 @@ export function AiChat({
       ...(catalogProjectId ? { projectId: catalogProjectId } : {}),
       ...(selectedThreadId ? { threadId: selectedThreadId } : {}),
       ...(!selectedThreadId && catalogCodexProjectIdentity ? catalogCodexProjectIdentity : {}),
-      trigger: composerQueryState.trigger,
+      trigger: composerQueryTrigger,
       query: composerRequestQuery,
     }, controller.signal).then(
       (next) => {
@@ -1697,7 +1681,7 @@ export function AiChat({
     catalogCodexProjectIdentity?.codexProjectId,
     catalogCodexProjectIdentity?.codexProjectKind,
     catalogCodexProjectIdentity?.workspacePath,
-    composerQueryState,
+    composerQueryTrigger,
     composerRequestQuery,
     selectedThreadId,
   ]);
@@ -1767,6 +1751,7 @@ export function AiChat({
     selectedThreadId && deletingThreadId === selectedThreadId,
   );
   const sendBlocked = loading
+    || sending
     || settingsSaving
     || composerBlocked
     || Boolean(selectedThreadId && !snapshot);
@@ -1815,11 +1800,13 @@ export function AiChat({
     if (attachmentBlocked) setAttachmentDragActive(false);
   }, [attachmentBlocked]);
 
-  function resetComposer() {
+  function resetComposer(submittedAttachmentIds?: ReadonlySet<string>) {
     editorRef.current?.replaceChildren();
     if (attachmentInputRef.current) attachmentInputRef.current.value = "";
     setDraft("");
-    setAttachments([]);
+    setAttachments((current) => submittedAttachmentIds
+      ? current.filter((attachment) => !submittedAttachmentIds.has(attachment.id))
+      : []);
     setSkillIds([]);
     setComposerSkillTokens([]);
     setComposerQueryState(null);
@@ -2092,7 +2079,7 @@ export function AiChat({
   function syncComposerState() {
     const editor = editorRef.current;
     if (!editor) return;
-    const next = serializeComposer(editor);
+    const { fragment: next } = readComposer(editor);
     setDraft(next.message);
     setSkillIds(next.skillIds);
     setComposerSkillTokens((current) => current.filter((token) => editor.contains(token.element)));
@@ -2234,6 +2221,11 @@ export function AiChat({
 
     const lastNode = content.lastChild;
     range.deleteContents();
+    if (editor.innerHTML === "<br>") {
+      editor.replaceChildren();
+      range.selectNodeContents(editor);
+      range.collapse(true);
+    }
     range.insertNode(content);
     if (lastNode.nodeType === Node.TEXT_NODE) {
       range.setStart(lastNode, lastNode.textContent?.length ?? 0);
@@ -2338,10 +2330,13 @@ export function AiChat({
   ) {
     if (sendBlocked) return;
     if (boundSkillIds === undefined && slashQueryBlocked) return;
+    const submittedEditor = editorRef.current;
+    const submittedComposer = submittedEditor ? readComposer(submittedEditor) : null;
+    const submittedDocument = JSON.stringify(submittedComposer?.document);
     const trimmed = message.trim();
     const submittedSkillIds = boundSkillIds ?? [...realSkillIdsForMessage()];
     let currentComposerDocument = boundComposerDocument
-      ?? (editorRef.current ? serializeComposerDocumentFromDom(editorRef.current) : undefined);
+      ?? submittedComposer?.document;
     let currentComposerRevision = boundComposerRevision ?? composerRevision ?? undefined;
     const hasPersistedReference = currentComposerDocument
       ? hasPersistedComposerReference(currentComposerDocument)
@@ -2392,9 +2387,13 @@ export function AiChat({
       contentType: attachment.contentType,
       dataBase64: attachment.dataBase64,
     }));
+    const submittedAttachmentIds = new Set(attachments.filter((attachment) => (
+      messageAttachments.some((submitted) => submitted.filename === attachment.filename
+        && submitted.contentType === attachment.contentType
+        && submitted.dataBase64 === attachment.dataBase64)
+    )).map((attachment) => attachment.id));
     if (!trimmed && messageAttachments.length === 0) return;
     let thread = snapshot?.thread ?? null;
-    const creatingThread = !thread;
     const messageSandbox = thread?.sandbox ?? draftSandbox;
     if (needsDangerConfirmation(messageSandbox, dangerConfirmed)) {
       setPendingDangerInput({
@@ -2409,7 +2408,6 @@ export function AiChat({
       });
       return;
     }
-    if (creatingThread && clearSubmittedDraft && !useComposerTurn) resetComposer();
     if (!thread) thread = await createThreadForDraftOrigin();
     if (!thread) return;
     const messageSkillIds = (
@@ -2417,6 +2415,7 @@ export function AiChat({
     ) ? submittedSkillIds : [];
     setPendingDangerInput(null);
     setError(null);
+    setSending(true);
     try {
       let resolvedComposerDocument: ComposerDocument | undefined;
       if (useComposerTurn && currentComposerDocument) {
@@ -2469,9 +2468,6 @@ export function AiChat({
             messageAttachments,
           )
         : null;
-      if (clearSubmittedDraft && !creatingThread && !composerTurnInput) {
-        resetComposer();
-      }
       const run = composerTurnInput
         ? await startAiChatComposerTurn(thread.id, composerTurnInput)
         : await startAiChatTurn(thread.id, buildTurnInput(
@@ -2480,7 +2476,16 @@ export function AiChat({
             dangerConfirmed,
             messageAttachments,
           ));
-      if (clearSubmittedDraft && composerTurnInput) resetComposer();
+      if (clearSubmittedDraft && selectedThreadRef.current === thread.id) {
+        const editor = editorRef.current;
+        if (
+          editor && editor === submittedEditor
+          && JSON.stringify(readComposer(editor).document) === submittedDocument
+        ) resetComposer(submittedAttachmentIds);
+        else setAttachments((current) => current.filter(
+          (attachment) => !submittedAttachmentIds.has(attachment.id),
+        ));
+      }
       observedRunStatusesRef.current.set(run.id, run.status);
       setSnapshot((current) => current?.thread.id === thread.id ? {
           ...current,
@@ -2501,6 +2506,8 @@ export function AiChat({
       if (selectedThreadRef.current === thread.id) {
         void selectedHintRefreshQueue.request(thread.id);
       }
+    } finally {
+      setSending(false);
     }
   }
 

--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -1278,6 +1278,7 @@ export function AiChat({
   );
   const [panelResizeEdge, setPanelResizeEdge] = useState<PanelResizeEdge | null>(null);
   const editorRef = useRef<HTMLDivElement>(null);
+  const composerEditVersionRef = useRef(0);
   const composerQueryRangeRef = useRef<Range | null>(null);
   const dismissedComposerQueryRef = useRef<string | null>(null);
   const composerBeforeInputRef = useRef<ComposerBeforeInput | null>(null);
@@ -1801,6 +1802,7 @@ export function AiChat({
   }, [attachmentBlocked]);
 
   function resetComposer(submittedAttachmentIds?: ReadonlySet<string>) {
+    composerEditVersionRef.current += 1;
     editorRef.current?.replaceChildren();
     if (attachmentInputRef.current) attachmentInputRef.current.value = "";
     setDraft("");
@@ -1887,6 +1889,7 @@ export function AiChat({
   useEffect(() => {
     const editor = editorRef.current;
     if (!panelOpen || requestedComposerText === null || !editor) return;
+    composerEditVersionRef.current += 1;
     editor.replaceChildren(document.createTextNode(requestedComposerText));
     setDraft(requestedComposerText);
     setRequestedComposerText(null);
@@ -2080,6 +2083,7 @@ export function AiChat({
     const editor = editorRef.current;
     if (!editor) return;
     const { fragment: next } = readComposer(editor);
+    composerEditVersionRef.current += 1;
     setDraft(next.message);
     setSkillIds(next.skillIds);
     setComposerSkillTokens((current) => current.filter((token) => editor.contains(token.element)));
@@ -2332,7 +2336,7 @@ export function AiChat({
     if (boundSkillIds === undefined && slashQueryBlocked) return;
     const submittedEditor = editorRef.current;
     const submittedComposer = submittedEditor ? readComposer(submittedEditor) : null;
-    const submittedDocument = JSON.stringify(submittedComposer?.document);
+    const submittedComposerVersion = composerEditVersionRef.current;
     const trimmed = message.trim();
     const submittedSkillIds = boundSkillIds ?? [...realSkillIdsForMessage()];
     let currentComposerDocument = boundComposerDocument
@@ -2477,14 +2481,13 @@ export function AiChat({
             messageAttachments,
           ));
       if (clearSubmittedDraft && selectedThreadRef.current === thread.id) {
-        const editor = editorRef.current;
-        if (
-          editor && editor === submittedEditor
-          && JSON.stringify(readComposer(editor).document) === submittedDocument
-        ) resetComposer(submittedAttachmentIds);
-        else setAttachments((current) => current.filter(
-          (attachment) => !submittedAttachmentIds.has(attachment.id),
-        ));
+        if (composerEditVersionRef.current === submittedComposerVersion) {
+          resetComposer(submittedAttachmentIds);
+        } else {
+          setAttachments((current) => current.filter(
+            (attachment) => !submittedAttachmentIds.has(attachment.id),
+          ));
+        }
       }
       observedRunStatusesRef.current.set(run.id, run.status);
       setSnapshot((current) => current?.thread.id === thread.id ? {


### PR DESCRIPTION
AI 普通消息在创建线程或发送失败前会清空草稿和附件。本改动统一在发送成功后清理提交内容；等待期间改过的正文和新附件保留，发送按钮在请求期间禁用。正文清理使用提交时的编辑版本，关闭或重开面板也能清理已发送草稿。

LOCAL-392、LOCAL-409 共用同一输入路径，本 PR 只改 `web/src/components/AiChat.tsx`：

- 一次 DOM 解码生成原有 marker/skillIds 与结构化 document，保留外部协议和候选 revision 规则。
- 补全请求依赖 trigger/query 等语义值；同值光标移动不再重复请求。
- 修复全选删除后粘贴引用时，空编辑区占位 `<br>` 被保留为末尾换行的问题。

验证：`npm run typecheck`、`npm run build:web`、`git diff --check` 通过。使用独立数据目录和 Chrome 页面，在 AI API 边界临时返回创建/发送失败与受控成功响应：失败草稿及附件保留，成功仅清理已提交附件，等待期间新输入保留；段落和引用复制前后的真实发送 document 一致；相同查询移动光标请求数 6→6，查询变化后 6→7。页面运行错误 0。

验证未调用真实 Codex 运行，不涉及 Launcher、权限映射或服务端生命周期。未新增测试、运行时护栏或兼容层。普通 Agent review 的面板卸载问题已修正并复核通过；[最终 head CI](https://github.com/chuspeeism/dashi-taskboard/actions/runs/34192168108) 成功，等待批次集成。
