### PR TITLE
Use explicit Launcher lifecycle events

### DIFF
--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -2800,6 +2800,10 @@ async function resolveRunnableCodexExecutable(appPath) {
   return cachedExecutable;
 }
 
+function emitLauncherEvent(event) {
+  console.log(JSON.stringify({ launcherEvent: event }));
+}
+
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   options.startupToken ??= taskboardInstanceToken;
@@ -2884,6 +2888,7 @@ async function main() {
   const queueTaskboardOpen = () => {
     openRequestGeneration += 1;
     console.log(JSON.stringify({ openTaskboardSignalQueued: true }));
+    emitLauncherEvent("openSignalQueued");
   };
   let openControl = null;
   const requestTaskboardOpen = async () => {
@@ -2898,6 +2903,7 @@ async function main() {
         await openWithDefaultApplication(deepLink.toString());
         openedRequestGeneration = Math.max(openedRequestGeneration, generation);
         console.log(JSON.stringify({ openedTaskboardInExistingCodex: true }));
+        emitLauncherEvent("openedInExistingCodex");
         return true;
       }
       const evaluation = await connection.send("Runtime.evaluate", {
@@ -2946,6 +2952,7 @@ async function main() {
       process.on("SIGUSR2", queueTaskboardOpen);
     }
     console.log(JSON.stringify({ openTaskboardSignalReady: true }));
+    emitLauncherEvent("openSignalReady");
   }
   const detached = !options.watch;
   const codexConnectionForHost = async (hostId) => {
@@ -2995,7 +3002,10 @@ async function main() {
   const supervisor = createTaskboardSupervisor({
     detached,
     isReachable: isTaskboardReachable,
-    waitUntilReachable: waitUntilTaskboardReachable,
+    waitUntilReachable: async (timeoutMs) => {
+      await waitUntilTaskboardReachable(timeoutMs);
+      emitLauncherEvent("serviceReady");
+    },
     start: () => {
       const child = startTaskboard({
         detached,
@@ -3139,6 +3149,7 @@ async function main() {
       nativeCodexBrowser = false;
       idleAfterNormalExit = true;
       console.error(`Waiting for Codex after update recovery failed: ${restartError.message}`);
+      emitLauncherEvent("waitingForCodex");
     }
     return true;
   };
@@ -3247,6 +3258,7 @@ async function main() {
         );
         idleAfterNormalExit = true;
         console.error(`Waiting for Codex launch: ${error.message}`);
+        emitLauncherEvent("waitingForCodex");
       }
     } else {
       if (options.launch) {
@@ -3298,6 +3310,7 @@ async function main() {
       } catch (error) {
         if (!options.watch) throw error;
         console.error(`Waiting for Codex renderer: ${error.message}`);
+        emitLauncherEvent("waitingForCodex");
       }
     }
     if (stopping) return;
@@ -3307,6 +3320,7 @@ async function main() {
         activateCodexApp(codexAppPid);
       }
       console.log(JSON.stringify({ injected: firstResults }, null, 2));
+      emitLauncherEvent("injected");
     }
     if (hasOpenPending()) {
       await requestTaskboardOpen();
@@ -3341,6 +3355,7 @@ async function main() {
           console.error(
             "Waiting for Codex after exit; open Codex Taskboard again to restart it.",
           );
+          emitLauncherEvent("waitingForCodex");
           continue;
         }
         if (hasOpenPending()) await requestTaskboardOpen();
@@ -3389,6 +3404,7 @@ async function main() {
         );
         if (results.length > 0) {
           console.log(JSON.stringify({ injected: results }, null, 2));
+          emitLauncherEvent("injected");
         }
         if (hasOpenPending()) {
           await requestTaskboardOpen();
@@ -3421,6 +3437,7 @@ async function main() {
             console.error(
               "Waiting for Codex after normal exit; open Codex Taskboard again to restart it.",
             );
+            emitLauncherEvent("waitingForCodex");
             continue;
           }
           if (
@@ -3456,6 +3473,7 @@ async function main() {
               console.error(
                 "Waiting for Codex after normal exit; open Codex Taskboard again to restart it.",
               );
+              emitLauncherEvent("waitingForCodex");
               continue;
             }
             console.error("Codex exited unexpectedly; restarting it for the taskboard launcher.");
@@ -3483,9 +3501,11 @@ async function main() {
           console.error(
             "Waiting for Codex after exit; open Codex Taskboard again to restart it.",
           );
+          emitLauncherEvent("waitingForCodex");
           continue;
         }
         console.error(`Waiting for Codex renderer: ${error.message}`);
+        emitLauncherEvent("waitingForCodex");
       }
     }
   } finally {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -925,7 +925,6 @@ fn update_snapshot(
                 match snapshot.phase.as_str() {
                     "running" => "运行状态：正常",
                     "error" => "运行状态：异常",
-                    "stopped" => "运行状态：已停止",
                     _ => "运行状态：启动中",
                 }
             };
@@ -2469,6 +2468,16 @@ fn main() {
             #[cfg(target_os = "macos")]
             app.set_activation_policy(ActivationPolicy::Accessory);
             let home_directory = app.path().home_dir()?;
+            let bundled_skill = app
+                .path()
+                .resource_dir()?
+                .join("app/skills/manage-taskboard");
+            let legacy_skill_conflict = reconcile_legacy_skill(&home_directory, &bundled_skill)?;
+            let global_skill = home_directory.join(".agents/skills/manage-taskboard");
+            if global_skill.exists() {
+                fs::remove_dir_all(&global_skill)?;
+            }
+            copy_directory(&bundled_skill, &global_skill)?;
             #[cfg(target_os = "macos")]
             let data_directory = home_directory.join("Library/Application Support/Codex Taskboard");
             #[cfg(target_os = "macos")]
@@ -2502,16 +2511,6 @@ fn main() {
                 app.handle().exit(0);
                 return Ok(());
             };
-            let bundled_skill = app
-                .path()
-                .resource_dir()?
-                .join("app/skills/manage-taskboard");
-            let legacy_skill_conflict = reconcile_legacy_skill(&home_directory, &bundled_skill)?;
-            let global_skill = home_directory.join(".agents/skills/manage-taskboard");
-            if global_skill.exists() {
-                fs::remove_dir_all(&global_skill)?;
-            }
-            copy_directory(&bundled_skill, &global_skill)?;
             let version = release_version().to_string();
             let state = Arc::new(LauncherState::new(
                 data_directory,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -139,6 +139,17 @@ struct LauncherRuntimeDescriptor {
     url: String,
 }
 
+#[derive(Deserialize)]
+#[serde(tag = "launcherEvent", rename_all = "camelCase")]
+enum LauncherEvent {
+    WaitingForCodex,
+    ServiceReady,
+    OpenSignalReady,
+    OpenSignalQueued,
+    OpenedInExistingCodex,
+    Injected,
+}
+
 struct LauncherState {
     child: Mutex<Option<u32>>,
     snapshot: Mutex<LauncherSnapshot>,
@@ -914,6 +925,7 @@ fn update_snapshot(
                 match snapshot.phase.as_str() {
                     "running" => "运行状态：正常",
                     "error" => "运行状态：异常",
+                    "stopped" => "运行状态：已停止",
                     _ => "运行状态：启动中",
                 }
             };
@@ -1342,8 +1354,10 @@ fn process_group_is_running(pid: u32) -> bool {
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]
-fn signal_pending_taskboard_open(state: &LauncherState) -> Result<(), String> {
-    let mut snapshot = state.snapshot.lock().unwrap();
+fn signal_pending_taskboard_open(
+    _state: &LauncherState,
+    snapshot: &mut LauncherSnapshot,
+) -> Result<(), String> {
     if !snapshot.open_request_pending {
         return Ok(());
     }
@@ -1358,8 +1372,10 @@ fn signal_pending_taskboard_open(state: &LauncherState) -> Result<(), String> {
 }
 
 #[cfg(target_os = "windows")]
-fn signal_pending_taskboard_open(state: &LauncherState) -> Result<(), String> {
-    let mut snapshot = state.snapshot.lock().unwrap();
+fn signal_pending_taskboard_open(
+    state: &LauncherState,
+    snapshot: &mut LauncherSnapshot,
+) -> Result<(), String> {
     if !snapshot.open_request_pending {
         return Ok(());
     }
@@ -1539,64 +1555,48 @@ fn watch_launcher_output<R: std::io::Read + Send + 'static>(
     thread::spawn(move || {
         for line in BufReader::new(reader).lines().map_while(Result::ok) {
             append_log(&state, &line);
-            if is_stderr && line.contains("Waiting for Codex") {
-                update_snapshot(&app, &state, |snapshot| {
-                    if state.generation.load(Ordering::SeqCst) == generation
-                        && snapshot.child_pid == Some(pid)
-                    {
+            if is_stderr {
+                continue;
+            }
+            let Ok(event) = serde_json::from_str::<LauncherEvent>(&line) else {
+                continue;
+            };
+            update_snapshot(&app, &state, |snapshot| {
+                if state.generation.load(Ordering::SeqCst) != generation
+                    || snapshot.child_pid != Some(pid)
+                {
+                    return;
+                }
+                match event {
+                    LauncherEvent::WaitingForCodex => {
                         snapshot.phase = "starting".into();
                         snapshot.message = "正在等待 Codex 窗口…".into();
                     }
-                });
-            } else if !is_stderr && line.contains("Codex Taskboard listening") {
-                update_snapshot(&app, &state, |snapshot| {
-                    if state.generation.load(Ordering::SeqCst) == generation
-                        && snapshot.child_pid == Some(pid)
-                    {
+                    LauncherEvent::ServiceReady => {
                         snapshot.phase = "starting".into();
                         snapshot.message = "任务面板服务已启动，正在注入 Codex…".into();
                     }
-                });
-            } else if !is_stderr && line.contains("\"openTaskboardSignalReady\":true") {
-                let snapshot = update_snapshot(&app, &state, |snapshot| {
-                    if state.generation.load(Ordering::SeqCst) == generation
-                        && snapshot.child_pid == Some(pid)
-                    {
+                    LauncherEvent::OpenSignalReady => {
                         snapshot.open_signal_pid = Some(pid);
+                        if let Err(error) = signal_pending_taskboard_open(&state, snapshot) {
+                            append_log(&state, &format!("Taskboard open signal failed: {error}"));
+                        }
                     }
-                });
-                if snapshot.child_pid == Some(pid) && snapshot.open_signal_pid == Some(pid) {
-                    if let Err(error) = signal_pending_taskboard_open(&state) {
-                        append_log(&state, &format!("Taskboard open signal failed: {error}"));
+                    LauncherEvent::OpenSignalQueued => {
+                        if snapshot.open_signal_pid == Some(pid) {
+                            snapshot.open_request_pending = false;
+                        }
                     }
-                }
-            } else if !is_stderr && line.contains("\"openTaskboardSignalQueued\":true") {
-                let mut snapshot = state.snapshot.lock().unwrap();
-                if state.generation.load(Ordering::SeqCst) == generation
-                    && snapshot.child_pid == Some(pid)
-                    && snapshot.open_signal_pid == Some(pid)
-                {
-                    snapshot.open_request_pending = false;
-                }
-            } else if !is_stderr && line.contains("\"openedTaskboardInExistingCodex\":true") {
-                update_snapshot(&app, &state, |snapshot| {
-                    if state.generation.load(Ordering::SeqCst) == generation
-                        && snapshot.child_pid == Some(pid)
-                    {
+                    LauncherEvent::OpenedInExistingCodex => {
                         snapshot.phase = "running".into();
                         snapshot.message = "任务面板已在现有 Codex 的浏览面板中打开。".into();
                     }
-                });
-            } else if !is_stderr && line.contains("\"injected\"") {
-                update_snapshot(&app, &state, |snapshot| {
-                    if state.generation.load(Ordering::SeqCst) == generation
-                        && snapshot.child_pid == Some(pid)
-                    {
+                    LauncherEvent::Injected => {
                         snapshot.phase = "running".into();
                         snapshot.message = "任务面板已在 Codex 客户端中打开。".into();
                     }
-                });
-            }
+                }
+            });
         }
     });
 }
@@ -1944,8 +1944,9 @@ fn restart_launcher(
 }
 
 fn open_taskboard(state: &LauncherState) -> Result<(), String> {
-    state.snapshot.lock().unwrap().open_request_pending = true;
-    signal_pending_taskboard_open(state)
+    let mut snapshot = state.snapshot.lock().unwrap();
+    snapshot.open_request_pending = true;
+    signal_pending_taskboard_open(state, &mut snapshot)
 }
 
 fn open_taskboard_in_browser(state: &LauncherState) -> Result<(), String> {
@@ -2468,16 +2469,6 @@ fn main() {
             #[cfg(target_os = "macos")]
             app.set_activation_policy(ActivationPolicy::Accessory);
             let home_directory = app.path().home_dir()?;
-            let bundled_skill = app
-                .path()
-                .resource_dir()?
-                .join("app/skills/manage-taskboard");
-            let legacy_skill_conflict = reconcile_legacy_skill(&home_directory, &bundled_skill)?;
-            let global_skill = home_directory.join(".agents/skills/manage-taskboard");
-            if global_skill.exists() {
-                fs::remove_dir_all(&global_skill)?;
-            }
-            copy_directory(&bundled_skill, &global_skill)?;
             #[cfg(target_os = "macos")]
             let data_directory = home_directory.join("Library/Application Support/Codex Taskboard");
             #[cfg(target_os = "macos")]
@@ -2511,6 +2502,16 @@ fn main() {
                 app.handle().exit(0);
                 return Ok(());
             };
+            let bundled_skill = app
+                .path()
+                .resource_dir()?
+                .join("app/skills/manage-taskboard");
+            let legacy_skill_conflict = reconcile_legacy_skill(&home_directory, &bundled_skill)?;
+            let global_skill = home_directory.join(".agents/skills/manage-taskboard");
+            if global_skill.exists() {
+                fs::remove_dir_all(&global_skill)?;
+            }
+            copy_directory(&bundled_skill, &global_skill)?;
             let version = release_version().to_string();
             let state = Arc::new(LauncherState::new(
                 data_directory,


### PR DESCRIPTION
Launcher 原先从英文诊断日志和多行 JSON 判断状态，诊断文字或排版会影响生命周期判定。现在 injector 在已有生命周期节点输出六种单行事件，Rust 将其解析为枚举，在统一核对 generation/PID 后更新阶段和 pending open。诊断日志与现有恢复流程保持原有行为。

对应 Taskboard：LOCAL-412。实现由 [GPT-6 Pro](https://chatgpt.com/c/6a9f9970-dc64-83e8-aaee-789bbfc552cd) 交付，Codex 独立验证。

验证：

- Node 语法与 diff 检查通过。
- ARM Rust 1.88 编译了实际事件接收函数；真实 Node stdout → Rust → SIGUSR2 → Node queue 验证六种事件和 pending open 确认。
- 诊断文字、多行展示、旧 generation/PID 不驱动状态；原生状态投影 API 未改。
- [exact-head CI](https://github.com/chuspeeism/dashi-taskboard/actions/runs/34195940932) 对 4ab2112fbbe6a22f447ad437df0a38e5a4bdf61f 五项全部成功，包含 Web、macOS universal、Windows x64、Ubuntu x64 Launcher。

未新增产品测试、依赖、兼容层或通用事件框架。隔离验证使用临时 Tauri 界面适配器，未将其表述为整套真实 Codex 冷启动/注入验证。
