### PR TITLE
fix: serialize Jira configuration and synchronization

### DIFF
--- a/server/jira-integration.mjs
+++ b/server/jira-integration.mjs
@@ -150,6 +150,14 @@ function safeConfig(config, lastSyncedAt = null) {
 export function createJiraIntegration({ configStore, database, fetch: fetchImplementation = globalThis.fetch }) {
   let lastSyncedAt = null;
   let pendingSync = null;
+  let pendingOperation = Promise.resolve();
+
+  function runInOrder(operation) {
+    const result = pendingOperation.then(operation);
+    // Recover only the scheduling tail; callers still receive the rejection.
+    pendingOperation = result.catch(() => {});
+    return result;
+  }
 
   async function request(config, pathname, init = {}) {
     const controller = new AbortController();
@@ -271,16 +279,26 @@ export function createJiraIntegration({ configStore, database, fetch: fetchImple
   }
 
   async function sync({ force = false } = {}) {
-    const config = await configStore.read();
-    if (!config) return safeConfig(null);
-    if (!force && lastSyncedAt && Date.now() - new Date(lastSyncedAt).getTime() < SYNC_INTERVAL_MS) {
-      return safeConfig(config, lastSyncedAt);
+    if (pendingSync) {
+      // A forced caller must not inherit a queued, throttled no-op.
+      pendingSync.force ||= force;
+      return pendingSync.promise;
     }
-    if (pendingSync) return pendingSync;
-    pendingSync = syncWithConfig(config).finally(() => {
-      pendingSync = null;
+    const syncRequest = { force, promise: null };
+    syncRequest.promise = runInOrder(async () => {
+      try {
+        const config = await configStore.read();
+        if (!config) return safeConfig(null);
+        if (!syncRequest.force && lastSyncedAt && Date.now() - new Date(lastSyncedAt).getTime() < SYNC_INTERVAL_MS) {
+          return safeConfig(config, lastSyncedAt);
+        }
+        return await syncWithConfig(config);
+      } finally {
+        pendingSync = null;
+      }
     });
-    return pendingSync;
+    pendingSync = syncRequest;
+    return syncRequest.promise;
   }
 
   async function resolveTransition(config, issueKey, targetStatus) {
@@ -346,54 +364,58 @@ export function createJiraIntegration({ configStore, database, fetch: fetchImple
       return safeConfig(await configStore.read(), lastSyncedAt);
     },
     async configure(input) {
-      const current = await configStore.read();
-      const username = input.username || current?.username;
-      const password = input.password || current?.password;
-      const candidate = configStore.validate({ ...input, username, password });
-      if (current?.version === 1 && candidate.baseUrl !== current.baseUrl) {
-        throw new ApiError(
-          409,
-          "JIRA_LEGACY_URL_CHANGE_UNAVAILABLE",
-          "请先使用原 Jira 地址完成配置升级，再修改地址",
+      return runInOrder(async () => {
+        const current = await configStore.read();
+        const username = input.username || current?.username;
+        const password = input.password || current?.password;
+        const candidate = configStore.validate({ ...input, username, password });
+        if (current?.version === 1 && candidate.baseUrl !== current.baseUrl) {
+          throw new ApiError(
+            409,
+            "JIRA_LEGACY_URL_CHANGE_UNAVAILABLE",
+            "请先使用原 Jira 地址完成配置升级，再修改地址",
+          );
+        }
+        if (
+          !input.password
+          && (
+            !current
+            || candidate.baseUrl !== current.baseUrl
+            || candidate.username !== current.username
+          )
+        ) {
+          throw new ApiError(
+            400,
+            "JIRA_PASSWORD_REQUIRED",
+            "修改 Jira 地址或用户名时必须重新输入密码",
+          );
+        }
+        const { config, issues } = await validateConnection(candidate);
+        const legacyIdentity = current?.version === 1
+          ? { urlHash: legacyJiraOriginId(current.baseUrl), originId: config.originId }
+          : null;
+        database.syncJiraTasks(
+          issues.map((issue, index) => normalizeIssue(issue, config, index)),
+          {
+            archiveMissing: true,
+            projectName: `Jira · ${config.displayName}`,
+            legacyIdentity,
+          },
         );
-      }
-      if (
-        !input.password
-        && (
-          !current
-          || candidate.baseUrl !== current.baseUrl
-          || candidate.username !== current.username
-        )
-      ) {
-        throw new ApiError(
-          400,
-          "JIRA_PASSWORD_REQUIRED",
-          "修改 Jira 地址或用户名时必须重新输入密码",
-        );
-      }
-      const { config, issues } = await validateConnection(candidate);
-      const legacyIdentity = current?.version === 1
-        ? { urlHash: legacyJiraOriginId(current.baseUrl), originId: config.originId }
-        : null;
-      database.syncJiraTasks(
-        issues.map((issue, index) => normalizeIssue(issue, config, index)),
-        {
-          archiveMissing: true,
-          projectName: `Jira · ${config.displayName}`,
-          legacyIdentity,
-        },
-      );
-      const savedConfig = await configStore.save(config);
-      lastSyncedAt = new Date().toISOString();
-      return safeConfig(savedConfig, lastSyncedAt);
+        const savedConfig = await configStore.save(config);
+        lastSyncedAt = new Date().toISOString();
+        return safeConfig(savedConfig, lastSyncedAt);
+      });
     },
     sync,
     async reconcile() {
-      const config = await configStore.read();
-      if (!config || config.version !== 2) {
-        throw new ApiError(409, "JIRA_NOT_CONFIGURED", "Jira 尚未完成稳定身份配置");
-      }
-      return syncWithConfig(config, { archiveMissing: false });
+      return runInOrder(async () => {
+        const config = await configStore.read();
+        if (!config || config.version !== 2) {
+          throw new ApiError(409, "JIRA_NOT_CONFIGURED", "Jira 尚未完成稳定身份配置");
+        }
+        return syncWithConfig(config, { archiveMissing: false });
+      });
     },
     async updateTask(task, changes) {
       const config = await configStore.read();


### PR DESCRIPTION
旧 Jira 同步请求挂起时，用户保存新配置；旧响应晚返回会再次写入同一 Jira 项目，并归档新配置刚同步的任务。此改动让 `configure`、`sync` 和 `reconcile` 共用集成实例内的执行顺序，在获得执行权后读取配置。

保留普通同步去重、60 秒节流、强制同步、错误传递和现有数据库绑定/版本语义。仅修改 `server/jira-integration.mjs`。

验证：用真实临时配置文件、SQLite 和可控 Jira 响应复现原竞态；修复后 B 的任务保持活动，排队的 reconcile 读取 B。并发同步只发出一次搜索，无变化时版本保持，内容变化时版本增加一次，五字段绑定保留。`node --check` 和 `git diff --check` 通过。未使用真实 Jira 或已安装 App 数据。

对应 Taskboard：LOCAL-415。
