### PR TITLE
统一 AI 普通与结构化消息的权限映射

### DIFF
--- a/server/ai-chat-process.mjs
+++ b/server/ai-chat-process.mjs
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 import { withoutTaskboardLauncherEnvironment } from "../shared/codex-environment.mjs";
+import { resolveCodexPermissions } from "../shared/codex-permissions.mjs";
 import { signalProcessTree } from "../shared/process-tree.mjs";
 
 const VISIBLE_TEXT_LIMIT = 65_536;
@@ -164,23 +165,7 @@ function normalizedItem(rawType, item) {
 }
 
 export function buildCodexArgs(thread, addDirectories, imagePaths = []) {
-  const permission = thread.sandbox === "read-only"
-    ? {
-        sandbox: "workspace-write",
-        approvalPolicy: "on-request",
-        reviewer: "user",
-      }
-    : thread.sandbox === "workspace-write"
-      ? {
-          sandbox: "workspace-write",
-          approvalPolicy: "on-request",
-          reviewer: "auto_review",
-        }
-      : {
-          sandbox: "danger-full-access",
-          approvalPolicy: "never",
-          reviewer: null,
-        };
+  const permission = resolveCodexPermissions(thread.sandbox);
   const args = [
     "exec",
     "--json",

--- a/server/ai-chat.mjs
+++ b/server/ai-chat.mjs
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { signalProcessTree } from "../shared/process-tree.mjs";
+import { resolveCodexPermissions } from "../shared/codex-permissions.mjs";
 import { ApiError } from "../shared/api-fields.mjs";
 import {
   ComposerCatalog,
@@ -55,16 +56,14 @@ function wait(milliseconds) {
 }
 
 function appServerThreadSettings(thread, resolved) {
-  const dangerous = thread.sandbox === "danger-full-access";
+  const permission = resolveCodexPermissions(thread.sandbox);
   return {
     model: thread.model,
     cwd: resolved.workspacePath,
     runtimeWorkspaceRoots: [resolved.workspacePath, ...resolved.addDirectories],
-    approvalPolicy: dangerous ? "never" : "on-request",
-    ...(dangerous
-      ? {}
-      : { approvalsReviewer: thread.sandbox === "read-only" ? "user" : "auto_review" }),
-    sandbox: thread.sandbox,
+    approvalPolicy: permission.approvalPolicy,
+    ...(permission.reviewer ? { approvalsReviewer: permission.reviewer } : {}),
+    sandbox: permission.sandbox,
   };
 }
 

--- a/shared/codex-permissions.mjs
+++ b/shared/codex-permissions.mjs
@@ -1,0 +1,9 @@
+// Stored sandbox values are product permission choices, not literal Codex sandbox modes.
+export function resolveCodexPermissions(sandbox) {
+  const fullAccess = sandbox === "danger-full-access";
+  return {
+    sandbox: fullAccess ? "danger-full-access" : "workspace-write",
+    approvalPolicy: fullAccess ? "never" : "on-request",
+    reviewer: fullAccess ? null : sandbox === "read-only" ? "user" : "auto_review",
+  };
+}


### PR DESCRIPTION
AI 的“请求批准”选项在普通消息中允许工作区写入，结构化消息却误用只读沙箱。本次将存储的产品权限选项解析成共享的 sandbox、approvalPolicy 和 reviewer，CLI 与 App Server 各自适配字段。保留三档存储值及现有逐轮完整访问确认，不做迁移或新增批准界面。

仅涉及 LOCAL-393：shared/codex-permissions.mjs、server/ai-chat-process.mjs、server/ai-chat.mjs。原 GPT-6 Pro 交付保持不变，未新增测试。

直接验证已完成：
- 真实 Codex 0.153.4 普通 CLI 与结构化临时 Skill 在“请求批准”选项下均可写工作区，外部探针均未写入。
- 获得用户明确授权后，完整访问模式分别执行普通消息和结构化 Skill 各一次。两条路径均使用 danger-full-access、never 和 ephemeral，均将工作区和外部指定探针写成预期内容。CLI 退出码 0，App Server 运行 completed；两个本组进程均已退出。
- 原有改动文件语法检查通过。提交 791a50b96c82fb054d6208496895bb957cb2aac1 的 5 项 CI 全部成功；源码未新增改动。当前 main 的权限函数未变，合并计算无冲突。
