### PR TITLE
修复远程自动认领等待阻塞并复用完成通知

### DIFF
--- a/scripts/codex-injector.mjs
+++ b/scripts/codex-injector.mjs
@@ -109,7 +109,7 @@ const quotaPolicyQueues = new Map();
 const quotaPolicyCdps = new Set();
 const restoredQuotaPolicyCdps = new WeakSet();
 const quotaPolicyRestorePromises = new WeakMap();
-const remoteAutomationDecisionWaiters = new Map();
+const remoteAutomationTurnWaiters = new Map();
 let quotaPoliciesLoadPromise = null;
 let quotaPoliciesWritePromise = Promise.resolve();
 const taskConversationAppServerTimeoutMs = 30_000;
@@ -1403,44 +1403,61 @@ function remoteAutomationPrompt(task, comments, attachments, target) {
   ].join("\n");
 }
 
-function waitForRemoteAutomationDecision(hostId, threadId) {
+function waitForRemoteAutomationTurn(hostId, threadId) {
   const key = `${hostId}\0${threadId}`;
-  let cancel;
-  const promise = new Promise((resolve, reject) => {
-    const finish = (error, answer) => {
-      clearTimeout(timer);
-      remoteAutomationDecisionWaiters.delete(key);
-      if (error) reject(error);
-      else resolve(answer);
-    };
-    const timer = setTimeout(
-      () => finish(new Error("Codex 自动认领判断超时")),
-      remoteAutomationTurnTimeoutMs,
-    );
-    timer.unref();
-    remoteAutomationDecisionWaiters.set(key, { finish });
-    cancel = () => {
-      clearTimeout(timer);
-      remoteAutomationDecisionWaiters.delete(key);
-    };
-  });
-  return { promise, cancel };
+  const earlyTurns = new Map();
+  let expectedTurnId;
+  let resolveTurn;
+  const completed = new Promise((resolve) => { resolveTurn = resolve; });
+  const onCompleted = (turn) => {
+    // turn/completed can arrive before the turn/start RPC returns its id.
+    if (expectedTurnId === undefined) earlyTurns.set(turn.id, turn);
+    else if (turn.id === expectedTurnId) resolveTurn(turn);
+  };
+  remoteAutomationTurnWaiters.set(key, onCompleted);
+  const cancel = () => {
+    if (remoteAutomationTurnWaiters.get(key) === onCompleted) {
+      remoteAutomationTurnWaiters.delete(key);
+    }
+    earlyTurns.clear();
+  };
+  return {
+    cancel,
+    async wait(turnId, timeoutMessage, timeoutMs = remoteAutomationTurnTimeoutMs) {
+      expectedTurnId = turnId;
+      const earlyTurn = earlyTurns.get(turnId);
+      earlyTurns.clear();
+      let timer;
+      try {
+        if (earlyTurn) return earlyTurn;
+        return await Promise.race([
+          completed,
+          new Promise((_, reject) => {
+            timer = setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs);
+            timer.unref();
+          }),
+        ]);
+      } finally {
+        clearTimeout(timer);
+        cancel();
+      }
+    },
+  };
 }
 
-function handleRemoteAutomationDecisionNotification(notification) {
-  const params = notification.params;
-  const waiter = remoteAutomationDecisionWaiters.get(
-    `${notification.hostId}\0${params?.threadId}`,
-  );
-  if (!waiter) return;
+function handleRemoteAutomationTurnNotification(notification) {
   if (notification.method !== "turn/completed") return;
-  if (params.turn?.status !== "completed") {
-    waiter.finish(new Error(params.turn?.error?.message || "Codex 自动认领判断失败"));
-    return;
-  }
-  const answer = [...params.turn.items].reverse()
+  const params = notification.params;
+  if (typeof params?.turn?.id !== "string" || !params.turn.id) return;
+  const onCompleted = remoteAutomationTurnWaiters.get(
+    `${notification.hostId}\0${params.threadId}`,
+  );
+  onCompleted?.(params.turn);
+}
+
+function remoteAutomationTurnText(turn) {
+  return [...(turn?.items ?? [])].reverse()
     .find((item) => item.type === "agentMessage")?.text?.trim() || "";
-  waiter.finish(null, answer);
 }
 
 async function remoteAutomationCanStart(cdp, request, task, comments) {
@@ -1464,7 +1481,8 @@ async function remoteAutomationCanStart(cdp, request, task, comments) {
     throw new Error("Codex 未创建临时自动认领判断线程");
   }
 
-  const completion = waitForRemoteAutomationDecision(request.codexHostId, threadId);
+  const deadline = Date.now() + remoteAutomationTurnTimeoutMs;
+  const completion = waitForRemoteAutomationTurn(request.codexHostId, threadId);
   let turnStarted;
   try {
     turnStarted = await requestCodexAppServerViaCdp(
@@ -1513,7 +1531,15 @@ async function remoteAutomationCanStart(cdp, request, task, comments) {
     completion.cancel();
     throw new Error("Codex 未返回自动认领判断 turn");
   }
-  const answer = await completion.promise;
+  const turn = await completion.wait(
+    turnId,
+    "Codex 自动认领判断超时",
+    Math.max(0, deadline - Date.now()),
+  );
+  if (turn.status !== "completed") {
+    throw new Error(turn.error?.message || "Codex 自动认领判断失败");
+  }
+  const answer = remoteAutomationTurnText(turn);
   let decision;
   try {
     decision = JSON.parse(answer).decision;
@@ -1535,20 +1561,25 @@ async function runRemoteTaskboardAutomation(record) {
   const listed = await taskboardRequest(
     `/api/tasks?projectId=${encodeURIComponent(request.taskboardProjectId)}&status=todo`,
   );
-  const listedTask = listed.tasks?.find(eligibleRemoteAutomationTask);
-  if (!listedTask) return;
-
-  const taskPath = `/api/tasks/${encodeURIComponent(listedTask.id)}`;
-  const commentsPath = `${taskPath}/comments`;
-  const attachmentsPath = `${taskPath}/attachments`;
-  const [{ task }, { comments }, { attachments }] = await Promise.all([
-    taskboardRequest(taskPath),
-    taskboardRequest(commentsPath),
-    taskboardRequest(attachmentsPath),
-  ]);
-  if (!eligibleRemoteAutomationTask(task) || task.projectId !== request.taskboardProjectId) return;
-  const cdp = currentQuotaPolicyCdp();
-  if (!(await remoteAutomationCanStart(cdp, request, task, comments))) return;
+  let selected;
+  for (const listedTask of listed.tasks ?? []) {
+    if (!eligibleRemoteAutomationTask(listedTask)) continue;
+    const taskPath = `/api/tasks/${encodeURIComponent(listedTask.id)}`;
+    const commentsPath = `${taskPath}/comments`;
+    const attachmentsPath = `${taskPath}/attachments`;
+    const [{ task }, { comments }, { attachments }] = await Promise.all([
+      taskboardRequest(taskPath),
+      taskboardRequest(commentsPath),
+      taskboardRequest(attachmentsPath),
+    ]);
+    if (!eligibleRemoteAutomationTask(task) || task.projectId !== request.taskboardProjectId) return;
+    const cdp = currentQuotaPolicyCdp();
+    if (!(await remoteAutomationCanStart(cdp, request, task, comments))) continue;
+    selected = { taskPath, commentsPath, attachmentsPath, task, comments, attachments, cdp };
+    break;
+  }
+  if (!selected) return;
+  const { taskPath, commentsPath, attachmentsPath, task, comments, attachments, cdp } = selected;
   const existingBinding = task.threadBinding?.codexProjectKind === "remote"
     ? task.threadBinding
     : null;
@@ -1624,6 +1655,7 @@ async function runRemoteTaskboardAutomation(record) {
     })
   ).task;
 
+  const completion = waitForRemoteAutomationTurn(target.codexHostId, threadId);
   try {
     const turnStarted = await requestCodexAppServerViaCdp(
       cdp,
@@ -1649,36 +1681,26 @@ async function runRemoteTaskboardAutomation(record) {
       throw new Error("Codex did not return the remote automation turn id");
     }
 
-    const deadline = Date.now() + remoteAutomationTurnTimeoutMs;
-    let finalText = "";
-    while (Date.now() < deadline) {
-      let read;
-      try {
-        read = await requestCodexAppServerViaCdp(
-          cdp,
-          undefined,
-          target.codexHostId,
-          "thread/read",
-          { threadId, includeTurns: true },
-        );
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        if (!message.includes("rollout") || !message.includes("is empty")) throw error;
-        await new Promise((resolve) => setTimeout(resolve, 1_000));
-        continue;
-      }
-      const turn = read?.thread?.turns?.find((candidate) => candidate.id === turnId);
-      if (turn?.status === "completed") {
-        finalText = [...turn.items].reverse().find((item) => item.type === "agentMessage")?.text?.trim() || "";
-        if (!finalText) throw new Error("Codex completed without a final result");
-        break;
-      }
-      if (turn?.status === "failed" || turn?.status === "interrupted") {
-        throw new Error(turn.error?.message || `Codex remote turn ${turn.status}`);
-      }
-      await new Promise((resolve) => setTimeout(resolve, 1_000));
+    const turn = await completion.wait(turnId, "Codex remote automation turn timed out");
+    if (turn.status !== "completed") {
+      throw new Error(turn.error?.message || `Codex remote turn ${turn.status}`);
     }
-    if (!finalText) throw new Error("Codex remote automation turn timed out");
+    let finalText = remoteAutomationTurnText(turn);
+    if (!finalText) {
+      // Some completion notifications omit items; read the completed turn once.
+      const read = await requestCodexAppServerViaCdp(
+        cdp,
+        undefined,
+        target.codexHostId,
+        "thread/read",
+        { threadId, includeTurns: true },
+      );
+      const savedTurn = read?.thread?.turns?.find((candidate) => (
+        candidate.id === turnId && candidate.status === "completed"
+      ));
+      finalText = remoteAutomationTurnText(savedTurn);
+    }
+    if (!finalText) throw new Error("Codex completed without a final result");
 
     await taskboardRequest(commentsPath, {
       method: "POST",
@@ -1725,6 +1747,8 @@ async function runRemoteTaskboardAutomation(record) {
         threadBinding,
       },
     });
+  } finally {
+    completion.cancel();
   }
 }
 
@@ -2982,7 +3006,7 @@ async function main() {
     );
   };
   const forwardCodexAppServerNotification = (cdp, notification) => {
-    handleRemoteAutomationDecisionNotification(notification);
+    handleRemoteAutomationTurnNotification(notification);
     if (remoteCodexConnections.get(notification.hostId) !== cdp) return;
     if (!taskboardChild?.connected) return;
     taskboardChild.send({

--- a/shared/taskboard-automation.mjs
+++ b/shared/taskboard-automation.mjs
@@ -96,12 +96,15 @@ export function buildTaskboardAutomationPrompt(request) {
   const taskctlCommand = buildTaskctlCommand(request);
   const remoteProject = request.codexProjectKind === "remote";
   const remoteProjects = request.remoteProjects ?? [];
+  const candidateInstructions = [
+    "从返回的 todo 中只选择依赖已完成的议题：relations.blockedBy 为空，或其中每个依赖的 status 都严格等于 done。无依赖的 todo 仍可并行处理。若有 todo 但全部被未完成依赖阻塞，本轮直接结束，不暂停自动化，也不创建或打开新的任务会话。",
+    "每次仅处理一个符合依赖条件的 todo：选定后先用 issue get 读取最新议题内容，并用 comment list 读取全部评论。根据描述和最新评论判断是否允许开始；若其中写明等待、暂不执行或当前不应开始，立即跳过并报告，不改状态。评论也包含已完成后被打回的返工要求。",
+    "完成 issue get 和 comment list 后、移动状态前，必须再次运行 issue get，并复核 relations.blockedBy 仍为空或其中每个依赖的 status 都严格等于 done。若依赖条件不再满足，立即跳过并结束本轮，不改状态，也不暂停自动化。",
+  ];
   const executionInstructions = remoteProject
     ? [
         `本自动化仅在本机作为任务面板控制器运行；实际开发必须派发到 Codex SSH 远程项目。导入项目的基础 identity 是 projectId=${JSON.stringify(request.codexProjectId)}、hostId=${JSON.stringify(request.codexHostId)}、workspacePath=${JSON.stringify(request.workspacePath)}；同一保存主机当前可用的精确远程项目映射是 ${JSON.stringify(remoteProjects)}。不要在当前本地自动化会话修改项目文件。`,
-        "从返回的 todo 中只选择依赖已完成的议题：relations.blockedBy 为空，或其中每个依赖的 status 都严格等于 done。无依赖的 todo 仍可并行处理。若有 todo 但全部被未完成依赖阻塞，本轮直接结束，不暂停自动化，也不创建或打开新的任务会话。",
-        "每次仅处理一个符合依赖条件的 todo：选定后先用 issue get 读取最新议题内容，并用 comment list 读取全部评论。根据描述和最新评论判断是否允许开始；若其中写明等待、暂不执行或当前不应开始，立即跳过并报告，不改状态。评论也包含已完成后被打回的返工要求。",
-        "完成 issue get 和 comment list 后、移动状态前，必须再次运行 issue get，并复核 relations.blockedBy 仍为空或其中每个依赖的 status 都严格等于 done。若依赖条件不再满足，立即跳过并结束本轮，不改状态，也不暂停自动化。",
+        ...candidateInstructions,
         "先检查 issue get 的 projectId、version、status、archivedAt、threadId 和 threadBinding。完整 threadBinding 包含 threadId、codexProjectId、codexProjectKind、codexHostId、workspacePath，且它是该议题后续 send、wait 和状态写回的唯一目标；当前自动化的项目和主机只能作为未绑定议题的首次目标，不能替换已有绑定。若存在 threadId 但没有完整 threadBinding，这是只能由 UI 打开的 legacy local 绑定：使用 comment add 说明自动化无法确认项目和主机，再使用首次读取的 version 作为 --if-version、用 --binding-thread-id 保留原 threadId 将议题移动到 blocked；若冲突立即停止。不得 send、create 或覆盖该绑定。",
         `未绑定议题必须先从上述精确远程项目映射解析 actualTarget。若 developmentContext.type 是 worktree，只保留 codexProjectKind="remote"、codexHostId=${JSON.stringify(request.codexHostId)} 且 workspacePath 与 developmentContext.path 完全相同的项；必须恰好命中一项，并使用该项自己的 codexProjectId、codexHostId 和 workspacePath。零项或多项时使用 comment add 明确记录“目标 SSH worktree 未映射”，随后结束本轮，不认领、不 create、不写基础项目 binding。若没有 worktree，actualTarget 才是上述基础 identity，并且它必须存在于精确映射中。不得回退到基础 root、local、项目名、其他主机或同路径的其他主机。`,
         "确认允许开始后，只有未绑定且仍为未归档 todo 的议题才可在读取代码、下载附件、分析或实施前，由当前本地控制器使用刚读取的 version 移到 in_progress。已有完整 threadBinding 时，issue move 必须同时传 --binding-thread-id、--binding-codex-project-id、--binding-codex-project-kind、--binding-codex-host-id、--binding-workspace-path 的保存值，但在旧会话 send/stale 判断完成前不得把这个 todo 移到 in_progress；stale 清除步骤按后文显式使用 --clear-binding-thread。未绑定时必须传 --clear-binding-thread，避免把本地控制器 CODEX_THREAD_ID 写成任务绑定。写入成功后记录响应 task 的 version 为 ownedVersion、projectId 为 ownedProjectId，并记录本轮 binding；以后本轮每次 issue move 都必须显式传 --if-version ownedVersion，成功后再用响应 version 更新 ownedVersion。不得省略 --if-version 后让 taskctl 自动读取最新 version。写入成功前不得继续。所有认领、评论和状态写入只由当前本地控制器完成，不得要求远程会话运行 taskctl。",
@@ -113,9 +116,7 @@ export function buildTaskboardAutomationPrompt(request) {
         "使用 Codex wait_threads 等待远程会话时，目标必须使用任务保存的 threadBinding.threadId 和 threadBinding.codexHostId。wait_threads 失败、远程会话明确需要用户输入或无法继续时，使用 comment add 记录原因，再用 ownedVersion、显式 --if-version 和完整保存 binding 将议题移动到 blocked；409 时立即停止。远程会话完成后，使用 comment add 写入改动、验证结果、执行结果和剩余风险，再用 ownedVersion、显式 --if-version 和完整保存 binding 将议题移动到 in_review。worker 确认后的每一次 issue move 都必须显式传完整远程 binding；不要把未完成工作标记为 in_review。",
       ]
     : [
-        "从返回的 todo 中只选择依赖已完成的议题：relations.blockedBy 为空，或其中每个依赖的 status 都严格等于 done。无依赖的 todo 仍可并行处理。若有 todo 但全部被未完成依赖阻塞，本轮直接结束，不暂停自动化，也不创建或打开新的任务会话。",
-        "每次仅处理一个符合依赖条件的 todo：选定后先用 issue get 读取最新议题内容，并用 comment list 读取全部评论。根据描述和最新评论判断是否允许开始；若其中写明等待、暂不执行或当前不应开始，立即跳过并报告，不改状态。评论也包含已完成后被打回的返工要求。",
-        "完成 issue get 和 comment list 后、移动状态前，必须再次运行 issue get，并复核 relations.blockedBy 仍为空或其中每个依赖的 status 都严格等于 done。若依赖条件不再满足，立即跳过并结束本轮，不改状态，也不暂停自动化。",
+        ...candidateInstructions,
         `确认允许开始后，只有 threadId 和 threadBinding 都为空且仍为未归档 todo 的议题才可在读取代码、下载附件、分析或实施前认领。认领必须使用刚读取的 version 移到 in_progress，并显式传 --binding-thread-id "$CODEX_THREAD_ID"、--binding-codex-project-id ${JSON.stringify(request.codexProjectId)}、--binding-codex-project-kind "local"、--binding-codex-host-id ${JSON.stringify(request.codexHostId)}、--binding-workspace-path ${JSON.stringify(request.workspacePath)}，把当前自动化会话一次写成完整 binding；记录响应 task.version 为 ownedVersion。写入成功前不得继续。已有完整 binding 或 legacy local binding 的议题必须先按旧会话规则处理，不得先认领；不得认领已被其他会话绑定或其他 Agent 领取的议题。认领后的每一次 issue move 都必须显式传 ownedVersion 和这五个完整 binding 字段，成功后更新 ownedVersion。`,
         "若因 version 陈旧发生版本冲突，重新运行 issue get 和 comment list；仅当仍为可认领 todo、未绑定其他会话、未归档且描述和最新评论未变化时，用最新 version 重试一次。若已被认领、状态或要求已变、已归档、服务或永久 API 错误，或重试仍失败，立即跳过该议题、退出并报告；不得抢占或循环重试。",
         `若首次 issue get 返回完整 threadBinding，议题已绑定原会话：不要在当前自动化会话认领；只能使用保存的 threadId 和 codexHostId 调用 Codex send_message_to_thread。send 成功时保留 binding 并结束本轮；只有工具明确返回终态 NOT_FOUND 或 CLOSED 等会话不存在或已关闭结果时才确认 stale。timeout、network failure、Codex host 暂时不可达或 Taskboard service unavailable 都保留 binding 并结束本轮，不得猜测 stale。确认 stale 后，先用 comment add 同时传 --thread-id 和完整旧 binding 保存历史，再用同一次 issue get 的 version 执行 issue move --status todo --clear-binding-thread --if-version；然后只重新 issue get 一次，仍为未归档 todo 且 threadId、threadBinding 都为空时，才在当前自动化会话处理。若任务已是 in_progress、活跃、已归档、状态或 binding 已变化，或发生 409，立即停止，不得抢占。若返回 threadId 但没有完整 threadBinding，这是 legacy local 绑定：先调用 Codex list_threads（limit=50），合并 pinnedThreads 与 threads，并按完整 threadId 精确查找。只有恰好一项 kind="codex"、projectId=${JSON.stringify(request.codexProjectId)}、hostId=${JSON.stringify(request.codexHostId)}、cwd=${JSON.stringify(request.workspacePath)} 全部一致时，才把该项视为可核验旧会话；使用最新 issue version 执行 issue move --status todo --if-version，并显式传旧 threadId 及上述 projectId、kind="local"、hostId、workspacePath 五字段，将 legacy local 原位升级为完整 binding。升级成功后只向该旧 threadId 和 hostId 调用 send_message_to_thread，随后结束本轮，由旧会话按议题最新要求继续。若 list_threads 未找到、出现多项或任一字段不一致，不得迁移或发送；使用 comment add 记录实际不一致项，再用首次读取的 version 和 --if-version、--binding-thread-id 保留原 threadId 将议题移到 blocked。若升级发生 409，立即停止，不得用新 version 覆盖。若没有 threadId，则按未绑定议题处理。`,
@@ -172,11 +173,6 @@ export function taskboardAutomationPolicyOperation(request, {
     && (!request.quotaAware || previousQuotaState === "available")
   ) return "list";
   if (request.quotaAware && quotaState !== "available") return "pause";
-  if (
-    explicit
-    || currentStatus === undefined
-    || (request.quotaAware && previousQuotaState !== "available")
-  ) return "ensure-active";
   return "ensure-active";
 }
 


### PR DESCRIPTION
远程自动认领遇到队首明确等待的议题后，原本会结束整轮，使后续可执行议题无法启动。现在按顺序跳过等待项，选中第一项可执行议题后只运行这一项；等待项及后续议题保持原状态。

正式远端执行复用现有宿主完成通知，按 host、thread、turn 匹配结果，处理 turn/start 返回前到达的完成事件。完整通知不再读取会话历史；通知缺少结果时只补读一次当前已完成 turn。保留旧会话恢复、完整绑定、快照/version 核对及失败、超时写回。同时合并三段相同提示语，移除返回值相同的 policy 条件。

验证：

- 从实际源码提取自动认领、语义判断及通知转发函数作隔离执行：wait/start/start 仅第二项完成；普通任务、恢复旧任务、提前通知、错误 host/thread/turn 的结果匹配通过。
- 完整通知 thread/read = 0；缺少 items 时为 1；失败、中断、超时沿原路径进入 blocked。
- 真实 Codex 0.153.4 独立 app-server stdio / ephemeral 回合：原生 turn/completed → 实际通知转发和等待器 → 临时 HTTP/SQLite Taskboard；唯一结果评论、in_review，thread/read = 0。
- 本地与远程提示词与基线逐字节一致；既有 automation 相关 12 项检查、两份源码语法检查和 diff 检查通过。未新增测试文件。

实现由 GPT-6 Pro 交付，Codex 独立检查并验证。精确提交 bf55fce72d64cffc3f642a1b2223281e93bf3ca1 的 Check、macOS、Windows、Linux 五项 CI 均通过。真实 SSH 传输和 Codex renderer 界面未验证；原生探针使用独立 stdio 和临时数据，未运行 injector 或变更共享 App/runtime。

Taskboard：LOCAL-394。
