### PR TITLE
Prepare v1.1.23-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-taskboard",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-taskboard",
-      "version": "1.1.22",
+      "version": "1.1.23",
       "dependencies": {
         "dhtmlx-gantt": "^10.0.0",
         "dompurify": "^3.4.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-taskboard",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "private": true,
   "type": "module",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "codex-taskboard-launcher"
-version = "1.1.22"
+version = "1.1.23"
 dependencies = [
  "dispatch2",
  "futures-util",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-taskboard-launcher"
-version = "1.1.22"
+version = "1.1.23"
 description = "Codex Taskboard launcher"
 edition = "2021"
 rust-version = "1.88"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex Taskboard",
-  "version": "1.1.22",
+  "version": "1.1.23",
   "identifier": "com.chuspeeism.codex-taskboard",
   "app": {
     "windows": []


### PR DESCRIPTION
将 13 个已合并产品 PR 的审计改动发布为 v1.1.23-beta.1。此 PR 只将 npm、Cargo 和 Tauri 的六处产品版本更新为 1.1.23；Beta 通道由发布标签确定。

已核对产品合并后的代码与独立集成验证版本一致。集成类型检查、Web 构建及真实创建→评论→实时更新路径通过；现有发布元数据入口返回 prerelease=true，DMG 为首项资产。三平台构建由本 PR 的 CI 验证。
