### PR TITLE
fix: restore task and comment attachment lists

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "start": "node server/index.mjs",
     "taskctl": "node cli/taskctl.mjs",
     "test": "node --test && npm run test:components",
-    "test:components": "vitest run web/src/components/MarkdownDocument.test.tsx --environment jsdom",
+    "test:components": "vitest run web/src/components/MarkdownDocument.test.tsx web/src/components/DescriptionDocument.test.tsx web/src/components/TaskDetail.test.tsx --environment jsdom",
     "test:cloud": "node --test test/cloud-shared-worker.test.mjs",
     "cloud:migrate:local": "wrangler d1 migrations apply codex-taskboard-db --local",
     "cloud:migrate": "wrangler d1 migrations apply codex-taskboard-db --remote",

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -782,6 +782,12 @@ export async function uploadCommentAttachment(
   return data.attachment;
 }
 
+export async function deleteAttachment(attachment: Attachment): Promise<void> {
+  await request(`/api/attachments/${encodeURIComponent(attachment.id)}`, {
+    method: "DELETE",
+  });
+}
+
 export function attachmentContentUrl(attachment: { id: string }): string {
   return `api/attachments/${encodeURIComponent(attachment.id)}/content`;
 }

--- a/web/src/components/TaskDetail.test.tsx
+++ b/web/src/components/TaskDetail.test.tsx
@@ -1,0 +1,188 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { forwardRef, useImperativeHandle } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Task } from "../types";
+import { TaskDetail } from "./TaskDetail";
+
+const fixtures = vi.hoisted(() => {
+  const taskAttachment = {
+    id: "task-attachment",
+    taskId: "task-id",
+    commentId: null,
+    kind: "attachment" as const,
+    filename: "task.txt",
+    contentType: "text/plain",
+    size: 12,
+    createdAt: "2026-09-09T00:00:00.000Z",
+  };
+  const commentAttachment = {
+    id: "comment-attachment",
+    taskId: "task-id",
+    commentId: "comment-id",
+    kind: "attachment" as const,
+    filename: "comment.txt",
+    contentType: "text/plain",
+    size: 18,
+    createdAt: "2026-09-09T00:00:00.000Z",
+  };
+  return {
+    taskAttachment,
+    commentAttachment,
+    listAttachments: vi.fn(async () => [taskAttachment]),
+    listComments: vi.fn(async () => [{
+      id: "comment-id",
+      taskId: "task-id",
+      body: "",
+      authorType: "user" as const,
+      authorId: "user-id",
+      authorName: "User",
+      authorAvatarUrl: null,
+      threadId: null,
+      threadBinding: null,
+      legacyLocalThreadId: null,
+      attachments: [commentAttachment],
+      version: 1,
+      createdAt: "2026-09-09T00:00:00.000Z",
+      updatedAt: "2026-09-09T00:00:00.000Z",
+    }]),
+    listTaskActivities: vi.fn(async () => []),
+    deleteAttachment: vi.fn(async () => undefined),
+  };
+});
+
+vi.mock("../api", () => ({
+  ApiError: class ApiError extends Error {},
+  attachmentDownloadUrl: ({ id }: { id: string }) => `api/attachments/${id}/download`,
+  createComment: vi.fn(),
+  deleteAttachment: fixtures.deleteAttachment,
+  deleteComment: vi.fn(),
+  getTask: vi.fn(),
+  listAttachments: fixtures.listAttachments,
+  listComments: fixtures.listComments,
+  listTaskActivities: fixtures.listTaskActivities,
+  resolveTaskboardUrl: (value: string) => value,
+  uploadAttachment: vi.fn(),
+  uploadCommentAttachment: vi.fn(),
+  updateComment: vi.fn(),
+}));
+
+vi.mock("./ActorAvatar", () => ({ ActorAvatar: () => <span /> }));
+vi.mock("./DescriptionDocument", () => ({
+  DescriptionDocument: ({ value }: { value: string }) => <div>{value}</div>,
+}));
+vi.mock("./InlineMediaComposer", () => ({
+  InlineMediaComposer: forwardRef((_props: unknown, ref) => {
+    useImperativeHandle(ref, () => ({
+      addFiles: vi.fn(),
+      focus: vi.fn(),
+      focusAtText: vi.fn(),
+    }));
+    return <div />;
+  }),
+}));
+vi.mock("./IssueRelations", () => ({
+  IssueParentLink: () => null,
+  IssueRelationSidebar: () => null,
+  IssueSubIssues: () => null,
+}));
+vi.mock("./LabelPicker", () => ({ LabelPicker: () => null }));
+vi.mock("./TaskPropertyPicker", () => ({ TaskPropertyPicker: () => null }));
+
+const task: Task = {
+  id: "task-id",
+  identifier: "TASK-1",
+  projectId: "project-id",
+  title: "Attachment list regression",
+  description: "",
+  status: "todo",
+  priority: "none",
+  labels: [],
+  sortOrder: 0,
+  threadId: null,
+  threadBinding: null,
+  legacyLocalThreadId: null,
+  conversationRefs: [],
+  participants: [],
+  previewImage: null,
+  activityKey: "activity-key",
+  activityUpdatedAt: "2026-09-09T00:00:00.000Z",
+  creatorType: "user",
+  creatorId: "user-id",
+  creatorName: "User",
+  creatorAvatarUrl: null,
+  assignee: { type: "user", id: "user-id", name: "User", avatarUrl: null },
+  developmentContext: null,
+  startDate: null,
+  dueDate: null,
+  recurrence: null,
+  source: "local",
+  externalOrigin: null,
+  externalKey: null,
+  externalUrl: null,
+  archivedAt: null,
+  relations: { parent: null, subIssues: [], blockedBy: [], blocks: [], related: [] },
+  version: 1,
+  createdAt: "2026-09-09T00:00:00.000Z",
+  updatedAt: "2026-09-09T00:00:00.000Z",
+};
+
+function renderTaskDetail() {
+  return render(
+    <TaskDetail
+      task={task}
+      tasks={[task]}
+      referenceTasks={[]}
+      currentUser={{ type: "user", id: "user-id", name: "User", avatarUrl: null }}
+      availableLabels={[]}
+      developmentScan={{ workspacePath: null, contexts: [] }}
+      developmentScanLoading={false}
+      commentsRevision={0}
+      attachmentsRevision={0}
+      onCreateLabel={vi.fn(async () => undefined)}
+      onDeleteLabel={vi.fn(async () => undefined)}
+      onUpdate={vi.fn(async (value) => value)}
+      onOpenTask={vi.fn()}
+      onAddRelation={vi.fn(async () => ({ task, relatedTask: task }))}
+      onRemoveRelation={vi.fn(async () => ({ task, relatedTask: task }))}
+      onOpenThread={vi.fn()}
+      onOpenLegacyLocalThread={vi.fn()}
+      onOpenInThread={vi.fn()}
+      onCopy={vi.fn()}
+      openingThread={false}
+      onError={vi.fn()}
+    />,
+  );
+}
+
+describe("TaskDetail attachment lists", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders task and comment attachments that are not referenced in text", async () => {
+    renderTaskDetail();
+
+    await waitFor(() => expect(screen.getByText("task.txt")).not.toBeNull());
+
+    const taskList = document.querySelector<HTMLElement>(".attachment-list");
+    expect(taskList).not.toBeNull();
+    if (!taskList) return;
+    expect(screen.getByRole("heading", { name: "Attachments" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Add attachment" })).not.toBeNull();
+    expect(within(taskList).getByText("task.txt")).not.toBeNull();
+    expect(within(screen.getByRole("list", { name: "Comment attachments" })).getByText("comment.txt"))
+      .not.toBeNull();
+  });
+
+  it("deletes an attachment through the existing delete API and removes it from the list", async () => {
+    renderTaskDetail();
+
+    const deleteButton = await screen.findByRole("button", { name: "Delete task.txt" });
+    fireEvent.click(deleteButton);
+    fireEvent.click(screen.getByRole("button", { name: "Delete attachment" }));
+
+    await waitFor(() => expect(fixtures.deleteAttachment).toHaveBeenCalledWith(fixtures.taskAttachment));
+    await waitFor(() => expect(screen.queryByText("task.txt")).toBeNull());
+  });
+});

--- a/web/src/components/TaskDetail.tsx
+++ b/web/src/components/TaskDetail.tsx
@@ -13,6 +13,7 @@ import {
   ApiError,
   attachmentDownloadUrl,
   createComment,
+  deleteAttachment,
   deleteComment,
   getTask,
   listAttachments,
@@ -167,6 +168,14 @@ function relativeTime(value: string, locale: string): string {
   if (Math.abs(days) < 30) return formatter.format(days, "day");
   return new Intl.DateTimeFormat(locale, { month: "short", day: "numeric" }).format(new Date(value));
 }
+
+function fileSize(value: number): string {
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(value < 10 * 1024 ? 1 : 0)} KB`;
+  return `${(value / (1024 * 1024)).toFixed(value < 10 * 1024 * 1024 ? 1 : 0)} MB`;
+}
+
+const MAX_ATTACHMENT_SIZE = 25 * 1024 * 1024;
 
 function resizeTextarea(element: HTMLTextAreaElement | null) {
   if (!element) return;
@@ -404,6 +413,7 @@ export function TaskDetail({
   const [savingProperty, setSavingProperty] = useState<string | null>(null);
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [attachmentsError, setAttachmentsError] = useState<TaskDetailError | null>(null);
+  const [uploadingAttachments, setUploadingAttachments] = useState(false);
   const [comments, setComments] = useState<Comment[]>([]);
   const [taskActivities, setTaskActivities] = useState<TaskChangeActivity[]>([]);
   const [commentsLoading, setCommentsLoading] = useState(true);
@@ -424,6 +434,8 @@ export function TaskDetail({
   const [savingCommentId, setSavingCommentId] = useState<string | null>(null);
   const [pendingDelete, setPendingDelete] = useState<Comment | null>(null);
   const [deleting, setDeleting] = useState(false);
+  const [pendingAttachmentDelete, setPendingAttachmentDelete] = useState<Attachment | null>(null);
+  const [deletingAttachment, setDeletingAttachment] = useState(false);
   const titleRef = useRef<HTMLTextAreaElement>(null);
   const descriptionComposerRef = useRef<InlineMediaComposerHandle>(null);
   const descriptionScrollPositionRef = useRef<{ element: HTMLElement; top: number } | null>(null);
@@ -432,6 +444,7 @@ export function TaskDetail({
   const editingComposerRef = useRef<InlineMediaComposerHandle>(null);
   const editingCommentScrollPositionRef = useRef<{ element: HTMLElement; top: number } | null>(null);
   const attachmentInputRef = useRef<HTMLInputElement>(null);
+  const issueAttachmentInputRef = useRef<HTMLInputElement>(null);
   const descriptionAttachmentPickerOpenRef = useRef(false);
   const commentAttachmentInputRef = useRef<HTMLInputElement>(null);
   const editCommentAttachmentInputRef = useRef<HTMLInputElement>(null);
@@ -965,6 +978,54 @@ export function TaskDetail({
     }
   }
 
+  async function uploadFiles(files: FileList) {
+    const selected = Array.from(files);
+    if (selected.length === 0 || uploadingAttachments) return;
+    const oversized = selected.find((file) => file.size > MAX_ATTACHMENT_SIZE);
+    if (oversized) {
+      setAttachmentsError([
+        `“${oversized.name}” 超过 25 MB，无法上传。`,
+        `“${oversized.name}” is larger than 25 MB and cannot be uploaded.`,
+      ]);
+      if (issueAttachmentInputRef.current) issueAttachmentInputRef.current.value = "";
+      return;
+    }
+    setUploadingAttachments(true);
+    setAttachmentsError(null);
+    try {
+      for (const file of selected) {
+        const attachment = await uploadAttachment(task.id, file, "attachment");
+        setAttachments((current) => current.some((item) => item.id === attachment.id)
+          ? current
+          : [...current, attachment]);
+      }
+    } catch (error) {
+      setAttachmentsError(messageFor(error));
+    } finally {
+      setUploadingAttachments(false);
+      if (issueAttachmentInputRef.current) issueAttachmentInputRef.current.value = "";
+    }
+  }
+
+  async function confirmAttachmentDelete() {
+    if (!pendingAttachmentDelete || deletingAttachment) return;
+    setDeletingAttachment(true);
+    setAttachmentsError(null);
+    try {
+      await deleteAttachment(pendingAttachmentDelete);
+      setAttachments((current) => current.filter((attachment) => attachment.id !== pendingAttachmentDelete.id));
+      setComments((current) => current.map((comment) => ({
+        ...comment,
+        attachments: comment.attachments.filter((attachment) => attachment.id !== pendingAttachmentDelete.id),
+      })));
+      setPendingAttachmentDelete(null);
+    } catch (error) {
+      setAttachmentsError(messageFor(error));
+    } finally {
+      setDeletingAttachment(false);
+    }
+  }
+
   const handleAttachmentDownload = useCallback((
     event: MouseEvent<HTMLAnchorElement>,
     attachment: Attachment,
@@ -992,6 +1053,9 @@ export function TaskDetail({
     .filter((actor, index, actors) => (
       actors.findIndex((candidate) => actorKey(candidate) === actorKey(actor)) === index
     ));
+  const visibleTaskAttachments = attachments.filter(
+    (attachment) => attachment.kind === "attachment",
+  );
   const activityTimeline = [
     ...taskActivities.flatMap((activity) => activity.changes.map((change, index) => ({
       kind: "change" as const,
@@ -1213,6 +1277,78 @@ export function TaskDetail({
                   </div>
                 )}
               </div>
+              <div className="attachments-heading issue-attachment-controls">
+                {visibleTaskAttachments.length > 0 && (
+                  <div>
+                    <h2 id="attachments-heading">{text("附件", "Attachments")}</h2>
+                    <span>{visibleTaskAttachments.length}</span>
+                  </div>
+                )}
+                <button
+                  className="attachment-add-button"
+                  type="button"
+                  disabled={uploadingAttachments}
+                  onClick={() => issueAttachmentInputRef.current?.click()}
+                >
+                  <AttachmentIcon color="currentColor" />
+                  {uploadingAttachments
+                    ? text("上传中…", "Uploading…")
+                    : text("添加附件", "Add attachment")}
+                </button>
+                <input
+                  ref={issueAttachmentInputRef}
+                  type="file"
+                  multiple
+                  hidden
+                  onChange={(event) => {
+                    if (event.currentTarget.files) void uploadFiles(event.currentTarget.files);
+                  }}
+                />
+              </div>
+              {visibleTaskAttachments.length > 0 && (
+                <section className="issue-attachments" aria-labelledby="attachments-heading">
+                  <ul className="attachment-list">
+                    {visibleTaskAttachments.map((attachment) => (
+                      <li key={attachment.id}>
+                        <a
+                          className="attachment-link"
+                          href={attachmentDownloadUrl(attachment)}
+                          download={attachment.filename}
+                          title={text(`下载 ${attachment.filename}`, `Download ${attachment.filename}`)}
+                          onClick={(event) => handleAttachmentDownload(event, attachment)}
+                        >
+                          <span className="attachment-file-icon" aria-hidden="true">
+                            <LinearIcon name="file" />
+                          </span>
+                          <span className="attachment-copy">
+                            <strong>{attachment.filename}</strong>
+                            <span>{fileSize(attachment.size)} · {relativeTime(attachment.createdAt, locale)}</span>
+                          </span>
+                        </a>
+                        <div className="attachment-actions">
+                          <a
+                            href={attachmentDownloadUrl(attachment)}
+                            download={attachment.filename}
+                            aria-label={text(`下载 ${attachment.filename}`, `Download ${attachment.filename}`)}
+                            title={text("下载附件", "Download attachment")}
+                            onClick={(event) => handleAttachmentDownload(event, attachment)}
+                          >
+                            <LinearIcon name="openExternal" />
+                          </a>
+                          <button
+                            type="button"
+                            aria-label={text(`删除 ${attachment.filename}`, `Delete ${attachment.filename}`)}
+                            title={text("删除附件", "Delete attachment")}
+                            onClick={() => setPendingAttachmentDelete(attachment)}
+                          >
+                            <DeleteIcon color="currentColor" />
+                          </button>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )}
               {attachmentsError && (
                 <div className="attachments-error" role="alert">
                   {typeof attachmentsError === "string"
@@ -1488,6 +1624,37 @@ export function TaskDetail({
                             />
                           </div>
                         )
+                      )}
+                      {comment.attachments.some((attachment) => attachment.kind === "attachment") && (
+                        <ul className="comment-attachment-list" aria-label={text("评论附件", "Comment attachments")}>
+                          {comment.attachments
+                            .filter((attachment) => attachment.kind === "attachment")
+                            .map((attachment) => (
+                              <li key={attachment.id}>
+                                <a
+                                  href={attachmentDownloadUrl(attachment)}
+                                  download={attachment.filename}
+                                  title={text(`下载 ${attachment.filename}`, `Download ${attachment.filename}`)}
+                                  onClick={(event) => handleAttachmentDownload(event, attachment)}
+                                >
+                                  <span className="attachment-file-icon" aria-hidden="true">
+                                    <LinearIcon name="file" />
+                                  </span>
+                                  <span><strong>{attachment.filename}</strong><small>{fileSize(attachment.size)}</small></span>
+                                </a>
+                                {editingId !== comment.id && (
+                                  <button
+                                    type="button"
+                                    aria-label={text(`删除 ${attachment.filename}`, `Delete ${attachment.filename}`)}
+                                    title={text("删除附件", "Delete attachment")}
+                                    onClick={() => setPendingAttachmentDelete(attachment)}
+                                  >
+                                    <DeleteIcon color="currentColor" />
+                                  </button>
+                                )}
+                              </li>
+                            ))}
+                        </ul>
                       )}
                       {(comment.threadBinding || comment.legacyLocalThreadId) && (
                         <div className="comment-conversation-link">
@@ -1879,6 +2046,24 @@ export function TaskDetail({
             <div>
               <button className="button secondary" type="button" disabled={deleting} onClick={() => setPendingDelete(null)}>{text("取消", "Cancel")}</button>
               <button className="button danger" type="button" disabled={deleting} onClick={() => void confirmDelete()}>{deleting ? text("删除中…", "Deleting…") : text("删除评论", "Delete comment")}</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {pendingAttachmentDelete && (
+        <div className="delete-backdrop" role="presentation" onMouseDown={(event) => {
+          if (event.target === event.currentTarget && !deletingAttachment) setPendingAttachmentDelete(null);
+        }}>
+          <div className="delete-dialog" role="alertdialog" aria-modal="true" aria-labelledby="delete-attachment-title">
+            <h2 id="delete-attachment-title">{text("删除这个附件？", "Delete this attachment?")}</h2>
+            <p>{text(
+              `“${pendingAttachmentDelete.filename}” 将被永久删除，此操作无法撤销。`,
+              `“${pendingAttachmentDelete.filename}” will be permanently deleted. This action cannot be undone.`,
+            )}</p>
+            <div>
+              <button className="button secondary" type="button" disabled={deletingAttachment} onClick={() => setPendingAttachmentDelete(null)}>{text("取消", "Cancel")}</button>
+              <button className="button danger" type="button" disabled={deletingAttachment} onClick={() => void confirmAttachmentDelete()}>{deletingAttachment ? text("删除中…", "Deleting…") : text("删除附件", "Delete attachment")}</button>
             </div>
           </div>
         </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2974,6 +2974,72 @@ kbd {
   text-align: center;
 }
 
+.attachments-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 28px;
+  gap: 12px;
+  margin-bottom: 7px;
+}
+
+.issue-attachment-controls .attachment-add-button {
+  margin-left: auto;
+}
+
+.issue-attachment-controls {
+  margin-top: 18px;
+}
+
+.attachments-heading > div {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.attachments-heading h2 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 560;
+  line-height: 20px;
+}
+
+.attachments-heading > div > span {
+  color: var(--text-tertiary);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.attachment-add-button {
+  display: flex;
+  align-items: center;
+  height: 26px;
+  gap: 5px;
+  padding: 0 7px;
+  border: var(--border-hairline) solid transparent;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
+.attachment-add-button:hover:not(:disabled) {
+  border-color: var(--border);
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.attachment-add-button svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.25;
+}
+
 .attachment-list {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -2999,6 +3065,16 @@ kbd {
 .attachment-list li:focus-within {
   border-color: color-mix(in srgb, var(--border) 70%, transparent);
   background: color-mix(in srgb, var(--surface-active) 64%, var(--surface-muted));
+}
+
+.attachment-link {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  gap: 9px;
+  color: inherit;
+  text-decoration: none;
 }
 
 .document-attachment-card,
@@ -3033,7 +3109,7 @@ kbd {
   width: 30px;
   height: 30px;
   border-radius: 5px;
-  background: #cacaca;
+  background: #b489f6;
   color: #fff;
 }
 
@@ -3067,6 +3143,57 @@ kbd {
 .attachment-copy > span {
   color: var(--text-tertiary);
   font-size: 9px;
+}
+
+.attachment-actions {
+  position: absolute;
+  right: 5px;
+  display: flex;
+  flex: 0 0 auto;
+  gap: 1px;
+  margin-left: 0;
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--surface-muted) 92%, transparent);
+  opacity: 0;
+  transition: opacity 100ms ease;
+}
+
+.attachment-list li:hover .attachment-actions,
+.attachment-list li:focus-within .attachment-actions {
+  opacity: 1;
+}
+
+.attachment-actions a,
+.attachment-actions button {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-tertiary);
+}
+
+.attachment-actions a:hover,
+.attachment-actions button:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.attachment-actions button:hover {
+  color: var(--danger);
+}
+
+.attachment-actions svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.25;
 }
 
 .attachments-empty {
@@ -3438,6 +3565,14 @@ kbd {
   margin-bottom: 6px;
 }
 
+.comment-attachment-list {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+  padding: 2px 16px 16px;
+  list-style: none;
+}
+
 .comment-body .issue-description-document blockquote > :last-child {
   margin-bottom: 0;
 }
@@ -3460,6 +3595,82 @@ kbd {
   opacity: 1;
   visibility: visible;
   transition-delay: 0s;
+}
+
+.comment-attachment-list li {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  min-height: 38px;
+  gap: 6px;
+  padding: 4px 5px 4px 6px;
+  border: var(--border-hairline) solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-muted);
+}
+
+.comment-attachment-list a {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  gap: 7px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.comment-attachment-list .attachment-file-icon {
+  width: 26px;
+  height: 26px;
+  background: var(--surface);
+}
+
+.comment-attachment-list a > span:last-child {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.comment-attachment-list strong {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 10px;
+  font-weight: 520;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.comment-attachment-list small {
+  color: var(--text-tertiary);
+  font-size: 9px;
+}
+
+.comment-attachment-list > li > button {
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-tertiary);
+}
+
+.comment-attachment-list > li > button:hover {
+  background: var(--surface-hover);
+  color: var(--danger);
+}
+
+.comment-attachment-list > li > button svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.25;
 }
 
 .comment-attach-button {
@@ -7273,7 +7484,8 @@ kbd {
 @media (hover: none) {
   .column-actions,
 .comment-actions,
-.ai-chat-history-delete {
+.ai-chat-history-delete,
+.attachment-actions {
     opacity: 1;
   }
 }


### PR DESCRIPTION
## Summary

Restore the standalone attachment lists that were accidentally removed from the task detail page. Uploaded task attachments and comment attachments are visible again, while inline referenced attachments and the existing open, download, and delete behavior remain unchanged.

## Root cause

Commit `5e4f61217a16e07464393ec1f7cde75dd43315eb` removed the standalone attachment-list rendering from `web/src/components/TaskDetail.tsx` while leaving the attachment data-loading logic in place. As a result, attachments that were not referenced in task or comment content were stored successfully but could no longer be discovered or managed from the UI.

## Changes

- Restore the task attachment list, including the attachment heading, count, add-attachment entry point, file cards, and existing actions.
- Restore the comment attachment list and its existing actions.
- Restore the attachment deletion confirmation flow and client API call.
- Preserve the current description editor and inline attachment rendering.
- Validate the 25 MiB limit before starting a task attachment batch upload, avoiding partial uploads when a selected file is too large.
- Keep attachment actions visible on touch devices.

## Verification

- `npm run typecheck` — passed.
- `npm run test:components` — 11/11 passed.
- `npm run build:web` — passed.
- `git diff --check` — passed.
- Manually verified that task attachments and comment attachments are displayed.
- Manually verified that an oversized file is rejected without starting the upload.

## Scope

This PR restores the missing attachment-list behavior and includes only the directly related upload-limit and touch-device action-area fixes.

It does not include the DAS-7 “copy local attachment path” feature and does not change the semantics of the existing open, download, or delete actions.

Refs #403