### PR TITLE
Simplify issue creation and keep realtime subscriptions stable

### DIFF
--- a/test/cloud-revision-polling.test.mjs
+++ b/test/cloud-revision-polling.test.mjs
@@ -365,7 +365,7 @@ test("the app connects the selected realtime transport without reloading the pag
   assert.match(appSource, /createRevisionWebSocketClient\(\{/);
   assert.doesNotMatch(appSource, /revisionFallbackInterval|fallbackIntervalMs/);
   assert.match(appSource, /controller\.abort\(\);\s*poller\.stop\(\)/);
-  assert.match(appSource, /new EventSource\(resolveTaskboardUrl\("\/api\/events"\)\)/);
+  assert.match(appSource, /const eventsUrl = resolveTaskboardUrl\("\/api\/events"\);[\s\S]*new EventSource\(eventsUrl\)/);
   assert.doesNotMatch(appSource, /location\.reload\(/);
 
   const pollingEffect = appSource.slice(

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -174,7 +174,6 @@ const GanttView = lazy(() => import("./components/GanttView").then((module) => (
 })));
 
 interface EditorState {
-  task: Task | null;
   status: TaskStatus;
   projectId?: string | null;
 }
@@ -590,23 +589,39 @@ function LocalRealtimeSync({
   setAttachmentsRevision,
   setReadmeRevision,
 }: LocalRealtimeSyncProps) {
+  const selectionRef = useRef({ selectedProjectId, detailTaskId });
+  const eventsUrl = resolveTaskboardUrl("/api/events");
+
+  useLayoutEffect(() => {
+    selectionRef.current = { selectedProjectId, detailTaskId };
+  }, [selectedProjectId, detailTaskId]);
+
   useEffect(() => {
-    const source = new EventSource(resolveTaskboardUrl("/api/events"));
+    const source = new EventSource(eventsUrl);
     let refreshTimer: number | undefined;
     let refreshProjectsPending = false;
-    let refreshTasksPending = false;
+    const pendingTaskProjects = new Set<string | undefined>();
 
-    const scheduleRefresh = (options: { projects?: boolean; tasks?: boolean }) => {
+    const scheduleRefresh = (options: { projects?: boolean; tasks?: boolean; projectId?: string }) => {
       refreshProjectsPending ||= options.projects === true;
-      refreshTasksPending ||= options.tasks === true;
+      if (options.tasks) pendingTaskProjects.add(options.projectId);
       window.clearTimeout(refreshTimer);
       refreshTimer = window.setTimeout(() => {
+        const { selectedProjectId } = selectionRef.current;
         if (refreshProjectsPending) void refreshProjectList();
-        if (refreshTasksPending && selectedProjectId) {
+        if (
+          selectedProjectId
+          && pendingTaskProjects.size > 0
+          && (
+            selectedProjectId === ALL_PROJECTS_ID
+            || pendingTaskProjects.has(undefined)
+            || pendingTaskProjects.has(selectedProjectId)
+          )
+        ) {
           void refreshTasks(selectedProjectId, { quiet: true });
         }
         refreshProjectsPending = false;
-        refreshTasksPending = false;
+        pendingTaskProjects.clear();
       }, 120);
     };
 
@@ -630,6 +645,7 @@ function LocalRealtimeSync({
         void refreshProjectBoardDisplaySettings();
         return;
       }
+      const { selectedProjectId, detailTaskId } = selectionRef.current;
       const eventProjectId = payload.projectId ?? payload.project?.id;
       const affectsSelectedProject = Boolean(selectedProjectId)
         && (
@@ -642,11 +658,15 @@ function LocalRealtimeSync({
         return;
       }
       if (event.type === "project.labels.updated") {
-        scheduleRefresh({ projects: true, tasks: affectsSelectedProject });
+        scheduleRefresh({ projects: true, tasks: affectsSelectedProject, projectId: eventProjectId });
         return;
       }
       if (event.type.startsWith("task.")) {
-        scheduleRefresh({ projects: true, tasks: affectsSelectedProject });
+        scheduleRefresh({
+          projects: event.type !== "task.relation.updated",
+          tasks: affectsSelectedProject,
+          projectId: eventProjectId,
+        });
         return;
       }
       if (!affectsSelectedProject) return;
@@ -658,7 +678,7 @@ function LocalRealtimeSync({
         if (!detailTaskId || !payload.taskId || payload.taskId === detailTaskId) {
           setCommentsRevision((current) => current + 1);
         }
-        scheduleRefresh({ tasks: true });
+        scheduleRefresh({ tasks: true, projectId: eventProjectId });
         return;
       }
       if (event.type.startsWith("attachment.")) {
@@ -672,6 +692,7 @@ function LocalRealtimeSync({
     EVENT_NAMES.forEach((name) => source.addEventListener(name, handleEvent));
     source.onopen = () => {
       setConnection("live");
+      const { selectedProjectId, detailTaskId } = selectionRef.current;
       void refreshProjectBoardDisplaySettings();
       scheduleRefresh({ projects: true, tasks: Boolean(selectedProjectId) });
       if (selectedProjectId && selectedProjectId !== ALL_PROJECTS_ID) {
@@ -682,7 +703,9 @@ function LocalRealtimeSync({
         setAttachmentsRevision((current) => current + 1);
       }
     };
-    source.onerror = () => setConnection("reconnecting");
+    source.onerror = () => {
+      setConnection("reconnecting");
+    };
 
     return () => {
       window.clearTimeout(refreshTimer);
@@ -690,11 +713,10 @@ function LocalRealtimeSync({
       source.close();
     };
   }, [
-    detailTaskId,
+    eventsUrl,
     refreshProjectBoardDisplaySettings,
     refreshProjectList,
     refreshTasks,
-    selectedProjectId,
     setAttachmentsRevision,
     setCommentsRevision,
     setConnection,
@@ -1204,8 +1226,7 @@ export function App() {
     : projectMenuCandidates;
   const firstEmptyProjectId = projectMenuChoices.find((project) => project.issueCount === 0)?.id ?? null;
   const hasProjectsWithIssues = projectMenuChoices.some((project) => project.issueCount > 0);
-  const editorProjectId = editor?.task?.projectId
-    ?? editor?.projectId
+  const editorProjectId = editor?.projectId
     ?? (newTaskDraft?.projectId === selectedProjectId ? newTaskDraft.targetProjectId : undefined)
     ?? (isAllProjects ? GLOBAL_PROJECT_ID : selectedProjectId);
   const developmentEditorProjectId = isAllProjects && editor ? editorProjectId : null;
@@ -2197,7 +2218,7 @@ export function App() {
         && !isJiraProject
       ) {
         event.preventDefault();
-        setEditor({ task: null, status: "todo" });
+        setEditor({ status: "todo" });
       }
       if (
         event.key === "/"
@@ -2358,27 +2379,14 @@ export function App() {
     if (!selectedProjectId || !editor) return;
     const targetProjectId = editorProjectId ?? selectedProjectId;
     setActionError(null);
-    const creating = editor.task === null;
-    let saved: Task;
-    try {
-      saved = editor.task
-        ? await updateTaskRequest(editor.task, draft)
-        : await createTaskRequest(targetProjectId, draft);
-    } catch (error) {
-      if (error instanceof ApiError && error.code === "VERSION_CONFLICT") {
-        void refreshTasks(taskScopeProjectId, { quiet: true });
-      }
-      throw error;
-    }
-    if (creating) {
-      setProjects((current) => current.map((project) => (
-        project.id === targetProjectId
-          ? { ...project, issueCount: project.issueCount + 1 }
-          : project
-      )));
-    }
+    let saved = await createTaskRequest(targetProjectId, draft);
+    setProjects((current) => current.map((project) => (
+      project.id === targetProjectId
+        ? { ...project, issueCount: project.issueCount + 1 }
+        : project
+    )));
     let postCreateWriteFailed = false;
-    if (creating && (inlineFiles.length > 0 || inlineImages.length > 0)) {
+    if (inlineFiles.length > 0 || inlineImages.length > 0) {
       const [fileResults, inlineResults] = await Promise.all([
           Promise.allSettled(
             inlineFiles.map((file) => uploadAttachment(saved.id, file.file, "attachment")),
@@ -2416,7 +2424,7 @@ export function App() {
     let addedParentId: string | null = null;
     const addedRelatedIds: string[] = [];
     let relationWriteFailed = false;
-    if (creating && createOptions) {
+    if (createOptions) {
       const { parentId, relatedIds, subIssueIds } = createOptions.relations;
       try {
         if (parentId) {
@@ -2449,67 +2457,56 @@ export function App() {
       ...current.filter((task) => !relationUpdates.has(task.id)),
       ...relationUpdates.values(),
     ]));
-    if (creating) setNewTaskDraft(null);
+    setNewTaskDraft(null);
     const failedWrites = [
       ...(relationWriteFailed ? [{ zh: "关系", en: "relations" }] : []),
       ...(postCreateWriteFailed ? [{ zh: "正文或媒体", en: "description or media" }] : []),
     ];
-    if (!creating || !createOptions?.keepOpen || failedWrites.length > 0) setEditor(null);
+    if (!createOptions?.keepOpen || failedWrites.length > 0) setEditor(null);
     if (failedWrites.length > 0) {
       setActionError(text(
         `${saved.identifier} 已创建，但以下内容写入失败：${failedWrites.map((failure) => failure.zh).join("、")}。`,
         `${saved.identifier} was created, but these follow-up writes failed: ${failedWrites.map((failure) => failure.en).join(", ")}.`,
       ));
     }
-    if (creating) {
-      pushUndo(null, async () => {
-        const restoredRelations = new Map<string, Task>();
-        const candidate = tasksRef.current.find((task) => task.id === saved.id);
-        let current = candidate && candidate.version >= saved.version ? candidate : saved;
-        if (addedParentId) {
-          const result = await removeTaskRelation(current, "parent", addedParentId);
-          current = result.task;
-          restoredRelations.set(result.relatedTask.id, result.relatedTask);
-        }
-        for (const relatedId of [...addedRelatedIds].reverse()) {
-          const result = await removeTaskRelation(current, "related", relatedId);
-          current = result.task;
-          restoredRelations.set(result.relatedTask.id, result.relatedTask);
-        }
-        for (const movedSubIssue of [...movedSubIssues].reverse()) {
-          const latestChild = tasksRef.current.find((task) => task.id === movedSubIssue.task.id);
-          const child = latestChild && latestChild.version >= movedSubIssue.task.version
-            ? latestChild
-            : movedSubIssue.task;
-          const removed = await removeTaskRelation(child, "parent", saved.id);
-          restoredRelations.set(removed.task.id, removed.task);
-          current = removed.relatedTask;
-          if (movedSubIssue.previousParentId) {
-            const restored = await addTaskRelation(
-              removed.task,
-              "parent",
-              movedSubIssue.previousParentId,
-            );
-            restoredRelations.set(restored.task.id, restored.task);
-            restoredRelations.set(restored.relatedTask.id, restored.relatedTask);
-          }
-        }
-        await archiveTaskRequest(current);
-        setTasks((tasks) => sortTasks([
-          ...tasks.filter((task) => task.id !== saved.id && !restoredRelations.has(task.id)),
-          ...[...restoredRelations.values()].filter((task) => task.id !== saved.id),
-        ]));
-      });
-    } else if (editor.task) {
-      const previous = editor.task;
-      const previousAssigneeTarget = assigneeTargetForActor(previous.assignee, currentUser);
-      if (!draft.assigneeTarget || previousAssigneeTarget) {
-        pushUndo(
-          null,
-          () => restoreTaskDetails(previous, saved, previousAssigneeTarget),
-        );
+    pushUndo(null, async () => {
+      const restoredRelations = new Map<string, Task>();
+      const candidate = tasksRef.current.find((task) => task.id === saved.id);
+      let current = candidate && candidate.version >= saved.version ? candidate : saved;
+      if (addedParentId) {
+        const result = await removeTaskRelation(current, "parent", addedParentId);
+        current = result.task;
+        restoredRelations.set(result.relatedTask.id, result.relatedTask);
       }
-    }
+      for (const relatedId of [...addedRelatedIds].reverse()) {
+        const result = await removeTaskRelation(current, "related", relatedId);
+        current = result.task;
+        restoredRelations.set(result.relatedTask.id, result.relatedTask);
+      }
+      for (const movedSubIssue of [...movedSubIssues].reverse()) {
+        const latestChild = tasksRef.current.find((task) => task.id === movedSubIssue.task.id);
+        const child = latestChild && latestChild.version >= movedSubIssue.task.version
+          ? latestChild
+          : movedSubIssue.task;
+        const removed = await removeTaskRelation(child, "parent", saved.id);
+        restoredRelations.set(removed.task.id, removed.task);
+        current = removed.relatedTask;
+        if (movedSubIssue.previousParentId) {
+          const restored = await addTaskRelation(
+            removed.task,
+            "parent",
+            movedSubIssue.previousParentId,
+          );
+          restoredRelations.set(restored.task.id, restored.task);
+          restoredRelations.set(restored.relatedTask.id, restored.relatedTask);
+        }
+      }
+      await archiveTaskRequest(current);
+      setTasks((tasks) => sortTasks([
+        ...tasks.filter((task) => task.id !== saved.id && !restoredRelations.has(task.id)),
+        ...[...restoredRelations.values()].filter((task) => task.id !== saved.id),
+      ]));
+    });
   }
 
   async function moveTask(
@@ -3494,7 +3491,7 @@ export function App() {
               <button
                 className="icon-button header-create-button"
                 type="button"
-                onClick={() => setEditor({ task: null, status: "todo" })}
+                onClick={() => setEditor({ status: "todo" })}
                 aria-label={text("新建议题", "Create issue")}
                 title={text("新建议题 (C)", "Create issue (C)")}
               >
@@ -3716,7 +3713,7 @@ export function App() {
               <button
                 className="button secondary"
                 type="button"
-                onClick={() => setEditor({ task: null, status: "todo" })}
+                onClick={() => setEditor({ status: "todo" })}
               >
                 {text("添加议题", "Add issue")}
               </button>
@@ -3828,7 +3825,7 @@ export function App() {
                         showBody={boardDisplaySettings.body}
                         createEnabled={!isJiraProject}
                         onCreateLabel={persistProjectLabel}
-                        onCreate={(initialStatus) => setEditor({ task: null, status: initialStatus })}
+                        onCreate={(initialStatus) => setEditor({ status: initialStatus })}
                         onEdit={openTaskDetail}
                         onUpdate={updateTaskProperties}
                         onComplete={(task) => moveTask(task, "done")}
@@ -3868,7 +3865,7 @@ export function App() {
                     onTabChange={setOtherTasksTab}
                     onCreate={isJiraProject
                       ? undefined
-                      : (initialStatus) => setEditor({ task: null, status: initialStatus })}
+                      : (initialStatus) => setEditor({ status: initialStatus })}
                     onRestore={(task) => void restoreArchivedTask(task)}
                     onDelete={setPendingArchivedTaskDelete}
                     onEdit={openTaskDetail}
@@ -4099,17 +4096,16 @@ export function App() {
 
       {editor && (
         <TaskEditor
-          key={editor.task?.id ?? `new-${selectedProjectId}-${editor.status}`}
+          key={`new-${selectedProjectId}-${editor.status}`}
           projectId={editorProjectId}
-          projectOptions={!editor.task && isAllProjects ? createTargetProjects : undefined}
+          projectOptions={isAllProjects ? createTargetProjects : undefined}
           onProjectChange={(projectId) => setEditor((current) => (
             current ? { ...current, projectId } : current
           ))}
-          task={editor.task}
           tasks={tasks.filter((task) => task.projectId === editorProjectId)}
           referenceTasks={referenceTasks.filter((task) => task.projectId === editorProjectId)}
           initialStatus={editor.status}
-          initialDraft={editor.task || newTaskDraft?.projectId !== selectedProjectId
+          initialDraft={newTaskDraft?.projectId !== selectedProjectId
             ? null
             : newTaskDraft.draft}
           labels={projects.find((project) => project.id === editorProjectId)?.labels ?? []}
@@ -4118,13 +4114,11 @@ export function App() {
           developmentScanLoading={developmentScanLoading}
           onCreateLabel={(label) => persistProjectLabel(label, editorProjectId ?? selectedProjectId)}
           onCancel={(draft) => {
-            if (!editor.task) {
-              setNewTaskDraft(draft ? {
-                projectId: selectedProjectId,
-                targetProjectId: editorProjectId,
-                draft,
-              } : null);
-            }
+            setNewTaskDraft(draft ? {
+              projectId: selectedProjectId,
+              targetProjectId: editorProjectId,
+              draft,
+            } : null);
             setEditor(null);
           }}
           onSave={saveEditor}

--- a/web/src/components/TaskEditor.tsx
+++ b/web/src/components/TaskEditor.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { FormEvent, KeyboardEvent } from "react";
-import { ApiError } from "../api";
 import {
   taskPriorityLabel,
   taskStatusLabel,
@@ -100,7 +99,6 @@ interface TaskEditorProps {
   projectId: string | null;
   projectOptions?: Array<{ id: string; name: string }>;
   onProjectChange?: (projectId: string | null) => void;
-  task: Task | null;
   tasks: Task[];
   referenceTasks: Task[];
   initialStatus: TaskStatus;
@@ -159,7 +157,6 @@ export function TaskEditor({
   projectId,
   projectOptions,
   onProjectChange,
-  task,
   tasks,
   referenceTasks,
   initialStatus,
@@ -180,19 +177,18 @@ export function TaskEditor({
   const descriptionComposerRef = useRef<InlineMediaComposerHandle>(null);
   const createSubmitIntentRef = useRef(false);
   const attachmentInputRef = useRef<HTMLInputElement>(null);
-  const [title, setTitle] = useState(task?.title ?? initialDraft?.title ?? "");
-  const [description, setDescription] = useState(task?.description ?? "");
+  const [title, setTitle] = useState(initialDraft?.title ?? "");
   const [descriptionSegments, setDescriptionSegments] = useState<InlineMediaSegment[]>(
     () => initialDraft?.descriptionSegments ?? createInlineMediaSegments(),
   );
-  const [status, setStatus] = useState<TaskStatus>(task?.status ?? initialStatus);
-  const [priority, setPriority] = useState<TaskPriority>(task?.priority ?? initialDraft?.priority ?? "none");
-  const [assignee, setAssignee] = useState<ActorIdentity>(task?.assignee ?? initialDraft?.assignee ?? currentUser);
-  const [selectedLabels, setSelectedLabels] = useState<string[]>(task?.labels ?? initialDraft?.selectedLabels ?? []);
-  const [developmentContext, setDevelopmentContext] = useState<DevelopmentContext | null>(task?.developmentContext ?? initialDraft?.developmentContext ?? null);
-  const [startDate] = useState(task?.startDate ?? initialDraft?.startDate ?? "");
-  const [dueDate, setDueDate] = useState(task?.dueDate ?? initialDraft?.dueDate ?? "");
-  const [recurrence, setRecurrence] = useState<Recurrence | null>(task?.recurrence ?? initialDraft?.recurrence ?? null);
+  const [status, setStatus] = useState<TaskStatus>(initialStatus);
+  const [priority, setPriority] = useState<TaskPriority>(initialDraft?.priority ?? "none");
+  const [assignee, setAssignee] = useState<ActorIdentity>(initialDraft?.assignee ?? currentUser);
+  const [selectedLabels, setSelectedLabels] = useState<string[]>(initialDraft?.selectedLabels ?? []);
+  const [developmentContext, setDevelopmentContext] = useState<DevelopmentContext | null>(initialDraft?.developmentContext ?? null);
+  const [startDate] = useState(initialDraft?.startDate ?? "");
+  const [dueDate, setDueDate] = useState(initialDraft?.dueDate ?? "");
+  const [recurrence, setRecurrence] = useState<Recurrence | null>(initialDraft?.recurrence ?? null);
   const [parentId, setParentId] = useState<string | null>(initialDraft?.relations.parentId ?? null);
   const [relatedIds, setRelatedIds] = useState<string[]>(initialDraft?.relations.relatedIds ?? []);
   const [subIssueIds, setSubIssueIds] = useState<string[]>(initialDraft?.relations.subIssueIds ?? []);
@@ -267,8 +263,7 @@ export function TaskEditor({
         : subIssueIds,
   );
 
-  const assigneeOptions = [task?.assignee, currentUser, CODEX_AGENT_ACTOR]
-    .filter((actor): actor is ActorIdentity => actor !== undefined)
+  const assigneeOptions = [currentUser, CODEX_AGENT_ACTOR]
     .filter((actor, index, actors) => (
       actors.findIndex((candidate) => actorKey(candidate) === actorKey(actor)) === index
     ));
@@ -352,13 +347,11 @@ export function TaskEditor({
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (!task) {
-      if (!createSubmitIntentRef.current) return;
-      createSubmitIntentRef.current = false;
-      if (projectOptions && !projectId) {
-        setError(["请选择项目。", "Select a project."]);
-        return;
-      }
+    if (!createSubmitIntentRef.current) return;
+    createSubmitIntentRef.current = false;
+    if (projectOptions && !projectId) {
+      setError(["请选择项目。", "Select a project."]);
+      return;
     }
     const cleanTitle = title.trim();
     if (!cleanTitle) {
@@ -380,12 +373,8 @@ export function TaskEditor({
     setSaving(true);
     setError(null);
     try {
-      const assigneeTarget = task && actorKey(assignee) === actorKey(task.assignee)
-        ? undefined
-        : assigneeTargetForActor(assignee, currentUser);
-      const descriptionValue = task
-        ? description.trim()
-        : serializeInlineMedia(descriptionSegments).trim();
+      const assigneeTarget = assigneeTargetForActor(assignee, currentUser);
+      const descriptionValue = serializeInlineMedia(descriptionSegments).trim();
       await onSave({
         title: cleanTitle,
         description: descriptionValue,
@@ -397,11 +386,11 @@ export function TaskEditor({
         startDate: startDate || null,
         dueDate: dueDate || null,
         recurrence,
-      }, inlineMediaFiles(descriptionSegments), inlineMediaImages(descriptionSegments), task ? undefined : {
+      }, inlineMediaFiles(descriptionSegments), inlineMediaImages(descriptionSegments), {
         keepOpen: createMore,
         relations: { parentId, relatedIds, subIssueIds },
       });
-      if (!task && createMore) {
+      if (createMore) {
         setTitle("");
         setDescriptionSegments(createInlineMediaSegments());
         setSubIssueIds([]);
@@ -411,16 +400,9 @@ export function TaskEditor({
         requestAnimationFrame(() => titleRef.current?.focus());
       }
     } catch (caught) {
-      if (caught instanceof ApiError && caught.code === "VERSION_CONFLICT") {
-        setError([
-          "这个议题已在其他位置发生变更，请关闭并刷新后重试。",
-          "This issue changed elsewhere. Close the editor, refresh, and try again.",
-        ]);
-      } else {
-        setError(caught instanceof Error
-          ? caught.message
-          : ["无法保存这个议题。", "Could not save this issue."]);
-      }
+      setError(caught instanceof Error
+        ? caught.message
+        : ["无法保存这个议题。", "Could not save this issue."]);
     } finally {
       setSaving(false);
     }
@@ -430,7 +412,7 @@ export function TaskEditor({
     if (event.defaultPrevented) return;
     if (event.nativeEvent.isComposing || event.keyCode === 229) return;
     if (event.key !== "Enter") return;
-    if (!task && (event.metaKey || event.ctrlKey)) {
+    if (event.metaKey || event.ctrlKey) {
       event.preventDefault();
       createSubmitIntentRef.current = true;
       event.currentTarget.requestSubmit();
@@ -438,7 +420,6 @@ export function TaskEditor({
     }
     if (event.target !== titleRef.current) return;
     event.preventDefault();
-    if (task) event.currentTarget.requestSubmit();
   }
 
   function chooseDueDate(value: string) {
@@ -447,7 +428,7 @@ export function TaskEditor({
   }
 
   function cancelEditor() {
-    onCancel(task ? null : {
+    onCancel({
       title,
       descriptionSegments,
       status,
@@ -491,10 +472,10 @@ export function TaskEditor({
         if (backdropClick && !saving) cancelEditor();
       }}
     >
-      <form className={`task-form${task ? "" : " is-creating"}`} onSubmit={handleSubmit} onKeyDown={handleKeyDown}>
+      <form className="task-form is-creating" onSubmit={handleSubmit} onKeyDown={handleKeyDown}>
         <header className="dialog-header">
           <div className="dialog-context">
-            <strong id="task-dialog-title">{task ? task.identifier : text("新建议题", "New issue")}</strong>
+            <strong id="task-dialog-title">{text("新建议题", "New issue")}</strong>
           </div>
           <div className="dialog-header-actions">
             <button
@@ -524,33 +505,26 @@ export function TaskEditor({
             <span className="sr-only">{text("标题", "Title")}</span>
             <textarea ref={titleRef} rows={1} value={title} onChange={(event) => setTitle(event.target.value.replace(/\n/g, ""))} placeholder={text("议题标题", "Issue title")} maxLength={240} autoComplete="off" />
           </label>
-          {task ? (
-            <label className="composer-description">
-              <span className="sr-only">{text("描述", "Description")}</span>
-              <textarea value={description} onChange={(event) => setDescription(event.target.value)} placeholder={text("添加描述…", "Add description…")} rows={5} />
-            </label>
-          ) : (
-            <InlineMediaComposer
-              ref={descriptionComposerRef}
-              className="composer-description inline-media-description"
-              segments={descriptionSegments}
-              mentionTasks={tasks}
-              referenceTasks={referenceTasks}
-              completionContext={projectId ? { projectId, surface: "issue-description" } : undefined}
-              placeholder={text("添加描述…", "Add description…")}
-              ariaLabel={text("描述", "Description")}
-              disabled={saving}
-              allowAttachments
-              onChange={setDescriptionSegments}
-              onError={setAttachmentError}
-            />
-          )}
+          <InlineMediaComposer
+            ref={descriptionComposerRef}
+            className="composer-description inline-media-description"
+            segments={descriptionSegments}
+            mentionTasks={tasks}
+            referenceTasks={referenceTasks}
+            completionContext={projectId ? { projectId, surface: "issue-description" } : undefined}
+            placeholder={text("添加描述…", "Add description…")}
+            ariaLabel={text("描述", "Description")}
+            disabled={saving}
+            allowAttachments
+            onChange={setDescriptionSegments}
+            onError={setAttachmentError}
+          />
 
         </div>
 
         <div className="task-form-dock">
           <div className="property-row">
-            {!task && projectOptions && (
+            {projectOptions && (
               <TaskPropertyPicker
                 value={projectId ?? ""}
                 options={[
@@ -677,7 +651,7 @@ export function TaskEditor({
               </button>
             )}
 
-            {!task && selectedRelationChips.map(({ type, issue }) => {
+            {selectedRelationChips.map(({ type, issue }) => {
               const identifier = issue.externalKey ?? issue.identifier;
               const relationLabel = type === "subIssue"
                 ? text("子", "Sub")
@@ -724,24 +698,20 @@ export function TaskEditor({
                 >
                   <button type="button" onClick={() => setMenu("due")}><span><DueDateIcon color="currentColor" /></span><strong>{text("设置截止日期", "Set due date")}</strong><kbd>⇧ D</kbd><b><LinearIcon name="chevronRight" /></b></button>
                   <button type="button" onClick={() => setMenu("recurrence")}><span><RecurrenceIcon color="currentColor" /></span><strong>{text("设置重复…", "Set recurrence…")}</strong><b><LinearIcon name="chevronRight" /></b></button>
-                  {!task && (
-                    <>
-                      <div className="more-popover-divider" />
-                      <button className={relationMenu === "subIssue" ? "is-open" : undefined} type="button" role="menuitem" aria-haspopup="menu" aria-expanded={relationMenu === "subIssue"} onClick={() => setRelationMenu("subIssue")}><span><PlusIcon color="currentColor" size={16} /></span><strong>{text("添加子议题", "Add sub-issue")}</strong>{selectedSubIssues.length > 0 && <small>{text(`${selectedSubIssues.length} 个已选`, `${selectedSubIssues.length} selected`)}</small>}<b><LinearIcon name="chevronRight" /></b></button>
-                      <button className={relationMenu === "parent" ? "is-open" : undefined} type="button" role="menuitem" aria-haspopup="menu" aria-expanded={relationMenu === "parent"} onClick={() => setRelationMenu("parent")}><span><PlusIcon color="currentColor" size={16} /></span><strong>{text("添加父议题", "Add parent issue")}</strong>{selectedParent && <small>{selectedParent.externalKey ?? selectedParent.identifier}</small>}<b><LinearIcon name="chevronRight" /></b></button>
-                      <button className={relationMenu === "related" ? "is-open" : undefined} type="button" role="menuitem" aria-haspopup="menu" aria-expanded={relationMenu === "related"} onClick={() => setRelationMenu("related")}><span><RelationIcon color="currentColor" size={16} /></span><strong>{text("添加关联议题", "Add related issue")}</strong>{selectedRelated.length > 0 && <small>{text(`${selectedRelated.length} 个已选`, `${selectedRelated.length} selected`)}</small>}<b><LinearIcon name="chevronRight" /></b></button>
-                      {relationMenu && (
-                        <div className="issue-relation-popover task-create-relation-submenu" aria-label={text("选择关系议题", "Select relation issue")}>
-                          <IssuePickerContent
-                            key={relationMenu}
-                            candidates={relationCandidates}
-                            selectedIds={selectedRelationIds}
-                            onEscape={() => setRelationMenu(null)}
-                            onSelect={toggleDraftRelation}
-                          />
-                        </div>
-                      )}
-                    </>
+                  <div className="more-popover-divider" />
+                  <button className={relationMenu === "subIssue" ? "is-open" : undefined} type="button" role="menuitem" aria-haspopup="menu" aria-expanded={relationMenu === "subIssue"} onClick={() => setRelationMenu("subIssue")}><span><PlusIcon color="currentColor" size={16} /></span><strong>{text("添加子议题", "Add sub-issue")}</strong>{selectedSubIssues.length > 0 && <small>{text(`${selectedSubIssues.length} 个已选`, `${selectedSubIssues.length} selected`)}</small>}<b><LinearIcon name="chevronRight" /></b></button>
+                  <button className={relationMenu === "parent" ? "is-open" : undefined} type="button" role="menuitem" aria-haspopup="menu" aria-expanded={relationMenu === "parent"} onClick={() => setRelationMenu("parent")}><span><PlusIcon color="currentColor" size={16} /></span><strong>{text("添加父议题", "Add parent issue")}</strong>{selectedParent && <small>{selectedParent.externalKey ?? selectedParent.identifier}</small>}<b><LinearIcon name="chevronRight" /></b></button>
+                  <button className={relationMenu === "related" ? "is-open" : undefined} type="button" role="menuitem" aria-haspopup="menu" aria-expanded={relationMenu === "related"} onClick={() => setRelationMenu("related")}><span><RelationIcon color="currentColor" size={16} /></span><strong>{text("添加关联议题", "Add related issue")}</strong>{selectedRelated.length > 0 && <small>{text(`${selectedRelated.length} 个已选`, `${selectedRelated.length} selected`)}</small>}<b><LinearIcon name="chevronRight" /></b></button>
+                  {relationMenu && (
+                    <div className="issue-relation-popover task-create-relation-submenu" aria-label={text("选择关系议题", "Select relation issue")}>
+                      <IssuePickerContent
+                        key={relationMenu}
+                        candidates={relationCandidates}
+                        selectedIds={selectedRelationIds}
+                        onEscape={() => setRelationMenu(null)}
+                        onSelect={toggleDraftRelation}
+                      />
+                    </div>
                   )}
                 </div>
               )}
@@ -779,45 +749,35 @@ export function TaskEditor({
           )}
 
           <footer className="dialog-footer">
-            {!task && (
-              <>
-                <button className="composer-attach-icon" type="button" disabled={saving} onClick={() => attachmentInputRef.current?.click()} aria-label={text("上传附件", "Upload attachments")}>
-                  <AttachmentIcon color="currentColor" />
-                </button>
-                <input ref={attachmentInputRef} type="file" multiple hidden onChange={(event) => { if (event.currentTarget.files) descriptionComposerRef.current?.addFiles(event.currentTarget.files); event.currentTarget.value = ""; }} />
-              </>
-            )}
-            {task && <span aria-hidden="true" />}
+            <button className="composer-attach-icon" type="button" disabled={saving} onClick={() => attachmentInputRef.current?.click()} aria-label={text("上传附件", "Upload attachments")}>
+              <AttachmentIcon color="currentColor" />
+            </button>
+            <input ref={attachmentInputRef} type="file" multiple hidden onChange={(event) => { if (event.currentTarget.files) descriptionComposerRef.current?.addFiles(event.currentTarget.files); event.currentTarget.value = ""; }} />
             <div className="dialog-actions">
-              {task && <span className="dialog-updated">{text(`编辑 ${task.identifier}`, `Editing ${task.identifier}`)}</span>}
-              {!task && (
-                <div className="create-more-control">
-                  <span>{text("创建更多", "Create more")}</span>
-                  <button
-                    type="button"
-                    className={`board-setting-switch${createMore ? " is-on" : ""}`}
-                    role="switch"
-                    aria-checked={createMore}
-                    disabled={saving}
-                    onClick={() => setCreateMore((current) => !current)}
-                  >
-                    <span aria-hidden="true" />
-                  </button>
-                </div>
-              )}
+              <div className="create-more-control">
+                <span>{text("创建更多", "Create more")}</span>
+                <button
+                  type="button"
+                  className={`board-setting-switch${createMore ? " is-on" : ""}`}
+                  role="switch"
+                  aria-checked={createMore}
+                  disabled={saving}
+                  onClick={() => setCreateMore((current) => !current)}
+                >
+                  <span aria-hidden="true" />
+                </button>
+              </div>
               <button
                 className="button primary"
                 type="submit"
                 disabled={saving}
                 onClick={() => {
-                  if (!task) createSubmitIntentRef.current = true;
+                  createSubmitIntentRef.current = true;
                 }}
               >
                 {saving
                   ? text("正在保存…", "Saving…")
-                  : task
-                    ? text("保存更改", "Save changes")
-                    : text("创建议题", "Create issue")}
+                  : text("创建议题", "Create issue")}
               </button>
             </div>
           </footer>


### PR DESCRIPTION
TaskEditor 的生产入口都用于新建，但仍保留旧编辑表单和保存分支；打开或关闭详情还会重建 SSE，触发项目、任务、归档和设置的重复读取。

删除创建器不可达的旧编辑模式，保留草稿、创建更多、项目选择和列状态。SSE 的生命周期绑定服务 URL，通过当前选择处理事件，并保留 120ms 合并、项目过滤以及首次连接和重连后的补齐读取。

验证：typecheck、build:web 和真实独立 Web 路径通过。详情开关新增连接从各 1 次降为 0；打开详情的评论、活动和附件从各 2 次降为 1；切项目活动/归档从各 2 次降为 1。顶栏/列创建、草稿恢复、连续创建、目标项目选择、详情编辑、跨项目事件、重连补齐均已验证。首次握手窗口的漏更新在独立验证中发现，并回到同一 Pro 对话修正后复验通过。

同步了现有 realtime 断言中的 URL 变量写法；对应检查文件通过，没有新增测试用例。

Taskboard: LOCAL-398, LOCAL-400. 未添加产品测试、兼容层或共享 App 操作。
