### PR TITLE
共用任务卡拖拽预览与菜单关闭规则

### DIFF
--- a/web/src/components/BoardColumn.tsx
+++ b/web/src/components/BoardColumn.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
 import type { DragEvent } from "react";
+import { useTaskCardDragPreview } from "../useTaskCardDragPreview";
 import type { ActorIdentity, Task, TaskDraft, TaskStatus } from "../types";
 import { taskStatusLabel, useTaskboardI18n } from "../i18n";
 import type { TaskCardPresentation, TaskConversationItem } from "../taskConversations";
@@ -83,27 +83,8 @@ export function BoardColumn({
   const { language, text } = useTaskboardI18n();
   const details = STATUS_DETAILS[status];
   const label = taskStatusLabel(language, status);
-  const [dropBeforeTaskId, setDropBeforeTaskId] = useState<string | null | undefined>();
-  const taskIndexes = new Map(tasks.map((task, index) => [task.id, index]));
-  const remainingTasks = tasks.filter((task) => task.id !== draggedTaskId);
-  const remainingIndexes = new Map(remainingTasks.map((task, index) => [task.id, index]));
-  const draggedTaskIndex = draggedTaskId ? taskIndexes.get(draggedTaskId) ?? -1 : -1;
-  const beforeIndex = dropBeforeTaskId
-    ? remainingIndexes.get(dropBeforeTaskId) ?? remainingTasks.length
-    : remainingTasks.length;
-  const previewIndex = isDropTarget && dropBeforeTaskId !== undefined ? beforeIndex : -1;
-  const dragDistance = draggedTaskHeight + 8;
-
-  useEffect(() => {
-    if (!isDropTarget || !draggedTaskId) setDropBeforeTaskId(undefined);
-  }, [draggedTaskId, isDropTarget]);
-
-  function findDropBefore(container: HTMLElement, clientY: number): string | null {
-    const cards = Array.from(container.querySelectorAll<HTMLElement>("[data-task-id]"))
-      .filter((card) => card.dataset.taskId !== draggedTaskId);
-    return cards.find((card) => clientY < card.getBoundingClientRect().top + card.offsetHeight / 2)
-      ?.dataset.taskId ?? null;
-  }
+  const { findDropBefore, clearDropPreview, updateDropPreview, leaveDropPreview, getTaskDragShift } =
+    useTaskCardDragPreview({ tasks, draggedTaskId, draggedTaskHeight, isDropTarget });
 
   function handleDrop(event: DragEvent<HTMLElement>) {
     event.preventDefault();
@@ -111,18 +92,7 @@ export function BoardColumn({
       event.dataTransfer.getData("application/x-taskboard-task") ||
       event.dataTransfer.getData("text/plain");
     if (taskId) onDrop(status, taskId, findDropBefore(event.currentTarget, event.clientY));
-    setDropBeforeTaskId(undefined);
-  }
-
-  function getTaskDragShift(task: Task): number {
-    if (!draggedTaskId || task.id === draggedTaskId) return 0;
-    let shift = 0;
-    const taskIndex = taskIndexes.get(task.id) ?? -1;
-    const remainingIndex = remainingIndexes.get(task.id) ?? -1;
-
-    if (draggedTaskIndex >= 0 && taskIndex > draggedTaskIndex) shift -= dragDistance;
-    if (previewIndex >= 0 && remainingIndex >= previewIndex) shift += dragDistance;
-    return shift;
+    clearDropPreview();
   }
 
   return (
@@ -131,16 +101,10 @@ export function BoardColumn({
       aria-labelledby={`column-${status}`}
       onDragEnter={() => onDragEnter(status)}
       onDragOver={(event) => {
-        event.preventDefault();
-        event.dataTransfer.dropEffect = "move";
         onDragEnter(status);
-        setDropBeforeTaskId(findDropBefore(event.currentTarget, event.clientY));
+        updateDropPreview(event);
       }}
-      onDragLeave={(event) => {
-        if (!(event.relatedTarget instanceof Node) || !event.currentTarget.contains(event.relatedTarget)) {
-          setDropBeforeTaskId(undefined);
-        }
-      }}
+      onDragLeave={leaveDropPreview}
       onDrop={handleDrop}
     >
       <header className="column-header">
@@ -169,7 +133,7 @@ export function BoardColumn({
 
       <div className="column-list" ref={scrollRef}>
         {tasks.map((task) => {
-          const dragShift = getTaskDragShift(task);
+          const dragShift = getTaskDragShift(task.id);
           return (
             <TaskCard
               key={task.id}

--- a/web/src/components/OtherTasksPanel.tsx
+++ b/web/src/components/OtherTasksPanel.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from "react";
 import type { CSSProperties, DragEvent } from "react";
+import { useTaskCardDragPreview } from "../useTaskCardDragPreview";
 import type { ActorIdentity, Task, TaskDraft, TaskStatus } from "../types";
 import type { TaskCardPresentation, TaskConversationItem } from "../taskConversations";
 import { taskStatusLabel, useTaskboardI18n } from "../i18n";
@@ -206,27 +206,8 @@ export function OtherTasksPanel({
     ? text("已归档", "Archived")
     : taskStatusLabel(language, activeTab);
   const tasks = archived ? archivedTasks : tasksByStatus[activeTab];
-  const [dropBeforeTaskId, setDropBeforeTaskId] = useState<string | null | undefined>();
-  const taskIndexes = new Map(tasks.map((task, index) => [task.id, index]));
-  const remainingTasks = tasks.filter((task) => task.id !== draggedTaskId);
-  const remainingIndexes = new Map(remainingTasks.map((task, index) => [task.id, index]));
-  const draggedTaskIndex = draggedTaskId ? taskIndexes.get(draggedTaskId) ?? -1 : -1;
-  const beforeIndex = dropBeforeTaskId
-    ? remainingIndexes.get(dropBeforeTaskId) ?? remainingTasks.length
-    : remainingTasks.length;
-  const previewIndex = isDropTarget && dropBeforeTaskId !== undefined ? beforeIndex : -1;
-  const dragDistance = draggedTaskHeight + 8;
-
-  useEffect(() => {
-    if (!isDropTarget || !draggedTaskId) setDropBeforeTaskId(undefined);
-  }, [draggedTaskId, isDropTarget]);
-
-  function findDropBefore(container: HTMLElement, clientY: number): string | null {
-    const cards = Array.from(container.querySelectorAll<HTMLElement>("[data-task-id]"))
-      .filter((card) => card.dataset.taskId !== draggedTaskId);
-    return cards.find((card) => clientY < card.getBoundingClientRect().top + card.offsetHeight / 2)
-      ?.dataset.taskId ?? null;
-  }
+  const { findDropBefore, clearDropPreview, updateDropPreview, leaveDropPreview, getTaskDragShift } =
+    useTaskCardDragPreview({ tasks, draggedTaskId, draggedTaskHeight, isDropTarget });
 
   function handleDrop(event: DragEvent<HTMLElement>) {
     event.preventDefault();
@@ -235,18 +216,7 @@ export function OtherTasksPanel({
       event.dataTransfer.getData("application/x-taskboard-task") ||
       event.dataTransfer.getData("text/plain");
     if (taskId) onDrop(activeTab, taskId, findDropBefore(event.currentTarget, event.clientY));
-    setDropBeforeTaskId(undefined);
-  }
-
-  function getTaskDragShift(task: Task): number {
-    if (!draggedTaskId || task.id === draggedTaskId) return 0;
-    let shift = 0;
-    const taskIndex = taskIndexes.get(task.id) ?? -1;
-    const remainingIndex = remainingIndexes.get(task.id) ?? -1;
-
-    if (draggedTaskIndex >= 0 && taskIndex > draggedTaskIndex) shift -= dragDistance;
-    if (previewIndex >= 0 && remainingIndex >= previewIndex) shift += dragDistance;
-    return shift;
+    clearDropPreview();
   }
 
   return (
@@ -311,16 +281,10 @@ export function OtherTasksPanel({
         }}
         onDragOver={(event) => {
           if (archived) return;
-          event.preventDefault();
-          event.dataTransfer.dropEffect = "move";
           onDragEnter(activeTab);
-          setDropBeforeTaskId(findDropBefore(event.currentTarget, event.clientY));
+          updateDropPreview(event);
         }}
-        onDragLeave={(event) => {
-          if (!(event.relatedTarget instanceof Node) || !event.currentTarget.contains(event.relatedTarget)) {
-            setDropBeforeTaskId(undefined);
-          }
-        }}
+        onDragLeave={leaveDropPreview}
         onDrop={handleDrop}
       >
         {archived ? archivedTasks.map((task) => (
@@ -333,7 +297,7 @@ export function OtherTasksPanel({
             onDelete={onDelete}
           />
         )) : tasks.map((task) => {
-          const dragShift = getTaskDragShift(task);
+          const dragShift = getTaskDragShift(task.id);
           return (
             <TaskCard
               key={task.id}

--- a/web/src/components/ProjectAutomationMenu.tsx
+++ b/web/src/components/ProjectAutomationMenu.tsx
@@ -5,6 +5,7 @@ import { ProjectIcon, RecurrenceIcon } from "./SemanticIcons";
 import { TaskPropertyPicker } from "./TaskPropertyPicker";
 import { TaskboardIcon } from "./TaskboardIcon";
 import { useTaskboardI18n } from "../i18n";
+import { listenForMenuViewportChange, listenForOutsidePointerDown } from "../menuEvents";
 import type { AiChatModel } from "../types";
 
 type AutomationStatus = "ACTIVE" | "PAUSED";
@@ -127,29 +128,20 @@ export function ProjectAutomationMenu({
 
   useEffect(() => {
     if (!open) return;
-    function closeFromOutside(event: PointerEvent) {
-      if (!menuRef.current?.contains(event.target as Node) && !triggerRef.current?.contains(event.target as Node)) {
-        setOpen(false);
-      }
-    }
-    function closeFromViewportChange() {
-      setOpen(false);
-    }
+    const close = () => setOpen(false);
+    const stopOutside = listenForOutsidePointerDown([triggerRef, menuRef], close);
+    const stopViewport = listenForMenuViewportChange(menuRef, close);
     function closeFromEscape(event: KeyboardEvent) {
       if (event.key === "Escape" && !pickerMenu) {
         setOpen(false);
         triggerRef.current?.focus();
       }
     }
-    document.addEventListener("pointerdown", closeFromOutside);
     document.addEventListener("keydown", closeFromEscape);
-    window.addEventListener("resize", closeFromViewportChange);
-    window.addEventListener("scroll", closeFromViewportChange, true);
     return () => {
-      document.removeEventListener("pointerdown", closeFromOutside);
+      stopOutside();
+      stopViewport();
       document.removeEventListener("keydown", closeFromEscape);
-      window.removeEventListener("resize", closeFromViewportChange);
-      window.removeEventListener("scroll", closeFromViewportChange, true);
     };
   }, [open, pickerMenu]);
 

--- a/web/src/components/TaskConversationMenu.tsx
+++ b/web/src/components/TaskConversationMenu.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useRef, useState, type SyntheticEvent } fro
 import { createPortal } from "react-dom";
 import type { TaskConversationItem } from "../taskConversations";
 import { useTaskboardI18n } from "../i18n";
+import { listenForMenuViewportChange, listenForOutsidePointerDown } from "../menuEvents";
 import { ConversationIcon } from "./SemanticIcons";
 
 interface TaskConversationMenuProps {
@@ -63,28 +64,19 @@ export function TaskConversationMenu({
 
   useEffect(() => {
     if (!open) return;
-    function closeFromOutside(event: PointerEvent) {
-      const target = event.target as Node;
-      if (triggerRef.current?.contains(target) || menuRef.current?.contains(target)) return;
-      setOpen(false);
-    }
+    const close = () => setOpen(false);
+    const stopOutside = listenForOutsidePointerDown([triggerRef, menuRef], close);
+    const stopViewport = listenForMenuViewportChange(menuRef, close);
     function closeFromEscape(event: KeyboardEvent) {
       if (event.key !== "Escape") return;
       setOpen(false);
       triggerRef.current?.focus();
     }
-    function closeFromViewportChange() {
-      setOpen(false);
-    }
-    document.addEventListener("pointerdown", closeFromOutside);
     window.addEventListener("keydown", closeFromEscape);
-    window.addEventListener("resize", closeFromViewportChange);
-    window.addEventListener("scroll", closeFromViewportChange, true);
     return () => {
-      document.removeEventListener("pointerdown", closeFromOutside);
+      stopOutside();
+      stopViewport();
       window.removeEventListener("keydown", closeFromEscape);
-      window.removeEventListener("resize", closeFromViewportChange);
-      window.removeEventListener("scroll", closeFromViewportChange, true);
     };
   }, [open]);
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -8218,6 +8218,8 @@ kbd {
   position: fixed;
   z-index: 1600;
   width: min(286px, calc(100vw - 16px));
+  max-height: calc(100vh - 16px);
+  overflow-y: auto;
   padding: 6px;
   border: var(--border-hairline) solid var(--border-strong);
   border-radius: 12px;

--- a/web/src/useTaskCardDragPreview.ts
+++ b/web/src/useTaskCardDragPreview.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState, type DragEvent } from "react";
+
+interface TaskCardDragPreviewOptions {
+  tasks: readonly { id: string }[];
+  draggedTaskId: string | null;
+  draggedTaskHeight: number;
+  isDropTarget: boolean;
+}
+
+export function useTaskCardDragPreview({
+  tasks,
+  draggedTaskId,
+  draggedTaskHeight,
+  isDropTarget,
+}: TaskCardDragPreviewOptions) {
+  const [dropBeforeTaskId, setDropBeforeTaskId] = useState<string | null | undefined>();
+  const taskIndexes = new Map(tasks.map((task, index) => [task.id, index]));
+  const remainingTasks = tasks.filter((task) => task.id !== draggedTaskId);
+  const remainingIndexes = new Map(remainingTasks.map((task, index) => [task.id, index]));
+  const draggedTaskIndex = draggedTaskId ? taskIndexes.get(draggedTaskId) ?? -1 : -1;
+  const beforeIndex = dropBeforeTaskId
+    ? remainingIndexes.get(dropBeforeTaskId) ?? remainingTasks.length
+    : remainingTasks.length;
+  const previewIndex = isDropTarget && dropBeforeTaskId !== undefined ? beforeIndex : -1;
+  const dragDistance = draggedTaskHeight + 8;
+
+  useEffect(() => {
+    if (!isDropTarget || !draggedTaskId) setDropBeforeTaskId(undefined);
+  }, [draggedTaskId, isDropTarget]);
+
+  function findDropBefore(container: HTMLElement, clientY: number): string | null {
+    const cards = Array.from(container.querySelectorAll<HTMLElement>("[data-task-id]"))
+      .filter((card) => card.dataset.taskId !== draggedTaskId);
+    return cards.find((card) => clientY < card.getBoundingClientRect().top + card.offsetHeight / 2)
+      ?.dataset.taskId ?? null;
+  }
+
+  function clearDropPreview() {
+    setDropBeforeTaskId(undefined);
+  }
+
+  function updateDropPreview(event: DragEvent<HTMLElement>) {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+    setDropBeforeTaskId(findDropBefore(event.currentTarget, event.clientY));
+  }
+
+  function leaveDropPreview(event: DragEvent<HTMLElement>) {
+    if (!(event.relatedTarget instanceof Node) || !event.currentTarget.contains(event.relatedTarget)) {
+      clearDropPreview();
+    }
+  }
+
+  function getTaskDragShift(taskId: string): number {
+    if (!draggedTaskId || taskId === draggedTaskId) return 0;
+    let shift = 0;
+    const taskIndex = taskIndexes.get(taskId) ?? -1;
+    const remainingIndex = remainingIndexes.get(taskId) ?? -1;
+
+    if (draggedTaskIndex >= 0 && taskIndex > draggedTaskIndex) shift -= dragDistance;
+    if (previewIndex >= 0 && remainingIndex >= previewIndex) shift += dragDistance;
+    return shift;
+  }
+
+  return { findDropBefore, clearDropPreview, updateDropPreview, leaveDropPreview, getTaskDragShift };
+}


### PR DESCRIPTION
主看板与侧栏现在共用任务卡的插入点、预览位移和拖出清理计算，保留各自的 DOM、归档禁拖和保存入口。会话及自动化菜单改用现有关闭事件工具，内部滚动保持打开，外部点击和视口变化关闭菜单；原有 Escape 与焦点处理保留。长会话菜单增加视口高度限制和内部滚动，使末尾会话可见。

对应 Taskboard：LOCAL-407、LOCAL-408。

验证：
- 真实隔离 Web：列内排序、侧栏与主板双向插入、刷新后的顺序、归档禁拖通过。
- 20 条会话菜单滚动到底部后保持打开；外部滚动、外部点击、Escape 和焦点恢复通过。
- 自动化组件以临时模型目录验证内部滚动、逐层 Escape、间隔选择与外部关闭；未运行 Codex 自动化任务。
- `npm run typecheck`、`npm run build:web` 通过；独立 Agent review 未发现阻碍。
