### PR TITLE
Acquire Launcher lock before shared Skill writes

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -914,6 +914,7 @@ fn update_snapshot(
                 match snapshot.phase.as_str() {
                     "running" => "运行状态：正常",
                     "error" => "运行状态：异常",
+                    "stopped" => "运行状态：已停止",
                     _ => "运行状态：启动中",
                 }
             };
@@ -2468,16 +2469,6 @@ fn main() {
             #[cfg(target_os = "macos")]
             app.set_activation_policy(ActivationPolicy::Accessory);
             let home_directory = app.path().home_dir()?;
-            let bundled_skill = app
-                .path()
-                .resource_dir()?
-                .join("app/skills/manage-taskboard");
-            let legacy_skill_conflict = reconcile_legacy_skill(&home_directory, &bundled_skill)?;
-            let global_skill = home_directory.join(".agents/skills/manage-taskboard");
-            if global_skill.exists() {
-                fs::remove_dir_all(&global_skill)?;
-            }
-            copy_directory(&bundled_skill, &global_skill)?;
             #[cfg(target_os = "macos")]
             let data_directory = home_directory.join("Library/Application Support/Codex Taskboard");
             #[cfg(target_os = "macos")]
@@ -2511,6 +2502,16 @@ fn main() {
                 app.handle().exit(0);
                 return Ok(());
             };
+            let bundled_skill = app
+                .path()
+                .resource_dir()?
+                .join("app/skills/manage-taskboard");
+            let legacy_skill_conflict = reconcile_legacy_skill(&home_directory, &bundled_skill)?;
+            let global_skill = home_directory.join(".agents/skills/manage-taskboard");
+            if global_skill.exists() {
+                fs::remove_dir_all(&global_skill)?;
+            }
+            copy_directory(&bundled_skill, &global_skill)?;
             let version = release_version().to_string();
             let state = Arc::new(LauncherState::new(
                 data_directory,


### PR DESCRIPTION
Launcher 的第二个实例原先会先协调并替换共享 manage-taskboard Skill，再被单实例锁拒绝。本次把现有 Skill 写入放到持锁之后，并为已有 stopped 状态显示“运行状态：已停止”。不改 Skill 策略、迁移或退出语义。

对应 Taskboard：LOCAL-395。本实现从原分组 PR #390 拆出，保持 [GPT-6 Pro](https://chatgpt.com/c/6a9f9970-dc64-83e8-aaee-789bbfc552cd) 的原交付逻辑；本 PR 为待恢复的完整实现草稿。

已验证：

- 原分组 exact head d103343ca3ca340bce725e38e53fde1ec30d694d 的完整 aarch64 候选 App，实际第二实例在 0.239 秒内 exit 0；global Skill、legacy Skill 的存在状态和 launcher-runtime.json 前后不变。
- 临时目录中的原样 Rust setup/锁/复制函数，真实双进程抢锁拒绝及首实例复制通过；存在 legacy Skill 的拒绝路径也通过。
- 原分组五项 CI 成功。拆分后的 Skill/锁/stopped 子集与该已验证源码一致；本分支源码无依赖与事件协议改动。

待验项：实际“取消重新启动 Codex → stopped → 托盘显示已停止”。当前正式 CUA 无法取得 Launcher 托盘，冷启动/取消后的实际界面未读回。函数级映射不替代原生 UI 证据。本 PR 保持草稿，Taskboard 记为 blocked，等待可用原生验证入口；不代表验收完成。
