### PR TITLE
复用 updater 下载验签并统一发布元数据

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -22,6 +22,7 @@ jobs:
       package_version: ${{ steps.validate.outputs.package_version }}
       release_version: ${{ steps.validate.outputs.release_version }}
       prerelease: ${{ steps.validate.outputs.prerelease }}
+      metadata: ${{ steps.validate.outputs.metadata }}
 
     steps:
       - name: Checkout
@@ -78,26 +79,11 @@ jobs:
             exit 1
           fi
 
-          STABLE_TAG="v$PACKAGE_VERSION"
-          BETA_PREFIX="$STABLE_TAG-beta."
-          if [[ "$RELEASE_TAG" == "$STABLE_TAG" ]]; then
-            RELEASE_VERSION="$PACKAGE_VERSION"
-            RELEASE_CHANNEL="stable"
-            PRERELEASE=false
-            BETA_NUMBER=""
-          elif [[ "$RELEASE_TAG" == "$BETA_PREFIX"* ]]; then
-            BETA_NUMBER="${RELEASE_TAG#"$BETA_PREFIX"}"
-            if [[ ! "$BETA_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
-              echo "Beta 标签必须是 $BETA_PREFIX 加正整数。" >&2
-              exit 1
-            fi
-            RELEASE_VERSION="$PACKAGE_VERSION-beta.$BETA_NUMBER"
-            RELEASE_CHANNEL="beta"
-            PRERELEASE=true
-          else
-            echo "发布标签必须是 $STABLE_TAG 或 $BETA_PREFIX<正整数>。" >&2
-            exit 1
-          fi
+          RELEASE_METADATA="$(node scripts/release-metadata-cli.mjs "$PACKAGE_VERSION" "$RELEASE_TAG")"
+          RELEASE_VERSION="$(jq -r '.releaseVersion' <<< "$RELEASE_METADATA")"
+          RELEASE_CHANNEL="$(jq -r '.channel' <<< "$RELEASE_METADATA")"
+          PRERELEASE="$(jq -r '.prerelease' <<< "$RELEASE_METADATA")"
+          BETA_NUMBER="$(jq -r '.betaNumber' <<< "$RELEASE_METADATA")"
 
           RELEASE_CHECK="$RUNNER_TEMP/release-check.json"
           if ! RELEASE_STATUS="$(curl --silent --show-error \
@@ -198,6 +184,7 @@ jobs:
           echo "package_version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
           echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
           echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "metadata=$RELEASE_METADATA" >> "$GITHUB_OUTPUT"
 
   release-linux:
     name: Build Ubuntu 24.04 x64 packages
@@ -206,6 +193,7 @@ jobs:
     timeout-minutes: 40
     env:
       CODEX_TASKBOARD_RELEASE_VERSION: ${{ needs['release-preflight'].outputs.release_version }}
+      RELEASE_METADATA: ${{ needs['release-preflight'].outputs.metadata }}
 
     steps:
       - name: Checkout
@@ -265,21 +253,22 @@ jobs:
 
       - name: Stage Ubuntu 24.04 x64 release assets
         run: |
-          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          LINUX_DEB_NAME="$(jq -r '.assets.linuxDeb' <<< "$RELEASE_METADATA")"
+          LINUX_APPIMAGE_NAME="$(jq -r '.assets.linuxAppImage' <<< "$RELEASE_METADATA")"
           LINUX_RELEASE="$RUNNER_TEMP/linux-release"
           mkdir -p "$LINUX_RELEASE"
           cp \
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb \
-            "$LINUX_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb"
+            "$LINUX_RELEASE/$LINUX_DEB_NAME"
           cp \
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb.sig \
-            "$LINUX_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb.sig"
+            "$LINUX_RELEASE/$LINUX_DEB_NAME.sig"
           cp \
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage \
-            "$LINUX_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage"
+            "$LINUX_RELEASE/$LINUX_APPIMAGE_NAME"
           cp \
             src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage.sig \
-            "$LINUX_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage.sig"
+            "$LINUX_RELEASE/$LINUX_APPIMAGE_NAME.sig"
 
       - name: Preserve Ubuntu 24.04 x64 release assets
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -342,7 +331,8 @@ jobs:
       CODEX_TASKBOARD_RELEASE_VERSION: ${{ needs['release-preflight'].outputs.release_version }}
       RELEASE_TAG: ${{ needs['release-preflight'].outputs.release_tag }}
       PACKAGE_VERSION: ${{ needs['release-preflight'].outputs.package_version }}
-      APP_NAME: ${{ needs['release-preflight'].outputs.prerelease == 'true' && 'Codex Taskboard Beta.app' || 'Codex Taskboard.app' }}
+      APP_NAME: ${{ fromJSON(needs['release-preflight'].outputs.metadata).appName }}
+      RELEASE_METADATA: ${{ needs['release-preflight'].outputs.metadata }}
 
     steps:
       - name: Checkout
@@ -452,8 +442,8 @@ jobs:
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
         run: |
           BUNDLE_ROOT="src-tauri/target/universal-apple-darwin/release/bundle"
-          RAW_DMG_NAME="${APP_NAME%.app}_${PACKAGE_VERSION}_universal.dmg"
-          RELEASE_DMG_NAME="Codex.Taskboard_${PACKAGE_VERSION}_universal.dmg"
+          RAW_DMG_NAME="$(jq -r '.rawDmgName' <<< "$RELEASE_METADATA")"
+          RELEASE_DMG_NAME="$(jq -r '.buildDmgName' <<< "$RELEASE_METADATA")"
           rm -f "$BUNDLE_ROOT/dmg/$RAW_DMG_NAME" "$BUNDLE_ROOT/macos/$RAW_DMG_NAME"
           (
             cd "$BUNDLE_ROOT/macos"
@@ -496,7 +486,7 @@ jobs:
           set -euo pipefail
           BUNDLE_ROOT="src-tauri/target/universal-apple-darwin/release/bundle"
           APP_PATH="$BUNDLE_ROOT/macos/$APP_NAME"
-          DMG_PATH="$BUNDLE_ROOT/dmg/Codex.Taskboard_${PACKAGE_VERSION}_universal.dmg"
+          DMG_PATH="$BUNDLE_ROOT/dmg/$(jq -r '.buildDmgName' <<< "$RELEASE_METADATA")"
           RELEASE_ROOT="$BUNDLE_ROOT/release"
           npm run app:verify-release -- "$APP_PATH" "$DMG_PATH" "$RELEASE_ROOT" "$RELEASE_TAG"
 
@@ -504,12 +494,15 @@ jobs:
         run: |
           BUNDLE_ROOT="src-tauri/target/universal-apple-darwin/release/bundle"
           MACOS_RELEASE="$RUNNER_TEMP/macos-release"
+          BUILD_DMG_NAME="$(jq -r '.buildDmgName' <<< "$RELEASE_METADATA")"
+          PUBLIC_DMG_NAME="$(jq -r '.assets.dmg' <<< "$RELEASE_METADATA")"
+          UPDATER_NAME="$(jq -r '.assets.macosUpdater' <<< "$RELEASE_METADATA")"
           mkdir -p "$MACOS_RELEASE"
           cp \
-            "$BUNDLE_ROOT/dmg/Codex.Taskboard_${PACKAGE_VERSION}_universal.dmg" \
-            "$MACOS_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg"
-          cp "$BUNDLE_ROOT/release/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" "$MACOS_RELEASE/"
-          cp "$BUNDLE_ROOT/release/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" "$MACOS_RELEASE/"
+            "$BUNDLE_ROOT/dmg/$BUILD_DMG_NAME" \
+            "$MACOS_RELEASE/$PUBLIC_DMG_NAME"
+          cp "$BUNDLE_ROOT/release/$UPDATER_NAME" "$MACOS_RELEASE/"
+          cp "$BUNDLE_ROOT/release/$UPDATER_NAME.sig" "$MACOS_RELEASE/"
           cp "$BUNDLE_ROOT/release/latest.json" "$MACOS_RELEASE/"
 
       - name: Preserve final public macOS release assets
@@ -539,6 +532,7 @@ jobs:
       RELEASE_TAG: ${{ needs['release-preflight'].outputs.release_tag }}
       PACKAGE_VERSION: ${{ needs['release-preflight'].outputs.package_version }}
       PRERELEASE: ${{ needs['release-preflight'].outputs.prerelease }}
+      RELEASE_METADATA: ${{ needs['release-preflight'].outputs.metadata }}
 
     steps:
       - name: Checkout
@@ -572,8 +566,8 @@ jobs:
       - name: Add and verify the Linux x64 updater
         run: |
           LATEST_PATH="$RUNNER_TEMP/macos-release/latest.json"
-          LINUX_DEB_NAME="Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb"
-          LINUX_APPIMAGE_NAME="Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage"
+          LINUX_DEB_NAME="$(jq -r '.assets.linuxDeb' <<< "$RELEASE_METADATA")"
+          LINUX_APPIMAGE_NAME="$(jq -r '.assets.linuxAppImage' <<< "$RELEASE_METADATA")"
           LINUX_DEB="$RUNNER_TEMP/linux-release/$LINUX_DEB_NAME"
           LINUX_APPIMAGE="$RUNNER_TEMP/linux-release/$LINUX_APPIMAGE_NAME"
           jq \
@@ -597,38 +591,35 @@ jobs:
           MACOS_RELEASE="$RUNNER_TEMP/macos-release"
           RELEASE_ASSETS="$RUNNER_TEMP/release-assets"
           MANIFEST_ROOT="$RUNNER_TEMP/release-manifest"
+          PUBLIC_DMG_NAME="$(jq -r '.assets.dmg' <<< "$RELEASE_METADATA")"
+          UPDATER_NAME="$(jq -r '.assets.macosUpdater' <<< "$RELEASE_METADATA")"
+          WINDOWS_INSTALLER_NAME="$(jq -r '.assets.windowsInstaller' <<< "$RELEASE_METADATA")"
+          LINUX_DEB_NAME="$(jq -r '.assets.linuxDeb' <<< "$RELEASE_METADATA")"
+          LINUX_APPIMAGE_NAME="$(jq -r '.assets.linuxAppImage' <<< "$RELEASE_METADATA")"
+          mapfile -t ASSET_NAMES < <(jq -r '.assetNames[]' <<< "$RELEASE_METADATA")
           mkdir -p "$RELEASE_ASSETS" "$MANIFEST_ROOT"
-          cp "$MACOS_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg" "$RELEASE_ASSETS/"
-          cp "$MACOS_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" "$RELEASE_ASSETS/"
-          cp "$MACOS_RELEASE/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" "$RELEASE_ASSETS/"
+          cp "$MACOS_RELEASE/$PUBLIC_DMG_NAME" "$RELEASE_ASSETS/"
+          cp "$MACOS_RELEASE/$UPDATER_NAME" "$RELEASE_ASSETS/"
+          cp "$MACOS_RELEASE/$UPDATER_NAME.sig" "$RELEASE_ASSETS/"
           cp "$MACOS_RELEASE/latest.json" "$RELEASE_ASSETS/"
           cp \
             "$RUNNER_TEMP/windows-preview/"*-setup.exe \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_NSIS-x64-unsigned.exe"
+            "$RELEASE_ASSETS/$WINDOWS_INSTALLER_NAME"
           cp \
-            "$RUNNER_TEMP/linux-release/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb" \
+            "$RUNNER_TEMP/linux-release/$LINUX_DEB_NAME" \
             "$RELEASE_ASSETS/"
           cp \
-            "$RUNNER_TEMP/linux-release/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb.sig" \
+            "$RUNNER_TEMP/linux-release/$LINUX_DEB_NAME.sig" \
             "$RELEASE_ASSETS/"
           cp \
-            "$RUNNER_TEMP/linux-release/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage" \
+            "$RUNNER_TEMP/linux-release/$LINUX_APPIMAGE_NAME" \
             "$RELEASE_ASSETS/"
           cp \
-            "$RUNNER_TEMP/linux-release/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage.sig" \
+            "$RUNNER_TEMP/linux-release/$LINUX_APPIMAGE_NAME.sig" \
             "$RELEASE_ASSETS/"
           (
             cd "$RELEASE_ASSETS"
-            shasum -a 256 \
-              "Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg" \
-              "Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb" \
-              "Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb.sig" \
-              "Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage" \
-              "Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage.sig" \
-              "Codex.Taskboard_${PACKAGE_VERSION}_NSIS-x64-unsigned.exe" \
-              "Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" \
-              "Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" \
-              "latest.json" > "$MANIFEST_ROOT/release-assets.sha256"
+            shasum -a 256 "${ASSET_NAMES[@]}" > "$MANIFEST_ROOT/release-assets.sha256"
           )
 
       - name: Preserve trusted release asset manifest
@@ -645,6 +636,10 @@ jobs:
         run: |
           set -euo pipefail
           RELEASE_ASSETS="$RUNNER_TEMP/release-assets"
+          ASSET_PATHS=()
+          while read -r SHA256 ASSET_NAME; do
+            ASSET_PATHS+=("$RELEASE_ASSETS/$ASSET_NAME")
+          done < "$RUNNER_TEMP/release-manifest/release-assets.sha256"
           RELEASE_FLAGS=(--draft)
           if [[ "$PRERELEASE" == "true" ]]; then
             RELEASE_FLAGS+=(--prerelease --latest=false)
@@ -659,17 +654,10 @@ jobs:
             "${RELEASE_FLAGS[@]}" \
             --title "Codex Taskboard $RELEASE_TAG" \
             --generate-notes \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg"
+            "${ASSET_PATHS[0]}"
           gh release upload "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.deb.sig" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_Ubuntu-24.04-x64.AppImage.sig" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_NSIS-x64-unsigned.exe" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz" \
-            "$RELEASE_ASSETS/Codex.Taskboard_${PACKAGE_VERSION}_universal.app.tar.gz.sig" \
-            "$RELEASE_ASSETS/latest.json"
+            "${ASSET_PATHS[@]:1}"
 
   promote-release:
     name: Verify and publish immutable release
@@ -773,7 +761,7 @@ jobs:
           API_VERSION_HEADER="X-GitHub-Api-Version: 2026-03-10"
           MANIFEST_PATH="$RUNNER_TEMP/trusted-release-manifest/release-assets.sha256"
           LATEST_PATH="$RUNNER_TEMP/release-latest.json"
-          FIRST_ASSET_NAME="Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg"
+          FIRST_ASSET_NAME="$(awk 'NR == 1 { print $2 }' "$MANIFEST_PATH")"
           RELEASES="$(gh api --header "$API_VERSION_HEADER" \
             "repos/$GITHUB_REPOSITORY/releases?per_page=100")"
           DRAFT_RELEASE="$(jq -c \
@@ -860,7 +848,7 @@ jobs:
           set -euo pipefail
           API_VERSION_HEADER="X-GitHub-Api-Version: 2026-03-10"
           MANIFEST_PATH="$RUNNER_TEMP/trusted-release-manifest/release-assets.sha256"
-          FIRST_ASSET_NAME="Codex.Taskboard_${PACKAGE_VERSION}_macOS-universal.dmg"
+          FIRST_ASSET_NAME="$(awk 'NR == 1 { print $2 }' "$MANIFEST_PATH")"
           FINAL_RELEASE="$(gh api --header "$API_VERSION_HEADER" \
             "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG")"
           LATEST_RELEASE="$(gh api --header "$API_VERSION_HEADER" \

--- a/scripts/create-macos-updater.mjs
+++ b/scripts/create-macos-updater.mjs
@@ -5,6 +5,8 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
+import { releaseMetadata } from "./release-metadata.mjs";
+
 const scriptPath = fileURLToPath(import.meta.url);
 const projectRoot = path.resolve(path.dirname(scriptPath), "..");
 const appPath = process.argv[2] ? path.resolve(process.argv[2]) : null;
@@ -16,15 +18,7 @@ if (!appPath || !outputDirectory || !releaseTag) {
 }
 
 const packageJson = JSON.parse(await readFile(path.join(projectRoot, "package.json"), "utf8"));
-const stableTag = `v${packageJson.version}`;
-const betaPrefix = `${stableTag}-beta.`;
-const betaNumber = releaseTag.startsWith(betaPrefix)
-  ? releaseTag.slice(betaPrefix.length)
-  : "";
-if (releaseTag !== stableTag && !/^[1-9]\d*$/.test(betaNumber)) {
-  throw new Error("Release tag does not match package.json version");
-}
-const releaseVersion = releaseTag.slice(1);
+const { releaseVersion, assets } = releaseMetadata(packageJson.version, releaseTag);
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, { encoding: "utf8", ...options });
@@ -34,7 +28,7 @@ function run(command, args, options = {}) {
 }
 
 await mkdir(outputDirectory, { recursive: true });
-const artifactName = `Codex.Taskboard_${packageJson.version}_universal.app.tar.gz`;
+const artifactName = assets.macosUpdater;
 const artifactPath = path.join(outputDirectory, artifactName);
 run("/usr/bin/tar", ["-czf", artifactPath, path.basename(appPath)], {
   cwd: path.dirname(appPath),

--- a/scripts/release-metadata-cli.mjs
+++ b/scripts/release-metadata-cli.mjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+import { releaseMetadata } from "./release-metadata.mjs";
+
+const [packageVersion, releaseTag] = process.argv.slice(2);
+console.log(JSON.stringify(releaseMetadata(packageVersion, releaseTag)));

--- a/scripts/release-metadata.mjs
+++ b/scripts/release-metadata.mjs
@@ -1,0 +1,43 @@
+export function releaseMetadata(packageVersion, releaseTag, stableProductName = "Codex Taskboard") {
+  const stableTag = `v${packageVersion}`;
+  const betaPrefix = `${stableTag}-beta.`;
+  const betaNumber = releaseTag.startsWith(betaPrefix)
+    ? releaseTag.slice(betaPrefix.length)
+    : "";
+  if (releaseTag !== stableTag && betaNumber.match(/^[1-9]\d*/)?.[0] !== betaNumber) {
+    throw new Error("Release tag does not match package.json version");
+  }
+
+  const prerelease = Boolean(betaNumber);
+  const productName = prerelease ? "Codex Taskboard Beta" : stableProductName;
+  const prefix = `Codex.Taskboard_${packageVersion}`;
+  const linuxDeb = `${prefix}_Ubuntu-24.04-x64.deb`;
+  const linuxAppImage = `${prefix}_Ubuntu-24.04-x64.AppImage`;
+  const macosUpdater = `${prefix}_universal.app.tar.gz`;
+  const assets = {
+    dmg: `${prefix}_macOS-universal.dmg`,
+    linuxDeb,
+    linuxDebSignature: `${linuxDeb}.sig`,
+    linuxAppImage,
+    linuxAppImageSignature: `${linuxAppImage}.sig`,
+    windowsInstaller: `${prefix}_NSIS-x64-unsigned.exe`,
+    macosUpdater,
+    macosUpdaterSignature: `${macosUpdater}.sig`,
+    latest: "latest.json",
+  };
+
+  return {
+    packageVersion,
+    releaseTag,
+    releaseVersion: releaseTag.slice(1),
+    channel: prerelease ? "beta" : "stable",
+    prerelease,
+    betaNumber,
+    productName,
+    appName: `${productName}.app`,
+    rawDmgName: `${productName}_${packageVersion}_universal.dmg`,
+    buildDmgName: `${prefix}_universal.dmg`,
+    assets,
+    assetNames: Object.values(assets),
+  };
+}

--- a/scripts/verify-linux-updater.mjs
+++ b/scripts/verify-linux-updater.mjs
@@ -4,6 +4,7 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
+import { releaseMetadata } from "./release-metadata.mjs";
 import { verifyUpdaterSignature } from "./verify-updater-signature.mjs";
 
 const scriptPath = fileURLToPath(import.meta.url);
@@ -23,15 +24,7 @@ const tauriConfig = JSON.parse(await readFile(
   path.join(projectRoot, "src-tauri", "tauri.conf.json"),
   "utf8",
 ));
-const stableTag = `v${packageJson.version}`;
-const betaPrefix = `${stableTag}-beta.`;
-const betaNumber = releaseTag.startsWith(betaPrefix)
-  ? releaseTag.slice(betaPrefix.length)
-  : "";
-if (releaseTag !== stableTag && !/^[1-9]\d*$/.test(betaNumber)) {
-  throw new Error("Release tag does not match package.json version");
-}
-const releaseVersion = releaseTag.slice(1);
+const { releaseVersion } = releaseMetadata(packageJson.version, releaseTag);
 
 const latest = JSON.parse(await readFile(latestPath, "utf8"));
 if (latest.version !== releaseVersion) throw new Error("latest.json version is incorrect");

--- a/scripts/verify-macos-release.mjs
+++ b/scripts/verify-macos-release.mjs
@@ -14,6 +14,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { releaseMetadata } from "./release-metadata.mjs";
 import { verifyUpdaterSignature } from "./verify-updater-signature.mjs";
 
 const appPath = process.argv[2] ? path.resolve(process.argv[2]) : null;
@@ -36,17 +37,11 @@ const releasePolicy = JSON.parse(await readFile(
   path.join(projectRoot, "src-tauri", "release.json"),
   "utf8",
 ));
-const stableTag = `v${packageJson.version}`;
-const betaPrefix = `${stableTag}-beta.`;
-const betaNumber = releaseTag.startsWith(betaPrefix)
-  ? releaseTag.slice(betaPrefix.length)
-  : "";
-if (releaseTag !== stableTag && !/^[1-9]\d*$/.test(betaNumber)) {
-  throw new Error("Release tag does not match package.json version");
-}
-const releaseVersion = releaseTag.slice(1);
-const productName = betaNumber ? "Codex Taskboard Beta" : tauriConfig.productName;
-const appName = `${productName}.app`;
+const { releaseVersion, productName, appName, assets } = releaseMetadata(
+  packageJson.version,
+  releaseTag,
+  tauriConfig.productName,
+);
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, { encoding: "utf8", ...options });
@@ -147,7 +142,7 @@ async function manifest(root, relative = "") {
   return entries;
 }
 
-const artifactName = `Codex.Taskboard_${packageJson.version}_universal.app.tar.gz`;
+const artifactName = assets.macosUpdater;
 const artifactPath = path.join(releaseDirectory, artifactName);
 const signaturePath = `${artifactPath}.sig`;
 const signature = await readFile(signaturePath, "utf8");

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -345,15 +345,12 @@ dependencies = [
 name = "codex-taskboard-launcher"
 version = "1.1.22"
 dependencies = [
- "base64 0.22.1",
  "dispatch2",
  "futures-util",
  "libc",
- "minisign-verify",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
- "reqwest",
  "serde",
  "serde_json",
  "sha2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,11 +9,8 @@ rust-version = "1.88"
 tauri-build = { version = "2.6.0", features = [] }
 
 [dependencies]
-base64 = "0.22"
 futures-util = "0.3"
 libc = "0.2"
-minisign-verify = "0.2"
-reqwest = { version = "0.13", default-features = false, features = ["stream", "rustls-no-provider"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,10 +1,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use base64::Engine;
 #[cfg(target_os = "macos")]
 use dispatch2::{run_on_main, MainThreadBound};
-use futures_util::{future::{BoxFuture, Shared}, FutureExt, StreamExt};
-use minisign_verify::{PublicKey, Signature};
+use futures_util::{future::{BoxFuture, Shared}, FutureExt};
 #[cfg(target_os = "macos")]
 use objc2::{
     define_class, msg_send,
@@ -19,7 +17,6 @@ use objc2_app_kit::{
 };
 #[cfg(target_os = "macos")]
 use objc2_foundation::{NSObject, NSSize, NSString};
-use reqwest::header::{HeaderValue, ACCEPT};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 #[cfg(target_os = "macos")]
@@ -2034,96 +2031,6 @@ async fn check_for_startup_update(
     Ok(update)
 }
 
-async fn download_update<C: FnMut(usize, Option<u64>), D: FnOnce()>(
-    app: &AppHandle,
-    update: &Update,
-    cancel_requested: &AtomicBool,
-    mut on_chunk: C,
-    on_download_finish: D,
-) -> Result<Option<Vec<u8>>, String> {
-    let pubkey = app
-        .config()
-        .plugins
-        .0
-        .get("updater")
-        .and_then(|value| value.get("pubkey"))
-        .and_then(serde_json::Value::as_str)
-        .ok_or("Updater public key is unavailable")?;
-    let mut headers = update.headers.clone();
-    if !headers.contains_key(ACCEPT) {
-        headers.insert(ACCEPT, HeaderValue::from_static("application/octet-stream"));
-    }
-    let mut request = reqwest::Client::builder().user_agent("tauri-plugin-updater/2.10.1");
-    if let Some(timeout) = update.timeout {
-        request = request.timeout(timeout);
-    }
-    if update.no_proxy {
-        request = request.no_proxy();
-    } else if let Some(proxy) = &update.proxy {
-        request =
-            request.proxy(reqwest::Proxy::all(proxy.as_str()).map_err(|error| error.to_string())?);
-    }
-    let response = request
-        .build()
-        .map_err(|error| error.to_string())?
-        .get(update.download_url.clone())
-        .headers(headers)
-        .send()
-        .await
-        .map_err(|error| error.to_string())?;
-    if !response.status().is_success() {
-        return Err(format!(
-            "Download request failed with status: {}",
-            response.status()
-        ));
-    }
-    let content_length = response
-        .headers()
-        .get("Content-Length")
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.parse().ok());
-    let mut buffer = Vec::new();
-    let mut stream = response.bytes_stream();
-    loop {
-        if cancel_requested.load(Ordering::SeqCst) {
-            return Ok(None);
-        }
-        let Some(chunk) = stream.next().await else {
-            break;
-        };
-        let chunk = chunk.map_err(|error| error.to_string())?;
-        if cancel_requested.load(Ordering::SeqCst) {
-            return Ok(None);
-        }
-        on_chunk(chunk.len(), content_length);
-        if cancel_requested.load(Ordering::SeqCst) {
-            return Ok(None);
-        }
-        buffer.extend_from_slice(&chunk);
-    }
-    if cancel_requested.load(Ordering::SeqCst) {
-        return Ok(None);
-    }
-    on_download_finish();
-    if cancel_requested.load(Ordering::SeqCst) {
-        return Ok(None);
-    }
-    let pubkey = base64::engine::general_purpose::STANDARD
-        .decode(pubkey)
-        .map_err(|error| error.to_string())?;
-    let pubkey = std::str::from_utf8(&pubkey).map_err(|error| error.to_string())?;
-    let pubkey = PublicKey::decode(pubkey).map_err(|error| error.to_string())?;
-    let signature = base64::engine::general_purpose::STANDARD
-        .decode(&update.signature)
-        .map_err(|error| error.to_string())?;
-    let signature = std::str::from_utf8(&signature).map_err(|error| error.to_string())?;
-    let signature = Signature::decode(signature).map_err(|error| error.to_string())?;
-    pubkey
-        .verify(&buffer, &signature, true)
-        .map_err(|error| error.to_string())?;
-    Ok(Some(buffer))
-}
-
 async fn prepare_update(
     app: &AppHandle,
     state: &Arc<LauncherState>,
@@ -2139,7 +2046,6 @@ async fn prepare_update(
         snapshot.update_message = format!("正在下载 {update_version}…");
         snapshot.update_available = true;
     });
-    let cancel_requested = AtomicBool::new(false);
     let progress_app = app.clone();
     let progress_state = Arc::clone(state);
     let progress_version = update_version.clone();
@@ -2149,10 +2055,7 @@ async fn prepare_update(
     let finish_dialog = Arc::clone(dialog);
     let mut downloaded = 0_u64;
     let mut displayed_progress = None;
-    let bytes = download_update(
-        app,
-        update,
-        &cancel_requested,
+    let bytes = update.download(
         move |chunk_length, content_length| {
             downloaded = downloaded.saturating_add(chunk_length as u64);
             let progress = content_length.filter(|total| *total > 0).map(|total| {
@@ -2186,8 +2089,8 @@ async fn prepare_update(
             }
         },
     )
-    .await?
-    .ok_or_else(|| "Update download was cancelled".to_string())?;
+    .await
+    .map_err(|error| error.to_string())?;
 
     append_log(
         state,


### PR DESCRIPTION
更新器目前自行维护一套请求、分块读取和签名校验，同时发布流程在多处计算版本、频道和资产名。本 PR 用锁定 updater 2.10.1 的 `Update.download` 替代重复下载器，并让发布脚本与工作流共用一个纯元数据模块。

- LOCAL-413：删除无生产者的取消参数与 Option 分支，移除三个专用直接依赖。共享预下载、手动确认、进度回调和安装恢复继续使用现有路径。
- LOCAL-414：统一稳定版/Beta 版本、产品名和九项有序资产名。已有 SHA manifest 同时供上传顺序与 promotion 首资产校验使用，DMG 仍排首位。

验证：锁定插件的独立原生调用下载了已发布 v1.1.22 的 87,755,985-byte 签名包，下载中和下载后均复用同一 Arc 结果，on_finish 只调用一次；篡改包被真实验签拒绝。稳定版/Beta 元数据、旧新发布命令参数与资产顺序对照通过；6 个 job、52 个 step 的顺序和控制项保持，Node/Bash 语法检查通过，Cargo.lock 只移除根包的三个依赖引用。

产品各平台编译由本 PR 的 exact-head CI 验证；真实安装/重启及下一次 Beta 发布由批次集成流程完成。本次未执行安装或发布。