### PR TITLE
feat: add Kimi execution to task conversations

### DIFF
--- a/server/ai-chat-process.mjs
+++ b/server/ai-chat-process.mjs
@@ -245,6 +245,66 @@ export function buildCodexPrompt(thread, { message, skills, attachmentPaths }, s
   ].join("\n");
 }
 
+export function buildKimiArgs(thread, prompt) {
+  const args = ["--output-format", "stream-json"];
+  if (thread.agentSessionId) args.push("--session", thread.agentSessionId);
+  args.push("--prompt", prompt);
+  return args;
+}
+
+export function buildKimiPrompt(thread, message, issue) {
+  const context = [
+    `project_id: ${thread.origin.projectId}`,
+    `project_name: ${thread.origin.projectName}`,
+    `workspace_path: ${thread.origin.workspacePath}`,
+  ];
+  if (issue) {
+    context.push(
+      `issue_identifier: ${issue.identifier}`,
+      `issue_title: ${issue.title}`,
+      "issue_description:",
+      issue.description || "(empty)",
+    );
+  }
+  return [
+    "<taskboard_context>",
+    ...context,
+    "</taskboard_context>",
+    "",
+    "<user_message>",
+    message,
+    "</user_message>",
+  ].join("\n");
+}
+
+export function normalizeKimiEvent(raw) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  if (raw.role === "meta" && raw.type === "session.resume_hint") {
+    const sessionId = typeof raw.session_id === "string" ? raw.session_id.trim() : "";
+    if (!sessionId || sessionId.length > 256 || sessionId.includes("\0")) return null;
+    return { kind: "session.started", sessionId };
+  }
+  if (raw.role === "assistant" && typeof raw.content === "string") {
+    return {
+      kind: "event",
+      type: "agent_message",
+      role: "assistant",
+      content: cappedText(raw.content),
+      data: { status: "completed", agentType: "kimi" },
+    };
+  }
+  if (raw.role === "error") {
+    return {
+      kind: "event",
+      type: typeof raw.type === "string" ? cappedText(raw.type) : "error",
+      role: "error",
+      content: errorMessage(raw.content ?? raw.message ?? raw.error),
+      data: { status: "failed", agentType: "kimi" },
+    };
+  }
+  return null;
+}
+
 export function normalizeCodexEvent(raw) {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
 
@@ -325,10 +385,12 @@ export function spawnCodexTurn({
   args,
   prompt,
   env,
+  cwd,
   onRawEvent,
   maxLineBytes = MAX_CODEX_JSONL_LINE_BYTES,
 }) {
   const child = spawn(process.execPath, [TURN_OWNER_PATH, executable, JSON.stringify(args)], {
+    cwd,
     detached: true,
     env: withoutTaskboardLauncherEnvironment(env),
     stdio: ["pipe", "pipe", "pipe", "pipe"],

--- a/server/ai-chat.mjs
+++ b/server/ai-chat.mjs
@@ -16,7 +16,10 @@ import { CodexAppServer, CodexHostAppServer } from "./codex-app-server.mjs";
 import {
   buildCodexArgs,
   buildCodexPrompt,
+  buildKimiArgs,
+  buildKimiPrompt,
   normalizeCodexEvent,
+  normalizeKimiEvent,
   spawnCodexTurn,
 } from "./ai-chat-process.mjs";
 
@@ -82,6 +85,13 @@ function codexTargetFromOrigin(origin) {
   };
 }
 
+function resolvedIssueWorkspace(resolved) {
+  const worktreePath = resolved.issue?.developmentContext?.type === "worktree"
+    ? resolved.issue.developmentContext.path
+    : null;
+  return worktreePath ? { ...resolved, workspacePath: worktreePath } : resolved;
+}
+
 function normalizedAppServerItem(item) {
   if (!item || typeof item !== "object") return null;
   const itemId = typeof item.id === "string" ? item.id.slice(0, ERROR_CONTENT_LIMIT) : "";
@@ -141,6 +151,7 @@ export class AiChatService {
   constructor(options) {
     this.database = options.database;
     this.codexExecutable = options.codexExecutable;
+    this.kimiExecutable = options.kimiExecutable;
     this.codexStatePath = options.codexStatePath;
     this.manageTaskboardSkillPath = options.manageTaskboardSkillPath;
     this.processEnv = options.processEnv ?? process.env;
@@ -355,6 +366,9 @@ export class AiChatService {
 
   async compactThread(threadId) {
     const thread = this.getThread(threadId);
+    if (thread.agentType === "kimi") {
+      throw new ApiError(400, "KIMI_COMPACTION_UNAVAILABLE", "Kimi conversations cannot be compacted here");
+    }
     if (thread.status === "running") {
       throw new ApiError(409, "AI_CHAT_THREAD_RUNNING", "Cannot compact a running conversation");
     }
@@ -366,19 +380,35 @@ export class AiChatService {
   }
 
   async createThread(input) {
-    const codexTarget = input.codexProjectKind === "remote" ? input : undefined;
-    const resolved = await this.resolveContext(input.projectId, input.issueId, codexTarget);
-    const catalog = await this.getCatalog(input.projectId, resolved, codexTarget);
-    const model = this.#resolveModel(catalog, input.model);
-    const reasoningEffort = input.reasoningEffort ?? model.defaultReasoningEffort;
-    this.#validateReasoningEffort(model, reasoningEffort);
-    const sandbox = input.sandbox ?? "workspace-write";
-    this.#validateSandbox(sandbox);
+    const agentType = input.agentType ?? "codex";
+    const codexTarget = agentType === "codex" && input.codexProjectKind === "remote"
+      ? input
+      : undefined;
+    const resolved = resolvedIssueWorkspace(
+      await this.resolveContext(input.projectId, input.issueId, codexTarget),
+    );
+    let model;
+    let reasoningEffort;
+    let sandbox;
+    if (agentType === "kimi") {
+      model = "kimi-default";
+      reasoningEffort = "default";
+      sandbox = "workspace-write";
+    } else {
+      const catalog = await this.getCatalog(input.projectId, resolved, codexTarget);
+      const resolvedModel = this.#resolveModel(catalog, input.model);
+      model = resolvedModel.slug;
+      reasoningEffort = input.reasoningEffort ?? resolvedModel.defaultReasoningEffort;
+      this.#validateReasoningEffort(resolvedModel, reasoningEffort);
+      sandbox = input.sandbox ?? "workspace-write";
+      this.#validateSandbox(sandbox);
+    }
 
     const issue = resolved.issue;
 
     return this.database.createAiChatThread({
       title: input.title ?? issue?.identifier ?? "New conversation",
+      agentType,
       origin: {
         projectId: resolved.project.id,
         projectName: resolved.project.name,
@@ -390,7 +420,7 @@ export class AiChatService {
         } : {}),
         ...(issue ? { issueId: issue.id, issueIdentifier: issue.identifier } : {}),
       },
-      model: model.slug,
+      model,
       reasoningEffort,
       sandbox,
     });
@@ -401,6 +431,9 @@ export class AiChatService {
     const changesSettings = ["model", "reasoningEffort", "sandbox"].some(
       (key) => Object.hasOwn(changes, key),
     );
+    if (thread.agentType === "kimi" && changesSettings) {
+      throw new ApiError(400, "KIMI_SETTINGS_UNAVAILABLE", "Kimi settings are managed by Kimi Code");
+    }
     const wasActive = changesSettings && this.#threadIsActive(thread);
 
     if (Object.hasOwn(changes, "sandbox")) this.#validateSandbox(changes.sandbox);
@@ -448,6 +481,9 @@ export class AiChatService {
       );
     }
     if (input?.contractVersion === "composer.v1") {
+      if (thread.agentType === "kimi") {
+        throw new ApiError(400, "KIMI_COMPOSER_UNSUPPORTED", "Kimi conversations accept plain text turns");
+      }
       return this.#startComposerTurn(thread, input);
     }
     this.#validateTurnInput(input);
@@ -460,11 +496,14 @@ export class AiChatService {
     }
 
     const codexTarget = codexTargetFromOrigin(thread.origin);
-    const resolved = await this.resolveContext(
+    const resolved = resolvedIssueWorkspace(await this.resolveContext(
       thread.origin.projectId,
       thread.origin.issueId,
       codexTarget,
-    );
+    ));
+    if (thread.agentType === "kimi") {
+      return this.#startKimiTurn(thread, input, resolved);
+    }
     const catalog = await this.getCatalog(thread.origin.projectId, resolved, codexTarget);
 
     thread = this.getThread(threadId);
@@ -622,6 +661,115 @@ export class AiChatService {
       if (temporaryDirectory) {
         await rm(temporaryDirectory, { recursive: true, force: true });
       }
+      throw error;
+    }
+  }
+
+  async #startKimiTurn(thread, input, resolved) {
+    if (resolved.workspacePath !== thread.origin.workspacePath) {
+      throw new ApiError(
+        409,
+        "PROJECT_WORKSPACE_CHANGED",
+        "The project's device workspace no longer matches this conversation",
+      );
+    }
+    const attachments = input.attachments ?? [];
+    const { temporaryDirectory, attachmentPaths } = await this.#writeTurnAttachments(attachments);
+    const attachmentMessage = attachmentPaths.length > 0
+      ? `${input.message}\n\nAttached files:\n${attachmentPaths.map((item) => `- ${item}`).join("\n")}`
+      : input.message;
+    try {
+      const prompt = buildKimiPrompt(thread, attachmentMessage, resolved.issue);
+      const args = buildKimiArgs(thread, prompt);
+      const run = this.database.createAiChatRun({ threadId: thread.id });
+      this.#emit(thread.id, { type: "ai.run", run });
+      const userEvent = this.database.insertAiChatEvent({
+        threadId: thread.id,
+        runId: run.id,
+        type: "user_message",
+        role: "user",
+        content: input.message,
+        data: attachments.length > 0 ? {
+          attachments: attachments.map(({ filename, contentType, size }) => ({
+            filename,
+            contentType,
+            size,
+          })),
+        } : undefined,
+      });
+      this.#emit(thread.id, { type: "ai.event", event: userEvent });
+
+      const resumingSessionId = thread.agentSessionId;
+      let startedSessionId = null;
+      let terminalOutcome = null;
+      let terminalError = "";
+      const { child, completion } = spawnCodexTurn({
+        executable: this.kimiExecutable,
+        args,
+        prompt: "",
+        env: this.processEnv,
+        cwd: resolved.workspacePath,
+        onRawEvent: (raw) => {
+          const normalized = normalizeKimiEvent(raw);
+          if (!normalized) return;
+          if (normalized.kind === "session.started") {
+            if (
+              (resumingSessionId && normalized.sessionId !== resumingSessionId)
+              || (startedSessionId && normalized.sessionId !== startedSessionId)
+            ) {
+              throw new Error("Kimi returned an unexpected session id");
+            }
+            startedSessionId = normalized.sessionId;
+            this.database.updateAiChatThread(thread.id, { agentSessionId: normalized.sessionId });
+            return;
+          }
+          const event = this.database.insertAiChatEvent({
+            threadId: thread.id,
+            runId: run.id,
+            type: normalized.type,
+            role: normalized.role,
+            content: normalized.content,
+            data: normalized.data,
+          });
+          if (normalized.role === "assistant") terminalOutcome = "completed";
+          if (normalized.role === "error") {
+            terminalOutcome = "failed";
+            terminalError ||= normalized.content;
+          }
+          this.#emit(thread.id, { type: "ai.event", event });
+        },
+      });
+      const active = { child, threadId: thread.id, interrupted: false, temporaryDirectory };
+      this.active.set(run.id, active);
+      const finalization = completion.then(
+        (result) => this.#finishRun({
+          run,
+          active,
+          result,
+          resumingThreadId: resumingSessionId,
+          startedThreadId: () => startedSessionId,
+          terminalOutcome: () => terminalOutcome,
+          terminalError: () => terminalError,
+          pendingError: () => "",
+          agentLabel: "Kimi",
+        }),
+        (error) => this.#finishRun({
+          run,
+          active,
+          error,
+          resumingThreadId: resumingSessionId,
+          startedThreadId: () => startedSessionId,
+          terminalOutcome: () => terminalOutcome,
+          terminalError: () => terminalError,
+          pendingError: () => "",
+          agentLabel: "Kimi",
+        }),
+      );
+      this.completions.set(run.id, finalization);
+      void finalization.finally(() => this.completions.delete(run.id)).catch(() => {});
+      return run;
+    } catch (error) {
+      if (temporaryDirectory) await rm(temporaryDirectory, { recursive: true, force: true });
       throw error;
     }
   }
@@ -1172,6 +1320,7 @@ export class AiChatService {
     terminalOutcome,
     terminalError,
     pendingError,
+    agentLabel = "Codex",
   }) {
     let status;
     let publicError = null;
@@ -1180,21 +1329,21 @@ export class AiChatService {
       publicError = "Interrupted";
     } else if (error) {
       status = "failed";
-      publicError = cappedError(error) || "Codex turn failed";
+      publicError = cappedError(error) || `${agentLabel} turn failed`;
     } else if (terminalOutcome() === "failed") {
       status = "failed";
-      publicError = terminalError() || "Codex reported a failed turn";
+      publicError = terminalError() || `${agentLabel} reported a failed turn`;
     } else if (result.exitCode !== 0) {
       status = "failed";
       publicError = result.exitCode === null
-        ? `Codex exited due to signal ${result.signal ?? "unknown"}`
-        : `Codex exited with code ${result.exitCode}`;
+        ? `${agentLabel} exited due to signal ${result.signal ?? "unknown"}`
+        : `${agentLabel} exited with code ${result.exitCode}`;
     } else if (terminalOutcome() !== "completed") {
       status = "failed";
-      publicError = pendingError() || "Codex exited without reporting turn completion";
+      publicError = pendingError() || `${agentLabel} exited without reporting turn completion`;
     } else if (!resumingThreadId && !startedThreadId()) {
       status = "failed";
-      publicError = "Codex did not provide a thread id";
+      publicError = `${agentLabel} did not provide a ${agentLabel === "Codex" ? "thread" : "session"} id`;
     } else {
       status = "completed";
     }

--- a/server/ai-chat.mjs
+++ b/server/ai-chat.mjs
@@ -335,7 +335,9 @@ export class AiChatService {
 
     let resolved;
     try {
-      resolved = await this.resolveContext(projectId, thread?.origin.issueId, codexTarget);
+      resolved = resolvedIssueWorkspace(
+        await this.resolveContext(projectId, thread?.origin.issueId, codexTarget),
+      );
     } catch (error) {
       if (error instanceof ApiError && ["PROJECT_NOT_FOUND", "AI_CHAT_ISSUE_NOT_FOUND"].includes(error.code)) {
         throw new ApiError(400, "INVALID_COMPOSER_QUERY", "Composer project is invalid");
@@ -1063,11 +1065,11 @@ export class AiChatService {
     }
 
     const codexTarget = codexTargetFromOrigin(thread.origin);
-    const resolved = await this.resolveContext(
+    const resolved = resolvedIssueWorkspace(await this.resolveContext(
       thread.origin.projectId,
       thread.origin.issueId,
       codexTarget,
-    );
+    ));
     const runtime = this.#runtimeForTarget(resolved);
     thread = this.getThread(thread.id);
     if (this.#threadIsActive(thread)) {

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -555,6 +555,14 @@ function parseAiSandbox(value) {
   return value;
 }
 
+function parseAiAgentType(value) {
+  if (value === undefined) return undefined;
+  if (value !== "codex" && value !== "kimi") {
+    throw new ApiError(400, "INVALID_AGENT_TYPE", "'agentType' must be codex or kimi");
+  }
+  return value;
+}
+
 function parseAiSetting(value, name, maxLength) {
   const setting = stringField(value, name, { maxLength });
   if (setting === "") {
@@ -606,6 +614,7 @@ function parseAiThreadCreate(body) {
     "projectId",
     "issueId",
     "title",
+    "agentType",
     "model",
     "reasoningEffort",
     "sandbox",
@@ -618,6 +627,7 @@ function parseAiThreadCreate(body) {
     projectId: validateProjectId(body.projectId),
     issueId: parseAiSetting(body.issueId, "issueId", 128),
     title: parseAiSetting(body.title, "title", 160),
+    agentType: parseAiAgentType(body.agentType),
     model: parseAiSetting(body.model, "model", 128),
     reasoningEffort: parseAiSetting(body.reasoningEffort, "reasoningEffort", 64),
     sandbox: parseAiSandbox(body.sandbox),
@@ -1340,6 +1350,9 @@ export function resolveServerOptions(options = {}) {
       ?? environment.CODEX_TASKBOARD_SKILL_PATH
       ?? path.join(PROJECT_ROOT, "skills", "manage-taskboard", "SKILL.md"),
     codexExecutable: resolveCodexExecutable({ explicit: options.codexExecutable }),
+    kimiExecutable: options.kimiExecutable
+      ?? environment.KIMI_CODE_EXECUTABLE
+      ?? path.join(os.homedir(), ".kimi-code", "bin", "kimi"),
     codexStatePath: options.codexStatePath
       ?? path.join(codexHome, ".codex-global-state.json"),
     codexProcessesPath: options.codexProcessesPath
@@ -1589,6 +1602,7 @@ export function createTaskboardServer(options = {}) {
   const aiChat = new AiChatService({
     database,
     codexExecutable: resolved.codexExecutable,
+    kimiExecutable: resolved.kimiExecutable,
     codexStatePath: resolved.codexStatePath,
     manageTaskboardSkillPath: resolved.skillPath,
     processEnv: codexProcessEnvironment,

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -217,6 +217,8 @@ function aiChatThreadFromRow(row) {
     id: row.id,
     title: row.title,
     status: row.status,
+    agentType: row.agent_type ?? "codex",
+    agentSessionId: row.agent_session_id ?? null,
     origin: {
       projectId: row.origin_project_id,
       projectName: row.origin_project_name,
@@ -403,6 +405,8 @@ export class TaskboardDatabase {
         id TEXT PRIMARY KEY,
         title TEXT NOT NULL,
         status TEXT NOT NULL CHECK (status IN ('idle', 'running', 'failed')),
+        agent_type TEXT NOT NULL DEFAULT 'codex' CHECK (agent_type IN ('codex', 'kimi')),
+        agent_session_id TEXT,
         origin_project_id TEXT NOT NULL,
         origin_project_name TEXT NOT NULL,
         origin_workspace_path TEXT NOT NULL,
@@ -458,6 +462,14 @@ export class TaskboardDatabase {
         ON ai_chat_events(thread_id, created_at, id);
 
     `);
+
+    const aiChatThreadColumns = this.database.prepare("PRAGMA table_info(ai_chat_threads)").all();
+    if (!aiChatThreadColumns.some((column) => column.name === "agent_type")) {
+      this.database.exec("ALTER TABLE ai_chat_threads ADD COLUMN agent_type TEXT NOT NULL DEFAULT 'codex'");
+    }
+    if (!aiChatThreadColumns.some((column) => column.name === "agent_session_id")) {
+      this.database.exec("ALTER TABLE ai_chat_threads ADD COLUMN agent_session_id TEXT");
+    }
 
     const projectColumns = this.database.prepare("PRAGMA table_info(projects)").all();
     if (!projectColumns.some((column) => column.name === "workspace_path")) {
@@ -1442,17 +1454,19 @@ export class TaskboardDatabase {
     const timestamp = input.createdAt ?? now();
     this.database.prepare(`
       INSERT INTO ai_chat_threads (
-        id, title, status,
+        id, title, status, agent_type, agent_session_id,
         origin_project_id, origin_project_name, origin_workspace_path,
         origin_codex_project_id, origin_codex_project_kind, origin_codex_host_id,
         origin_issue_id, origin_issue_identifier,
         codex_thread_id, model, reasoning_effort, sandbox,
         created_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       id,
       input.title,
       input.status ?? "idle",
+      input.agentType ?? "codex",
+      input.agentSessionId ?? null,
       input.origin.projectId,
       input.origin.projectName,
       input.origin.workspacePath,
@@ -1479,6 +1493,7 @@ export class TaskboardDatabase {
     const columns = {
       title: "title",
       status: "status",
+      agentSessionId: "agent_session_id",
       codexThreadId: "codex_thread_id",
       model: "model",
       reasoningEffort: "reasoning_effort",

--- a/server/database.mjs
+++ b/server/database.mjs
@@ -463,11 +463,11 @@ export class TaskboardDatabase {
 
     `);
 
-    const aiChatThreadColumns = this.database.prepare("PRAGMA table_info(ai_chat_threads)").all();
-    if (!aiChatThreadColumns.some((column) => column.name === "agent_type")) {
+    const agentChatThreadColumns = this.database.prepare("PRAGMA table_info(ai_chat_threads)").all();
+    if (!agentChatThreadColumns.some((column) => column.name === "agent_type")) {
       this.database.exec("ALTER TABLE ai_chat_threads ADD COLUMN agent_type TEXT NOT NULL DEFAULT 'codex'");
     }
-    if (!aiChatThreadColumns.some((column) => column.name === "agent_session_id")) {
+    if (!agentChatThreadColumns.some((column) => column.name === "agent_session_id")) {
       this.database.exec("ALTER TABLE ai_chat_threads ADD COLUMN agent_session_id TEXT");
     }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3084,6 +3084,27 @@ export function App() {
     });
   }
 
+  function openTaskInKimi(task: Task) {
+    if (!localAiChatAvailable) {
+      setActionError(text(
+        "Kimi 仅可通过本机 Taskboard 运行。",
+        "Kimi is available only through the local Taskboard runtime.",
+      ));
+      return;
+    }
+    setActionError(null);
+    setAiOpenThreadRequest((current) => ({
+      projectId: task.projectId,
+      issueId: task.id,
+      agentType: "kimi",
+      composerText: text(
+        `处理 Taskboard 议题 ${task.identifier}。请在议题绑定的工作目录中执行，持续报告进度，完成后总结改动、验证结果和剩余限制。`,
+        `Work on Taskboard issue ${task.identifier} in its bound workspace. Report progress as you work, then summarize changes, verification, and remaining limitations.`,
+      ),
+      requestId: (current?.requestId ?? 0) + 1,
+    }));
+  }
+
   function changeProject(projectId: string) {
     closeContextMenu();
     setProjectContextMenu(null);
@@ -3676,6 +3697,7 @@ export function App() {
             onOpenThread={openThread}
             onOpenLegacyLocalThread={openLegacyLocalThread}
             onOpenInThread={openTaskInThread}
+            onOpenInKimi={openTaskInKimi}
             onCopy={(text, message) => void copyText(text, message)}
             openingThread={openingThreadTaskId === detailTask.id}
             onError={setActionError}
@@ -4145,6 +4167,7 @@ export function App() {
           onCopy={(text, message) => void copyText(text, message)}
           openInThreadDisabled={developmentScanLoading}
           onOpenInThread={openTaskInThread}
+          onOpenInKimi={openTaskInKimi}
           onArchive={(task) => void archiveTask(task)}
         />
       )}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -2,6 +2,7 @@ import type {
   ActorIdentity,
   AiChatCatalog,
   AiChatAttachmentInput,
+  AiAgentType,
   AiChatRun,
   AiChatSandbox,
   AiChatThread,
@@ -309,6 +310,7 @@ export async function createAiChatThread(input: {
   projectId: string;
   issueId?: string;
   title?: string;
+  agentType?: AiAgentType;
   model?: string;
   reasoningEffort?: string;
   sandbox?: AiChatSandbox;

--- a/web/src/components/AiChat.tsx
+++ b/web/src/components/AiChat.tsx
@@ -51,6 +51,7 @@ import {
   serializeComposerDocument,
 } from "../aiChatState";
 import type {
+  AiAgentType,
   AiChatCatalog,
   AiChatEvent,
   AiChatAttachmentInput,
@@ -95,7 +96,18 @@ export type AiChatOpenThreadRequest = {
 } | {
   projectId: string;
   issueId: string | null;
+  agentType?: AiAgentType;
   composerText: string;
+  requestId: number;
+} | {
+  projectId: string;
+  issueId: string | null;
+  agentType?: AiAgentType;
+  composerDraft: {
+    ready: boolean;
+    revision: string;
+    document: ComposerDocument | ComposerPersistedDocument;
+  };
   requestId: number;
 };
 
@@ -165,6 +177,7 @@ type ComposerBeforeInput = {
 type DraftThreadOrigin = {
   projectId: string;
   issueId: string | null;
+  agentType: AiAgentType;
   codexProjectIdentity: CodexProjectIdentity | null;
 };
 type PanelResizeEdge = "top" | "left" | "top-left";
@@ -1576,6 +1589,10 @@ export function AiChat({
   ]);
 
   const selectedThreadSummary = threads.find((thread) => thread.id === selectedThreadId) ?? null;
+  const activeAgentType = snapshot?.thread.agentType
+    ?? selectedThreadSummary?.agentType
+    ?? draftOrigin?.agentType
+    ?? "codex";
   const catalogProjectId = snapshot?.thread.origin.projectId
     ?? selectedThreadSummary?.origin.projectId
     ?? draftOrigin?.projectId
@@ -1748,7 +1765,7 @@ export function AiChat({
   const currentRun = snapshot?.thread.currentRun
     ?? snapshot?.runs.find((run) => run.status === "running")
     ?? null;
-  const visibleError = error ?? catalogError;
+  const visibleError = error ?? (activeAgentType === "codex" ? catalogError : null);
   const composerBlocked = Boolean(
     selectedThreadId && deletingThreadId === selectedThreadId,
   );
@@ -1834,6 +1851,7 @@ export function AiChat({
       setDraftOrigin({
         projectId: openThreadRequest.projectId,
         issueId: openThreadRequest.issueId,
+        agentType: openThreadRequest.agentType ?? "codex",
         codexProjectIdentity: openThreadRequest.projectId === projectId
           ? codexProjectIdentity
           : null,
@@ -1841,6 +1859,7 @@ export function AiChat({
       taskComposerDraftOriginRef.current = {
         projectId: openThreadRequest.projectId,
         issueId: openThreadRequest.issueId,
+        agentType: openThreadRequest.agentType ?? "codex",
         codexProjectIdentity: openThreadRequest.projectId === projectId
           ? codexProjectIdentity
           : null,
@@ -1941,6 +1960,7 @@ export function AiChat({
     setDraftOrigin({
       projectId: input.projectId,
       issueId: input.issueId ?? null,
+      agentType: "codex",
       codexProjectIdentity,
     });
     setSnapshot(null);
@@ -1952,7 +1972,12 @@ export function AiChat({
 
   async function createThreadForDraftOrigin(): Promise<AiChatThread | null> {
     const origin = draftOrigin ?? (
-      projectId ? { projectId, issueId, codexProjectIdentity } : null
+      projectId ? {
+        projectId,
+        issueId,
+        agentType: "codex" as const,
+        codexProjectIdentity,
+      } : null
     );
     const input = buildThreadCreateInput(origin?.projectId ?? "", origin?.issueId ?? null);
     if (!input) {
@@ -1969,26 +1994,30 @@ export function AiChat({
     };
     setLoading(true);
     try {
-      const targetCatalog = catalogLoadedProjectId === input.projectId && activeCatalog
-        ? activeCatalog
-        : await getAiChatCatalog(input.projectId, undefined, origin?.codexProjectIdentity);
-      const normalized = normalizeChatSelection(
-        targetCatalog.models,
-        inheritedSettings.model,
-        inheritedSettings.reasoningEffort,
-      );
-      const sandbox = targetCatalog.sandboxes.includes(inheritedSettings.sandbox)
-        ? inheritedSettings.sandbox
-        : targetCatalog.sandboxes.find(
-          (candidate): candidate is AiChatSandbox => candidate === "workspace-write",
-        ) ?? targetCatalog.sandboxes.find(isAiChatSandbox) ?? inheritedSettings.sandbox;
-      const settings = {
-        model: normalized?.model ?? inheritedSettings.model,
-        reasoningEffort: normalized?.reasoningEffort ?? inheritedSettings.reasoningEffort,
-        sandbox,
-      };
+      let settings = {};
+      if (origin?.agentType !== "kimi") {
+        const targetCatalog = catalogLoadedProjectId === input.projectId && activeCatalog
+          ? activeCatalog
+          : await getAiChatCatalog(input.projectId, undefined, origin?.codexProjectIdentity);
+        const normalized = normalizeChatSelection(
+          targetCatalog.models,
+          inheritedSettings.model,
+          inheritedSettings.reasoningEffort,
+        );
+        const sandbox = targetCatalog.sandboxes.includes(inheritedSettings.sandbox)
+          ? inheritedSettings.sandbox
+          : targetCatalog.sandboxes.find(
+            (candidate): candidate is AiChatSandbox => candidate === "workspace-write",
+          ) ?? targetCatalog.sandboxes.find(isAiChatSandbox) ?? inheritedSettings.sandbox;
+        settings = {
+          model: normalized?.model ?? inheritedSettings.model,
+          reasoningEffort: normalized?.reasoningEffort ?? inheritedSettings.reasoningEffort,
+          sandbox,
+        };
+      }
       const thread = await createAiChatThread({
         ...input,
+        agentType: origin?.agentType ?? "codex",
         ...settings,
         ...(origin?.codexProjectIdentity ?? {}),
       });
@@ -2352,7 +2381,7 @@ export function AiChat({
       || node.type === "unsupportedReference"
     )) ?? false;
     const isTaskOriginPlainTextDraft = Boolean(
-      taskComposerDraftOriginRef.current
+      taskComposerDraftOriginRef.current?.agentType === "codex"
       && currentComposerDocument?.nodes.every((node) => node.type === "text"),
     );
     if (isTaskOriginPlainTextDraft) {
@@ -2379,7 +2408,8 @@ export function AiChat({
         }
       }
     }
-    const useComposerTurn = hasStructuredReference || isTaskOriginPlainTextDraft;
+    const useComposerTurn = activeAgentType === "codex"
+      && (hasStructuredReference || isTaskOriginPlainTextDraft);
     if (useComposerTurn && !hasPersistedReference && !currentComposerRevision) {
       setError(text(
         "补全来源已失效，请重新选择 Skill",
@@ -2765,8 +2795,8 @@ export function AiChat({
           ref={panelRef}
           className={`ai-chat-panel${panelResizeEdge ? ` is-resizing-${panelResizeEdge}` : ""}`}
           style={panelGeometry ?? undefined}
-          aria-label={text("Codex AI 对话", "Codex AI chat")}
-          data-screen-label={text("Codex AI 对话", "Codex AI chat")}
+          aria-label={activeAgentType === "kimi" ? "Kimi Code" : text("Codex AI 对话", "Codex AI chat")}
+          data-screen-label={activeAgentType === "kimi" ? "Kimi Code" : text("Codex AI 对话", "Codex AI chat")}
         >
           <div
             className="ai-chat-resize-handle is-top"
@@ -2786,7 +2816,7 @@ export function AiChat({
           <header className="ai-chat-panel-header">
             <div className="ai-chat-panel-title">
               <strong>{snapshot?.thread.title ?? text("新对话", "New chat")}</strong>
-              <span>{snapshot?.thread.origin.projectName ?? text(
+              <span>{activeAgentType === "kimi" ? "Kimi Code · " : "Codex · "}{snapshot?.thread.origin.projectName ?? text(
                 "选择对话或从当前项目新建",
                 "Select a chat or start one in the current project",
               )}</span>
@@ -2848,7 +2878,7 @@ export function AiChat({
                     <span className={`ai-chat-thread-status is-${thread.status}`} aria-hidden="true" />
                     <span>
                       <strong>{thread.title}</strong>
-                      <small>{thread.origin.projectName} · {dateLabel(thread.updatedAt, locale)}</small>
+                      <small>{thread.agentType === "kimi" ? "Kimi" : "Codex"} · {thread.origin.projectName} · {dateLabel(thread.updatedAt, locale)}</small>
                     </span>
                   </button>
                   <button
@@ -2889,7 +2919,9 @@ export function AiChat({
                 {snapshot.thread.status === "running" && (
                   <div className="ai-chat-running" role="status">
                     <span className="ai-chat-spinner" />
-                    {text("Codex 正在处理", "Codex is working")}
+                    {snapshot.thread.agentType === "kimi"
+                      ? text("Kimi 正在处理", "Kimi is working")
+                      : text("Codex 正在处理", "Codex is working")}
                   </div>
                 )}
                 {retryableUserEvent && (
@@ -2918,10 +2950,15 @@ export function AiChat({
                   ? text("在当前项目中开始对话", "Start a chat in the current project")
                   : text("打开一个历史对话", "Open a chat from history")}</strong>
                 <p>{projectId
-                  ? text(
-                    "Codex 会在新对话创建时记住当前项目。",
-                    "Codex will remember the current project when it creates the new chat.",
-                  )
+                  ? activeAgentType === "kimi"
+                    ? text(
+                        "Kimi 会在议题绑定的项目或 worktree 中执行。",
+                        "Kimi will run in the project or worktree bound to this issue.",
+                      )
+                    : text(
+                        "Codex 会在新对话创建时记住当前项目。",
+                        "Codex will remember the current project when it creates the new chat.",
+                      )
                   : text("进入项目后可以新建对话。", "Open a project to start a new chat.")}</p>
               </div>
             )}
@@ -2985,9 +3022,9 @@ export function AiChat({
                 ref={editorRef}
                 className="ai-chat-composer-editor"
                 contentEditable={!composerBlocked}
-                data-placeholder={text("询问 Codex", "Ask Codex")}
+                data-placeholder={activeAgentType === "kimi" ? text("交给 Kimi", "Ask Kimi") : text("询问 Codex", "Ask Codex")}
                 role="textbox"
-                aria-label={text("发送给 Codex 的消息", "Message to Codex")}
+                aria-label={activeAgentType === "kimi" ? text("发送给 Kimi 的消息", "Message to Kimi") : text("发送给 Codex 的消息", "Message to Codex")}
                 aria-multiline="true"
                 aria-autocomplete="list"
                 aria-controls={composerQueryState ? "ai-chat-composer-candidates" : undefined}
@@ -3143,7 +3180,7 @@ export function AiChat({
               >
                 <PlusIcon color="currentColor" size={15} />
               </button>
-              <div className="ai-chat-menu-wrap ai-chat-permission-menu-wrap">
+              {activeAgentType === "codex" && <div className="ai-chat-menu-wrap ai-chat-permission-menu-wrap">
                 <button
                   className="ai-chat-permission-trigger"
                   type="button"
@@ -3196,10 +3233,10 @@ export function AiChat({
                     ))}
                   </div>
                 )}
-              </div>
+              </div>}
 
               <span className="ai-chat-toolbar-spacer" />
-              <div className="ai-chat-menu-wrap ai-chat-model-menu-wrap">
+              {activeAgentType === "codex" && <div className="ai-chat-menu-wrap ai-chat-model-menu-wrap">
                 <button
                   className="ai-chat-model-trigger"
                   type="button"
@@ -3309,7 +3346,7 @@ export function AiChat({
                     ))}
                   </div>
                 )}
-              </div>
+              </div>}
 
               {primaryAction === "stop" ? (
                 <button
@@ -3331,7 +3368,7 @@ export function AiChat({
                     primaryAction === "disabled"
                     || loading
                     || settingsSaving
-                    || Boolean(catalogError)
+                    || (activeAgentType === "codex" && Boolean(catalogError))
                   }
                   onClick={() => void startMessage(draft, false)}
                 >

--- a/web/src/components/TaskContextMenu.tsx
+++ b/web/src/components/TaskContextMenu.tsx
@@ -20,6 +20,7 @@ import { labelPresentation } from "../labels";
 import { taskPriorityLabel, taskStatusLabel, useTaskboardI18n } from "../i18n";
 import { LinearIcon } from "./LinearIcon";
 import {
+  ConversationIcon,
   DeleteIcon,
   EditIcon,
   LabelIcon,
@@ -43,6 +44,7 @@ interface TaskContextMenuProps {
   onCopy: (text: string, announcement: string) => void;
   openInThreadDisabled?: boolean;
   onOpenInThread: (task: Task) => void;
+  onOpenInKimi: (task: Task) => void;
   onArchive: (task: Task) => void;
 }
 
@@ -115,6 +117,7 @@ export function TaskContextMenu({
   onCopy,
   openInThreadDisabled = false,
   onOpenInThread,
+  onOpenInKimi,
   onArchive,
 }: TaskContextMenuProps) {
   const { language, text } = useTaskboardI18n();
@@ -415,11 +418,18 @@ export function TaskContextMenu({
           )}
         </MenuItem>
         <MenuItem
-          label={text("在新对话打开", "Open in new conversation")}
+          label={text("使用 Codex", "Use Codex")}
           icon={<NewConversationIcon color="currentColor" size={16} />}
           disabled={openInThreadDisabled}
           onPointerEnter={closeSubmenu}
           onClick={() => closeThen(() => onOpenInThread(task))}
+        />
+        <MenuItem
+          label={text("使用 Kimi", "Use Kimi")}
+          icon={<ConversationIcon color="currentColor" size={16} />}
+          disabled={openInThreadDisabled}
+          onPointerEnter={closeSubmenu}
+          onClick={() => closeThen(() => onOpenInKimi(task))}
         />
       </div>
 

--- a/web/src/components/TaskConversationMenu.tsx
+++ b/web/src/components/TaskConversationMenu.tsx
@@ -14,7 +14,8 @@ function conversationSource(
   conversation: TaskConversationItem,
   text: (chinese: string, english: string) => string,
 ) {
-  if (conversation.kind === "local-ai") return text("内置 AI", "Built-in AI");
+  if (conversation.agentType === "kimi") return "Kimi Code";
+  if (conversation.kind === "local-ai") return text("内置 Codex", "Built-in Codex");
   return conversation.source === "comment"
     ? text("评论对话", "Comment conversation")
     : text("任务对话", "Task conversation");
@@ -30,6 +31,7 @@ function conversationStatus(
     }
     return text("正在处理", "Processing");
   }
+  if (conversation.agentType === "kimi") return "Kimi";
   return conversation.kind === "local-ai" ? text("已暂停", "Paused") : "Codex";
 }
 

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -127,6 +127,7 @@ interface TaskDetailProps {
   onOpenThread: (binding: CodexThreadBinding) => void;
   onOpenLegacyLocalThread: (threadId: string) => void;
   onOpenInThread: (task: Task) => void;
+  onOpenInKimi: (task: Task) => void;
   onCopy: (text: string, announcement: string) => void;
   openingThread: boolean;
   onError: (message: TaskDetailError | null) => void;
@@ -386,6 +387,7 @@ export function TaskDetail({
   onOpenThread,
   onOpenLegacyLocalThread,
   onOpenInThread,
+  onOpenInKimi,
   onCopy,
   openingThread,
   onError,
@@ -1607,7 +1609,15 @@ export function TaskDetail({
                 <NewConversationIcon color="currentColor" />
                 <span>{openingThread
                   ? text("正在打开…", "Opening…")
-                  : text("在新对话打开", "Open in new conversation")}</span>
+                  : text("使用 Codex", "Use Codex")}</span>
+              </button>
+              <button
+                className="detail-open-thread-action is-kimi"
+                type="button"
+                onClick={() => onOpenInKimi(currentTask)}
+              >
+                <ConversationIcon color="currentColor" />
+                <span>{text("使用 Kimi", "Use Kimi")}</span>
               </button>
               {currentTask.externalUrl && (
                 <a

--- a/web/src/taskConversations.ts
+++ b/web/src/taskConversations.ts
@@ -10,6 +10,7 @@ export interface TaskConversationItem {
   key: string;
   projectId: string;
   kind: "native" | "local-ai";
+  agentType: "codex" | "kimi";
   title: string;
   source: "task" | "comment" | "local-ai";
   nativeThreadId: string | null;
@@ -67,6 +68,7 @@ export function taskConversations(task: Task, aiThreads: AiChatThread[]) {
       key,
       projectId: task.projectId,
       kind: "native",
+      agentType: "codex",
       title: ref.title || task.title,
       source: ref.source,
       nativeThreadId: ref.threadId,
@@ -100,6 +102,7 @@ export function taskConversations(task: Task, aiThreads: AiChatThread[]) {
       key,
       projectId: task.projectId,
       kind: "local-ai",
+      agentType: thread.agentType,
       title: thread.title || thread.origin.issueIdentifier || task.title,
       source: "local-ai",
       nativeThreadId: current?.nativeThreadId ?? thread.codexThreadId,

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -54,6 +54,7 @@ export interface TaskboardCapabilities {
 }
 
 export type AiChatSandbox = "read-only" | "workspace-write" | "danger-full-access";
+export type AiAgentType = "codex" | "kimi";
 export type AiChatThreadStatus = "idle" | "running" | "failed";
 export type AiChatRunStatus = "running" | "completed" | "failed" | "interrupted";
 
@@ -297,6 +298,8 @@ export interface AiChatThread {
   id: string;
   title: string;
   status: AiChatThreadStatus;
+  agentType: AiAgentType;
+  agentSessionId: string | null;
   origin: AiChatOrigin;
   codexThreadId: string | null;
   model: string;


### PR DESCRIPTION
## Summary
- add Codex/Kimi execution choices to task detail and conversation menus
- run Kimi Code conversations in the issue project or bound worktree
- persist Kimi session IDs and stream replies into the existing AI conversation panel
- preserve current remote Codex project support

## Direct verification
- TypeScript check passed
- production web build passed
- real UI path showed “使用 Kimi” and opened a Kimi Code conversation
- source runtime returned `KIMI-DAS2-OK`
- packaged runtime returned `PACKAGED-KIMI-OK` and persisted a Kimi session ID

Closes #285